### PR TITLE
26.04: fix risc-v notes, indentation and opensbi version

### DIFF
--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -212,7 +212,7 @@ Other notable new features:
 
   * Add `riscv64` to `FirmwareArchitecture`
 
-  * Update OpenSBI to v1.7
+  * Update OpenSBI to v1.8.1
 
   * Implement MonitorDef HMP API
 

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -482,7 +482,7 @@ If you wish to keep specific applications, simply "install" them with `apt` firs
 
 The creation of the swap file on the desktop images is now handled by [`cloud-init`](https://cloudinit.readthedocs.io/en/latest/) ([LP: #2116275](https://launchpad.net/bugs/2116275)). You may customize the size of the swap file by editing `user-data` on the boot partition prior to first boot (commented examples are included in the image).
 
-#### New RISC-V requirements
+### New RISC-V requirements
 :::{versionchanged} 25.10
 :::
 


### PR DESCRIPTION
Fix "New RISC-V changes" title; it should be h3, not h4.
Fix OpenSBI version, it is 1.8.1 in Resolute, see https://launchpad.net/ubuntu/+source/opensbi