### PR TITLE
Separate LTS and interim releases in the navigation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,11 +38,9 @@ Future releases <future>
 Older releases <archive>
 :::
 
-## 25.10 (Questing Quokka)
+## LTS releases
 
-* {ref}`ubuntu-25.10-release-notes`
-
-## 24.04 LTS (Noble Numbat)
+### 24.04 LTS (Noble Numbat)
 
 * {ref}`changes-in-ubuntu-24.04.4`
 * {ref}`changes-in-ubuntu-24.04.3`
@@ -51,7 +49,7 @@ Older releases <archive>
 * {ref}`ubuntu-24.04-lts-release-notes`
 * {ref}`noble-numbat-schedule`
 
-## 22.04 LTS (Jammy Jellyfish)
+### 22.04 LTS (Jammy Jellyfish)
 
 * {ref}`changes-in-ubuntu-22.04.5`
 * {ref}`changes-in-ubuntu-22.04.4`
@@ -60,6 +58,12 @@ Older releases <archive>
 * {ref}`changes-in-ubuntu-22.04.1`
 * {ref}`ubuntu-22.04-lts-release-notes`
 * {ref}`jammy-jellyfish-schedule`
+
+## Interim releases
+
+### 25.10 (Questing Quokka)
+
+* {ref}`ubuntu-25.10-release-notes`
 
 (release-policy-and-schedule)=
 ## Release policy and schedule


### PR DESCRIPTION
Since we generally prioritize LTS releases, even on the download page, it makes sense to separate LTS and interim releases in the release notes, too.