### PR TITLE
Add Django LTS update on 26.04 lts-to-lts page

### DIFF
--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -216,6 +216,12 @@ Updated to 1.4.3 with many new features
 
 For complete details of all changes leading up to 1.4.3, please see the upstream release notes at <https://blog.clamav.net/>.
 
+### Django
+:::{versionadded} 25.10
+:::
+
+Django has been updated to the latest LTS release 5.2 from 4.2, which includes many new features and bug fixes. All Django middleware provided in Ubuntu has also been updated to be compatible with the new version. See the [5.0 release notes](https://docs.djangoproject.com/en/5.2/releases/5.0/) for features and updates added with the major version change and the [5.2 release notes](https://docs.djangoproject.com/en/5.2/releases/5.2/) for the changes made leading up to the LTS release.
+
 ### PHP
 
 PHP was updated to version 8.5. Among other enhancements and bugfixes, the highlighted changes since Ubuntu Noble 24.04 are:


### PR DESCRIPTION
# Adding a release note

## Which Ubuntu release is affected by this change?
26.04

## What kind of change is this? Try to select just one if possible.

- [x] New feature or improvement
- [ ] Backwards-incompatible change, including removed features
- [ ] Deprecated feature – will be removed in a later release
- [ ] Bug fix
- [ ] Known issue
- [ ] Something else (please describe)

## Workaround

If this is a known issue, how can users work around it for now? Add here if you haven't already described it in the PR.

## Which part of Ubuntu does the change affect? Try to select just one if possible.

- [ ] Desktop
- [x] Server
- [ ] Containers
- [ ] Virtualization
- [ ] Databases
- [ ] High availability and clustering
- [ ] Development tools
- [ ] Enterprise
- [ ] Cloud
- [ ] Security
- [ ] WSL
- [ ] Real-time Ubuntu
- [ ] Hardware support
- [ ] A common, underlying change

## Major change

Is this a major change? Major changes are highlighted in an overview and are repeated when the next LTS release comes out.

yes
