### PR TITLE
26.04: clarify remaining X.org compatibility

### DIFF
--- a/docs/26.04/index.md
+++ b/docs/26.04/index.md
@@ -93,11 +93,13 @@ The Terminal app is now provided by [Ptyxis](https://gitlab.gnome.org/chergert/p
 :::{versionchanged} 25.10
 :::
 
-The "Ubuntu Desktop" session now runs only on the Wayland back end, because GNOME Shell can [no longer run as an X\.org session](https://discourse.ubuntu.com/t/ubuntu-25-10-drops-support-for-gnome-on-xorg/62538).
-X\.org programs can still be run through Xwayland.
-Other sessions (such as [`i3`](https://i3wm.org/), [KDE X11](https://kde.org/), [XFCE](https://www.xfce.org/), [MATE](https://mate-desktop.org/), ...) can be launched using an X\.org session.
+The *Ubuntu Desktop* session now runs only on the Wayland back end, because GNOME Shell can [no longer run as an X\.org session](https://discourse.ubuntu.com/t/ubuntu-25-10-drops-support-for-gnome-on-xorg/62538).
 
-Machines using Nvidia graphics now also fully support Wayland.
+You can still run applications developed for X\.org through the XWayland compatibility layer.
+
+Other desktop sessions, such as [KDE on X11](https://kde.org/), [Xfce](https://www.xfce.org/), [MATE](https://mate-desktop.org/), [`i3`](https://i3wm.org/) and many others, can still be launched using an X\.org session.
+
+Machines using Nvidia graphics now fully support Wayland.
 
 #### App Center enhancements
 :::{versionadded} 24.10


### PR DESCRIPTION
the current paragraph sounds like we don't ship x.org at all any more.
i clarified by mentioning xwayland for programs, or using different sessions to have an xorg server session.
@msuchane the beta changelog should include this to avoid users being unhappy or confused.