### PR TITLE
doc(26.04/cloud/azure): Removing packages installed for ADE

### DIFF
--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -588,6 +588,19 @@ See [LP: #2142320](https://bugs.launchpad.net/ubuntu-release-notes/+bug/2142320)
 
 The `oracledb` and `zabbixagent` agents were replaced by the `oracle` and `zabbix-agent`, respectively. You might need to adjust your existing configuration.
 
+#### Microsoft Azure
+
+`Azure Disk Encryption` (ADE) is scheduled for retirement on September 15, 2028. A number of packages were historically pre-installed on Azure images to allow the enablement of ADE without requiring additional package installations. Due to its impending retirement, Ubuntu on Azure will no longer maintain the enablement of ADE without additional package installations. Accordingly, the following packages have been removed from one or more Ubuntu image-lines on Azure:
+
+`python3-parted`
+: This package is largely unsupported by its maintainers, imposing a potential security risk into the future. Its only known use was for the enablement of ADE. It is no longer pre-installed on any Ubuntu image on Azure.
+
+`python3-six`
+: The only known use of this package was for the enablement of ADE. It is no longer pre-installed on any Ubuntu image on Azure.
+
+`lsscsi`
+: This package was initially introduced to support ADE. It has been removed from all minimal Ubuntu image-lines to maintain the minimal footprint assertion. However, it remains a pre-installed package for all non-minimized Ubuntu images on Azure since it is a valuable debugging tool for individual instances and server deployments.
+
 <!--
 ### Development changes
 


### PR DESCRIPTION
Azure Disk Encryption (ADE) is retiring, so we have removed packages that were previously installed in our Ubuntu images by default since they are no longer needed.

# Adding a release note

Feel free to delete this template if you're making a minor or unrelated change.

## Which Ubuntu release is affected by this change?

26.04

## What kind of change is this? Try to select just one if possible.

- [ ] New feature or improvement
- [ ] Backwards-incompatible change, including removed features
- [ ] Deprecated feature – will be removed in a later release
- [ ] Bug fix
- [ ] Known issue
- [X] Something else (please describe)

Pre-installed package removal for impending Azure Disk Encryption retirement.

## Workaround

If this is a known issue, how can users work around it for now? Add here if you haven't already described it in the PR.

Users can simply manually install the packages if they wish to enable ADE.

## Which part of Ubuntu does the change affect? Try to select just one if possible.

- [ ] Desktop
- [ ] Server
- [ ] Containers
- [ ] Virtualization
- [ ] Databases
- [ ] High availability and clustering
- [ ] Development tools
- [ ] Enterprise
- [X] Cloud
- [ ] Security
- [ ] WSL
- [ ] Real-time Ubuntu
- [ ] Hardware support
- [ ] A common, underlying change

## Major change

Is this a major change? Major changes are highlighted in an overview and are repeated when the next LTS release comes out.

No, this is a minor change.

## Tickets

Are there any tickets related to the change, e.g. in Launchpad, Jira, GitHub? Paste the links here if you haven't included them in the PR already.

Current Jira tracking item: https://warthogs.atlassian.net/browse/CPC-10120
Ticket to remove python3-parted: https://warthogs.atlassian.net/browse/CPC-10020
Ticket to remove python3-six and lsscsi (will be complete in the next week or two): https://warthogs.atlassian.net/browse/CPC-10201

## Upstream release notes

Are there any upstream release notes related to the change? Paste the links here if you haven't included them in the PR already.

N/A
