### PR TITLE
Add Sphinx i18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,25 @@ cd docs
 ```bash
 make run
 ```
+
+### Translating the documentation
+
+To translate the documentation, you first need to update the translation template files to match the latest source documents.
+
+Run the following command:
+
+```bash
+cd docs
+make update-po DOCS_LANG=ja
+```
+
+This will generate or update `.po` files under the `locale/<lang>/` directory (for example, `locale/ja/LC_MESSAGES/`).
+
+If new `.po` files are created, make sure to add them to Git:
+
+```bash
+git add locale/
+git commit -m "Add new translation files"
+```
+
+After that, edit the `.po` files to add or update translations.

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -6,6 +6,7 @@
 .sphinx/warnings.txt
 .sphinx/.wordlist.dic
 .sphinx/.doctrees/
+.sphinx/.doctrees-gettext/
 .sphinx/update/
 .sphinx/node_modules/
 
@@ -24,3 +25,4 @@ package*.json
 __pycache__
 .idea/
 .vscode/
+locale/**/*.mo

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,8 @@
 # from the environment for the first two.
 
 SPHINX_DIR       ?= .sphinx
-SPHINX_OPTS      ?= -c . -d $(SPHINX_DIR)/.doctrees -j auto
+SPHINX_BASE_OPTS ?= -c . -j auto
+SPHINX_OPTS      ?= $(SPHINX_BASE_OPTS) -d $(SPHINX_DIR)/.doctrees
 SPHINX_BUILD     ?= $(DOCS_VENVDIR)/bin/sphinx-build
 SPHINX_HOST      ?= 127.0.0.1
 SPHINX_PORT      ?= 8000
@@ -21,6 +22,10 @@ VALE_CONFIG      ?= $(SPHINX_DIR)/vale.ini
 PA11Y_CMD        ?= $(SPHINX_DIR)/node_modules/pa11y/bin/pa11y.js --config $(SPHINX_DIR)/pa11y.json
 CONFIRM_SUDO     ?= N
 CHECK_PATH       ?= $(filter-out $(DOCS_VENVDIR),$(wildcard *))
+DOCS_LANG        ?= en
+DOCS_GETTEXTDIR  ?= $(DOCS_BUILDDIR)/gettext
+DOCS_POTDIR      ?= locale/pot
+
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -32,6 +37,7 @@ help:
 	@echo "* clean built doc files:                     make clean-doc"
 	@echo "* clean full environment:                    make clean"
 	@echo "* check links:                               make linkcheck"
+	@echo "* refresh PO files manually:                 make update-po DOCS_LANG=en,ja,..."
 	@echo "* check markdown:                            make lint-md"
 	@echo "* check spelling:                            make spelling"
 	@echo "* check spelling (without building again):   make spellcheck"
@@ -46,7 +52,7 @@ help:
 .PHONY: help full-help html epub pdf linkcheck spelling spellcheck woke \
         vale pa11y run serve install pa11y-install   \
         vale-install pdf-prep pdf-prep-force clean clean-doc \
-        update lint-md
+        update lint-md update-po
 
 full-help: $(DOCS_VENVDIR)
 	@. $(DOCS_VENV); $(SPHINX_BUILD) -M help "$(DOCS_SOURCEDIR)" "$(DOCS_BUILDDIR)" $(SPHINX_OPTS) $(O)
@@ -78,14 +84,20 @@ pymarkdownlnt-install: install
 install: $(DOCS_VENVDIR)
 
 run: install
-	. $(DOCS_VENV); $(DOCS_VENVDIR)/bin/sphinx-autobuild -b dirhtml --host $(SPHINX_HOST) --port $(SPHINX_PORT) "$(DOCS_SOURCEDIR)" "$(DOCS_BUILDDIR)" $(SPHINX_OPTS)
+	. $(DOCS_VENV); $(DOCS_VENVDIR)/bin/sphinx-autobuild -b dirhtml --host $(SPHINX_HOST) --port $(SPHINX_PORT) "$(DOCS_SOURCEDIR)" "$(DOCS_BUILDDIR)" $(SPHINX_OPTS) -D language="$(DOCS_LANG)"
 
 # Does not depend on $(DOCS_BUILDDIR) to rebuild properly at every run.
 html: install
-	. $(DOCS_VENV); $(SPHINX_BUILD) --fail-on-warning --keep-going -b dirhtml "$(DOCS_SOURCEDIR)" "$(DOCS_BUILDDIR)" -w $(SPHINX_DIR)/warnings.txt $(SPHINX_OPTS)
+	. $(DOCS_VENV); $(SPHINX_BUILD) --fail-on-warning --keep-going -b dirhtml "$(DOCS_SOURCEDIR)" "$(DOCS_BUILDDIR)" -w $(SPHINX_DIR)/warnings.txt $(SPHINX_OPTS) -D language="$(DOCS_LANG)"
 
 epub: install
 	. $(DOCS_VENV); $(SPHINX_BUILD) -b epub "$(DOCS_SOURCEDIR)" "$(DOCS_BUILDDIR)" -w $(SPHINX_DIR)/warnings.txt $(SPHINX_OPTS)
+
+# Use a separate doctree directory (-d) for the gettext builder,
+# because doctrees are not compatible between different builders.
+update-po: install
+	. $(DOCS_VENV); $(SPHINX_BUILD) -b gettext "$(DOCS_SOURCEDIR)" "$(DOCS_GETTEXTDIR)" -w $(SPHINX_DIR)/warnings.txt $(SPHINX_BASE_OPTS) -d $(SPHINX_DIR)/.doctrees-gettext
+	. $(DOCS_VENV); $(DOCS_VENVDIR)/bin/sphinx-intl update -p "$(DOCS_GETTEXTDIR)" $(foreach lang,$(DOCS_LANG),-l $(lang))
 
 serve: html
 	cd "$(DOCS_BUILDDIR)"; python3 -m http.server --bind $(SPHINX_HOST) $(SPHINX_PORT)
@@ -100,6 +112,7 @@ clean: clean-doc
 clean-doc:
 	git clean -fx "$(DOCS_BUILDDIR)"
 	rm -rf $(SPHINX_DIR)/.doctrees
+	rm -rf $(SPHINX_DIR)/.doctrees-gettext
 
 linkcheck: install
 	. $(DOCS_VENV) ; $(SPHINX_BUILD) -b linkcheck -q "$(DOCS_SOURCEDIR)" "$(DOCS_BUILDDIR)" $(SPHINX_OPTS) || { grep --color -F "[broken]" "$(DOCS_BUILDDIR)/output.txt"; exit 1; }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,11 @@ author = "Canonical Ltd."
 # html_title = project + " documentation"
 html_title = project
 
+# Internationalization (i18n)
+language = os.environ.get("READTHEDOCS_LANGUAGE", "en")
+locale_dirs = ["locale/"]
+gettext_compact = False
+gettext_uuid = True
 
 # The year in the copyright statement defaults to the current year, so
 # individual document versions show when they were built.

--- a/docs/locale/ja/LC_MESSAGES/22.04/1.po
+++ b/docs/locale/ja/LC_MESSAGES/22.04/1.po
@@ -1,0 +1,2626 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../22.04/1.md:2 1156ab596c664fc7a802dfe63b3a82fc
+msgid "Changes in Ubuntu 22.04.1"
+msgstr ""
+
+#: ../../22.04/1.md:4 b93a587a2a81484090633a7cedd10173
+msgid ""
+"This is a brief summary of bugs fixed between Ubuntu 22.04 LTS and "
+"22.04.1. **This summary covers only changes to packages in *main* and "
+"*restricted*, which account for all packages in the officially-supported "
+"images; there are further changes to various packages in *universe* and "
+"*multiverse*.** Some of these fixes were by Ubuntu developers directly, "
+"while others were by upstream developers and backported to Ubuntu. For "
+"full details, see the individual package changelogs."
+msgstr ""
+
+#: ../../22.04/1.md:6 c85e4105fe6d4d9cad9c794fc2c3f51b
+msgid ""
+"In addition to the bugs listed below, this update includes all security "
+"updates from the [Ubuntu Security Notice "
+"list](https://ubuntu.com/security/notices?order=newest&release=jammy&details=)"
+" affecting Ubuntu 22.04 LTS that were released up to and including August"
+" 9, 2022. The last update included was USN-5551-1 (mod-wsgi "
+"vulnerability)."
+msgstr ""
+
+#: ../../22.04/1.md:8 4ed654b3959545bba41480d6bed89baf
+msgid "Installation bug fixes"
+msgstr ""
+
+#: ../../22.04/1.md:10 845fb70075f14b82b9e4ac5303dba352
+msgid ""
+"Updated CD images are provided with this release, including fixes for "
+"some installation bugs.  (Many installation problems are hardware-"
+"specific; for those, see \"Hardware support bugs\" below.)"
+msgstr ""
+
+#: ../../22.04/1.md 1623c76115c849e2b8c69f00f184fbb7
+#: 1f474ec88535413e8464a30dc582d893 7d6c7bd685e24df78a31c8e7275a180f
+#: ac58f308e4e947baafd87cab817770c7 d286ae99a65e4cfcb57d8fd22e3e87c5
+#: dbe05ed720f94183b510f73a4f79c08e e96aff85848b4813b170b30a38499ce3
+msgid "Source Package"
+msgstr ""
+
+#: ../../22.04/1.md 14cfe071b2184296b5ce3803aa564090
+#: 50ca93b0556647f5ae7ca0c522097638 c1ab5e0c0a5a4dc19f16bd0d3c176789
+#: c2ffdd21c8bb465086d7b81f9c0937b2 c6e59e55a0e24f07b41b76be9f671b74
+#: fbb697c83b2a4c339aedf31e8ad3bd95 fedab8c5c78344cda5f788e0aad20cca
+msgid "Bug  #"
+msgstr ""
+
+#: ../../22.04/1.md 2268f51b00f24af8940f9cc6b4ce500c
+#: 34385474341c40f0a82d5654a12b8774 49cd203cc00c4ac1ab6a0794706259e5
+#: 5e338fe247ef4f2f9bedda51a7bf7373 b065942212bb4d13b29198a75ea8a64d
+#: d02ac710e8764f4499fcad22d5c4aadd da650dbda321442ba9fe68c55a7cf5f8
+msgid "Description"
+msgstr ""
+
+#: ../../22.04/1.md bee4ec6b210e4072b4d4018e73807a4b
+#: c2d7c647bbd644f589a4d1e220149c85
+msgid "ubiquity"
+msgstr ""
+
+#: ../../22.04/1.md 68625b07ece84740920b71dfba4c0b4a
+msgid "[1969455](https://bugs.launchpad.net/bugs/1969455)"
+msgstr ""
+
+#: ../../22.04/1.md e8d50f78cbb34418a67e5864d12ea68e
+msgid "Update the Ubuntu logo to the new branding for the Install Ubuntu screen."
+msgstr ""
+
+#: ../../22.04/1.md 0fe41074826b41d2b068343ea7e10c5f
+msgid "ubiquity-slideshow-ubuntu"
+msgstr ""
+
+#: ../../22.04/1.md e5bb0665e14d4881b510db0d665fcffb
+msgid "[1969880](https://bugs.launchpad.net/bugs/1969880)"
+msgstr ""
+
+#: ../../22.04/1.md dfabd3e5e436426393f4e54da7c1071f
+msgid "Update the appearance slideshow to reflect the current layout"
+msgstr ""
+
+#: ../../22.04/1.md 747109966dac4813af04c7315ca5fc24
+msgid "[1979997](https://bugs.launchpad.net/bugs/1979997)"
+msgstr ""
+
+#: ../../22.04/1.md 9de63064ea94499d87663c40dc77fa95
+msgid "Ensure minimum available amount of memory available"
+msgstr ""
+
+#: ../../22.04/1.md 0175fa744b704562b0d4db40ea5507ab
+#: 609f57ae987d490aa0c4b64894593ba7 6a2eb1da3e3845bea3034a2d7b452776
+#: 719471646c2e4062bd274183ca179d62 951a1c2fccfa47b99ce386e4382b5b1a
+#: a19a6162d15c4f6cbbf0ead5421fe848 e8608ab2a6334b319cd9d872b7da73f0
+#: f4847cfd8aba4453805fa51ee36391e1
+msgid "livecd-rootfs"
+msgstr ""
+
+#: ../../22.04/1.md 77499798caee44f1955821e77d3d22ff
+#: dd434c43d58c4251892cedda1026fa2f
+msgid "[1983521](https://bugs.launchpad.net/bugs/1983521)"
+msgstr ""
+
+#: ../../22.04/1.md 8f14fe0bc2904d37b2627b15ee45b912
+msgid "Manually blocklist DKMS modules for Ubuntu Studio builds."
+msgstr ""
+
+#: ../../22.04/1.md a926f0f2e164404282ac44d6a62ad66e
+msgid ""
+"The ubuntustudio dkms hook is only created when we're building "
+"ubuntustudio, so only chmod it when it exists."
+msgstr ""
+
+#: ../../22.04/1.md:22 73740852561e4ac380aeff7a878237cb
+msgid "Upgrade bug fixes"
+msgstr ""
+
+#: ../../22.04/1.md:24 1c867b28977a46ddac637e3081660c5a
+msgid ""
+"These changes fix upgrade issues, smoothing the way for future upgrades "
+"to later releases of Ubuntu (and not only)."
+msgstr ""
+
+#: ../../22.04/1.md 156bf93c81674b98a2a6b5453b424d1e
+#: 3ce428f96b5448dbab5a049f32f69502 6799e64b91724a90a4f948b0401b93b0
+#: b1ed0d190b734d748e6ccc04cebfd06a c9163bb144c7466496538d15c5197bfb
+#: cd412c5acdbd4866bac06b1e45438b8c d2a454c906824407bf940631a2582645
+#: f70677cb6a90415fa803a4ca3aaa1f29 f716ff82b45548988f4ec027d8bdd026
+msgid "ubuntu-release-upgrader"
+msgstr ""
+
+#: ../../22.04/1.md 2e246874433647a6b8a6de44d69bebd0
+msgid "[1970761](https://bugs.launchpad.net/bugs/1970761)"
+msgstr ""
+
+#: ../../22.04/1.md c5c75b01912745fd87e2506db65ae820
+msgid ""
+"DistUpgrade/DistUpgradeQuirks.py: Remove section of netplan config that "
+"is installed by default on Raspberry Pi and causes netplan failures after"
+" upgrade to jammy"
+msgstr ""
+
+#: ../../22.04/1.md 40376ff1eeac479cab3ebd8a1a37baa2
+msgid "[1965568](https://bugs.launchpad.net/bugs/1965568)"
+msgstr ""
+
+#: ../../22.04/1.md 771a2d7432ca40cea8e81ca71df0ab5e
+msgid "DistUpgrade: Gracefully handle missing dbus module."
+msgstr ""
+
+#: ../../22.04/1.md b951efd504124ac38b139986ff6df627
+msgid "[1973785](https://bugs.launchpad.net/bugs/1973785)"
+msgstr ""
+
+#: ../../22.04/1.md 37ef7c0590274d9b94b8fbfc4151d2c2
+msgid "DistUpgrade: Do not show lock screen error if XDG_SESSION_TYPE is tty."
+msgstr ""
+
+#: ../../22.04/1.md bd3bc3c020904b559299f4620afb4263
+msgid "[1975747](https://bugs.launchpad.net/bugs/1975747)"
+msgstr ""
+
+#: ../../22.04/1.md bb7b527395b24c60bda473d71dc7954c
+msgid "DistUpgrade: Add deb2snap entry for snapd-desktop-integration."
+msgstr ""
+
+#: ../../22.04/1.md 26adf3ea0f114a0fb5a04322b837cba8
+msgid "[1975533](https://bugs.launchpad.net/bugs/1975533)"
+msgstr ""
+
+#: ../../22.04/1.md 19458170b1dd4dcf8e6f17fae9576224
+msgid ""
+"Add support for upgrading from End of Life releases (Ubuntu 20.10 and "
+"Ubuntu 21.04) to Ubuntu 22.04 LTS."
+msgstr ""
+
+#: ../../22.04/1.md 96889d9d619d473d8d3c00f4ccca0852
+msgid "[1958668](https://bugs.launchpad.net/bugs/1958668)"
+msgstr ""
+
+#: ../../22.04/1.md f7d813c9628840168d80f63d78c8aae2
+msgid "DistUpgrade: Do not attempt to reboot in WSL."
+msgstr ""
+
+#: ../../22.04/1.md dd1ffaf48e1340a6ac4b683239aeedba
+msgid "[1981485](https://bugs.launchpad.net/bugs/1981485)"
+msgstr ""
+
+#: ../../22.04/1.md d48185902d8b4922a377fb3e25873f62
+msgid ""
+"DistUpgrade/deb2snap.json: gnome-3-34-1804 is no longer a seeded snap and"
+" should not be refreshed."
+msgstr ""
+
+#: ../../22.04/1.md c26d09202e8846f3998b883983074100
+msgid "speech-dispatcher"
+msgstr ""
+
+#: ../../22.04/1.md 6e421091efd446f3976d10cc7db1cb42
+msgid "[1981611](https://bugs.launchpad.net/bugs/1981611)"
+msgstr ""
+
+#: ../../22.04/1.md de1165bbcaa04829987f6977cd51aaa6
+msgid ""
+"don't remove mary-generic.conf on upgrade, it's included in the package "
+"again. Fix conffile prompt on update"
+msgstr ""
+
+#: ../../22.04/1.md 52853cc0d1d4420c8f5c2f522fc9750b
+msgid "[1955047](https://bugs.launchpad.net/bugs/1955047)"
+msgstr ""
+
+#: ../../22.04/1.md 0abe2dced12648c19188fd5a2e4a9d4f
+msgid ""
+"Add a quirk to resolve an issue where the nvidia driver would get "
+"suggested for autoremoval."
+msgstr ""
+
+#: ../../22.04/1.md a60133fa95614188a04f43d1356311cd
+msgid "[1977493](https://bugs.launchpad.net/bugs/1977493)"
+msgstr ""
+
+#: ../../22.04/1.md 18696759f761474386dd430bdc06508c
+msgid ""
+"On upgrade to 22.04, detect the presence of pam_tally* in /etc/pam.d and "
+"block the upgrade early, to avoid an abort from libpam-modules in the "
+"middle of the apt upgrade."
+msgstr ""
+
+#: ../../22.04/1.md:41 fabe5f44d6af410e98aecf59e9338e9f
+msgid "Desktop fixes"
+msgstr ""
+
+#: ../../22.04/1.md:43 c9046675151e43e2bf5abea0cdb1e53f
+msgid ""
+"These changes mainly affect desktop installations of Ubuntu, Kubuntu, "
+"Ubuntu MATE and other Ubuntu-based systems."
+msgstr ""
+
+#: ../../22.04/1.md 0b90b7a98a814636a7ddd8502cdc23d1
+#: d13d0677535e4500aacea1d72ddc7750
+msgid "gnome-control-center"
+msgstr ""
+
+#: ../../22.04/1.md d4ac6d615e4c4bf8a4e301b23949f4ab
+msgid "[1969619](https://bugs.launchpad.net/bugs/1969619)"
+msgstr ""
+
+#: ../../22.04/1.md 042690fb969449fabdc696920bfd0119
+msgid "Add patch to fix RDP Sharing on switch"
+msgstr ""
+
+#: ../../22.04/1.md 1463300cce2b446a81eb3ef0969bfc56
+#: 5d6fffcc3b5d43968274953ae2f92232 b54da2c402ef4af386363d2c5ea6088d
+#: e9fce07e9ef744de8713ff32848a902d f977422180254aabb03c637f1d04e47d
+msgid "gtk4"
+msgstr ""
+
+#: ../../22.04/1.md 4d4dde0282c149aa9d3efc6bba994e1b
+msgid "[1969622](https://bugs.launchpad.net/bugs/1969622)"
+msgstr ""
+
+#: ../../22.04/1.md 46cbd258e8e0477895d1b06bd6fb09c8
+msgid ""
+"Cherry-pick filechooser-Small-fix-for-save-mode.patch: Fix saving files "
+"to a folder that doesn't have any files in it"
+msgstr ""
+
+#: ../../22.04/1.md 95fb4f6ba5484d9da13700cabd670a17
+msgid "gdm3"
+msgstr ""
+
+#: ../../22.04/1.md 46629d93731b43fcb5949be43aaa200f
+msgid "[1968929](https://bugs.launchpad.net/bugs/1968929)"
+msgstr ""
+
+#: ../../22.04/1.md 59523f665ebe49e0b7015feeef578e15
+msgid ""
+"Default to Wayland for hybrid systems with Nvidia graphics drivers. "
+"Default to Xorg but offer Wayland with the gear button on the login "
+"screen for non-hybrid systems with Nvidia graphics drivers."
+msgstr ""
+
+#: ../../22.04/1.md c796d7c3144341b185b32b4e033aaf5d
+msgid "shotwell"
+msgstr ""
+
+#: ../../22.04/1.md b819fd6c87b14760aac8661233be36eb
+msgid "[1969439](https://bugs.launchpad.net/bugs/1969439)"
+msgstr ""
+
+#: ../../22.04/1.md 7940cda3ffe042d097902d888b1dd040
+msgid "fix an incorrect path handling making plugins not found"
+msgstr ""
+
+#: ../../22.04/1.md 07ae4992d37c48e79adc81370b0387c8
+#: f02abb3fee494d2fae4f881d7cfd0ea9
+msgid "software-properties"
+msgstr ""
+
+#: ../../22.04/1.md 574ba35370c9496ba698832fc5a932e4
+msgid "[1970244](https://bugs.launchpad.net/bugs/1970244)"
+msgstr ""
+
+#: ../../22.04/1.md 4c6e535beb744345a5799ba328df0ef2
+msgid "cloudarchive: Enable support for the Zed Ubuntu Cloud Archive on 22.04."
+msgstr ""
+
+#: ../../22.04/1.md 013911c56d464b8d8a4fb4e8c05e3b09
+#: 3458c3b7c8f74dc1ba78d6ea8bbabb5e
+msgid "gjs"
+msgstr ""
+
+#: ../../22.04/1.md 7cf4d2d1bd224ad3a8cc5073ef1360f7
+msgid "[1969838](https://bugs.launchpad.net/bugs/1969838)"
+msgstr ""
+
+#: ../../22.04/1.md 5aea9bd2c6e54fb2b17789d0ab6be142
+msgid ""
+"debian/patches: Correctly generate camelCase properties on all locales. "
+"And particularly looking at Turkish one."
+msgstr ""
+
+#: ../../22.04/1.md a58180e659a646e39b1a71c872f8d6b0
+#: c911c543b17041889b2033feddc45ca9 caed9f27be2b4e0fb28fd004f286396e
+msgid "libreoffice"
+msgstr ""
+
+#: ../../22.04/1.md a787a0ef94e14e7ebea28115a6d790b8
+msgid "[1971670](https://bugs.launchpad.net/bugs/1971670)"
+msgstr ""
+
+#: ../../22.04/1.md 15cf16d72ef84d8bbc6134efedab37c4
+#: 1f7da61fce424ab8912f1789da30ad27 29df2b542cbe4c6193aee0f6bf047369
+#: 3aea0464ad27405ebca75d0993258458 406017b9c1e54315a41df5a6dbb3075a
+#: 41dd648e8e814f1b8c8d80d76f069310 441f348e5c3b40ac92c520e6cce4ac08
+#: 4ae0e5b5e02447aea23aa0ff36a1fdb0 520b760898804c6e8b1a3f38bf6dfb34
+#: 56dbf0aa316b4543a3ac93a3b47d937f 56e25c70db7a4dadbf3f4d60779c2f1d
+#: 5bcb9728485546b28bf2a6bf0df53540 62d742e12d7047eda49678eac9defbe5
+#: 66910fa6428c4f3db16683105f2e9104 69053a36418d463e96dd40907a0cc1ae
+#: 6a82a25f186e44c1bcd5edb1a1bf60c9 6b7c54f865f046c19936ededba0f7da8
+#: 7128066c1edc47e990aebba97d9b44cc 7ac0ff247a49421693a02f2acaadeab2
+#: 851f5ece32de4407aeef34cfb1183830 98320b3a72764ec79ba80db6bc7a51df
+#: bdd528fdfe2740f2a227d08d92f67c7a c65f03ff2d6047a3aa3b114f807eae8e
+#: c8d14373c355420193df6931fb16eca2 ea3bd10fabc544748d1c5d0fff03abe4
+#: f2591e2aa1274cf0af71a3f7566f3f88 fadc4bd531e341719985c46a627bedc4
+msgid "New upstream release"
+msgstr ""
+
+#: ../../22.04/1.md 0080139959a0460aa708886fad7980d7
+#: dc5d1aed30014a0da7e0cf8c65112744
+msgid "nautilus"
+msgstr ""
+
+#: ../../22.04/1.md 48e57d4bfdf142a0834787fe1e4534a5
+msgid "[1970788](https://bugs.launchpad.net/bugs/1970788)"
+msgstr ""
+
+#: ../../22.04/1.md 83f52fd36f7841848a516547b0e7b362
+msgid "gnome-settings-daemon"
+msgstr ""
+
+#: ../../22.04/1.md 5c630e2fb00f4a7796951d98fa3732c2
+msgid "[1969637](https://bugs.launchpad.net/bugs/1969637)"
+msgstr ""
+
+#: ../../22.04/1.md ee0817f589b94d57a80bdec78c754630
+msgid "Upstream MR which fixes IBus config. issue on x11"
+msgstr ""
+
+#: ../../22.04/1.md 144a4adcc48048e2ba87649a413e3e26
+#: 145abe572ee846bc92a55d16196bdeb4
+msgid "freerdp2"
+msgstr ""
+
+#: ../../22.04/1.md 38cb3f0bc7034fb39a15760eb4bb3167
+msgid "[1971170](https://bugs.launchpad.net/bugs/1971170)"
+msgstr ""
+
+#: ../../22.04/1.md fb6de0318d5b4066882ae80d4ccd2268
+msgid "Backport #7822 to fix connecting to windows server over RDP"
+msgstr ""
+
+#: ../../22.04/1.md 916d752955244cd6b5b5d99a3e22b56b
+#: b337bf1e617448a1ac7b883915488cb6
+msgid "gnome-desktop"
+msgstr ""
+
+#: ../../22.04/1.md f8fabdd6e69d4ef3839aa9fe516ee7c1
+msgid "[1970660](https://bugs.launchpad.net/bugs/1970660)"
+msgstr ""
+
+#: ../../22.04/1.md 60982170fdac404192a298eddb647c74
+#: e1ecf3c2a02f476eaa10b445f3057757
+msgid "nvidia-graphics-drivers-390"
+msgstr ""
+
+#: ../../22.04/1.md 6270f5cde4c04144925137dc8fd3b2de
+#: 9d8f3267fd154abcb2bdf1571b8a1556 b0115628c8de456ead14130ff86ea906
+#: bcdca4b63a5141dca0a058caa52dd33d c114dc63511e462fa06f0911637d8ff9
+#: d313b30db00d437b9fcd744a2237fb24
+msgid "[1973300](https://bugs.launchpad.net/bugs/1973300)"
+msgstr ""
+
+#: ../../22.04/1.md 0fda172233aa45dc985efebf83a02b12
+#: 1b076b5f524b483dae750588c52c554c 1fedda87bd8d436e94e1ccf70e0c862d
+#: 31e5d4ba675e42288da8f02826faced7 3626b70d6e78472e823d0aad2e69ccd0
+#: 3b2b04bac67e4279ac1bc4c1904a5696 3f4803bb38ae43738d3c011dfe3497b7
+#: 53ac992009124c619c2050d12b974405 5edd696999a34566a6b3f1cb134825d4
+#: 8208e0c5248c44dd96f4ee1df62faca3 9fe62fe4d61a4750ab6f9cb999242e5a
+#: a0a0d74e73ba46789667b49b651a4441 a3e6c20076ac4eaba03296336d491e77
+#: bfc04f5a62c14d1d9ac3d0ba001c1ada d1f1617fd1874c40b2b14926d85960de
+#: e277cfdb46f741118030449bbac463a9 ecbf7ec7aa6a477aa752f907ce30fbf4
+#: fc2884181dfe449d87a7ecb649621103
+msgid "New upstream release."
+msgstr ""
+
+#: ../../22.04/1.md 3bd3993e718a456889d170c791c578df
+#: 8fa43225f58d4d75a839a903aafe7c4a
+msgid "nvidia-graphics-drivers-470"
+msgstr ""
+
+#: ../../22.04/1.md 3a51deca5e8e4bd79c5670c347fa15b0
+#: 50cea4fa563d43589d4e2f9a307574ab f1a09480fade47b18d92abec79515536
+msgid "nvidia-graphics-drivers-510"
+msgstr ""
+
+#: ../../22.04/1.md 696626db26664ba6956ad7e1acae3a68
+msgid "[1970164](https://bugs.launchpad.net/bugs/1970164)"
+msgstr ""
+
+#: ../../22.04/1.md fb20a015fb4b4812b446bf51aaf9d64c
+msgid "Add the following IDs: 25BB 1FB6 25BA."
+msgstr ""
+
+#: ../../22.04/1.md 171878e95e8447fc8a854762340bac33
+#: e218adc2eb91494d9debb7fc6607faf1
+msgid "evolution-data-server"
+msgstr ""
+
+#: ../../22.04/1.md 532f2297b14644ff9f5cfb11ec360af7
+msgid "[1969934](https://bugs.launchpad.net/bugs/1969934)"
+msgstr ""
+
+#: ../../22.04/1.md a16294146eff4a04a767949d493781f3
+msgid "zenity"
+msgstr ""
+
+#: ../../22.04/1.md 0f88f9b3fe194716b48fbe5df7c31272
+msgid "[1970658](https://bugs.launchpad.net/bugs/1970658)"
+msgstr ""
+
+#: ../../22.04/1.md 36e3494a527b48289ad13f3e480ff445
+msgid "orca"
+msgstr ""
+
+#: ../../22.04/1.md 2aee634e78b24f66a70c5f2b5e20ca16
+msgid "[1971076](https://bugs.launchpad.net/bugs/1971076)"
+msgstr ""
+
+#: ../../22.04/1.md 769edf1c0286432fb04e998335d2f28a
+msgid "Fix some inaccessibility regressions in webkitgtk 2.36"
+msgstr ""
+
+#: ../../22.04/1.md 286a88d97fc145ca84833bc89b00a257
+msgid "gtk+3.0"
+msgstr ""
+
+#: ../../22.04/1.md e0637f0264e5416e9178e408660a98d3
+msgid "[1972721](https://bugs.launchpad.net/bugs/1972721)"
+msgstr ""
+
+#: ../../22.04/1.md 3afa6268614f41409d0e92c4d97546f2
+msgid "Cherry-pick gtk-3-24 commits needed for mutter 42.1"
+msgstr ""
+
+#: ../../22.04/1.md 9ce878b6fb3340c4ac98aa463b025441
+msgid "clutter-gst-3.0"
+msgstr ""
+
+#: ../../22.04/1.md 865bbf2e56634c7e9f27f7e4f768f5bc
+msgid "[1967843](https://bugs.launchpad.net/bugs/1967843)"
+msgstr ""
+
+#: ../../22.04/1.md a0908487f65a4a52a6be6ca1472179b7
+msgid "Add patch from Arch Linux to fix corrupted display with Cheese"
+msgstr ""
+
+#: ../../22.04/1.md c9a7457f76444ae790cf9f7946cead5b
+msgid "xdg-utils"
+msgstr ""
+
+#: ../../22.04/1.md fc97a4319fe74c9e88478cf47c5a9395
+msgid "[1970594](https://bugs.launchpad.net/bugs/1970594)"
+msgstr ""
+
+#: ../../22.04/1.md 92eeecd8acc94c12915b01fdc5759fe5
+msgid "Cherry-pick an upstream merge request to remove bashisms from xdg-settings"
+msgstr ""
+
+#: ../../22.04/1.md 412405ece03240b296a0801e4c266861
+#: 82ae608ef2214a04a24a242cb586d3a8 9daffa7c18fb48e3bb0c72e93f67d73a
+msgid "xdg-desktop-portal"
+msgstr ""
+
+#: ../../22.04/1.md 805fec1503c64fe4af87e3d80001175d
+msgid "[1973596](https://bugs.launchpad.net/bugs/1973596)"
+msgstr ""
+
+#: ../../22.04/1.md 740403ed8a174af09404cb004aa150a5
+#: cb835a68e9d241e994a49eccfd6b15c2
+msgid "Update the native messaging portal patch to pick up a new commit"
+msgstr ""
+
+#: ../../22.04/1.md c6cded3a22ea44f8ba85f3528fb5e968
+msgid "[1973219](https://bugs.launchpad.net/bugs/1973219)"
+msgstr ""
+
+#: ../../22.04/1.md 051d4d8c98c14621b6bd7e894f48af4a
+#: 4ad5253905fc4be3a1bf95f871374e69 f60ac106704b4037bd3781d0a804db2c
+msgid "New upstream bugfix release"
+msgstr ""
+
+#: ../../22.04/1.md be4e10eab6194feaaa406d44a936eb46
+msgid "[1972722](https://bugs.launchpad.net/bugs/1972722)"
+msgstr ""
+
+#: ../../22.04/1.md d099c13841694bc59d66825896cf0f3d
+msgid "Fix text view scrolling with mutter 42.1"
+msgstr ""
+
+#: ../../22.04/1.md 6b2124eb35c248e0be1c6ca137d54fa3
+msgid "xdg-desktop-portal-gnome"
+msgstr ""
+
+#: ../../22.04/1.md 279c8a4a823d4a1eaf58c2a488edd189
+msgid "[1970609](https://bugs.launchpad.net/bugs/1970609)"
+msgstr ""
+
+#: ../../22.04/1.md 549e0f66781742308911a961d94e90fb
+#: d3fc7ecb7ccd43cb898216ce4a2d92c3 d64ff3fc76d340c18f6c659ae4d50e02
+msgid "gnome-shell"
+msgstr ""
+
+#: ../../22.04/1.md 0ba9fff831874464ba5c73b359f3c742
+msgid "[1973373](https://bugs.launchpad.net/bugs/1973373)"
+msgstr ""
+
+#: ../../22.04/1.md a6fb95e7df1f421eb736dbde925174ac
+msgid "[1968911](https://bugs.launchpad.net/bugs/1968911)"
+msgstr ""
+
+#: ../../22.04/1.md 2689a7c701cf4e4fab3c53473b184f93
+#: 406fa367fd1d430784a952def0ab3c7b 55fe3f3307d347d98b8bcca4b67e93a6
+msgid "mutter"
+msgstr ""
+
+#: ../../22.04/1.md 6964c4b66b4942958c9b3cacd2a2deed
+msgid ""
+"[1972726](https://bugs.launchpad.net/bugs/1972726) "
+"[1948410](https://bugs.launchpad.net/bugs/1948410) "
+"[1967219](https://bugs.launchpad.net/bugs/1967219) "
+"[1971693](https://bugs.launchpad.net/bugs/1971693)"
+msgstr ""
+
+#: ../../22.04/1.md 511efc89c4cb4eddabe9d7fb26c48d26
+msgid "ubuntu-advantage-desktop-daemon"
+msgstr ""
+
+#: ../../22.04/1.md 658451a70ce64053b9120fb779c8d928
+msgid "[1972809](https://bugs.launchpad.net/bugs/1972809)"
+msgstr ""
+
+#: ../../22.04/1.md b868d7a350fe4bbe912d75df7e854f0a
+msgid "relax the hardening rules to fix livepatch and other services"
+msgstr ""
+
+#: ../../22.04/1.md 69f74618065347c88d660a4a495fc608
+#: c1b7f4b233a04bc1848473b79ab82f79
+msgid "network-manager"
+msgstr ""
+
+#: ../../22.04/1.md c5fcb0f14eef4d31802765819e901e5b
+msgid "[1974428](https://bugs.launchpad.net/bugs/1974428)"
+msgstr ""
+
+#: ../../22.04/1.md dec18e6e035c4b168685a303a5d5fefb
+msgid "New stable version"
+msgstr ""
+
+#: ../../22.04/1.md 8c5b892fc53649109a0395663e776fb4
+#: c2ecb892562949078e0070aac12bfe75
+msgid "mesa"
+msgstr ""
+
+#: ../../22.04/1.md 0a833cd296c743fd8301d77802db0645
+msgid "[1971712](https://bugs.launchpad.net/bugs/1971712)"
+msgstr ""
+
+#: ../../22.04/1.md 697e46d491e7458089de301d751c2543
+msgid "Add patches to support Intel DG2."
+msgstr ""
+
+#: ../../22.04/1.md 09609acd08294d08b3d8d2973fed785d
+#: 53a080e2b9bc4d18838e22dd388c51d8 625d2c94758042158dcc6c57042b00e2
+#: b10d8206a0e847ec85e17adf0433c7c7 cc1bac058a1d46478b5c6cbe2a061eb3
+#: f2c504d18eef4ad082f27609eb594c64
+msgid "gnome-remote-desktop"
+msgstr ""
+
+#: ../../22.04/1.md 0642a98feae24ab28808e9b49adf5f27
+msgid "[1970662](https://bugs.launchpad.net/bugs/1970662)"
+msgstr ""
+
+#: ../../22.04/1.md f5ef25a7efa349b2b55203e140d7b176
+msgid "[1971195](https://bugs.launchpad.net/bugs/1971195)"
+msgstr ""
+
+#: ../../22.04/1.md 8f7d448ba5a145b8b8d76492b3ac7cb2
+msgid "Fixes black screen with virtio on qemu"
+msgstr ""
+
+#: ../../22.04/1.md ad503a47a72b4831b25efc3c622f7748
+msgid "[1970411](https://bugs.launchpad.net/bugs/1970411)"
+msgstr ""
+
+#: ../../22.04/1.md 4807760f0d3f4adcad4c602f53fb6034
+msgid "Depend on fuse3"
+msgstr ""
+
+#: ../../22.04/1.md a04398675ee24da38dd2c3663438fa3a
+msgid "[1973028](https://bugs.launchpad.net/bugs/1973028)"
+msgstr ""
+
+#: ../../22.04/1.md a8c1de868ce3402fb643dd6ef499583d
+msgid "Don't automatically enable the systemd user service"
+msgstr ""
+
+#: ../../22.04/1.md e523c56e74734e81a7f646e16571d058
+msgid "deja-dup"
+msgstr ""
+
+#: ../../22.04/1.md 0f6011ff28074bc9a65d23d67fe70925
+msgid "[1973816](https://bugs.launchpad.net/bugs/1973816)"
+msgstr ""
+
+#: ../../22.04/1.md c5f98c5939a64e96ad4922d20b900474
+msgid ""
+"update the oauth workflow, the local redirection currently used by deja-"
+"dup is being deprecated by Google and will stop working. Thanks Michael "
+"Terry providing us backports of the fix!"
+msgstr ""
+
+#: ../../22.04/1.md 5e38a634ec93475cafb74d8f83476799
+#: be36bf7ba0f54907b587d56b349c0bd3 dee828b060f7428688a534e8db348a2a
+#: e6b93b2ebe3c4c7dbe86a402e9fb4870
+msgid "adsys"
+msgstr ""
+
+#: ../../22.04/1.md ff51d72e37ed4a59ab47c2c528fbad82
+msgid "[1973745](https://bugs.launchpad.net/bugs/1973745)"
+msgstr ""
+
+#: ../../22.04/1.md 583fe296eeb443fb8823e2def8bb09eb
+msgid "Include 22.04 in admx/adml for lts only releases."
+msgstr ""
+
+#: ../../22.04/1.md fc28c7d2084445a384b6aea57c697122
+msgid "[1973748](https://bugs.launchpad.net/bugs/1973748)"
+msgstr ""
+
+#: ../../22.04/1.md 33773d28b84a4553aadab79bc7f54cde
+msgid "Fix dconf keys not being readable by user after applying policy."
+msgstr ""
+
+#: ../../22.04/1.md b1151f34133444d4a7d07498e0d98790
+msgid "[1973751](https://bugs.launchpad.net/bugs/1973751)"
+msgstr ""
+
+#: ../../22.04/1.md b67957728f494293a827d05258707664
+msgid ""
+"Ensure we can execute machine and user scripts: /run is now noexec on "
+"Ubuntu. Ensure that we can execute the scripts in /run/adsys "
+"subdirectories. The scripts mechanism has been reviewed by the security "
+"team, so we can reset them as executable."
+msgstr ""
+
+#: ../../22.04/1.md a01787dd028e486e922b5042337e9b50
+msgid "[1973752](https://bugs.launchpad.net/bugs/1973752)"
+msgstr ""
+
+#: ../../22.04/1.md ed58cd10224c4f6c9e3f3ebb90230ae3
+msgid "Fix privilege permission which can not be set to disabled."
+msgstr ""
+
+#: ../../22.04/1.md 971b8024ecd8419590d4d215271176c9
+msgid "[1975945](https://bugs.launchpad.net/bugs/1975945)"
+msgstr ""
+
+#: ../../22.04/1.md 8f299552a2024d19b32d3fbc19ac85ff
+msgid "[1976120](https://bugs.launchpad.net/bugs/1976120)"
+msgstr ""
+
+#: ../../22.04/1.md 29370305af96440389242cffcc6a13ab
+msgid "[1969460](https://bugs.launchpad.net/bugs/1969460)"
+msgstr ""
+
+#: ../../22.04/1.md 4852f9eb8f7f4110aa2ed5a3e6f55610
+msgid ""
+"softwareproperties/gtk/SoftwarePropertiesGtk.py: Don't crash if the "
+"driver package does not have a matching modules package"
+msgstr ""
+
+#: ../../22.04/1.md 4f7cad1800ae44409b608447c4fdb5b8
+msgid "[1976381](https://bugs.launchpad.net/bugs/1976381)"
+msgstr ""
+
+#: ../../22.04/1.md a876f2911be54b45a75ca673be3ef4dd
+msgid "[1969893](https://bugs.launchpad.net/bugs/1969893)"
+msgstr ""
+
+#: ../../22.04/1.md 8e261130821045b28b71b105eb0a3e01
+msgid "Fix crash when restarting GNOME Shell on Xorg"
+msgstr ""
+
+#: ../../22.04/1.md fe9c7644da6249a09b2b0bdbee5aab97
+msgid "[1977776](https://bugs.launchpad.net/bugs/1977776)"
+msgstr ""
+
+#: ../../22.04/1.md 2b90bec877ae4568ad44fa824f2d4eeb
+msgid "[1977772](https://bugs.launchpad.net/bugs/1977772)"
+msgstr ""
+
+#: ../../22.04/1.md 5189bdc26e7f4244868489b3d9fec4a9
+msgid "[1977619](https://bugs.launchpad.net/bugs/1977619)"
+msgstr ""
+
+#: ../../22.04/1.md e139730f535c46ca958a3bc63880ad42
+msgid "platform: workaround for preserving IPv6 address order"
+msgstr ""
+
+#: ../../22.04/1.md dcede4228e6343eca2ff33e3166fbfad
+msgid "[1977525](https://bugs.launchpad.net/bugs/1977525)"
+msgstr ""
+
+#: ../../22.04/1.md dbd47c23ba944ba7b105b6565b47302d
+msgid "gvfs"
+msgstr ""
+
+#: ../../22.04/1.md af41519684304db6b8df1f41f832a90b
+msgid "[1977467](https://bugs.launchpad.net/bugs/1977467)"
+msgstr ""
+
+#: ../../22.04/1.md 02438ae043634ed19014fa80147cd4a5
+#: 07c68ff7efb14e279200343198143454
+msgid "evince"
+msgstr ""
+
+#: ../../22.04/1.md f70139c32ff74112a4a5fdaa12410c5a
+msgid "[1975489](https://bugs.launchpad.net/bugs/1975489)"
+msgstr ""
+
+#: ../../22.04/1.md c4ecee1220714867810b54d5cfbad945
+#: c94c522c856f4404bce4e8b817f4ed9a
+msgid "nvidia-graphics-drivers-515"
+msgstr ""
+
+#: ../../22.04/1.md 061c4d026c48436ba7cccdc1e3f8574f
+#: 0b4e4f1ecf204b339315d03a876d7329 8cf15fa9c5454d24af24597b76c87487
+#: c00e3f27915741b8976a1cd36cf39c1d
+msgid "[1976425](https://bugs.launchpad.net/bugs/1976425)"
+msgstr ""
+
+#: ../../22.04/1.md 05b516de68f7492da5c14131df65b598
+#: f42f7c43e5b94e8a95a0d6e8aec336e3
+msgid "Initial release."
+msgstr ""
+
+#: ../../22.04/1.md b5706cf6a50a44268be05462b64afd11
+msgid "[1970994](https://bugs.launchpad.net/bugs/1970994)"
+msgstr ""
+
+#: ../../22.04/1.md 8c1f724ca98d443b9f838f30becb5714
+msgid ""
+"Cherry-pick !7836 to fix a crash seen when trying to connect to an "
+"Ubuntu/GNOME session when the screen is locked"
+msgstr ""
+
+#: ../../22.04/1.md f7bdaf98a46144e19d6841a55a60d41e
+msgid "gnome-keyring"
+msgstr ""
+
+#: ../../22.04/1.md 9e1e80a683dd4e63b4354ea64c966ad6
+msgid "[1964795](https://bugs.launchpad.net/bugs/1964795)"
+msgstr ""
+
+#: ../../22.04/1.md 4f3621d830334ae2bc9d1596bdeeaef2
+msgid ""
+"cherry pick an upstream change to fix the ssh agent crashing on arm, "
+"thanks Anthony Sottile for pointing out the fix"
+msgstr ""
+
+#: ../../22.04/1.md d5f3cc0c9fbf4102b46af388e12be6c7
+msgid "[1976371](https://bugs.launchpad.net/bugs/1976371)"
+msgstr ""
+
+#: ../../22.04/1.md 4493eb80b45945e9ba0460e5b8f5d7c0
+msgid "[1976547](https://bugs.launchpad.net/bugs/1976547)"
+msgstr ""
+
+#: ../../22.04/1.md 64f55e922170403c8b8b8ef29bce9b72
+msgid "[1976500](https://bugs.launchpad.net/bugs/1976500)"
+msgstr ""
+
+#: ../../22.04/1.md 8d0933a9652b49f0abc60b03fc4d4ee2
+msgid "[1971112](https://bugs.launchpad.net/bugs/1971112)"
+msgstr ""
+
+#: ../../22.04/1.md dede5fd1c1534539aea6a3e96b1086f9
+msgid "Fixes file chooser getting bigger each time it opens"
+msgstr ""
+
+#: ../../22.04/1.md d8474a30901f44b9a310f06f0bbb109f
+msgid "libsdl2"
+msgstr ""
+
+#: ../../22.04/1.md bfedf866691a48f6899a9aba0350910b
+msgid "[1976198](https://bugs.launchpad.net/bugs/1976198)"
+msgstr ""
+
+#: ../../22.04/1.md 96d9a771e2854b429fe457301a353bf7
+msgid "d/control: Add missing dependencies for static linking"
+msgstr ""
+
+#: ../../22.04/1.md 0b3224c7c0ad47e7a33b6616a430593b
+#: 534cae90742940b2838ee0cb2a615089 9d30291b97e74c9cb954941386982eec
+msgid "gnome-shell-extension-desktop-icons-ng"
+msgstr ""
+
+#: ../../22.04/1.md e066d08035174f83beeb926b4fee4ba4
+msgid "[1978330](https://bugs.launchpad.net/bugs/1978330)"
+msgstr ""
+
+#: ../../22.04/1.md 3ec688bc120b4d4cbe2635b45f8cb6d3
+msgid ""
+"Ensure that the extension isn't loaded twice, fixing problems when other "
+"extensions are disabled"
+msgstr ""
+
+#: ../../22.04/1.md 0c846e7059bf4e8c946719b828bdb8ed
+msgid "[1978331](https://bugs.launchpad.net/bugs/1978331)"
+msgstr ""
+
+#: ../../22.04/1.md ede7dc26255a4268953711d5f66b27f2
+msgid ""
+"Keep the application even if there are no connected monitors, fixing "
+"excessive journal error logging & CPU usage"
+msgstr ""
+
+#: ../../22.04/1.md 73e4d364d7ff4e7aa665ceaa20b23b60
+msgid "[1976204](https://bugs.launchpad.net/bugs/1976204)"
+msgstr ""
+
+#: ../../22.04/1.md 50d57353bd75414e916ddc2b95a56ebc
+msgid "Fix freeze when using 2 monitors with different zoom settings"
+msgstr ""
+
+#: ../../22.04/1.md d213d02a7ab44fd09e8277cf1591efdd
+msgid "[1978838](https://bugs.launchpad.net/bugs/1978838)"
+msgstr ""
+
+#: ../../22.04/1.md 5c78dcc1c1d94531a4b56ab265189737
+msgid ""
+"authorize the new at-spi socket location, fix warnings displayed and the "
+"screen reader not working"
+msgstr ""
+
+#: ../../22.04/1.md f4cf0ff103934092abc8e06a9ee66b70
+msgid "[1975638](https://bugs.launchpad.net/bugs/1975638)"
+msgstr ""
+
+#: ../../22.04/1.md f31cc29a4a8042fd917eeb1796467da4
+msgid ""
+"background: Fix a regression introduced in 1.14.0 which caused invalid "
+"autostart files to be generated."
+msgstr ""
+
+#: ../../22.04/1.md ed04365538e944a189ea33195bc8f112
+msgid "[1973638](https://bugs.launchpad.net/bugs/1973638)"
+msgstr ""
+
+#: ../../22.04/1.md cf58a43bc6a94002a735aad7062fb6f9
+msgid "Cherry-pick patch to fix memory leak seen when taking screenshots"
+msgstr ""
+
+#: ../../22.04/1.md 1a96a4b06a74493cb62f3bf9c553d992
+msgid "xserver-xorg-video-ati"
+msgstr ""
+
+#: ../../22.04/1.md dd5ba8200f874b5fa786ff1aa302b643
+msgid "[1970473](https://bugs.launchpad.net/bugs/1970473)"
+msgstr ""
+
+#: ../../22.04/1.md 1898659c7e464710b889a256b38cb8e4
+msgid "fix xserver crashing on screen rotation"
+msgstr ""
+
+#: ../../22.04/1.md d1ee5f5aa53b4d579dd2ee6031d5c140
+msgid "oem-somerville-tentacool-meta"
+msgstr ""
+
+#: ../../22.04/1.md 23a4b9be5b914a569fc5da1bbebf0190
+msgid "[1981784](https://bugs.launchpad.net/bugs/1981784)"
+msgstr ""
+
+#: ../../22.04/1.md ae7d10ad6b1e4059ae7cfa40cd8faa4e
+msgid "Meta package for Dell XPS 13 9320."
+msgstr ""
+
+#: ../../22.04/1.md aab04692f77743c2967c4696f6ee28d1
+msgid "libfprint"
+msgstr ""
+
+#: ../../22.04/1.md 67c232085c344c3bb7cf947a3d02cff4
+msgid "[1966911](https://bugs.launchpad.net/bugs/1966911)"
+msgstr ""
+
+#: ../../22.04/1.md 0027613590db4089a9ec4d4cf39f6d58
+msgid "debian/patches: Ensure that identify works with old goodix driver"
+msgstr ""
+
+#: ../../22.04/1.md 22ade38b24e045c2a7ecdc3f50c2a11a
+msgid "gnome-shell-extension-ubuntu-dock"
+msgstr ""
+
+#: ../../22.04/1.md b1b14d9ce316439cb20e60b3e3b2737f
+msgid "[1967121](https://bugs.launchpad.net/bugs/1967121)"
+msgstr ""
+
+#: ../../22.04/1.md 11fe17154b7f4c879afd8c375acf8d79
+msgid "Ignore loss of the hover state while a menu is open:"
+msgstr ""
+
+#: ../../22.04/1.md 688bee1090d44914a0256d0f872f901f
+msgid "[1982340](https://bugs.launchpad.net/bugs/1982340)"
+msgstr ""
+
+#: ../../22.04/1.md d88af54b9f9245de9fe9599c65e1ccee
+msgid "brltty"
+msgstr ""
+
+#: ../../22.04/1.md 8d5b8ad5aeed490ba306c2755369a12a
+msgid "[1958224](https://bugs.launchpad.net/bugs/1958224)"
+msgstr ""
+
+#: ../../22.04/1.md 9852d32dc0804e8f8f80e44ef28b93bb
+msgid "Try to resolve brltty conflicting with generic serials"
+msgstr ""
+
+#: ../../22.04/1.md 62cd3e006b274e2e8914872881221a33
+msgid "gstreamer1.0"
+msgstr ""
+
+#: ../../22.04/1.md 16c415156cce4dfdbd17544ed5f25c76
+#: 8b49428a03de423fa62ca5bceb24c658
+msgid "[1980239](https://bugs.launchpad.net/bugs/1980239)"
+msgstr ""
+
+#: ../../22.04/1.md eb9428cc484d4ccab89316752daf9e1a
+msgid "gst-plugins-good1.0"
+msgstr ""
+
+#: ../../22.04/1.md 6bd85426db6348b3ab6b4e3cfa2bb1ed
+msgid "[1980748](https://bugs.launchpad.net/bugs/1980748)"
+msgstr ""
+
+#: ../../22.04/1.md f3d0f104059d403c9e84583391d98d18
+msgid "[1981966](https://bugs.launchpad.net/bugs/1981966)"
+msgstr ""
+
+#: ../../22.04/1.md 5d1c386fdd804f7399ccf46141410d88
+msgid "[1980804](https://bugs.launchpad.net/bugs/1980804)"
+msgstr ""
+
+#: ../../22.04/1.md 26212eb14abc4640881a9fc62ae78554
+#: 2794a9be877f4a6cbea403d668731d58 4301d1bf42d043da9e3f26af8a7eae6f
+#: 5fcaf52de3f64982ab757d227bfcdc20 70ad6b3d63694573ace3dff878b45baf
+#: 77e9230de4f743d99f98e769d49b9cb2 79956242d6814a1d80db0b81e4a741f3
+#: 996b8d70df7b4e1db7de12a0d4931095 a569482a949e4ebb845fb5968e90b57e
+#: ccdba95e9595486d98f642b2f648508b
+msgid "[1982501](https://bugs.launchpad.net/bugs/1982501)"
+msgstr ""
+
+#: ../../22.04/1.md:130 e27b80fac59d49369ae35352e05a8131
+msgid "Server and Cloud related fixes"
+msgstr ""
+
+#: ../../22.04/1.md:132 6a10f0aa85264dfca25b125b5238d17f
+msgid ""
+"These changes mainly affect installations of Ubuntu on server systems and"
+" clouds."
+msgstr ""
+
+#: ../../22.04/1.md c3e75759d22c4e28b7c1a7362e586001
+msgid "net-snmp"
+msgstr ""
+
+#: ../../22.04/1.md 475da92c5e3e4e36831841437ab19a95
+msgid "[1969623](https://bugs.launchpad.net/bugs/1969623)"
+msgstr ""
+
+#: ../../22.04/1.md 899aa0b42aef4f48aa52b882c24ddf9c
+#, python-brace-format
+msgid ""
+"d/p/lp1969623-net-snmp-create-v3-user-Fix-the-snmpd.conf-path.patch: Set "
+"${datarootdir} value in net-snmp-create-v3-user and fix error when "
+"creating user."
+msgstr ""
+
+#: ../../22.04/1.md 3d282d21b35b4cdfa34e4205961ac873
+#: 58b0c672293b4fd1afd58b781d02ace4 59eae203c21041b990959061aaea2082
+msgid "mysql-8.0"
+msgstr ""
+
+#: ../../22.04/1.md 6ba0743685b6407a81073ae2359cf1ed
+msgid "[1971565](https://bugs.launchpad.net/bugs/1971565)"
+msgstr ""
+
+#: ../../22.04/1.md ef488256c1bf43b0b4e0a49213d7c30c
+msgid "SECURITY REGRESSION: 8.0.29 breaks existing charm configurations"
+msgstr ""
+
+#: ../../22.04/1.md 6ea852196a814daeb2c52f2d9b715f88
+msgid "ceph"
+msgstr ""
+
+#: ../../22.04/1.md 6d737e3573de4f578f0750c0b50bf0fa
+msgid "[1968318](https://bugs.launchpad.net/bugs/1968318)"
+msgstr ""
+
+#: ../../22.04/1.md 2afcba2f00b241b7bf201df06c421484
+msgid "New upstream release for Ceph Quincy:"
+msgstr ""
+
+#: ../../22.04/1.md 66a4f87bb1ee44fc8bb53710cdc2d6dd
+#: 69d27a9b7ae746cc8e84ac327d6276e5
+msgid "nvidia-graphics-drivers-450-server"
+msgstr ""
+
+#: ../../22.04/1.md 00ffb567fbb34da0a91b308bb27b3243
+#: c8c50f88b5384b859e2fd5928b49333b
+msgid "nvidia-graphics-drivers-470-server"
+msgstr ""
+
+#: ../../22.04/1.md 58fee4e1ebdb4ddcac9bdd1fb0c8d9dd
+#: 69903b974c6a40cea24f1555ce2f9467 8c02ff8baf074e14aa4bf34c649d8778
+msgid "nvidia-graphics-drivers-510-server"
+msgstr ""
+
+#: ../../22.04/1.md 2f5b6b25891c46499b1f2fa64d889f51
+msgid "walinuxagent"
+msgstr ""
+
+#: ../../22.04/1.md 7ff27a92be7141829c29f59b82d219c4
+msgid "[1971141](https://bugs.launchpad.net/bugs/1971141)"
+msgstr ""
+
+#: ../../22.04/1.md 3a63177eff294431bf2a11dfd07aa91d
+msgid "Add patch to fix handling of gen2 disks w/ udev rules."
+msgstr ""
+
+#: ../../22.04/1.md 11f4132315a74a6e9e6da9dc7028f6a4
+msgid "ec2-instance-connect"
+msgstr ""
+
+#: ../../22.04/1.md 00f6b8a9fe9e4a59be840a0858280d52
+msgid "[1973114](https://bugs.launchpad.net/bugs/1973114)"
+msgstr ""
+
+#: ../../22.04/1.md a218a3eb58fb4bca81ed47e166af9c21
+msgid "Add patch to fix parse authorized keys script to work with OpenSSL 3.0.2."
+msgstr ""
+
+#: ../../22.04/1.md 30820e4d8f7f43d89de3cede9283befc
+msgid "[1975509](https://bugs.launchpad.net/bugs/1975509)"
+msgstr ""
+
+#: ../../22.04/1.md 7377c099c686415794fb813667ed4f00
+msgid "qemu"
+msgstr ""
+
+#: ../../22.04/1.md 98de17d661694eee87d86d43bb7eaab8
+msgid "[1970563](https://bugs.launchpad.net/bugs/1970563)"
+msgstr ""
+
+#: ../../22.04/1.md fc4cdb35cd73495f916a14a4672073d8
+msgid ""
+"d/p/u/lp-1970563-ui-vnc.c-Fixed-a-deadlock-bug.patch: avoid deadlock in "
+"vnc connections"
+msgstr ""
+
+#: ../../22.04/1.md 9c7c5a9efe5346a4a0c8b8f3cf36b7e2
+msgid "libvirt"
+msgstr ""
+
+#: ../../22.04/1.md 1a3a384970e44971962f1b12ef27bdcb
+msgid "[1972075](https://bugs.launchpad.net/bugs/1972075)"
+msgstr ""
+
+#: ../../22.04/1.md 01a1574050704f29a923bde0fabb2190
+msgid ""
+"d/p/u/lp-1972075-Allow-VM-to-read-sysfs-PCI-config-revision-files.patch: "
+"apparmor allow new paths used for GL accelerated video"
+msgstr ""
+
+#: ../../22.04/1.md b2c4ee3c8c8f4f17976bb650070f6e55
+msgid "cloud-init"
+msgstr ""
+
+#: ../../22.04/1.md e29125fb8fef48609b00c70b50eade54
+msgid "[1974235](https://bugs.launchpad.net/bugs/1974235)"
+msgstr ""
+
+#: ../../22.04/1.md 7b76390a861a481bb9b14ec9d945fb01
+msgid "ec2-hibinit-agent"
+msgstr ""
+
+#: ../../22.04/1.md 1748ce85a9414aca80895aef1effe2c8
+msgid "[1968805](https://bugs.launchpad.net/bugs/1968805)"
+msgstr ""
+
+#: ../../22.04/1.md 47c93d6fcd4d484390ca244c36594c7b
+msgid ""
+"Swapon with maximum priority right before hibernation. This resolves "
+"swapfile priority issues with additional or multiple swapfiles enabled."
+msgstr ""
+
+#: ../../22.04/1.md c8f3a9e765fb420cb966cfe747e9fcf3
+msgid "python-oslo.log"
+msgstr ""
+
+#: ../../22.04/1.md 1dc3ed7e3f7547a7926323db5a0dc288
+msgid "[1976106](https://bugs.launchpad.net/bugs/1976106)"
+msgstr ""
+
+#: ../../22.04/1.md 183641fc7eaa45e396de1b6a33d7171f
+msgid ""
+"d/p/use-project-when-logging-the-user-identity.patch: Picked from "
+"upstream to change the logging_user_identity_format option's default the "
+"project instead of the tenant."
+msgstr ""
+
+#: ../../22.04/1.md ac51f8e42baf45ccb7efa14ed934e7b2
+#: e437eac68b6d485184fcb2beba492c94
+msgid "neutron"
+msgstr ""
+
+#: ../../22.04/1.md 2fce6bfbeeee4c0893c7a2e74f9cdda5
+msgid "[1965297](https://bugs.launchpad.net/bugs/1965297)"
+msgstr ""
+
+#: ../../22.04/1.md 0847430f473545e78fe6b27dc472b9f7
+msgid ""
+"d/p/partially-revert-do-not-link-up-ha-router-gateway-in.patch: Picked "
+"from upstream to ensure that ha_confs path is created when the keepalived"
+" manager is initialised."
+msgstr ""
+
+#: ../../22.04/1.md d739f37b19b44655b12d9a87e012d848
+msgid "[1975632](https://bugs.launchpad.net/bugs/1975632)"
+msgstr ""
+
+#: ../../22.04/1.md d97078eda2b740c38b068d1f70d47f18
+msgid "New stable point release for OpenStack Yoga."
+msgstr ""
+
+#: ../../22.04/1.md b8568ace75eb44e993640a7ee529b244
+msgid "exim4"
+msgstr ""
+
+#: ../../22.04/1.md 769840f5aca94dfea7507495d8fa97f0
+msgid "[1974214](https://bugs.launchpad.net/bugs/1974214)"
+msgstr ""
+
+#: ../../22.04/1.md 21625cf11a2c4078a7e9e60c33616f0d
+#, python-brace-format
+msgid ""
+"d/p/lp1974214-segfault-smtp-delivery-0{1,2}.patch: Fix segfault when "
+"there's an SMTP delivery attempt following a deferral."
+msgstr ""
+
+#: ../../22.04/1.md 463e901387274133bd5c929578d66d35
+#: 63c6fdf0da0e4c02b0130fb2f875e876
+msgid "nvidia-graphics-drivers-515-server"
+msgstr ""
+
+#: ../../22.04/1.md 2eb6b5e920744381b7102a076f52fd55
+msgid "gce-compute-image-packages"
+msgstr ""
+
+#: ../../22.04/1.md 2791d187029f4b79a78a6ab08653890b
+msgid "[1973159](https://bugs.launchpad.net/bugs/1973159)"
+msgstr ""
+
+#: ../../22.04/1.md 48c419bbd83f4136beb8a5f9336fb719
+msgid "No-change rebuild for Jammy."
+msgstr ""
+
+#: ../../22.04/1.md e4e32838d6d249ca81b4de762ed3e645
+msgid "[1970795](https://bugs.launchpad.net/bugs/1970795)"
+msgstr ""
+
+#: ../../22.04/1.md fde0ec3ed9184f8a803b5cc285ad5610
+msgid ""
+"live-build/ubuntu-cpc/hooks.d/base/ovf/ubuntu-ova-v1-vmdk.tmpl: Revert "
+"OVF cd-rom controller to be IDE for VMWare"
+msgstr ""
+
+#: ../../22.04/1.md bb171a9e947248208ecda1218e16ccf6
+msgid "postgresql-14"
+msgstr ""
+
+#: ../../22.04/1.md 135f59dc2cd54607acdec351f4d785ba
+msgid "[1978249](https://bugs.launchpad.net/bugs/1978249)"
+msgstr ""
+
+#: ../../22.04/1.md 0eb9ec81a97c447cbae65f7e6cd5f74c
+msgid "New upstream version."
+msgstr ""
+
+#: ../../22.04/1.md 8400f905d09642b5a198366abbd89ecc
+msgid "nova"
+msgstr ""
+
+#: ../../22.04/1.md caccef3956b14b8985d98cbdcef98a9e
+msgid "[1904580](https://bugs.launchpad.net/bugs/1904580)"
+msgstr ""
+
+#: ../../22.04/1.md ac48682660824d58b910ad61104044ae
+msgid ""
+"d/nova-common.postinst: Don't change file permissions under "
+"/var/lib/nova/.ssh."
+msgstr ""
+
+#: ../../22.04/1.md 047373a4fd75488bae8c5f09b94f7b77
+#: 113e4d52a4814906b30320c0cf928e0b 5f7ac097de6d41b585cb4fa27868f098
+#: b145adfdf5fc4f219130e483b27cddd0 ee5204e4e92d4ed0abab2c50e196634d
+msgid "s390-tools"
+msgstr ""
+
+#: ../../22.04/1.md 8398010fcfe240b5b8bbbcdb5e5d7cad
+msgid "[1971993](https://bugs.launchpad.net/bugs/1971993)"
+msgstr ""
+
+#: ../../22.04/1.md 66703da0b28d4919801c1574c7267ee1
+msgid "Fix chreipl-fcp-mpath"
+msgstr ""
+
+#: ../../22.04/1.md a56d91b574fc4d6c9e6885e6c911cee4
+msgid "[1960119](https://bugs.launchpad.net/bugs/1960119)"
+msgstr ""
+
+#: ../../22.04/1.md 1780b064ea4f446b9e538650cf120876
+msgid "Add new CPU-MF Counters for new IBM Z hardware by:"
+msgstr ""
+
+#: ../../22.04/1.md fb07df46d80e46bab12474f43b521cd1
+msgid "[1959548](https://bugs.launchpad.net/bugs/1959548)"
+msgstr ""
+
+#: ../../22.04/1.md 86a257114eef44f6a22faaec5e13d814
+msgid "Add exploitation support of new IBM Z crypto hardware with:"
+msgstr ""
+
+#: ../../22.04/1.md ecf2b053107241b383e638f0882e2ade
+msgid "[1971959](https://bugs.launchpad.net/bugs/1971959)"
+msgstr ""
+
+#: ../../22.04/1.md e75cbe74bac040f5b87c328a17dfb980
+msgid ""
+"Stabilization of data collection in dbginfo.sh script by adding several "
+"upstream patches:"
+msgstr ""
+
+#: ../../22.04/1.md baaed356c6f34f00b94de302b9819aa7
+msgid "[1978323](https://bugs.launchpad.net/bugs/1978323)"
+msgstr ""
+
+#: ../../22.04/1.md ebff9666843948d985fe04c9380e5c22
+msgid ""
+"Fix cmsfs-fuse mount failure due to unknown option '-o hard_remove' with:"
+" d/p/0981df6-cmsfs-fuse-fix-enabling-of-hard_remove-option.patch"
+msgstr ""
+
+#: ../../22.04/1.md 4ff7332b20ee4d21a9343d540cb0576b
+#: b9f10ece82af4b399cfacbbe911b009f f029bb6ddfa142f5b94e77a2ea7d2958
+msgid "sssd"
+msgstr ""
+
+#: ../../22.04/1.md aaf1c88412d24bc0b010df397c502400
+msgid "[1934997](https://bugs.launchpad.net/bugs/1934997)"
+msgstr ""
+
+#: ../../22.04/1.md 8ebeb06ab3aa461aa3b21baeabe38fe1
+msgid ""
+"d/p/lp1934997-authentication-fails-gpo-non-existent.patch: Fix "
+"authentication failure when GPO is enabled and SecEdit/GptTmpl.inf is "
+"missing."
+msgstr ""
+
+#: ../../22.04/1.md c6768d4c0af24a208c066762b7e53522
+msgid "[1979350](https://bugs.launchpad.net/bugs/1979350)"
+msgstr ""
+
+#: ../../22.04/1.md 10db9521ccbf47eebffba198be128170
+msgid ""
+"d/p/lp1979350-GPO-ignore-non-ascii-symbols-in-GPT.INI.patch: Ignore non-"
+"ASCII characters in GPT.INI."
+msgstr ""
+
+#: ../../22.04/1.md f1b09ae3bd4a4364a50a3602f93e3899
+msgid "[1979453](https://bugs.launchpad.net/bugs/1979453)"
+msgstr ""
+
+#: ../../22.04/1.md 48e089e870e24063967d48c0ae5c0482
+msgid "Fix \"sssctl analyze\""
+msgstr ""
+
+#: ../../22.04/1.md 2e769508a24346ad9a7fdd0efbdaee6f
+msgid "[1969369](https://bugs.launchpad.net/bugs/1969369)"
+msgstr ""
+
+#: ../../22.04/1.md 60a9afaee99240d0a047b0ac8e148e92
+msgid ""
+"d/a/source_mysql-8.0.py: Fix apport too many symbolic links report for "
+"my.cnf"
+msgstr ""
+
+#: ../../22.04/1.md 57bcd5e9e0594ccdb9930e5cba8597cb
+msgid "[1921378](https://bugs.launchpad.net/bugs/1921378)"
+msgstr ""
+
+#: ../../22.04/1.md f8f401db4e7e425abc0c2a5bb5bc82a8
+msgid ""
+"d/mysql-server-8.0.postinst: Confirm mysqld shuts down with stop_server "
+"after initialization to avoid overlapping use of port 3306"
+msgstr ""
+
+#: ../../22.04/1.md 19d52a8cdb664647a5804b8a051f4b0c
+#: e8fe7458fe6e4dd28b66cc736cbbd935
+msgid "netplan.io"
+msgstr ""
+
+#: ../../22.04/1.md 58f86f6f415b48898efadfb66b041579
+msgid "[1975576](https://bugs.launchpad.net/bugs/1975576)"
+msgstr ""
+
+#: ../../22.04/1.md 5667bd3ef98d4f7592f0e531ff9f85d1
+msgid "Cherry-pick fix for rendering WPA3 password (8934a1b)"
+msgstr ""
+
+#: ../../22.04/1.md b414030a6aa64eab966c9b2b081dfd00
+msgid "[1956264](https://bugs.launchpad.net/bugs/1956264)"
+msgstr ""
+
+#: ../../22.04/1.md fde29d62a59a4958bff6df705b6ff441
+msgid "Backport offloading tristate patches"
+msgstr ""
+
+#: ../../22.04/1.md 46bcf667981644bd947feebc04c537fd
+msgid "crmsh"
+msgstr ""
+
+#: ../../22.04/1.md d9057adc344b431f92ab36d8906ffa54
+msgid "[1972730](https://bugs.launchpad.net/bugs/1972730)"
+msgstr ""
+
+#: ../../22.04/1.md 0e9f7bcd65ed42f5bc2e8b77fdb04f1c
+msgid "d/p/lp1972730.patch: Handle the output of 'crmadmin -S' correctly."
+msgstr ""
+
+#: ../../22.04/1.md 3caf69123bfb459f8f146dd19b728c78
+#: 9c064e70c26d4978b97e06dd9c2e6308
+msgid "fabric-manager-515"
+msgstr ""
+
+#: ../../22.04/1.md 1f8eb7bcffaf44ca9ee5471783391aa1
+#: 9ef65ecc3b4543c7ad433136288a42cb
+msgid "libnvidia-nscq-515"
+msgstr ""
+
+#: ../../22.04/1.md:180 e468bab3bd7b4d94bf5a517fcb8683f0
+msgid "Base platform fixes"
+msgstr ""
+
+#: ../../22.04/1.md:182 0313cf0732e94f6a97c3af2e13985405
+msgid ""
+"These changes affect the core fundamental components of all the Ubuntu "
+"flavors."
+msgstr ""
+
+#: ../../22.04/1.md a1e1d2590fb34c739453a25651b13eca
+#: ec7c004be5b9476b8928f5bfa28316f4 f5448db1126848cbb4dcf8485fff5aef
+msgid "ubuntu-advantage-tools"
+msgstr ""
+
+#: ../../22.04/1.md 73d4f91846684cea81a7c2a077918281
+msgid "[1969125](https://bugs.launchpad.net/bugs/1969125)"
+msgstr ""
+
+#: ../../22.04/1.md fe89da3d747c43ada060edf87527c014
+msgid "New upstream release 27.8"
+msgstr ""
+
+#: ../../22.04/1.md 9d7c100fe1914ceb85c3687cfe771519
+msgid "[1968067](https://bugs.launchpad.net/bugs/1968067)"
+msgstr ""
+
+#: ../../22.04/1.md edbca3fe5dfa4620b766be723c58b621
+msgid "lib: fix upgrade script for unsupported releases"
+msgstr ""
+
+#: ../../22.04/1.md 0a1677e5026148fc9f93df78fc38ea82
+#: 0c4006fdf08443b7af4ceba57fe8a43a 13e9d4c51e9244a292e7ab31273be1eb
+#: 263910519d29468da86a2a2ff0e59602
+msgid "snapd"
+msgstr ""
+
+#: ../../22.04/1.md f8661d5cbc5b4abc90c338f28440b85c
+msgid "[1969162](https://bugs.launchpad.net/bugs/1969162)"
+msgstr ""
+
+#: ../../22.04/1.md 213196d6c50e43ae8c2fe59dd9e9a7e3
+msgid ""
+"This fixes a bad interaction between snapd and update-notifier during a "
+"release upgrade"
+msgstr ""
+
+#: ../../22.04/1.md 85f01a7ebe0d440fa9af05b60e8c5736
+msgid "base-files"
+msgstr ""
+
+#: ../../22.04/1.md 492ca18425b741139c8a0e575ff76b7e
+msgid "[1969960](https://bugs.launchpad.net/bugs/1969960)"
+msgstr ""
+
+#: ../../22.04/1.md b142f62e05064714808476469a3cba14
+msgid "/etc/os-release: add missing LTS to VERSION"
+msgstr ""
+
+#: ../../22.04/1.md cd77d9d568de46edadc93ec2089858e3
+msgid "wpa"
+msgstr ""
+
+#: ../../22.04/1.md b04bc21cdec8414380bd6eb1765db7aa
+msgid "[1962541](https://bugs.launchpad.net/bugs/1962541)"
+msgstr ""
+
+#: ../../22.04/1.md 2e0edad76f48457baa014ba49401b615
+msgid ""
+"debian/patches/allow-legacy-renegotiation.patch: allow legacy "
+"renegotiation to fix PEAP issues with some servers"
+msgstr ""
+
+#: ../../22.04/1.md 9b115b0946bd40148291d45c238f8206
+#: cf1fe0acf0d6423684d44c727a909239 d33bee34ed6d4f4a93a90053c61ef1e2
+msgid "openssl"
+msgstr ""
+
+#: ../../22.04/1.md 59aa455dc4db47a987b58210ce3d0226
+msgid "[1968997](https://bugs.launchpad.net/bugs/1968997)"
+msgstr ""
+
+#: ../../22.04/1.md a338d1e4613c4c62b7eeb4fa5ee9c9d3
+msgid ""
+"d/p/lp1968997/*: cherry-pick a patchset to fix issues with the Turkish "
+"locale"
+msgstr ""
+
+#: ../../22.04/1.md dea9ed08e7d9461fafb0ea63c5da88e5
+msgid "libusb-1.0"
+msgstr ""
+
+#: ../../22.04/1.md 224403db67534333bf991b16ccdc8f12
+msgid "[1973091](https://bugs.launchpad.net/bugs/1973091)"
+msgstr ""
+
+#: ../../22.04/1.md 8e242c3ce55940a38b9dc5a14f0a1c7c
+msgid ""
+"debian/patches/git_backward_compat.patch: revert a behaviour change in "
+"libusb 1.0.25 which triggers issues when the API is misused, fix ink "
+"segfaulting"
+msgstr ""
+
+#: ../../22.04/1.md d5a1e758fef3498391664b2065ab4525
+msgid "pkcs11-helper"
+msgstr ""
+
+#: ../../22.04/1.md 1bf0c18bcda84d489038193474e9a6aa
+msgid "[1970943](https://bugs.launchpad.net/bugs/1970943)"
+msgstr ""
+
+#: ../../22.04/1.md c5941030a79647669fdbcbc120227c0f
+msgid ""
+"openssl: set back key into EVP for openssl-3 to work, fix openvpn "
+"authentication using smartcards"
+msgstr ""
+
+#: ../../22.04/1.md 63498c9030094f109e1e3dfcb4e96be1
+msgid "raspberrypi-userland"
+msgstr ""
+
+#: ../../22.04/1.md d352be4cb8014cf180729210450a5ebf
+msgid "[1973285](https://bugs.launchpad.net/bugs/1973285)"
+msgstr ""
+
+#: ../../22.04/1.md 4c2e91b8893447c5822b9352274df63a
+msgid ""
+"Fix lintian-overrides to use arch-specific flags, ensuring both the armhf"
+" and arm64 versions can be simultaneously installed"
+msgstr ""
+
+#: ../../22.04/1.md 384da32e29f74a1490693d5644fe3b35
+msgid "[1965808](https://bugs.launchpad.net/bugs/1965808)"
+msgstr ""
+
+#: ../../22.04/1.md bf05835a66504b2c9ec1c565fc7a86d7
+msgid "[1974037](https://bugs.launchpad.net/bugs/1974037)"
+msgstr ""
+
+#: ../../22.04/1.md 238abac62bdb4bb99fd55d093cc1dc73
+msgid ""
+"d/p/lp1974037/*: cherry-pick another patchset to fix regressions with the"
+" previous lp1974037 one"
+msgstr ""
+
+#: ../../22.04/1.md 7bb902c6e8474d229e068340fc0f5e90
+msgid "[1972056](https://bugs.launchpad.net/bugs/1972056)"
+msgstr ""
+
+#: ../../22.04/1.md a01e82bd4ff34fc6968da2063c3618dc
+msgid ""
+"d/p/Set-systemwide-default-settings-for-libssl-users: partially apply it "
+"on Ubuntu to make it easier for user to change security level"
+msgstr ""
+
+#: ../../22.04/1.md 56feadbae9e14f508b9432705c8c65a1
+#: 5c5a40ecd432408894e6f7e1d644f327 607f4b628b684246849dc0509f4f8271
+#: 6a740b80305b40c298987ae2d514d508 cc04253fa09d4a64b1503be04bb09066
+msgid "flash-kernel"
+msgstr ""
+
+#: ../../22.04/1.md 8ef62b6daf3d4d7fa31b4a4594e337a2
+msgid "[1977713](https://bugs.launchpad.net/bugs/1977713)"
+msgstr ""
+
+#: ../../22.04/1.md b129b0fc899d4a98a6f04ddb6bc43f27
+msgid "Backport changes from 3.104ubuntu10"
+msgstr ""
+
+#: ../../22.04/1.md 6eefb86eb98249159321b03273056805
+#: e2158b62b77c4516838485db5c558a9b e97e41c625de47fdbc6aad11f8fd3ba4
+msgid "systemd"
+msgstr ""
+
+#: ../../22.04/1.md d72434b0ea0f469a99031c8e9cae3e6f
+msgid "[1969375](https://bugs.launchpad.net/bugs/1969375)"
+msgstr ""
+
+#: ../../22.04/1.md 97c3a07f7ebc46bbb106f9c456d2492b
+msgid ""
+"Build with and suggest fido2 and tpm libraries These are used via dlopen "
+"only if available by some tools like systemd-cryptsetup, systemd-"
+"cryptenroll and systemd-repart, with graceful fallbacks if they are not "
+"found. Build-depend on them so that the features get compiled in (apart "
+"from stage1 builds), and add appropriate Suggests. Backport of: "
+"https://salsa.debian.org/systemd-"
+"team/systemd/-/commit/6b5e99f1d7f63c0c83007de9f98f7745f4a564f8 Files:"
+msgstr ""
+
+#: ../../22.04/1.md 9c0749a6a02d44d49f4270c654719372
+msgid "[1964494](https://bugs.launchpad.net/bugs/1964494)"
+msgstr ""
+
+#: ../../22.04/1.md e6d47c5e63764707b7138be0ad49785b
+msgid ""
+"d/p/lp1964494-network-do-not-enable-IPv4-ACD-for-IPv4-link-local-a.patch:"
+" do not enable IPv4 ACD for IPv4 link-local address if ACD is disabled "
+"explicitly"
+msgstr ""
+
+#: ../../22.04/1.md e534ff61a8f94bd89adc6fbdbe4606cc
+msgid "[1973099](https://bugs.launchpad.net/bugs/1973099)"
+msgstr ""
+
+#: ../../22.04/1.md 72d3b293cbb342c48fca73e072c5238f
+msgid "Backport new upstream release: to jammy"
+msgstr ""
+
+#: ../../22.04/1.md b798725647074fadb9e994cc56212fe0
+msgid "apparmor"
+msgstr ""
+
+#: ../../22.04/1.md b13a203db3f44bf89fdd43d177e7f699
+msgid "[1969896](https://bugs.launchpad.net/bugs/1969896)"
+msgstr ""
+
+#: ../../22.04/1.md 853973c440224bb4974c25318c4f1e2d
+msgid ""
+"Add upstream commit to remove dbus deny rule from exo-open abstraction to"
+" fix evince startup"
+msgstr ""
+
+#: ../../22.04/1.md d669621f7cb6440fb018987e16a46293
+msgid "isc-dhcp"
+msgstr ""
+
+#: ../../22.04/1.md 154bc2dcc4524435825107cffd3cf7ae
+msgid "[1918410](https://bugs.launchpad.net/bugs/1918410)"
+msgstr ""
+
+#: ../../22.04/1.md d859d26274f94c898665f350fd968bb5
+msgid "d/apparmor/sbin.dhclient: fix apparmor=\"DENIED\" errors"
+msgstr ""
+
+#: ../../22.04/1.md 06250c57f21046329cfd8b59e3690582
+msgid "samba"
+msgstr ""
+
+#: ../../22.04/1.md 5184f780b00047de88bf3997f541cc30
+msgid "[1977491](https://bugs.launchpad.net/bugs/1977491)"
+msgstr ""
+
+#: ../../22.04/1.md 65657b466d504af9ad807f7393877560
+msgid "Fix abort when deleting a file and \"fruit:resource = stream\" is used."
+msgstr ""
+
+#: ../../22.04/1.md 783b7e5c515c450c9290bd05b521d10b
+msgid "libqb"
+msgstr ""
+
+#: ../../22.04/1.md bdd481913cf84e73abb4030781ddbb6b
+msgid "[1978955](https://bugs.launchpad.net/bugs/1978955)"
+msgstr ""
+
+#: ../../22.04/1.md 82e56fb99925421c894001019759aac2
+msgid ""
+"d/p/retry-if-posix-fallocate-interrupted-eintr.patch: Retry "
+"posix_fallocate when the error - couldn't create file for mmap - occurs"
+msgstr ""
+
+#: ../../22.04/1.md 29020a72d5e74de49d8e9008afd85944
+msgid "[1978923](https://bugs.launchpad.net/bugs/1978923)"
+msgstr ""
+
+#: ../../22.04/1.md 3fe595c204474df2aeb23eb478f0642c
+msgid "Add support for VisionFive, Nezha and LicheeRV boards"
+msgstr ""
+
+#: ../../22.04/1.md 742eb8a522ab46a98d05ebad0b9e2408
+msgid "wireless-regdb"
+msgstr ""
+
+#: ../../22.04/1.md 355b8832bab441ef9af937210697303e
+msgid "[1980145](https://bugs.launchpad.net/bugs/1980145)"
+msgstr ""
+
+#: ../../22.04/1.md 075f424b231a421baf9e00b4a3ba4817
+msgid "Backport to jammy"
+msgstr ""
+
+#: ../../22.04/1.md 4a2fe91255074b59a667dee019534875
+msgid "[1982735](https://bugs.launchpad.net/bugs/1982735)"
+msgstr ""
+
+#: ../../22.04/1.md e3e9934be51a4336bcb10e10ee528bc6
+msgid ""
+"Fix SiFive Unmatched build. While merging the VisionFive support, we "
+"removed the installation of u-boot-menu for the Unmatched by mistake."
+msgstr ""
+
+#: ../../22.04/1.md 6a317968fb7d4dae845045758dba782d
+msgid "[1980935](https://bugs.launchpad.net/bugs/1980935)"
+msgstr ""
+
+#: ../../22.04/1.md 7cafadd684774b8597890538fb815381
+msgid "Add support for the VisionFive and the Nezha boards"
+msgstr ""
+
+#: ../../22.04/1.md 0227b9547c0d45aca51e891c3e49479e
+#: ee0027b4ac4a462bb191073b85d766f5
+msgid "[1980929](https://bugs.launchpad.net/bugs/1980929)"
+msgstr ""
+
+#: ../../22.04/1.md b4c8a044c1a1406ca19e8793a81c17bf
+msgid ""
+"Set FK_FORCE_CONTAINER for RISC-V images build to force flash-kernel to "
+"run in a container."
+msgstr ""
+
+#: ../../22.04/1.md ec568274f6bb41f8a57d3ca1bbb36699
+msgid "[1980065](https://bugs.launchpad.net/bugs/1980065)"
+msgstr ""
+
+#: ../../22.04/1.md 52016c62c6724452babaf5240d9099e3
+msgid "Switch the intel-iot images to use the linux-intel-iotg kernel instead."
+msgstr ""
+
+#: ../../22.04/1.md 61c214bc22cf446a9faac8a39f257239
+#: b4023b5cbbb64b6aa01deb6bada6a091
+msgid "apt"
+msgstr ""
+
+#: ../../22.04/1.md df97ea4e96654ccea8cd70874f318696
+msgid "[1979244](https://bugs.launchpad.net/bugs/1979244)"
+msgstr ""
+
+#: ../../22.04/1.md 77fdb8bc80854f35a9c3d31b46781c14
+msgid "(Temporarily) Rewrite phased updates using a keep-back approach"
+msgstr ""
+
+#: ../../22.04/1.md ab0e6011a41347ca9baf2154da621502
+msgid "[1978125](https://bugs.launchpad.net/bugs/1978125)"
+msgstr ""
+
+#: ../../22.04/1.md 8f693cd5e91a433c82f4fc86b1633b16
+msgid "policy: Do not override negative pins with 1 due to phasing"
+msgstr ""
+
+#: ../../22.04/1.md 791f5900a88a44b58934472a37f7f0d6
+#: f37c253bd17f4b75bd6087d88e721c2f
+msgid "[1978798](https://bugs.launchpad.net/bugs/1978798)"
+msgstr ""
+
+#: ../../22.04/1.md f0ab84415cbc42bb97415f1d3870cea5
+msgid "Add ZCU111 support"
+msgstr ""
+
+#: ../../22.04/1.md e2494faaa57d497282d9bd2e552366ae
+msgid "bootscr.zynqmp"
+msgstr ""
+
+#: ../../22.04/1.md ba68cdeec4a147a3a92ca83ef1d560a6
+msgid ""
+"Allow to bypass container exit test by introducing FK_FORCE_CONTAINER for"
+" RISC-V images build to run flash-kernel in a container"
+msgstr ""
+
+#: ../../22.04/1.md 37d13f9f54904835b572ff74e0ea7604
+#: c52e4f101e07454784749f467799e6ee
+msgid "glibc"
+msgstr ""
+
+#: ../../22.04/1.md 1389948fbf794166a3ff7ec307b57ddb
+msgid "[1971612](https://bugs.launchpad.net/bugs/1971612)"
+msgstr ""
+
+#: ../../22.04/1.md f8ef29df6ae644e1b373526789043537
+msgid "0001-S390-Add-new-s390-platform-z16.patch"
+msgstr ""
+
+#: ../../22.04/1.md bddc7665d7614f0f9918b5dfdbcc92e1
+msgid "[1978130](https://bugs.launchpad.net/bugs/1978130)"
+msgstr ""
+
+#: ../../22.04/1.md 8d18444b73224daba49d1118ef790f15
+msgid "0002-powerpc-Fix-VSX-register-number-on-__strncpy_power9-.patch"
+msgstr ""
+
+#: ../../22.04/1.md 8dc59c78c5644b6e99bfff4a5c12704a
+msgid "[1983008](https://bugs.launchpad.net/bugs/1983008)"
+msgstr ""
+
+#: ../../22.04/1.md 242db71a949b441c83c5de398c581291
+msgid ""
+"Install wpasupplicant by default as for now, most of the RISC-V boards "
+"embed a Wifi chipset"
+msgstr ""
+
+#: ../../22.04/1.md 434e23dab5a84e32857bec6640d9d473
+msgid "[1983528](https://bugs.launchpad.net/bugs/1983528)"
+msgstr ""
+
+#: ../../22.04/1.md 48e1058b01d44bb195f260e271b25b0e
+msgid ""
+"Cherry pick https://github.com/snapcore/snapd/pull/12011 to fix launching"
+" snaps OEM install"
+msgstr ""
+
+#: ../../22.04/1.md 5beea59bf7c24f4186ea7ae8b3280a5b
+msgid "[1974147](https://bugs.launchpad.net/bugs/1974147)"
+msgstr ""
+
+#: ../../22.04/1.md:225 068812f2ccc24e138b9c43fb519631ac
+msgid "Kernel and Hardware support updates"
+msgstr ""
+
+#: ../../22.04/1.md:227 c0684c34a20b45afb584da4ad1c77863
+msgid ""
+"Considerable work has been done on improving support for many specific "
+"items of hardware."
+msgstr ""
+
+#: ../../22.04/1.md 2b8fac04616f4f848102d96b86cd3628
+#: 43c7bca6edff487faa5e8aa9a0bd5360 660bd96aa7dc40aea9b78f904c03aada
+#: 9fda156c96ef4072aaad5505948557d5 a6dadb700d7d4ad7b2608b5a2f0d5e46
+#: b2b16b67231c49b083122cd09c9c5b58 cf2c9d32681440668f517ae8c4c5530d
+msgid "linux"
+msgstr ""
+
+#: ../../22.04/1.md 203bf98028cd411fbcd6ea8ad4c556a0
+#: 2963779ab0d64493a2ec59259162c680 3a47478f855747b595f193b084dfe289
+#: 404ffd84e42844159e7f3035fad1de11 4eee9c3891e046eb9c21c6269d74301a
+#: 4f77e72f5dca4b0b90bb5914f8689f46 6e5bd37367714952ad5edec4873ab377
+#: 8ee2efcd5dbf41a58d38441373a6032e c6e7943bafa242f98b4ae43626934d7b
+#: ffb4ee7d6f7c401a9e45900aaa6d3a7e
+msgid "[1968954](https://bugs.launchpad.net/bugs/1968954)"
+msgstr ""
+
+#: ../../22.04/1.md 13f961a5c78e4c51969c0db312238b10
+#: 1afe6356d3ed441faf26e3ff5737f7df 1f17c074af1a484698744165d16157fe
+#: 30528a47236d425aa8f75c3606e528c8 3a08c5b542b34413933ffa62df43e234
+#: 6a341ba49ce74238a0597364c5e8d5e8 7af08731418640268788e8e66275c076
+#: ade8244cb29e4b34bb7079127f84eb0a e35cad9a6e5f4e29972d44496f22fd7f
+#: fdb5e430662f4d12b61e75f3a98faa80
+msgid "jammy/linux: 5.15.0-27.28 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md 22fa787c7e0a49ca8ca3520e9b1d528e
+#: 27eb6721a6b4489da83ebd028f6a2366 4a6635fcf0d7470fbedcc10b1ef6c19a
+#: 865a5e05c6d847c1ab4f0c316d3c6238 aa6c7d5c323448fcbfdc039261ddcb2d
+#: ba9ca1765c1046f2ac8f9e037ec47bbd c0217841517148b18c7e85e689647780
+#: c4a72690d365433abf845f721fef4722 e2fb510cda154707837918e8504116e6
+msgid "linux-gcp"
+msgstr ""
+
+#: ../../22.04/1.md 09992d6c8dec42788dcb118efceeb5d5
+#: 12385c131f20493a907e5954309e919f 3163eb5c0b61474eaee9837e3a8859f5
+#: 3413f5fbe52f45daa1fb40143beb80a8 3e6a70e4194a418bb93833d2708cbc0f
+#: 5fcbf611b102470a98aae0a0ffa8dc8f 815d88134033448daa9346fd79fc563f
+#: d0a5bfefc7e04f7e984031b2251d5a56 f5c0ead15bf546e3bfd5bfb1aee00ec3
+msgid "[1968850](https://bugs.launchpad.net/bugs/1968850)"
+msgstr ""
+
+#: ../../22.04/1.md 02a2b7ce51a4486abc7f3936e3138583
+#: 1aa3ab4620214c6f83d72a3b44dde04e 47df5d33fd804396b234ab77c07e4a35
+#: 5a481d77d7b64acaa0e91fde5a2c82a7 644528aa12a249e9b7f47359af62a7db
+#: 71c06f5132674c1cbed51b8b553735d1 76351f7849854af7bee5726086c15e0f
+#: 8733385c613445dcabc0ca976871be78 dffd782c54d1462cb0e5efd9e0327a5f
+msgid "jammy/linux: 5.15.0-26.27 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md 1cb4b202612a4551bd926b89527b4485
+#: 3725f74fd76248ce938f81d350b92c04 3dbf202083d24e3b85bde9cece26707f
+#: 4e49dbef44174b52a93a7996d19722f3 5827337093f14a779ffe93a9fa32f9d8
+#: 765d864cd9894f24a03c92dcd46c6c4f 7dd472ada25547b3811ec90b3b31fe02
+#: 805d1ffaf45240c9bc529409d97aca92 ec4cf8803f6a416e92cdc4b63b687325
+msgid "[1967579](https://bugs.launchpad.net/bugs/1967579)"
+msgstr ""
+
+#: ../../22.04/1.md 1e52fc016e8447a5a6c4d90ec75e0057
+#: 2652075814f04caeb47043e856af9a11 2b01ac86b5554836b546b97a8cbaa41d
+#: 2e49147f266d4fa094399d67e6b82bb9 50740208f55045599373cccd090bb3d2
+#: 519a00e97b454e469eb28b1de4875332 982d5b99e30c49c685a4b0860aeedb8f
+#: d93c77110ff34f3e80fa7499a19a064f da7d1c2d84d743cda9986cdc7d92bb95
+msgid "harden indirect calls against BHI attacks"
+msgstr ""
+
+#: ../../22.04/1.md 1604978790f54fdebba223b269f27dc2
+#: 46f733357dde4099bb99b87d550dcc93 62ac62d91fc54df997edcfcec161e4d1
+#: 82b7d46b460e4c5dbba33dbf0c2cdd11 899ce8f543cf4b3188748cd62b1a42b4
+#: 9c68b22d8116487f93a4020091fd3b55 c03cfd9cdb7a414ebe0005c96be4503d
+#: d82da4a027144a0c8b5aca0ecf6daabb fd8283dfe9354ce1ad15d9d7ac71169a
+msgid "linux-riscv"
+msgstr ""
+
+#: ../../22.04/1.md 21641ed7d8d74ec09671b86fbe105e12
+#: 3e7cb98e65284209acb3035550f82e16 4b52fddbaf0246988c88579d5dda6718
+#: 6b2283a6f2f447eda70a6b47a402c965 c3bc423438e542e1a72391b8c242ca42
+#: c3f833f913524090ae16496ec213e7b2 cdaeb04587a84725b1da9975141b230b
+#: e3227e37537241dc9613a40b9163af9e fae8945a2a234811aee087e4adf35eef
+msgid "linux-ibm"
+msgstr ""
+
+#: ../../22.04/1.md 23e11932156149bc8c51d2007b0a05d4
+#: 2e22375a2a674e41be57e3afac1b1762 2ec555226f914b8cb148406770c7a15b
+#: 30b6c759c6724ad6885181aac58f10dc 3faf300dd9d948cc852cc7e10be565b9
+#: 4d2eacef6b104bfeaab942923aba0511 7726f215c4774752a951b4e1999f8b76
+#: 79f7d2f581cc472ba2b10b4ebb341116 a56a9654afde43c88c3f88772b2821f7
+#: a8ccfa7469cd4428a8accd38e84b63cb cae4a788bf264621b56c8966405ba92f
+msgid "linux-lowlatency"
+msgstr ""
+
+#: ../../22.04/1.md 11f0413311814412b90b9c4e5f4cf0b7
+#: 21148865cc9345d09f1226fe6ad69735 29ddcfd45196497b9bae4fccd70bc105
+#: 4cd885dacec64f0daa95e7b7d37339f7 6e8d1b8d0bd646349668a40d0ca9e401
+#: 8ffd410f79134e7fb3687a6548902c4c 9ccadb7bd80640a7974a21ea52b9aadb
+#: ae68bda79eed42e2b6d310863b59b3fc b2ad9bf56cd541e9bae634fe4d500bb0
+#: c55db0b9e944430fba303dc039231350 cdec6fbb282147dbb098b5dd33933708
+#: eb06e94607524c2c957da52444f8fd77 f78ab18d5b8c42518c596fb996d34440
+msgid "linux-aws"
+msgstr ""
+
+#: ../../22.04/1.md 2bbec664b37d4528ab6dd953878d76e2
+#: 3ed70b0183504ad583da380282127e99 4d0c9558e54b4b06874abd4f0dc8bbeb
+#: 698cf6ca82244e388fc3d2cea815c140 85beb3680d474b789cab499e07786c32
+#: 8a0da2a203924acd9fe8404bb306dfe8 95e04aed764b4b6fa3fb0ee0d31fd717
+#: 9e4e76990c304e558168a0c898e0bb55 9f16e7fa60b442be9a14017430ea0040
+#: d64c1c5620534d8881899d54e4510198 eb875e2c82754d54b692430c80d010cf
+msgid "linux-azure"
+msgstr ""
+
+#: ../../22.04/1.md 4a673b5b34164d40b6c244372eda6efe
+msgid "[1969580](https://bugs.launchpad.net/bugs/1969580)"
+msgstr ""
+
+#: ../../22.04/1.md d5cf81b11ffe42bab5df94940cc39b03
+msgid "jammy/linux-azure: 5.15.0-1005.6 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md 022d255a2b6240a9b93f8eb88230ec00
+#: 1672d5b3dcea4b148e3ceaed4b793a47 26bae0f9a86d45318a08bdb826f381ba
+#: 2a2d2f41c76541438f5b70d81bcc6481 455dc691ae8246e8b4ecb5a06a501fa9
+#: 4fbb2f03e3234a9885b3d6d4c0333e35 506ae3a7800841f691423f7b3e0c98b4
+#: 957f4efda2524b2398b90209cfe9439f ce075a31b84b47408d59c5bd8fe7d546
+#: d84972e3981b4ab68c2cc23e923b0040
+msgid "linux-gke"
+msgstr ""
+
+#: ../../22.04/1.md 048a4f7820574fd3ab287517ccf542ba
+#: 1e6b58de3755433bab67ea72cce9eafe 25bc3a7c6e0f467099c2cfbc81217c98
+#: 40b35d7257bc47e3a3fc4fb6d1a2f4e6 716ee769c7dd44d6a9215002d5986f48
+#: 9e21ecad0a1d42d4a34a5933f30b246e bfcdd399b43b47a28013fe3f70b7a464
+#: c6b70f86d0c2443ebd54b227d87718d4 d94d1dc49ee440b19346c346a31cf471
+#: f50b1b0bf9df456ebd8cb4ca849c7210
+msgid "linux-kvm"
+msgstr ""
+
+#: ../../22.04/1.md 3238a220dd6a4156a70743b42f399b9e
+#: 5fbaf39f55eb40d696d104f5cb914a72 7deb0a851d9942969b4ee962735346a2
+#: 9c9a8b8b4564437789d7520557741dda af1b77a33e744b3186bb93fcc537a0a3
+#: b052e15e7baa4b5e9ff4b942982975eb c12ef416693d4081b3ff6a00765a2513
+#: c904dfc258e741a58a5ab3db7baa6e70 f45ede2ddc764dda808e4af43b48944d
+#: fadd61a66adf483396c9f55b88369eca
+msgid "linux-oracle"
+msgstr ""
+
+#: ../../22.04/1.md 35d3bec631014f36b1ce866ec53b2293
+#: 3c3fb72eb9b943a9b32312c53f024c39 56d3d7a354604fdcbb388b0232f98801
+#: b4122413b06d4fa2ac42c93d58c1ed90 b419861ced134195a880164def979b2d
+#: d713dfcd6fd747dca8f88fdefb26ed81 dc1b954e690740baab44f26dabbc0a2a
+#: e03f932f60fa4571844bd2be3c13ad75 f96a0c2608694a18935c647ff44188ad
+msgid "linux-raspi"
+msgstr ""
+
+#: ../../22.04/1.md b87deec3ae0b4de6b8be33ac0f726b9e
+msgid "[1967038](https://bugs.launchpad.net/bugs/1967038)"
+msgstr ""
+
+#: ../../22.04/1.md 42d9c3c133004a37a978fcc4428e864f
+msgid ""
+"Add mic mute key support for HP Elite x360 series Author: Andy Chi File: "
+"debian/patches/hwdb-Add-mic-mute-key-mapping-for-HP-Elite-x360.patch "
+"https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=45e809103de9c356c75b692d35089e8770602617"
+msgstr ""
+
+#: ../../22.04/1.md 29dd5ac2e8ad4dc0bb21458d91d6d649
+#: 3bd64b93ba3b4a88b1f65e77481a51d1 3f20ac39a6194f08bdd181308a4edf17
+#: a13c4466bc734073a7409c78a87df18d ba69d78e09924a56a2b6659ec264e05b
+#: bf4e86c7a099417ca20b9a3a26ff3f33 df5fdc7e0f4849458742762845e2e007
+msgid "linux-firmware"
+msgstr ""
+
+#: ../../22.04/1.md 192c2ed259b3421884c7ccbd0b7f0edd
+msgid "[1970543](https://bugs.launchpad.net/bugs/1970543)"
+msgstr ""
+
+#: ../../22.04/1.md 3584b369625346548e4e2b2d3fa75040
+msgid "Add missing inside-secure firmware"
+msgstr ""
+
+#: ../../22.04/1.md 8596d8b7526943998afa6b459fbbf58d
+msgid "[1970293](https://bugs.launchpad.net/bugs/1970293)"
+msgstr ""
+
+#: ../../22.04/1.md e9f181e8647d425d9b5fdd8b282fc543
+msgid ""
+"The system freezes when HDMI external monitor involved on AMD Yellow Carp"
+" platforms"
+msgstr ""
+
+#: ../../22.04/1.md 1e7b2d2cd6464f139ee21a89923da804
+msgid "[1969853](https://bugs.launchpad.net/bugs/1969853)"
+msgstr ""
+
+#: ../../22.04/1.md 83d66dbfebc748ceb606f497d813d8b9
+msgid "No Bluetooth Found on QCA9565 (but replacing the ar3k firmware works)"
+msgstr ""
+
+#: ../../22.04/1.md c656cacac8d84702bd5b905056ee5678
+msgid "autofs"
+msgstr ""
+
+#: ../../22.04/1.md 42abaefc4db548138136d801e47afb20
+msgid "[1970264](https://bugs.launchpad.net/bugs/1970264)"
+msgstr ""
+
+#: ../../22.04/1.md 6e874a3d75b944718098e3ddf0d3cdbf
+msgid ""
+"d/p/fix-nfsv4-only-mounts-should-not-use-rpcbind.patch: Make NFSv4-only "
+"mounts not depend on rpcbind."
+msgstr ""
+
+#: ../../22.04/1.md 0ef8174257fd474881beb6b618971cb4
+#: 18bfa05ff73d4f1ba8e3ce0e70a93d97 3d58ac020f9443a59943ce70f4be142b
+#: 46370197078640b9b00c0586079c16d5 53695353353045209fd18cca813e10b5
+#: b23765843b334d4392519d82607a8efb b23ba2dd57b748188cf0823a478298cf
+#: cee48d44616748f8877d0fb79a144a94 dfa8f57741f4449fa8fbd0ddc04b2d92
+#: e773a30eb87948fd991f205f91a324e4 fa0bf291f66d4920a8ad4938e164e88c
+msgid "[1971685](https://bugs.launchpad.net/bugs/1971685)"
+msgstr ""
+
+#: ../../22.04/1.md 1d23c75e9d4549169c46c81611490dc8
+#: 2052c51ca1bb4384950f0f0b50b5a9ea 47be48186f80450ea6564b4e694bcf8f
+#: 6776ff20a9bd4594968e5a1bd188539d 7699c86f8fd2411b9dbb9c7112a844b6
+#: 7923f064d9394eaebe7bb46090d4db16 85ed24ea395d42a5804151b23c10db32
+#: b52da3e4ab15479fb753dcc31659afe2 bffe3189c4184aec8cc13ffd76e304fe
+#: dd8976ce802640c3bf68a7b9376de55f f82189271d3048d5af2fdd53607ca503
+msgid "jammy/linux: 5.15.0-30.31 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md 1bedbabb44d24493a52991d9d12e11d6
+#: 1c16702e65884e7aa2c05460ae51c671 23310b92439d45b98b62612f35d949d2
+#: 25f04db31dee4727b232a0fedef7f202 28a2583a644c424482690d97ebc70898
+#: 472e95cdbd5340a0a05c724f3afa32ae 614413de670b48f790e9601f4612f633
+#: 77132496ade04775a9d8cff8a95ce50d 80dc17e6dc444e28b9711b954cec856e
+#: 8280512949d843b8a792a9a21ecc7e18 bb79d39f9689433e85babfa0eb3b79dd
+#: c2569a949eb9479abe08a3e1d3c3afa5 c4022253f7cb48c89e51c9e4918d6ee0
+#: f0c654aa0302482cabf8ebbf99c5d0e2
+msgid "[1967750](https://bugs.launchpad.net/bugs/1967750)"
+msgstr ""
+
+#: ../../22.04/1.md 0e08de2b66da4f998fba262257545e0c
+#: 1691d541aeb844de828cdace0739065a 16b54b5b82d946258b36f55bc4a76edb
+#: 35d06e63ebd54783a11aa92d09176129 43a68da282284177934d5fd3c1062c45
+#: 4bb7886514d643389c5c753d9382943f 6186cc4534794146809f2e58c09c2e9c
+#: 6a08667b60e343fb889d4f2fc820a1fe 720260dc046b4e96ae1f432f6536eead
+#: 74d41e4a94b04f68a81de45607f62fb1 99221c00f928444e81882bcb78e1c93f
+#: b4b1945146c7491a81478bdb602e634b c737d1f1e0344815863eb77bcbecb72b
+#: d27a46b3def945f888eab3dbde92b97f
+msgid "Intel: enable x86 AMX"
+msgstr ""
+
+#: ../../22.04/1.md c9a52901c9c04f2fa8a7ad2fc49c3fa7
+msgid "[1971684](https://bugs.launchpad.net/bugs/1971684)"
+msgstr ""
+
+#: ../../22.04/1.md 97d54e68108b41a0a016fc365e7ed245
+msgid "jammy/linux-lowlatency: 5.15.0-30.31 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md 35bd4b4691ac412ca5b8ffe736b13edf
+msgid "[1971641](https://bugs.launchpad.net/bugs/1971641)"
+msgstr ""
+
+#: ../../22.04/1.md 72178d091c8b468281381e5e7d8d9b50
+msgid "jammy/linux-gke: 5.15.0-1004.5 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md 049c399c47f04273915ff4f6f51a33f1
+#: 068a5f76d0794dcb8bda06fb18acffc0 37640f98e11144a1bb81ecdb33fb29b8
+#: 43f8a40f113a43eea213dd967e29b845 501ae5f03b904dfb985c2e332fc4dcd3
+#: 51287ebb5e144db0a22791fbcceac5d0 5a9bf4fa0a9d462f8bd6fb1e249af7a1
+#: 61eecc1a01814f62ad41330310879738 73d6553913a749a3874efa4e155774a3
+#: 74c09842a9c8436cade45bbd0d3470f4 8855584b015c4c2aba31fcaf14a34553
+#: 9d71b0ad66594696abc7b2b304c0d188 a3c55a120348442e847cf9ea9333a8d8
+#: ae338c4f4c1148ceaeb8fb92338cbdcf bdaaa49676854f8da42b860975319620
+#: cffe0fdd42e4443eaf6b23a809bd789d df928956e40d4e5681f235e560316318
+#: e91b278c2f6b4456bd9cd75848f95abf
+msgid "linux-oem-5.17"
+msgstr ""
+
+#: ../../22.04/1.md 9a4080f050364ef382012e812b420a97
+msgid "[1970584](https://bugs.launchpad.net/bugs/1970584)"
+msgstr ""
+
+#: ../../22.04/1.md 632c098207854b3093a99fd169b0d53f
+msgid "jammy/linux-oem-5.17: 5.17.0-1004.4 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md b9073424d3434947b048065025359aac
+msgid "[1969407](https://bugs.launchpad.net/bugs/1969407)"
+msgstr ""
+
+#: ../../22.04/1.md df8e7f2743da4ad58fe7b50971040561
+msgid ""
+"DMCUB freezes if a PSR unsupported set version command is sent on AMD "
+"Rembrandt platform"
+msgstr ""
+
+#: ../../22.04/1.md e6eab3d4c4f14a56970eab5071fce11c
+msgid "[1969219](https://bugs.launchpad.net/bugs/1969219)"
+msgstr ""
+
+#: ../../22.04/1.md 06ac121e4bc441d5884459144c468f0b
+msgid "jammy/linux-hwe-5.17: 5.17.0-8.8~22.04.2 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md 135972b8e5164c8591b53369aed694d7
+msgid "[1969016](https://bugs.launchpad.net/bugs/1969016)"
+msgstr ""
+
+#: ../../22.04/1.md cef2e33d9df2482d81a448112440e79e
+msgid "jammy/linux-unstable: 5.17.0-8.8 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md 91054f85889348acb986fce57f9611b2
+msgid "[1968988](https://bugs.launchpad.net/bugs/1968988)"
+msgstr ""
+
+#: ../../22.04/1.md a912eceb2d49451f8c6b5019bcd2b100
+msgid "jammy/linux-unstable: 5.17.0-7.7 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md 02bd05541cb2414aaaee282827d38c27
+msgid "[1965766](https://bugs.launchpad.net/bugs/1965766)"
+msgstr ""
+
+#: ../../22.04/1.md 8685604bc0f04a4aaaf5ad0e6db1bab3
+msgid "zfcpdump-kernel update to v5.15"
+msgstr ""
+
+#: ../../22.04/1.md 2fe4ed551575471aaf87b5f0dc765e20
+msgid "[1968986](https://bugs.launchpad.net/bugs/1968986)"
+msgstr ""
+
+#: ../../22.04/1.md 61723ae125a2486a8ac56f39bd6926a2
+msgid "Jammy update: v5.17.3 upstream stable release"
+msgstr ""
+
+#: ../../22.04/1.md fd681d5f22164017807bc28f2c4aa390
+msgid "[1968984](https://bugs.launchpad.net/bugs/1968984)"
+msgstr ""
+
+#: ../../22.04/1.md 9a94a31bfbdd405a8a82b1f9847507b8
+msgid "Jammy update: v5.17.2 upstream stable release Edit"
+msgstr ""
+
+#: ../../22.04/1.md d51b1ee2742849629ccef0e594d05cb9
+msgid "[1968982](https://bugs.launchpad.net/bugs/1968982)"
+msgstr ""
+
+#: ../../22.04/1.md 82c14b8a08c04b4894ac847a741dc4e2
+msgid "Jammy update: v5.17.1 upstream stable release"
+msgstr ""
+
+#: ../../22.04/1.md d6e673cd0370454085cc5eea25c4af57
+msgid "[1970923](https://bugs.launchpad.net/bugs/1970923)"
+msgstr ""
+
+#: ../../22.04/1.md 2a17bc9ebc9241eaa2466fe7575e5d21
+msgid "SRU][F/J] Update firmware of MT7922"
+msgstr ""
+
+#: ../../22.04/1.md f91f0fe2e2384ed38c8d831c39f8b6e3
+msgid "[1971539](https://bugs.launchpad.net/bugs/1971539)"
+msgstr ""
+
+#: ../../22.04/1.md 737d6de13f684ef5aa7042147204a562
+msgid "Add firmware for i915/DG2"
+msgstr ""
+
+#: ../../22.04/1.md 1c5b99701c5546839d7535c144791e56
+#: 2a36a83a3b2f4409a93057c3071b223d 6ca6daf5cbbd48fcbaa9984faf9f1306
+#: 6cad34d22ad04924a01e0ec0c971a0f3 74aa1fc8c9b744139133b1b547b29a24
+#: 9a7c14c0fb0540d28143a7575dd01bfd 9d4496ffc1ad4898b12d3f8570268fc0
+#: a24f4828103c49aba5fa85190fb0cd3c a66f4b9031384d4f9d1fca07288da860
+#: a67d649d29174a6db1b1b7fe2cb6fc17 cac5cc9c116a4bb2b949ac031c6267e8
+msgid "[1978610](https://bugs.launchpad.net/bugs/1978610)"
+msgstr ""
+
+#: ../../22.04/1.md 0afb8d540f8d465fa27c80a9859ffec5
+#: 0d20acd8ff8f4b3c9b14eb765efb5373 0fb8efbc6c6547fe9c2db9a4b3803025
+#: 32246e709838404bbbb196e373fee8ce 3f8c1b6e4043406799ecc051091916ed
+#: 4899648d324542bb8fc99e5628ddfcec 66db5dee7d32431bb80998d7b0d78686
+#: 924ad3c05fa348938beb7f4d5013f6a3 a97b7d017e0443938bc6012de373ae04
+#: c4a3be69dff74e03bcd77e75470a0f52 ec748a90f2a642d8baf48fbdf7ace88a
+msgid "jammy/linux: 5.15.0-40.43 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md 0385399ed40a4992bdc1971397c1a8cd
+#: 24989ea83e404514af8b6cbeb16d1b64 39c148895b484b939d213a06da840481
+#: 432e2b7f82e24af5a30e91e8d7dca046 4bc869ac164245899b602a2a654d4cab
+#: 5594df85b04942deb0cc03bc0b70e230 709e4a4ef7fb4c119c3fdf1eeb98d4e0
+#: 769b9f57aca043ee913bb6f1b3506a68 8b959606628d4a9d8ec2bcb453e4052f
+#: a22b0d80c5c241f8ae385395a07f8609 d05ae52d3bb5424695c7043cd8d72af9
+#: d1ea4ca5e2ab46fc9aec0525e9406bf3 ea94155f29c9435787083a93268e02a0
+#: eb075eca98aa4b77a1fa26e2026e0cb6
+msgid "[1971699](https://bugs.launchpad.net/bugs/1971699)"
+msgstr ""
+
+#: ../../22.04/1.md 016a720f9cff45a38bff8285618cd31e
+#: 1d3f93fe923543eb96850463dfb2c31a 76844c1e037248e0b7bfc01d657119b9
+#: 8073c4dfb572453fb7515ad197d622e6 876ea581024c4730aa0bee3e8322d4a0
+#: ac16c6a163d145eab011d05dcc5ab471 b99e6a53d6a944b7940ec5707a470ae4
+#: c2ea6ccbdfbd4fda821ecbfa19d5a739 c8fb7d4d305e42bb93d558b4705a32db
+#: d175359c2a784afabb062aada7f3bf92 dde7f98dc4784991907313e8388d5b6e
+#: fd45faadd75740d8a1f908585b62a3a5
+msgid "disable Intel DMA remapping by default"
+msgstr ""
+
+#: ../../22.04/1.md 0faf96a4737c4e6c8d32ac8227a8f002
+#: 17b2a41102ae4ed2af00c580ea941145 1d46473bcf394d9189fd4a8efae6af00
+#: 5105d1952eff4befab200fb738e60540 5812c176fc7e40b9be61484146410261
+#: 7127aec5f7e74530ad3fca4605c3f3e6 9046189172954fb29fece46ea9bc6b6a
+#: baf1e85517d1417498f2b3100f64f34b decff4ffd009438f9493849bc9f14f27
+#: f666227695bd407489fc97234f30c945 f9f8e06f458c41b8bcb94682c7ef4635
+msgid "[1972899](https://bugs.launchpad.net/bugs/1972899)"
+msgstr ""
+
+#: ../../22.04/1.md 08718256427046adaab7298e2eacfb3e
+#: 1992f09e3dfb482e84e6639f2f4b33f3 3d936e47ac664ad3be01a0204d0c482a
+#: 4426a239f6584da3a6636845cbdad284 56a6c8e3c02347c093c0a0b771369ad3
+#: 60d2498ba2494a388dda852e52230ef3 9972dc4fbda0450e9a49433a81e6a357
+#: ba8cb8a0b0a14e368ccea84df16d5d83 d1f4fb3040074d5fad8981a21170c6c2
+#: d9481c309165437e92ec1040ede43c1e dea1eb4468494beaa36f38206e4a1459
+msgid "Regression] Real-time Kernel Build Failure"
+msgstr ""
+
+#: ../../22.04/1.md 018947220474439fbcd74658867f0765
+#: 15170a9d92144706b09d64486870fd77 4ce96059b8b94e959606d3faef933522
+#: 56fff1d4d2c540df837f3606b3750837 711e0cf9ebc84723abf1d80a319d4f57
+#: 770f9ced720944c9af399ad55ad90e50 88f091b440da4e6aae698eb578f4464c
+#: 8eb31fda0f9145d4a495540a220ee780 d193b679babe4fe2b96b47cd6c02c200
+#: d842773bdfe5492082ae708f7ce3cb41 da0e99ab8dce47b7a6a1211c83a4d88c
+#: e41ee24a929e468ab322a73101894f15 fb708fefe0594d60810212e5edc2daac
+msgid "[1964983](https://bugs.launchpad.net/bugs/1964983)"
+msgstr ""
+
+#: ../../22.04/1.md 00d54144fe63452a94d44d868f790885
+#: 074610b4511848c19490a213463b29bb 0fa4658be63b443abd35142e00d2086b
+#: 2aaf9ff8e7dc4f03b8ad644583719f1a 35dca64c56bd47fa8eaf7afd994cfcd8
+#: 3a0e100926d94c82a6cb5b36fa08bc5c 4a9296ac37da4d3187c1084f344330b4
+#: 7bdf7e1409604435915e96329520a154 99e26615f0e14560882c420c89e879a6
+#: a27411558a0740db9c3efa5e22dea8de f872342d380a406887f3af72b60113ea
+msgid "IPU6 camera has no function on Andrews MLK"
+msgstr ""
+
+#: ../../22.04/1.md bbcf556b13f7467b904c03a0e81aa29e
+msgid "[1978586](https://bugs.launchpad.net/bugs/1978586)"
+msgstr ""
+
+#: ../../22.04/1.md 45af917d8b7b445aba41e521706db135
+msgid "jammy/linux-aws: 5.15.0-1014.18 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md 34f7ee97b3424bdba56332ee9509a3ce
+#: 3731c701d7cc4608928f54a76e6e78df 5ed111038de14fd2b7d9b316f6226a8d
+#: 80d12f8e6f7c41de9073969bc6cfb2be
+msgid ""
+"Support Intel IPU6 MIPI camera on Alder Lake platforms // IPU6 camera has"
+" no function on Andrews MLK // disable Intel DMA remapping by default"
+msgstr ""
+
+#: ../../22.04/1.md c0e5799b210f4a4f9a59b4df43d56127
+msgid "[1978588](https://bugs.launchpad.net/bugs/1978588)"
+msgstr ""
+
+#: ../../22.04/1.md 18d8126c024f4bde9eaa9f8ede17fa61
+msgid "jammy/linux-azure: 5.15.0-1013.16 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md e3eb8cbedfe74d859f420d2b2af01a57
+msgid "[1978603](https://bugs.launchpad.net/bugs/1978603)"
+msgstr ""
+
+#: ../../22.04/1.md b0d31187026341fc859d30aa68c823d8
+msgid "jammy/linux-lowlatency: 5.15.0-40.43 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md 86772263dc1648dd948af7dc44b0d3f4
+#: eef2d42bdf2e4c8f92d6a3d8c708f28b
+msgid "zfs-linux"
+msgstr ""
+
+#: ../../22.04/1.md 37ff65df22e043678198bea0b14531e4
+msgid "[1969482](https://bugs.launchpad.net/bugs/1969482)"
+msgstr ""
+
+#: ../../22.04/1.md 01a357675b9143bd8be16e71f7010725
+msgid "New upstream point release"
+msgstr ""
+
+#: ../../22.04/1.md 1eaaa35bbbb9436eaff391655954060e
+msgid "[1969247](https://bugs.launchpad.net/bugs/1969247)"
+msgstr ""
+
+#: ../../22.04/1.md 1e4359ec24414865bea9c1321ddd6bad
+msgid "fix fallocate"
+msgstr ""
+
+#: ../../22.04/1.md 6de3d586b58a4f9cab3458926871f02d
+msgid "[1978578](https://bugs.launchpad.net/bugs/1978578)"
+msgstr ""
+
+#: ../../22.04/1.md e85c52eb7d0748ca94be92643f11797a
+msgid "jammy/linux-oem-5.17: 5.17.0-1012.13 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md 0b5a46372c1b4100bee6d8849edd846e
+#: 1730dbf96f974bd0bf70d3b231fb75cc 3331f67383144c2a8e44167af6d16bd7
+#: 5383eca222f646e49858840fe3cf3632 69ce4d94091d4c8cbad4c6f9b03c5a0b
+#: 7c6b18a29a694214be6228b3a20e0fde 8c68e3acefa14f23b0ab40b97627da3e
+#: 902ca9a4bc374ef2828786b0ae45044e a1ff051c297d415f8611b47afe543c6c
+#: aa2505298dde4af284f846fe4e09ae1b b6d1f177a91e4096921638fe6b2e04f4
+msgid "linux-allwinner-5.17"
+msgstr ""
+
+#: ../../22.04/1.md 7cf72d298da342f1ae32fc7ce27c6d66
+msgid "[1979636](https://bugs.launchpad.net/bugs/1979636)"
+msgstr ""
+
+#: ../../22.04/1.md 85f778b7e7714ac78c740a059b7bc453
+msgid "jammy/linux-allwinner-5.17: 5.17.0-1002.2 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md d9ac6b45ecd244bbb049270c6700b7db
+msgid "[1979635](https://bugs.launchpad.net/bugs/1979635)"
+msgstr ""
+
+#: ../../22.04/1.md 8e4f8d628b904d51abb28561eb0c241d
+msgid "Rename nezha to allwinner"
+msgstr ""
+
+#: ../../22.04/1.md 17044dcc353f4a3ab6c721dd9da28753
+msgid "[1979628](https://bugs.launchpad.net/bugs/1979628)"
+msgstr ""
+
+#: ../../22.04/1.md 507e70ea245244f89ea2ac0d99c42d37
+msgid "Improve config to boot to userspace"
+msgstr ""
+
+#: ../../22.04/1.md 1360be1bb4164720a4913ebe7263c023
+#: 31218e26cb404c038d18d7d793a47437 34d0d2720944453cae4a83cccdfe45dd
+#: 373f2cfb3636412e8986cc5592c723b7 6c8ef891f4094fbba66e6dfb75ed10a5
+#: 80b4048a77914a6fb62fe586cf756b8b ac90a50e428a4cdb898863404a6b7f98
+#: aff5e32150284f10bc404e9605da6b30 bc477caf8deb4e7aac3eb92adc236a89
+#: edcbda24e9b44804a5f3df77c0051fde f9382128f8884d8a84d685cbabf871cf
+msgid "linux-starfive-5.17"
+msgstr ""
+
+#: ../../22.04/1.md da43e1233193482092e387390b7e9fec
+#: f0bbb39d97b24b6a972a88b9e4393cf7
+msgid "[1975580](https://bugs.launchpad.net/bugs/1975580)"
+msgstr ""
+
+#: ../../22.04/1.md 6fc654245d264f50bc3be16444f9080b
+#: d04b3a827fa645a699c13c1223c41e2f
+msgid "Enable StarFive VisionFive board"
+msgstr ""
+
+#: ../../22.04/1.md c2f91d250002457c82ce69c1439bb31a
+msgid "[1976388](https://bugs.launchpad.net/bugs/1976388)"
+msgstr ""
+
+#: ../../22.04/1.md 68db7738d4c0491fbb98d2769bf050af
+msgid "jammy/linux-starfive-5.17: 5.17.0-1001.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md 133a51e42e5742f98b5d601228612574
+#: 207a5d4106094d889d3d23a95f471f21 9bc327e7c2b14b9e9b18d6f4f2419ae0
+msgid "[1980479](https://bugs.launchpad.net/bugs/1980479)"
+msgstr ""
+
+#: ../../22.04/1.md 1a22373eb2b4479daf81e43f505b2270
+#: 5643eff45a56458ca96012410daec89e aa1d0cc57aaa4488b9167d2049aa5ae2
+msgid "jammy/linux-hwe-5.17: 5.17.0-8.8~22.04.6 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md 1fb7e1bb05b7453fab1044c367a1ef02
+#: b6b4b1d11fda441ba362b813d14c55ce c957214a9d1b4419ae65a303d4b4207a
+msgid "[1980389](https://bugs.launchpad.net/bugs/1980389)"
+msgstr ""
+
+#: ../../22.04/1.md 1d5229c89eeb46749244b3d065b010ab
+#: 42d37154b9e94d599e86a5d6eb25afae f3631ccdf56a46cc9292ea991327e6b8
+msgid "Jammy update: v5.17.15 upstream stable release"
+msgstr ""
+
+#: ../../22.04/1.md 56208cbb883046228e3446afd4ecc343
+#: 5c1b79907c9e4ad0919cd8f61db6f9f1 ae341713e87f4a8ab92da160559ec7b7
+msgid "[1980388](https://bugs.launchpad.net/bugs/1980388)"
+msgstr ""
+
+#: ../../22.04/1.md 18363e5a742a469e953cff91d5ecb05a
+#: 886414a563c84e86a9f13624c14d951c ef90f2c7d9d6425784ec0d1ea26a7c0d
+msgid "Jammy update: v5.17.14 upstream stable release"
+msgstr ""
+
+#: ../../22.04/1.md 2f9e333c4c4c4a3b84dbf7b214940d9a
+#: 9a3edaa816b948b98d00b94b891d431a bd87d55e26bb4c68b01e6f988f47268b
+msgid "[1976001](https://bugs.launchpad.net/bugs/1976001)"
+msgstr ""
+
+#: ../../22.04/1.md 0517897656264bbc83278f6a02878c47
+#: 25bc2e0fb8b8453fa799d15f83ed9bdb 9eb5d99b777441489be6e4f35bdcb4fd
+msgid "jammy/linux-hwe-5.17: 5.17.0-8.8~22.04.5 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/1.md 3cf8bd2be8834555b70e067720d83683
+#: 5741a6d0db3f4cd89ced96ad0ce3dccc 72a0f6601f984169b332f96ee386a613
+msgid "[1977721](https://bugs.launchpad.net/bugs/1977721)"
+msgstr ""
+
+#: ../../22.04/1.md 19a7d383bbb9448d8c418d9c568f9ff0
+#: 1c63b80cb49d4a008c9e5add4cc650d6 3ffa0c683db141a3aa7cb20980bd84eb
+msgid "Jammy update: v5.17.13 upstream stable release"
+msgstr ""
+
+#: ../../22.04/1.md 020f7ebe56e94b31a81632f943269987
+#: 8570b5f078e84f9394575012948bc6a2 c88ab1c3e7a44c9190d7e68adb20cd9e
+msgid "[1976470](https://bugs.launchpad.net/bugs/1976470)"
+msgstr ""
+
+#: ../../22.04/1.md 2a22302128c24236874d2264422407e6
+#: 771729cc19fd43a481e29ff78e02f5db b628d150ba96424e85df6a907bfcf805
+msgid "Jammy update: v5.17.12 upstream stable release"
+msgstr ""
+
+#: ../../22.04/1.md 5243ace158a14e8a81ff716a220d639d
+#: 8e9ee6723b65484cbcf6ca9217bcbce6 eff98b9710814eabaa6e14fdf09995d2
+msgid "[1975808](https://bugs.launchpad.net/bugs/1975808)"
+msgstr ""
+
+#: ../../22.04/1.md 2c4d7fe46a7a4f4c8ce3840aab1b94a6
+#: 50da01eb48524629bfa91de80832a6ee f6f4fbf30efd4bb0b1b6ee02e3b05c79
+msgid "Jammy update: v5.17.11 upstream stable release"
+msgstr ""
+
+#: ../../22.04/1.md 8397c30b03604074844862b7090d352e
+#: 963e226871fd4d0dab3590cbd8d036ee c18ed748e5584b9aa9e2adb5fcf833fe
+msgid "[1975807](https://bugs.launchpad.net/bugs/1975807)"
+msgstr ""
+
+#: ../../22.04/1.md 3ac543c3e158458e873cdc37ff4f390f
+#: 46cf107290004020ae29c81a7b28dc04 eef6c904fd4d4b9586e05a328c1201ca
+msgid "Jammy update: v5.17.10 upstream stable release"
+msgstr ""
+
+#: ../../22.04/1.md 7b74c79b536b44d9bf86973ab26d5545
+msgid "[1972806](https://bugs.launchpad.net/bugs/1972806)"
+msgstr ""
+
+#: ../../22.04/1.md 28bd1a7b8ca64a9882427260662d2ee0
+msgid "SRU][F][linux-firmware] UBUNTU: SAUCE: Update firmware of WCN6855"
+msgstr ""
+
+#: ../../22.04/1.md abc78361b45c45a68860eaa0a4fa2712
+msgid "[1977872](https://bugs.launchpad.net/bugs/1977872)"
+msgstr ""
+
+#: ../../22.04/1.md 611697294e994216b080d11e12ba420a
+msgid "Add symlinks to enable StarFive boards AP6212 Wi-Fi module"
+msgstr ""
+
+#: ../../22.04/1.md:393 5129b50409514a2480bf707ea8357d49
+msgid "Unsorted changes"
+msgstr ""
+
+#: ../../22.04/1.md b48e65b3b78746099f5b44f78b53ce10
+msgid "distro-info-data"
+msgstr ""
+
+#: ../../22.04/1.md e37afa29da1c47dc9eb398e3e9739322
+msgid "[1970227](https://bugs.launchpad.net/bugs/1970227)"
+msgstr ""
+
+#: ../../22.04/1.md 4ca9a0932ddf4b8098a0e16ed52728c4
+msgid "Add Ubuntu 22.10, Kinetic Kudu"
+msgstr ""
+
+#: ../../22.04/1.md 18f6538fc0f440828d7f507c9e9be631
+msgid "debootstrap"
+msgstr ""
+
+#: ../../22.04/1.md 81546f455de246749d1bfe556028c94f
+msgid "[1970454](https://bugs.launchpad.net/bugs/1970454)"
+msgstr ""
+
+#: ../../22.04/1.md f323e3a300374625a47aa1c3161e8e3c
+msgid "Add (Ubuntu) kinetic as a symlink to gutsy."
+msgstr ""
+
+#: ../../22.04/1.md 71a5a3cee81141b89c94b17010b59cbb
+msgid "ubuntu-docs"
+msgstr ""
+
+#: ../../22.04/1.md b8552322219e4f01987848e5257ee07e
+msgid "[1968757](https://bugs.launchpad.net/bugs/1968757)"
+msgstr ""
+
+#: ../../22.04/1.md 5de104f5bc5a40418c1643571f3668dc
+msgid "Improvements, e.g. use transparency for dark themes"
+msgstr ""
+
+#: ../../22.04/1.md dbe9bbdf07b04b7e9bef6d80d846c39a
+msgid "ubuntu-image"
+msgstr ""
+
+#: ../../22.04/1.md 7238db72761447cd9efd61392720b03a
+msgid "[1969979](https://bugs.launchpad.net/bugs/1969979)"
+msgstr ""
+
+#: ../../22.04/1.md ef71b36c4f5c4ea68b2a556ee6cd775e
+msgid "Pull in a newer snapd version and load snaps from all modes"
+msgstr ""
+
+#: ../../22.04/1.md 7c553c0f38c0420089e08686eaeca479
+msgid "lintian"
+msgstr ""
+
+#: ../../22.04/1.md 34e7f2aeb5754843bbc2787835311fec
+msgid "[1971692](https://bugs.launchpad.net/bugs/1971692)"
+msgstr ""
+
+#: ../../22.04/1.md 4a060ae20116485c85ce9d1e6c7f36f8
+msgid "Add \"kinetic\" as a known Ubuntu distribution"
+msgstr ""
+
+#: ../../22.04/1.md 7f321287719941e2b07f8987129a0b2b
+msgid "json-c"
+msgstr ""
+
+#: ../../22.04/1.md 2ee70415e9f949479049052c28d918ae
+msgid "[1973270](https://bugs.launchpad.net/bugs/1973270)"
+msgstr ""
+
+#: ../../22.04/1.md 7688220963094eda814095917946b254
+msgid "SRU to Ubuntu 22.04.1"
+msgstr ""
+
+#: ../../22.04/1.md 8e76241e2aa34f938f65433065ab54a9
+msgid "rustc"
+msgstr ""
+
+#: ../../22.04/1.md ecad13df3ea04559a9a8b2c76aa35795
+msgid "[1968345](https://bugs.launchpad.net/bugs/1968345)"
+msgstr ""
+
+#: ../../22.04/1.md dd14a9a0f4514822bbdbd5f26642859d
+msgid "Prepare backport for Jammy"
+msgstr ""
+
+#: ../../22.04/1.md 7f62e6ceb51846ed8be55e899ff86015
+msgid "ruby-xmlrpc"
+msgstr ""
+
+#: ../../22.04/1.md dd8f9056ff3a462faba7247b1bd0928a
+msgid "[1978152](https://bugs.launchpad.net/bugs/1978152)"
+msgstr ""
+
+#: ../../22.04/1.md c78706bb06ca429c9d0c7eb5e0fe1c1a
+#, python-brace-format
+msgid ""
+"d/control: add ${ruby:Depends} as runtime dependency. This will pull in "
+"ruby-webrick which was added only as build dependency, and fix issues "
+"when webrick cannot be found."
+msgstr ""
+
+#: ../../22.04/1.md 239d68126db14af696c92406adb76de3
+#: a32dbf0e905f4027aeab50caf9ed5b99
+msgid "Drop transitional packages for 460."
+msgstr ""
+
+#: ../../22.04/1.md 0bb08188e23f48488947a27e292ea16d
+msgid "pygobject"
+msgstr ""
+
+#: ../../22.04/1.md 2ea4944a17af4315a126c160394fb3f6
+msgid "[1979347](https://bugs.launchpad.net/bugs/1979347)"
+msgstr ""
+
+#: ../../22.04/1.md ac28a5ebe7504fd881e6bc945b232ee1
+#: d941f54bc357481da4ff23a104c9bc3a
+msgid "libnotify"
+msgstr ""
+
+#: ../../22.04/1.md 3a22a0e657a249a5a2a32b782a75d4b0
+msgid "[1970647](https://bugs.launchpad.net/bugs/1970647)"
+msgstr ""
+
+#: ../../22.04/1.md ea167c8dec10484b9510147c946f3332
+msgid "debian/patches: Exit with an error if showing notification fails"
+msgstr ""
+
+#: ../../22.04/1.md bd8bf9692a1e4c479a8c4b55a35374ab
+msgid "[1802483](https://bugs.launchpad.net/bugs/1802483)"
+msgstr ""
+
+#: ../../22.04/1.md fac1c8e8fa244e039df5b7efdf0d7b4a
+msgid "debian/patches: Handle file paths, uris and desktop-ID's in Snapped apps"
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/22.04/2.po
+++ b/docs/locale/ja/LC_MESSAGES/22.04/2.po
@@ -1,0 +1,4973 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../22.04/2.md:2 22d31bd963e642468f1683d83ab202d6
+msgid "Changes in Ubuntu 22.04.2"
+msgstr ""
+
+#: ../../22.04/2.md:4 bac9369c1f1d49d28572885038617679
+msgid ""
+"This is a brief summary of bugs fixed between Ubuntu 22.04.1 and 22.04.2."
+" **This summary covers only changes to packages in *main* and "
+"*restricted*, which account for all packages in the officially-supported "
+"images; there are further changes to various packages in *universe* and "
+"*multiverse*.** Some of these fixes were by Ubuntu developers directly, "
+"while others were by upstream developers and backported to Ubuntu. For "
+"full details, see the individual package changelogs."
+msgstr ""
+
+#: ../../22.04/2.md:6 0355fac1e0e340a2b0872bbcec833599
+msgid ""
+"In addition to the bugs listed below, this update includes all security "
+"updates from the [Ubuntu Security Notice "
+"list](https://ubuntu.com/security/notices?order=newest&release=jammy&details=)"
+" affecting Ubuntu 22.04 LTS that were released up to and including "
+"February 17, 2023. The last update included was USN-5879-1 () Linux "
+"kernel (HWE) vulnerabilities)."
+msgstr ""
+
+#: ../../22.04/2.md:8 da308ee315124edaa949437e9ba069e0
+msgid "Installation bug fixes"
+msgstr ""
+
+#: ../../22.04/2.md:10 f08d08248ca64406b5668275b37a9146
+msgid ""
+"Updated CD images are provided with this release, including fixes for "
+"some installation bugs. (Many installation problems are hardware-"
+"specific; for those, see “Hardware support bugs” below.)"
+msgstr ""
+
+#: ../../22.04/2.md 0913aaf7f6074cb1961c88d03ff66f6f
+#: 0ac0761fd76546139af89c9e8844a097 3b6fc3a2efa644f7bdeba9562fded65a
+#: 49b6c441873a474ba28cc8de12a0fddd 55d341f915e84c02ac7d8bd2c2e9aaa5
+#: a3ba750eba9e4f91925c1312b4efe3fc e5ca991274164fd3b728fceae9a02c45
+msgid "Source Package"
+msgstr ""
+
+#: ../../22.04/2.md 6136e02255454f2e9a51e837b1d4c62f
+#: 8b4bd089a5fb44ee911ac9140929eac5 9e05b6f2446c4f7d986f124f7a64d37a
+#: af89ee870943439dbc0cbbb47162a342 c3cf4ed1c91046e88ac20072baadcf65
+#: c3e00e742397417fa9ed2d50f0affc8e d3600b254d5042ec87750d2286532078
+msgid "Bug  #"
+msgstr ""
+
+#: ../../22.04/2.md 11f577bc021c4dfc920cd2d3e5d89c79
+#: 3756b81a07924d19aeb4e1be8076221e 7352d80367b34031ada22dd0d78de2f3
+#: b742b58ae9cf4aaa899874b6dc4990f5 dd3b43fc467e486c8998e502553d0fab
+#: e9a1a6c8f25d4bba99f78313d9ddaa7e f21b26cc061d41bbacc6e67af1eed3e6
+msgid "Description"
+msgstr ""
+
+#: ../../22.04/2.md 0a30f097af294fe4bcdf6564d3b032a1
+#: 39e69dc87d2e428e9ae1f0c0068cd669
+msgid "ubiquity"
+msgstr ""
+
+#: ../../22.04/2.md 109bc526cc194b4f8fdd966052cf6431
+msgid "[1990887](https://bugs.launchpad.net/bugs/1990887)"
+msgstr ""
+
+#: ../../22.04/2.md 228ae057d3cc42bc943aaf5fd4b084d5
+msgid ""
+"Increase the window size in the QT/KDE version of the installer dialog so"
+" that the keyboard is readable."
+msgstr ""
+
+#: ../../22.04/2.md d08925e1c0ce4ecc8adf784c7b68e427
+#: dd7fd4dab0bd42ddad14bb17488c28e1
+msgid "casper"
+msgstr ""
+
+#: ../../22.04/2.md f8b01d8a203b4f57bdcf50ee6f7ef991
+msgid "[1976287](https://bugs.launchpad.net/bugs/1976287)"
+msgstr ""
+
+#: ../../22.04/2.md 3ee8ab35e7e042ffbacfdd3c35ba8706
+msgid "Increase memory for qemu autopkgtest instances to 1G"
+msgstr ""
+
+#: ../../22.04/2.md 8afecb1d85bb4a0dbbada0619c99f9ce
+msgid "grub2"
+msgstr ""
+
+#: ../../22.04/2.md 363f6c87d0d74a6da5c07ff130ee39a7
+msgid "[1997795](https://bugs.launchpad.net/bugs/1997795)"
+msgstr ""
+
+#: ../../22.04/2.md 3f9e5e6cf77f436f922fb558c482de7c
+msgid "grub-multi-install: Reset partition type between partitions"
+msgstr ""
+
+#: ../../22.04/2.md 02e4ec216a8b41dfba70c574fee4c9af
+msgid "language-selector"
+msgstr ""
+
+#: ../../22.04/2.md 285e148517e44f8e83687ce37c90b9c0
+msgid "[2000551](https://bugs.launchpad.net/bugs/2000551)"
+msgstr ""
+
+#: ../../22.04/2.md 9bbadddd14f54c579156e91ecdff9fbd
+msgid ""
+"Make Noto Sans Sinhala and Noto Serif Sinhala default fonts for rendering"
+" Sinhala."
+msgstr ""
+
+#: ../../22.04/2.md 773d9f480f1b47bf92aa0a2a2888ddc5
+#: b6437e6dd84c47db82572b421ac4a2f1 b6d451f601734edba802058ba3bad5fa
+msgid "gnome-initial-setup"
+msgstr ""
+
+#: ../../22.04/2.md 2432d6589daf43cf8b955796d17181e4
+msgid "[2003231](https://bugs.launchpad.net/bugs/2003231)"
+msgstr ""
+
+#: ../../22.04/2.md 90d92568229e474d8d578e049a9fc621
+msgid "integrate with the new Ubuntu Pro service instead of Livepatch"
+msgstr ""
+
+#: ../../22.04/2.md 12dedcb5625d4d51a5323b6e37fe38d0
+msgid "[1986781](https://bugs.launchpad.net/bugs/1986781)"
+msgstr ""
+
+#: ../../22.04/2.md 5bc650b16cb04a799ed3d9c7d4ccd480
+msgid ""
+"d/casper.casper-md5check.service: order it After=multi-user.target. This "
+"should allow us to reach multi-user.target sooner, especially for users "
+"where the md5 check is slow."
+msgstr ""
+
+#: ../../22.04/2.md 5e0053771f2840ac9c9511d40bfa1a65
+msgid "[1993318](https://bugs.launchpad.net/bugs/1993318)"
+msgstr ""
+
+#: ../../22.04/2.md 1a8124764526488b86458f644c796362
+msgid "zsys-setup: generate correct zfs-list.cache for target"
+msgstr ""
+
+#: ../../22.04/2.md ad5ca52d4e364348a88702209f2b1e47
+msgid "[2004037](https://bugs.launchpad.net/bugs/2004037)"
+msgstr ""
+
+#: ../../22.04/2.md 740cb7dc84784b2b96ed4b9699453423
+msgid "fix an incorrect pointer use in the connectivity callback"
+msgstr ""
+
+#: ../../22.04/2.md 505d4fc849934995bbe753e935444dcb
+msgid "[2004518](https://bugs.launchpad.net/bugs/2004518)"
+msgstr ""
+
+#: ../../22.04/2.md b62eefe24a9d4420ad3cb10474787b36
+msgid "fix a crash in the dispose handler"
+msgstr ""
+
+#: ../../22.04/2.md 531eb2eb90494b61b7617049c03bea63
+#: 75bde18e4f4b4f25b9b79f983de79c49 984719149baf467bb478b14f8a8e6338
+#: a7d42989857442a888645ff7613d24e0 ab95c44c17724aabb46c35675b8749b3
+#: b403d5695a444236a80a900bdb32d82f
+msgid "livecd-rootfs"
+msgstr ""
+
+#: ../../22.04/2.md aa3987350d44487598c6283daf43f98c
+msgid "[2006481](https://bugs.launchpad.net/bugs/2006481)"
+msgstr ""
+
+#: ../../22.04/2.md eaaabac08aad4ccba075ce8c067febc7
+msgid "Enable the hwe kernel variant for 22.04.2."
+msgstr ""
+
+#: ../../22.04/2.md 8c2ad0ff4321476d8e566865c0714754
+msgid "[2007863](https://bugs.launchpad.net/bugs/2007863)"
+msgstr ""
+
+#: ../../22.04/2.md d6660bc384e6455bb1a63e56b918f092
+msgid "Do not offer the hwe kernel for RISC-V server-live images."
+msgstr ""
+
+#: ../../22.04/2.md:28 032558fe16a74a6ebd3cdc881c4d4eac
+msgid "Upgrade bug fixes"
+msgstr ""
+
+#: ../../22.04/2.md:30 dbb3b7a102054cac8fac69bfa09621c9
+msgid ""
+"These changes fix upgrade issues, smoothing the way for future upgrades "
+"to later releases of Ubuntu (and not only)."
+msgstr ""
+
+#: ../../22.04/2.md 44a8d59428e946688b452e6f0fc2e077
+#: 6771816bc4fc48dd8e70af81e6c161d6 841369be7ea04c0e921ac25bc0190e76
+msgid "apt"
+msgstr ""
+
+#: ../../22.04/2.md aa66d59c4b2f4da9b7624062ce8b6e80
+msgid "[1974196](https://bugs.launchpad.net/bugs/1974196)"
+msgstr ""
+
+#: ../../22.04/2.md 260373b7c3b6455ca2ed6b4d964414a2
+msgid "Mark broken reverse depends for upgrade"
+msgstr ""
+
+#: ../../22.04/2.md 574c3f57512743938ca8ad6ecb60a9c6
+#: 8198cf5f861348b4bb37b6c89ce67e9f b9377f4badf940fdb55b6bf323bcad0c
+#: f466d952ecd24dd8bd6c327b462d20ad
+msgid "ubuntu-release-upgrader"
+msgstr ""
+
+#: ../../22.04/2.md 88b1064bf2e644a997c0054a44e70b83
+msgid "[1987452](https://bugs.launchpad.net/bugs/1987452)"
+msgstr ""
+
+#: ../../22.04/2.md bdf9587142674b1f911fb9a6a383da7e
+msgid ""
+"When upgrading from Ubuntu 20.04 LTS or Ubuntu 20.10 require a version of"
+" apt which fixed a bug in apt (LP: 1871268) and prevents an early failure"
+" to upgrade."
+msgstr ""
+
+#: ../../22.04/2.md 844d84d1f30043e79e58ab54cae29192
+msgid "[1985253](https://bugs.launchpad.net/bugs/1985253)"
+msgstr ""
+
+#: ../../22.04/2.md 4854db98688a40539bb06af7f406b35d
+msgid ""
+"In the nvidia driver quirk handle the case where ubuntu-drivers-common is"
+" not installed on the system to be upgraded."
+msgstr ""
+
+#: ../../22.04/2.md 6a32e5687fb74609b39f6a31752b798b
+msgid "[1964036](https://bugs.launchpad.net/bugs/1964036)"
+msgstr ""
+
+#: ../../22.04/2.md 4163a74899c5446ca8a076484e426d6a
+msgid "DistUpgrade: Remove firefox from deb2snap.json"
+msgstr ""
+
+#: ../../22.04/2.md b50216b8ccb548c6a5031c41110dadf4
+msgid "[1985964](https://bugs.launchpad.net/bugs/1985964)"
+msgstr ""
+
+#: ../../22.04/2.md 0f586bd9ee784678a2b25fc871f702da
+msgid "DistUpgrade: Just pass filename to apport report"
+msgstr ""
+
+#: ../../22.04/2.md 15331fec6a694e73b7575b63c99a6f3d
+msgid "update-manager"
+msgstr ""
+
+#: ../../22.04/2.md 8e854973b16b4694985caba837e115f6
+msgid "[1991533](https://bugs.launchpad.net/bugs/1991533)"
+msgstr ""
+
+#: ../../22.04/2.md 8cfebbe4c5d646db8eb76998a1146b5a
+msgid ""
+"ubuntu-security-status: Don't show ESM Apps information when the service "
+"is disabled, and prefer 'pro security-status' when it is available."
+msgstr ""
+
+#: ../../22.04/2.md:43 ba101d15b98a4ef3899394a99c4c144a
+msgid "Desktop fixes"
+msgstr ""
+
+#: ../../22.04/2.md:45 920ad327c5e5494ca06ab10506dc2aff
+msgid ""
+"These changes mainly affect desktop installations of Ubuntu, Kubuntu, "
+"Ubuntu MATE and other Ubuntu-based systems."
+msgstr ""
+
+#: ../../22.04/2.md 5ce2ec4d1101423eb4e5f2800b61e884
+#: 7c0ded6a3e4d4548bae71e2c2dd81243 a01da4c3faea47abb0bfc3d81ac31577
+msgid "software-properties"
+msgstr ""
+
+#: ../../22.04/2.md c5ee1481a9af4fc1bc8e99d7347f369a
+msgid "[1970449](https://bugs.launchpad.net/bugs/1970449)"
+msgstr ""
+
+#: ../../22.04/2.md ba07861f565e4c6fbfd193ace25366ae
+msgid "Fix GPG keys are not shown in Software and Updates"
+msgstr ""
+
+#: ../../22.04/2.md 7053d6c418794b9fb465013864e9f5ee
+#: deea7609aa5145109e6d89d0fa3e8d70
+msgid "gtk4"
+msgstr ""
+
+#: ../../22.04/2.md 794147e63f114b5699189c34f0c85b74
+msgid "[1980742](https://bugs.launchpad.net/bugs/1980742)"
+msgstr ""
+
+#: ../../22.04/2.md 080cb1a6e82b4b5b8ab6debfa2fe7b28
+#: 23b007ec37864f2fa825c055b1b4a32a 27628900c8634606881e117802750d59
+#: 7d9cd7636d934512a117529a6d871294 83cb4524ce2b44199f95aaea7c5e3c70
+#: 868ae4904cc34ffb93da752c5ffd6c61 9dee4b139a844213ae8aa1459e6ee9e3
+#: a47490930883448d8e4d8c415b178c15 bacb110045a442f1900a706b5e8390bf
+#: c051d21ba0ba4cbebf51951466938f4e c056ee6496cd416f8e15ea39ffdf5399
+#: d251a88fadf941d995a619cbdf23fd16 f20789707828437193e70f0b64dbdee5
+msgid "New upstream release"
+msgstr ""
+
+#: ../../22.04/2.md 6ce2f36d75ad4b5cbeb4443468d82c9f
+msgid "[1947698](https://bugs.launchpad.net/bugs/1947698)"
+msgstr ""
+
+#: ../../22.04/2.md 730a7b2672a749a6b99418935e8d16a6
+msgid "Needed to fix missing translations and RTL support"
+msgstr ""
+
+#: ../../22.04/2.md 41de77c550f4464091d9d5da4bb24c50
+msgid "fprintd"
+msgstr ""
+
+#: ../../22.04/2.md 14dc98f6514045e883047a40597b512e
+msgid "[1976256](https://bugs.launchpad.net/bugs/1976256)"
+msgstr ""
+
+#: ../../22.04/2.md 528c7d2488e64db79db67385effc1646
+msgid "debian/patches: Fix build issue with newer dbusmock"
+msgstr ""
+
+#: ../../22.04/2.md 0e686118de1b461bb4e98ac39436286e
+#: 722e664cc2f04df299294d0000123391 99430efab5a44bd887ac174abe49e1b3
+#: ab46acf958c04183ac4fd4a727e1ac96 aff9ce5b11d145319de66e3ae1ac44e8
+#: b573f2db655447cc8cb590ac8fe7b61b
+msgid "gnome-control-center"
+msgstr ""
+
+#: ../../22.04/2.md 2a53485307144be28cc5ef201b057655
+#: 5ad684836e86446fbed521503de19cb7
+msgid "[1968213](https://bugs.launchpad.net/bugs/1968213)"
+msgstr ""
+
+#: ../../22.04/2.md dac8e8eecef844edaec23787c4ba9d62
+msgid ""
+"debian/patches: Read the user value for gedit setting before changing it."
+" This is an oversight while backporting the patch that is already in "
+"kinetic."
+msgstr ""
+
+#: ../../22.04/2.md a996d4490a0d4f4db2fc7ddc7d38d408
+msgid "[1980606](https://bugs.launchpad.net/bugs/1980606)"
+msgstr ""
+
+#: ../../22.04/2.md 2117bcf803a74558a7573237cf5a05f9
+msgid "debian/control.in: Depend on gnome-remote-desktop"
+msgstr ""
+
+#: ../../22.04/2.md 78b58e0be97f42f387d358184bc0fb63
+msgid "[1977663](https://bugs.launchpad.net/bugs/1977663)"
+msgstr ""
+
+#: ../../22.04/2.md c4b72e5381ea428f83be0ba5b4345277
+msgid "debian/patches: Ensure VNC/RDP remote control setting is honored"
+msgstr ""
+
+#: ../../22.04/2.md 39f8accd193646e285255416ca5e426f
+msgid ""
+"ubuntu-panel: Do not change themes on startup (or on user changes) Do not"
+" override user themes unless an user has explicitly selected a color "
+"theme. This applies to both the user theme and the icons, as we want a "
+"consistent experience. But users could still use tweaks to change them. "
+"At the same time, avoid changing the gedit color scheme if an user "
+"previously set a non-Yaru theme."
+msgstr ""
+
+#: ../../22.04/2.md 081b1f1aeb4142b8b529bca64c9478f5
+#: 0c08686368204c4d822c748d5b8bcc91 c0ffacce97e340d5a6fbcb843bc399e8
+#: e04e6e06234a45eda1c0957af059bdce
+msgid "gnome-shell"
+msgstr ""
+
+#: ../../22.04/2.md e34257722ddf472fbce457e1773b8ded
+msgid "[1985304](https://bugs.launchpad.net/bugs/1985304)"
+msgstr ""
+
+#: ../../22.04/2.md 14ced338f4d24e90a2aad3783482f29c
+#: 62833477d3064866bd3c5f4bf54f76ee d730e91ff9194c61a5014c5f28c6e130
+#: f8d3d6f670364dd999aaedea1fe90014
+msgid "New upstream release:"
+msgstr ""
+
+#: ../../22.04/2.md a33e7a444925456dac95a052dbf28366
+msgid "[1985128](https://bugs.launchpad.net/bugs/1985128)"
+msgstr ""
+
+#: ../../22.04/2.md bfa4437099ea449386ceb58238f442b5
+msgid "Fix logging in with realmd"
+msgstr ""
+
+#: ../../22.04/2.md 71ae72a914524da4b43dd2e144378a98
+#: caf7decd01d440f0a6cb28b025b0cfb1
+msgid "gnome-desktop"
+msgstr ""
+
+#: ../../22.04/2.md d8edfc3e5e2749fa89d6b31bd587dde4
+msgid "[1981602](https://bugs.launchpad.net/bugs/1981602)"
+msgstr ""
+
+#: ../../22.04/2.md bcf7d80ae43840fbb1ace15132cf435e
+#: c87eca67beb04a21bd8f1a100e68b83a
+msgid "gnome-remote-desktop"
+msgstr ""
+
+#: ../../22.04/2.md 01e6d700ae00437fbd70c17be77b62ca
+msgid "[1983788](https://bugs.launchpad.net/bugs/1983788)"
+msgstr ""
+
+#: ../../22.04/2.md b0085eeca56944b1bec0c30fc401b698
+msgid "New upstream version"
+msgstr ""
+
+#: ../../22.04/2.md e8502f594c4d4bd9a6167dae3a19f51c
+msgid "gjs"
+msgstr ""
+
+#: ../../22.04/2.md a4b409467aed47f5a693568797a55cff
+msgid "[1981722](https://bugs.launchpad.net/bugs/1981722)"
+msgstr ""
+
+#: ../../22.04/2.md 5c686c98cd7143e08e5e24e5e6ad1c33
+msgid "xserver-xorg-video-amdgpu"
+msgstr ""
+
+#: ../../22.04/2.md afb27b1bc9cf40b2b5d5f113ba335655
+msgid "[1987038](https://bugs.launchpad.net/bugs/1987038)"
+msgstr ""
+
+#: ../../22.04/2.md 3520363c295b486cbc75828673988b98
+msgid ""
+"Added patch from git to fix slow refresh rate with AMD GPU Screen output "
+"in reverse prime mode."
+msgstr ""
+
+#: ../../22.04/2.md 0062288abecd476394319a3f487aca00
+msgid "[1983645](https://bugs.launchpad.net/bugs/1983645)"
+msgstr ""
+
+#: ../../22.04/2.md 1fd62aa0ec554e7ebc6455dde7c042ec
+msgid "debian/patches: Add 5G connection support"
+msgstr ""
+
+#: ../../22.04/2.md 4924d167ee9c4fc390415904cd62ea99
+#: 978ac91ec9fd44e8835002cbb47a5fe0
+msgid "libreoffice"
+msgstr ""
+
+#: ../../22.04/2.md 396a51c80c184d00b99aad21f4910f1c
+msgid "[1988744](https://bugs.launchpad.net/bugs/1988744)"
+msgstr ""
+
+#: ../../22.04/2.md fff9dbb60ab145028a9192bffc3a719f
+msgid "evolution-data-server"
+msgstr ""
+
+#: ../../22.04/2.md af6cedd0304e4ea2bba5053276c8527a
+msgid "[1980545](https://bugs.launchpad.net/bugs/1980545)"
+msgstr ""
+
+#: ../../22.04/2.md 5b7eb2fceb79497c84acebbb93258cd6
+msgid "xwayland"
+msgstr ""
+
+#: ../../22.04/2.md 08084bc6c531439d86f673a29e75046f
+msgid "[1987628](https://bugs.launchpad.net/bugs/1987628)"
+msgstr ""
+
+#: ../../22.04/2.md ebdbae7d2af44c36a42cd9934c3fe3cb
+msgid ""
+"Add xwayland-Detect-gbm_bo_get_fd_for_plane-at-runtime.patch to fix "
+"startup failures on Xilinx"
+msgstr ""
+
+#: ../../22.04/2.md 3c01a579259f4d8caa6bb399bdaac106
+msgid "speech-dispatcher"
+msgstr ""
+
+#: ../../22.04/2.md f6f1f50587934d24a3c3166607ff4f8f
+msgid "[1988292](https://bugs.launchpad.net/bugs/1988292)"
+msgstr ""
+
+#: ../../22.04/2.md 7e38e0ce6d344e3eafabd66795ae4778
+msgid ""
+"backport fixes to ensure voices are correctly listed, that's needed to "
+"fix speechsynthesis in firefox"
+msgstr ""
+
+#: ../../22.04/2.md 3f9b7cef409544318d70a32a053b90f3
+#: 70753a19cef94d63b37470f6780a0536
+msgid "pipewire"
+msgstr ""
+
+#: ../../22.04/2.md 5205db6645b74514a49c8451eea13e07
+msgid "[1985057](https://bugs.launchpad.net/bugs/1985057)"
+msgstr ""
+
+#: ../../22.04/2.md 207370346d0245bb8067bc1f59b67e87
+msgid "Camera output freeze when using pipewiresrc"
+msgstr ""
+
+#: ../../22.04/2.md 3cfb824fd29f46b5a694b7f3d02ad55a
+#: 6333a5ebfd644d5d884944cac133373c
+msgid "pulseaudio"
+msgstr ""
+
+#: ../../22.04/2.md fa233c217f8443bcb074b703de9a6c94
+msgid "[1971632](https://bugs.launchpad.net/bugs/1971632)"
+msgstr ""
+
+#: ../../22.04/2.md 4fad03f3932741b78f9d8a275d0d3686
+msgid ""
+"cherrypick !695 from the upstream stable branch to fix disconnect and "
+"segfault issues with some bluetooth devices"
+msgstr ""
+
+#: ../../22.04/2.md 9c1c5f872de844db85d0b183179894fc
+msgid "[1987523](https://bugs.launchpad.net/bugs/1987523)"
+msgstr ""
+
+#: ../../22.04/2.md f49cb992ae5d4b85a22430b4ee050f05
+msgid ""
+"cherrypick a fix for the service segfaulting sometime after switching to "
+"HFP profile"
+msgstr ""
+
+#: ../../22.04/2.md 0ae48b69bc2e42dca138f8a05f899f9d
+#: 294b703990864e01b9c8d1727340602e 330f862174e74debbc8de2ef7983e585
+#: 5ce1f210f07c4d85bde2b08ccc6b44ce 77155e85d4ae4669a65c8b2367fa36b1
+#: dd82c26f7fdd4394b8052342eb9399ef
+msgid "alsa-ucm-conf"
+msgstr ""
+
+#: ../../22.04/2.md b4e4b5fe93ca4bbea5be12c11d930041
+msgid "[1992435](https://bugs.launchpad.net/bugs/1992435)"
+msgstr ""
+
+#: ../../22.04/2.md 5541088ad9124b0582596634d9b0cd35
+msgid "Backport patch to fix sof-hda-dsp Dmic0 initial."
+msgstr ""
+
+#: ../../22.04/2.md b19348d5648b467e922de79793133ebb
+msgid "[1993809](https://bugs.launchpad.net/bugs/1993809)"
+msgstr ""
+
+#: ../../22.04/2.md 42bed89213b94e6d8429d4f623028c53
+msgid "[1984147](https://bugs.launchpad.net/bugs/1984147)"
+msgstr ""
+
+#: ../../22.04/2.md 250149d9c5404d7a8bf164e7b610bfc8
+msgid "Fix switching monitor with Super-P"
+msgstr ""
+
+#: ../../22.04/2.md 307e226fcbf143a0807b825c9258205b
+#: 3eab669a94e1457094fd4322216191be c58a0b23f8f34eb6a5495465d93eba2d
+msgid "mutter"
+msgstr ""
+
+#: ../../22.04/2.md 004ea96845064454b053f86ec6711442
+msgid "[1985856](https://bugs.launchpad.net/bugs/1985856)"
+msgstr ""
+
+#: ../../22.04/2.md 9f9aa48807e4402c930dda82c89bc007
+msgid "[1969422](https://bugs.launchpad.net/bugs/1969422)"
+msgstr ""
+
+#: ../../22.04/2.md 482f5f509f5845ffb354addc4e357d29
+#: ab8b495572864600a3ad97556cba45b2
+msgid ""
+"Update Support-Dynamic-triple-double-buffering.patch. Dual-GPUs crash in "
+"gbm_surface_release_buffer Leftover mouse pointer when moving between "
+"monitors"
+msgstr ""
+
+#: ../../22.04/2.md 8cf67c5dbf96420b9f0ae64f24563bbb
+msgid "[1988625](https://bugs.launchpad.net/bugs/1988625)"
+msgstr ""
+
+#: ../../22.04/2.md fda0ae102a4b4c5ba0b29d732469d33a
+msgid "[1995054](https://bugs.launchpad.net/bugs/1995054)"
+msgstr ""
+
+#: ../../22.04/2.md ef416d86f1844e249984c57d5d52b4c0
+msgid "gdk-pixbuf"
+msgstr ""
+
+#: ../../22.04/2.md e8952766e543485097a3635785af0f8f
+msgid "[1993785](https://bugs.launchpad.net/bugs/1993785)"
+msgstr ""
+
+#: ../../22.04/2.md f54965b22b7a4becb10623f4d0a5abef
+msgid ""
+"fix the directory referenced for gdk-pixbuf-query-loaders in the .pc "
+"since that file is moved by the packaging"
+msgstr ""
+
+#: ../../22.04/2.md a99c9d8638044b98a40310afaa78374f
+msgid "[1992852](https://bugs.launchpad.net/bugs/1992852)"
+msgstr ""
+
+#: ../../22.04/2.md d63795730eb9438791bb95e504aaa58a
+msgid "glib2.0"
+msgstr ""
+
+#: ../../22.04/2.md 179e8c1d24314391b3de076707d9cc5c
+msgid "[1980408](https://bugs.launchpad.net/bugs/1980408)"
+msgstr ""
+
+#: ../../22.04/2.md 3fce382a26414f90a749f14dfbf7db51
+#: 496b22d374794831ae509d4c22f774cb 5fc38176b2684eed801f626270cc372e
+msgid "xorg-server"
+msgstr ""
+
+#: ../../22.04/2.md 4f634bfff4cf472ebce1970f49324ab6
+msgid "[1996490](https://bugs.launchpad.net/bugs/1996490)"
+msgstr ""
+
+#: ../../22.04/2.md c314ed5274b142528c2b85540d727e55
+msgid ""
+"re-calculate-the-clock-and-refresh-rate.diff: Fix modes on 2.5k@90Hz "
+"panels."
+msgstr ""
+
+#: ../../22.04/2.md dc423355440c4409a46bfec2fbe46de3
+msgid "[1994027](https://bugs.launchpad.net/bugs/1994027)"
+msgstr ""
+
+#: ../../22.04/2.md f099d88f9e3b43abac70ac9aa499fc0f
+msgid ""
+"patches: Don't send touch end to clients that do async grab without "
+"touches."
+msgstr ""
+
+#: ../../22.04/2.md af8cb85e260648da8708b401872ebd15
+msgid "nautilus"
+msgstr ""
+
+#: ../../22.04/2.md a2cdeb7417e748b5ad1109f923aec53c
+msgid "[1934579](https://bugs.launchpad.net/bugs/1934579)"
+msgstr ""
+
+#: ../../22.04/2.md b5665130bbda4c6eb32357447cd5502c
+msgid "d/p/ubuntu/unity_launcher_support.patch: Only set window time under x11"
+msgstr ""
+
+#: ../../22.04/2.md 982575e41202400c84345455aaccd335
+msgid "[1998966](https://bugs.launchpad.net/bugs/1998966)"
+msgstr ""
+
+#: ../../22.04/2.md 000e6e93010e4b9abf9a9de3237702c2
+#: 7bd39ba6de2f436d8527a68a75bb3da4 a44c9124410f4ef2b76503c3e200564d
+msgid "mesa"
+msgstr ""
+
+#: ../../22.04/2.md d75fae4108734524a8bc9a96d1eba7bc
+msgid "[1972977](https://bugs.launchpad.net/bugs/1972977)"
+msgstr ""
+
+#: ../../22.04/2.md 88c05f4a47b44baabfe29e3865337578
+msgid ""
+"crocus-fix-leak-in-query-code.patch: Fix gnome-shell crashing on older "
+"Intel hw."
+msgstr ""
+
+#: ../../22.04/2.md 1408b8ef1a3a423bb85569b9699e8bbc
+msgid "[1998893](https://bugs.launchpad.net/bugs/1998893)"
+msgstr ""
+
+#: ../../22.04/2.md abc3a2e666c1422f9715823fa022b82b
+msgid "patches: Update pci-id's for ADL-S/RPL-S."
+msgstr ""
+
+#: ../../22.04/2.md 3551955d362248fd9bb88ae2131d1a17
+#: d71f77b8773540a6a35ff09dcf894134
+msgid "open-vm-tools"
+msgstr ""
+
+#: ../../22.04/2.md 621017f34b904be993471277c991148b
+msgid "[1975767](https://bugs.launchpad.net/bugs/1975767)"
+msgstr ""
+
+#: ../../22.04/2.md 44dfe6680dcf44f59717793f18d03862
+msgid "Backport recent open-vm-tools"
+msgstr ""
+
+#: ../../22.04/2.md eaa4e9fbefcb460f9498b3d90dfc8307
+msgid "[1968354](https://bugs.launchpad.net/bugs/1968354)"
+msgstr ""
+
+#: ../../22.04/2.md f3bcfa966de24ceba81a0ac462b3cada
+msgid ""
+"Fixes issue with \"udevadm trigger\" affecting all devices that can cause"
+" unwanted side-effects."
+msgstr ""
+
+#: ../../22.04/2.md e5bccfb8b03b4673b93226c193074bc7
+msgid "[1996148](https://bugs.launchpad.net/bugs/1996148)"
+msgstr ""
+
+#: ../../22.04/2.md ba8552f0e7274539b721a9e1304a7b4f
+msgid ""
+"Revert the previous change to resolve a regression with screencasting. "
+"Extra fixes are available upstream but figuring out the details will take"
+" longer"
+msgstr ""
+
+#: ../../22.04/2.md a8ac6af75c504e38ac5752809484b873
+msgid "[1996067](https://bugs.launchpad.net/bugs/1996067)"
+msgstr ""
+
+#: ../../22.04/2.md 7e12a1a91cf240948ec6aadb9caa61b1
+msgid ""
+"cloudarchive: Enable support for the Antelope Ubuntu Cloud Archive on "
+"22.04."
+msgstr ""
+
+#: ../../22.04/2.md 168f28aa8862487f8522666c3047fc95
+msgid "libinput"
+msgstr ""
+
+#: ../../22.04/2.md f3156cc9ca8941b885bf4d692546cbd9
+msgid "[2002609](https://bugs.launchpad.net/bugs/2002609)"
+msgstr ""
+
+#: ../../22.04/2.md 5e313e356e26430bb408993ef98ad0ba
+msgid "Disable pressure for not detecting contact size"
+msgstr ""
+
+#: ../../22.04/2.md adadd3763df14bc9a38002e7a3a4d51e
+msgid "[2003527](https://bugs.launchpad.net/bugs/2003527)"
+msgstr ""
+
+#: ../../22.04/2.md faad1dc78a8c427c8204262659026bdf
+msgid "Replace Livepatch integration with Ubuntu Pro"
+msgstr ""
+
+#: ../../22.04/2.md 72490224976a4a1188bcdebb4a72e9c7
+msgid "[2000423](https://bugs.launchpad.net/bugs/2000423)"
+msgstr ""
+
+#: ../../22.04/2.md 38f2c5276b404d2194b4caa2fe443d6d
+msgid "Add nodefault_option after the main option, not before."
+msgstr ""
+
+#: ../../22.04/2.md 01302d42f79a473eab102e63cfd039f5
+msgid "libdrm"
+msgstr ""
+
+#: ../../22.04/2.md 44672e0009dd4b08b6b1d58ae59617af
+#: 4934716dd99844f49680737858ea3337 e8518af492de4d04ba66599e1aa1b220
+msgid "[1991761](https://bugs.launchpad.net/bugs/1991761)"
+msgstr ""
+
+#: ../../22.04/2.md 8e8aa26fd6544ca68d19b871e881f967
+#: de3ac5a356ec4fd5875db1914c5f16d8
+msgid "Backport to jammy."
+msgstr ""
+
+#: ../../22.04/2.md 68ad29ca92604aeab0e26484477cb744
+msgid "llvm-toolchain-15"
+msgstr ""
+
+#: ../../22.04/2.md 0e42c6e7ed614a74a31f316e874010e7
+msgid "Bootstrap build #2, bump to build with llvm-spirv-15."
+msgstr ""
+
+#: ../../22.04/2.md 7cc218f2981b46ec971f24fd6b22bfbf
+msgid "[1999008](https://bugs.launchpad.net/bugs/1999008)"
+msgstr ""
+
+#: ../../22.04/2.md e48c8b7b82d942d68d01b05bd1aeb27a
+msgid "re-calculate-the-clock-and-refresh-rate.diff: Import v3, fix a crash."
+msgstr ""
+
+#: ../../22.04/2.md 5206fa51e41f4b829bee2d1e088cbb7d
+msgid "fonts-noto-color-emoji"
+msgstr ""
+
+#: ../../22.04/2.md 42694fdcb7cb42b591e3b6eede6e7d05
+msgid "[1990677](https://bugs.launchpad.net/bugs/1990677)"
+msgstr ""
+
+#: ../../22.04/2.md e3681788d4764002adbbed2dafeb2dbd
+msgid "oem-sutton-balin-meta"
+msgstr ""
+
+#: ../../22.04/2.md dc9c51700b9c4c43b94b038cceff0f6d
+msgid "[1996862](https://bugs.launchpad.net/bugs/1996862)"
+msgstr ""
+
+#: ../../22.04/2.md fe6d776d6d3f440589ca842283538d24
+msgid "Meta package for Sutton Balin."
+msgstr ""
+
+#: ../../22.04/2.md f18b85c80bc74f30b4e62a30beb94990
+msgid "oem-sutton-cailyn-meta"
+msgstr ""
+
+#: ../../22.04/2.md 9aeef64a4a914f3f86e9eb29763ecff0
+msgid "[1996879](https://bugs.launchpad.net/bugs/1996879)"
+msgstr ""
+
+#: ../../22.04/2.md fb7ece9a844241ab947ed7a35e52a90f
+msgid "Meta package for Sutton Cailyn."
+msgstr ""
+
+#: ../../22.04/2.md 4bad31538d604a609a315e8160d445bf
+msgid "oem-sutton-cailean-meta"
+msgstr ""
+
+#: ../../22.04/2.md bd99adc53f884d04831154b1eb873e85
+msgid "[1996888](https://bugs.launchpad.net/bugs/1996888)"
+msgstr ""
+
+#: ../../22.04/2.md e20b185e26e74a45a0743cf2737ead57
+msgid "Meta package for Sutton Cailean."
+msgstr ""
+
+#: ../../22.04/2.md cfc22529095943cbb44d773f4eb6ed83
+msgid "oem-sutton-bambina-meta"
+msgstr ""
+
+#: ../../22.04/2.md f1031ade91be4bb9bcb91b9785466183
+msgid "[1996887](https://bugs.launchpad.net/bugs/1996887)"
+msgstr ""
+
+#: ../../22.04/2.md 33e6098ea60a46d18a865a2e22079679
+msgid "Meta package for Sutton Bambina."
+msgstr ""
+
+#: ../../22.04/2.md 6d5a5cbe7b0e4b7c87746dbbfd76082b
+msgid "oem-sutton-balint-meta"
+msgstr ""
+
+#: ../../22.04/2.md 0cb467ebd379450faad8754936838716
+msgid "[1996863](https://bugs.launchpad.net/bugs/1996863)"
+msgstr ""
+
+#: ../../22.04/2.md c608825c69644ee88bb1ee82de88aa0a
+msgid "Meta package for Sutton Balint."
+msgstr ""
+
+#: ../../22.04/2.md:107 ebfb9d4c648645cf953ebe50896bd56f
+msgid "Server and Cloud related fixes"
+msgstr ""
+
+#: ../../22.04/2.md:109 b86c4cc1148545b5bad9c6a0bbf27ab7
+msgid ""
+"These changes mainly affect installations of Ubuntu on server systems and"
+" clouds."
+msgstr ""
+
+#: ../../22.04/2.md 59e23d89a409498f90c96d83639672b9
+#: ea00845732e74da498fc44eed049a263 ed22ddf1689e4b688f0339961224809e
+msgid "google-guest-agent"
+msgstr ""
+
+#: ../../22.04/2.md 1115b44680794b5f8279328f5a865001
+#: 63e024eba2a4465da1314f7489ac6f80
+msgid "[1959392](https://bugs.launchpad.net/bugs/1959392)"
+msgstr ""
+
+#: ../../22.04/2.md 66225481b0a846ca9eefe3999738a6ef
+#: 87e89eeae975402894486debf7fe4629 8ee27e4b6b0e410586c6d7516b7a3dc8
+#: d0fd032eaf144db69ffcb942da2fe983
+msgid "No-change rebuild for Jammy."
+msgstr ""
+
+#: ../../22.04/2.md 3464fda426eb4de38d3ab1c229940cdd
+msgid "[1980725](https://bugs.launchpad.net/bugs/1980725)"
+msgstr ""
+
+#: ../../22.04/2.md 8d0e155a3fd04b23ad85cdd74c42e939
+msgid ""
+"d/rules: don't build google_authorized_keys as it conflicts with the same"
+" binary shipped by src:google-compute-engine-oslogin."
+msgstr ""
+
+#: ../../22.04/2.md 6591cbd99ffd41998b36309cbc1222db
+#: 758aa4108f0249a888b65673f9f2a3c6
+msgid "nova"
+msgstr ""
+
+#: ../../22.04/2.md 43069adfcdae4fd28a2fcc741b7924a3
+#: b83febc02adb4a99ac2c864c9f67abe9 f97a362b750a4fe8aac0b1ac2c7cf95f
+msgid "[1980369](https://bugs.launchpad.net/bugs/1980369)"
+msgstr ""
+
+#: ../../22.04/2.md 01b6a060cd49402f8fbfadd3083b2052
+#: 0be5a02a2623452e8be4cc02d4ad857c 2738c7d08c8443df9092d7a5d76e4f14
+#: 2ee562ff5513401eb7904b3556a81fc0 5ec217e03e334165aec6df1d02a78514
+#: 72ff070613904233923c6bac22188a6c 773ee35a267046d8807ff60bc86d379c
+#: 8fb4dff34fce43a389dda6dec0bf16c0 eb7714a3b51e42c9bd185c9ffccad467
+#: f5ebd98743964948955d72b61b183fe2
+msgid "New stable point release for OpenStack Yoga."
+msgstr ""
+
+#: ../../22.04/2.md 5c97e3042a3d4306901062438d8b9798
+msgid "glance"
+msgstr ""
+
+#: ../../22.04/2.md ce2c70dc5cd643feae1e5e6a3c3c1867
+msgid "designate"
+msgstr ""
+
+#: ../../22.04/2.md 890e65639dd2452997b999f36bd258ef
+#: 90aa149a1ec34ccb8d2e3ca1e5571926 b3d530b5f3ea416184e888dd8dbfdb3e
+#: cc9c77f3d0e344efb807fd69e010bc5d
+msgid "openvswitch"
+msgstr ""
+
+#: ../../22.04/2.md 50cb13f25b574ade83e60db80c0c9957
+msgid "[1980211](https://bugs.launchpad.net/bugs/1980211)"
+msgstr ""
+
+#: ../../22.04/2.md 0c4dfdfbc92e45d6a1eca30a6db4b88a
+msgid "New upstream point release."
+msgstr ""
+
+#: ../../22.04/2.md 0ac56a0f41bd47998ae6d2a22a92ef9d
+msgid "[1980809](https://bugs.launchpad.net/bugs/1980809)"
+msgstr ""
+
+#: ../../22.04/2.md 22555326955a425a922cb670d30c77e5
+msgid ""
+"d/p/0001-ovsdb-idl-Support-write-only-changed-IDL-monitor-mod.patch: "
+"Cherry pick feature to improve scalability and performance which is "
+"required for OVN 22.03.1."
+msgstr ""
+
+#: ../../22.04/2.md 300cbb7a1bba4290a6190669f87d7fe3
+#: cfee2c20a6994816bb781ee8c0a4aba7
+msgid "frr"
+msgstr ""
+
+#: ../../22.04/2.md 075ec394bf38437ab5c2e248ecd36214
+msgid "[1958162](https://bugs.launchpad.net/bugs/1958162)"
+msgstr ""
+
+#: ../../22.04/2.md 70d407b2927d4887baed3ab0d0fb6e74
+msgid "Fix logging with Ubuntu's unprivileged rsyslog:"
+msgstr ""
+
+#: ../../22.04/2.md 6d1230aec43f475db5b0f3cf2ce767dc
+msgid "isc-dhcp"
+msgstr ""
+
+#: ../../22.04/2.md 2071882589ac4615864422c09c5f76a0
+msgid "[1972029](https://bugs.launchpad.net/bugs/1972029)"
+msgstr ""
+
+#: ../../22.04/2.md 9212a2a2e1a3459d9e69038097943712
+msgid ""
+"Disable make_resolv_conf() if systemd-resolved is in use This "
+"functionality was moved from systemd 246-2ubuntu1 (enter-hook) to isc-"
+"dhcp 4.4.1-2.1ubuntu7 (exit-hook). The part overriding make_resolv_conf()"
+" was dropped, but is needed to avoid it overriding /etc/resolv.conf, "
+"managed by sd-resolved (stub-resolv.conf)."
+msgstr ""
+
+#: ../../22.04/2.md 377b6523f59544c09e9414037e255cc5
+msgid "nftables"
+msgstr ""
+
+#: ../../22.04/2.md 73e7eef37e07405c8fac696a2365c488
+msgid "[1984043](https://bugs.launchpad.net/bugs/1984043)"
+msgstr ""
+
+#: ../../22.04/2.md 3c0ab3acb12a48c9ab8b4f75eac32c22
+msgid "d/rules: ensure systemd service is restarted after upgrade"
+msgstr ""
+
+#: ../../22.04/2.md 318590fedbfd4bcb8f5554c70d9b6778
+msgid "openldap"
+msgstr ""
+
+#: ../../22.04/2.md 7f419d9bde724860b233f37869c606e4
+msgid "[1983618](https://bugs.launchpad.net/bugs/1983618)"
+msgstr ""
+
+#: ../../22.04/2.md 64655e17704e4b28813426727d50287d
+#: fd0774e303ea43298852800ed5ab1039
+msgid "New upstream version."
+msgstr ""
+
+#: ../../22.04/2.md 552d283eba66498a9142698d180c65de
+#: 8cc64df5db2b41c48e36544a5c957474 cb658895e4bc4c94b243ca4213f24143
+msgid "php8.1"
+msgstr ""
+
+#: ../../22.04/2.md 52beb22f4bf6436193d72d370370be0e
+msgid "[1882279](https://bugs.launchpad.net/bugs/1882279)"
+msgstr ""
+
+#: ../../22.04/2.md 40d680a978b843e991d690f2072a1844
+msgid ""
+"d/p/0047-Update-gcc-func-attr-macro.patch: fix detection of unknown gcc "
+"function attributes."
+msgstr ""
+
+#: ../../22.04/2.md e77c5f01757e40408ae2b4bd04783be5
+msgid "neutron"
+msgstr ""
+
+#: ../../22.04/2.md 3d49ecbd60874486a3bc461a734ce4cf
+#: 46cd3871436f4b05925c5e3ddae1052c
+msgid "[1985084](https://bugs.launchpad.net/bugs/1985084)"
+msgstr ""
+
+#: ../../22.04/2.md cb648446ef144ac3a087c86c843a147c
+msgid "python-cheroot"
+msgstr ""
+
+#: ../../22.04/2.md 9aa3dce353094a6ebbd2085256f709d9
+msgid "[1967139](https://bugs.launchpad.net/bugs/1967139)"
+msgstr ""
+
+#: ../../22.04/2.md 3f9d9a07d6384687b18842c6dfe75a45
+msgid ""
+"d/p/pep440_version_number.patch: Cherry-pick Debian patch to produce "
+"pep440 compliant versions."
+msgstr ""
+
+#: ../../22.04/2.md 2f04b0d101ad4ed1b01f3abf5cbfa9d7
+#: d3e485b99b5c43ea8134799aa467f3e1
+msgid "cinder"
+msgstr ""
+
+#: ../../22.04/2.md f06fa39c661a4d539a5bf8687a13cc9a
+msgid "pyroute2"
+msgstr ""
+
+#: ../../22.04/2.md 5741d5278b8d40dd8315cb18bda818f6
+msgid "[1985097](https://bugs.launchpad.net/bugs/1985097)"
+msgstr ""
+
+#: ../../22.04/2.md 326e794e1b284537b700e8b1c17b6672
+msgid ""
+"d/p/000*-netlink-NetlinkDumpInterrupted-exception.patch: Backport patches"
+" from 0.6.6 that introduce NetlinkDumpInterrupted exception."
+msgstr ""
+
+#: ../../22.04/2.md d51b649e24ab41efba9957495ab7f38c
+msgid "nginx"
+msgstr ""
+
+#: ../../22.04/2.md 76ef37dfb593422d90b997912af813ab
+msgid "[1981457](https://bugs.launchpad.net/bugs/1981457)"
+msgstr ""
+
+#: ../../22.04/2.md feebb5fcfe3748a2b01fc08d321ca4ac
+msgid ""
+"d/p/ssl-op-ignore-unexpected-eof-option.patch: Add compatibility flag for"
+" certain clients that don't close their connection properly."
+msgstr ""
+
+#: ../../22.04/2.md 0e689b1729a241e68882975d063ad814
+#: 364414d42a6346dba584d15ed57d7b26 3f745188ef304977a68303f3cb45738f
+#: 70676e14d42441b689b394f47b5a48a0 7f5040fe65b342348da35d87872cd643
+#: 84e2c5202cbf4359b916addd64decf04 898d3952cffc4f37bb058607c7552e5d
+#: a74a89759e3e4b85afb65ac1406ad766
+msgid "cloud-init"
+msgstr ""
+
+#: ../../22.04/2.md 7bcc29bf4fb840179d78fd545cf3bc15
+#: 88e6b0d05d704eed99ce371122637515 b928d89d665b40cdb0a353d65b215839
+msgid "[1987318](https://bugs.launchpad.net/bugs/1987318)"
+msgstr ""
+
+#: ../../22.04/2.md 2d3a058bd7204e4c9ab9e31dec2d5dff
+#: fbf29430e9064cdcb11b86c22969204d
+msgid "New upstream bugfix release."
+msgstr ""
+
+#: ../../22.04/2.md e0bdbe2983d6454a880409461eef5056
+msgid "[1986703](https://bugs.launchpad.net/bugs/1986703)"
+msgstr ""
+
+#: ../../22.04/2.md 1c0e3f2e4c4546d8bd0c948b3dccf7e2
+msgid "Release 22.3.4"
+msgstr ""
+
+#: ../../22.04/2.md 05e8ca06657a478a9497595db1b1b48d
+msgid "[1989686](https://bugs.launchpad.net/bugs/1989686)"
+msgstr ""
+
+#: ../../22.04/2.md 90636af77e5e400c93de0b03d198cce5
+msgid "Fix Oracle DS primary interface when using IMDS (#1757)"
+msgstr ""
+
+#: ../../22.04/2.md 1636ad3ea1484a99aadbaf51b8ae598f
+msgid "New upstream snapshot."
+msgstr ""
+
+#: ../../22.04/2.md 28462bb64e52470ababdeddc784460b1
+#: 4ac64bc7e6ba4fa1994db1d2684d5970 750ebd1ed4a946b4ac79688fa0670910
+#: b2bd5472f72c423ab5101b16b08e5e00
+msgid "libvirt"
+msgstr ""
+
+#: ../../22.04/2.md c8af40b5985c450d8fd01c28958a4dbc
+msgid "[1989078](https://bugs.launchpad.net/bugs/1989078)"
+msgstr ""
+
+#: ../../22.04/2.md 58551a10293e460a96e9945c768b9f20
+msgid ""
+"d/p/u/lp-1989078-apparmor-Allow-locking-AAVMF-firmware.patch: allow arm64"
+" to lock its OVMF resources"
+msgstr ""
+
+#: ../../22.04/2.md d4a2bea03b624a2192247b456fc5d98d
+msgid "[1985062](https://bugs.launchpad.net/bugs/1985062)"
+msgstr ""
+
+#: ../../22.04/2.md e91609beb6944280a28fa83990c8c458
+msgid ""
+"d/p/python-Do-not-send-non-zero-flag-for-a-SSL-socket.patch: Do not send "
+"non-zero flag for a SSL socket."
+msgstr ""
+
+#: ../../22.04/2.md b5bd620012ef4a8c8979685f2d04afe4
+msgid "[1990499](https://bugs.launchpad.net/bugs/1990499)"
+msgstr ""
+
+#: ../../22.04/2.md ec07753d86274f56adb395e45c1fd0d4
+msgid ""
+"d/p/u/lp-1990499-virt-aa-helper-allow-common-riscv64-loader-paths.patch: "
+"easen the use of riscv64 through libvirt"
+msgstr ""
+
+#: ../../22.04/2.md 3b5471eb19be4255a9581f13e41daf9e
+msgid "unbound"
+msgstr ""
+
+#: ../../22.04/2.md 24f0868b9aeb429c8f4a17728ddf17f2
+msgid "[1988055](https://bugs.launchpad.net/bugs/1988055)"
+msgstr ""
+
+#: ../../22.04/2.md a508fa5257314c00af09e5a9b01c5cf6
+msgid "Resolve interfaces using existing interface names with unbound-checkconf:"
+msgstr ""
+
+#: ../../22.04/2.md 8ff9c3a154894c0494d40d753ca8105e
+msgid "[1989196](https://bugs.launchpad.net/bugs/1989196)"
+msgstr ""
+
+#: ../../22.04/2.md a2c29ff022614ee49070473d01a717d3
+msgid "d/rules: fix PHP_EXTRA_VERSION setting."
+msgstr ""
+
+#: ../../22.04/2.md 341661625d41445f8bed32800cf36202
+msgid "python-oslo.messaging"
+msgstr ""
+
+#: ../../22.04/2.md bfb14c3f123847e9adc10fefd26156ee
+msgid "[1993149](https://bugs.launchpad.net/bugs/1993149)"
+msgstr ""
+
+#: ../../22.04/2.md 0d8d95009208478d8305c5b3ce5b5aff
+msgid ""
+"d/p/revert-limit-maximum-timeout-in-the-poll-loop.patch: This reverts an "
+"upstream patch that is preventing active/active rabbitmq from failing "
+"over when a node goes down."
+msgstr ""
+
+#: ../../22.04/2.md 2df9034f15024493afbf5bc283c84101
+msgid "nfs-ganesha"
+msgstr ""
+
+#: ../../22.04/2.md 4904e13980514677aeb7291d35181a48
+msgid "[1994699](https://bugs.launchpad.net/bugs/1994699)"
+msgstr ""
+
+#: ../../22.04/2.md 7c0180a3393148e99292e5a256d086ec
+msgid ""
+"d/p/fix-size-issue-on-arm64.patch: Cherry-pick upstream patch to resolve "
+"size issue on ARM64."
+msgstr ""
+
+#: ../../22.04/2.md 0f2f338279534dc08cdc149ca374fb43
+msgid "openvpn"
+msgstr ""
+
+#: ../../22.04/2.md bf08bbbbb62e45758c3f0daeb43db207
+msgid "[1975574](https://bugs.launchpad.net/bugs/1975574)"
+msgstr ""
+
+#: ../../22.04/2.md a3e2015ff2084c4a97af41e42c2f3871
+msgid ""
+"d/p/openssl-3/*.patch: backport upstream patch set to better support "
+"OpenSSL 3"
+msgstr ""
+
+#: ../../22.04/2.md 1d09a3bcb8c0493b9d0ad0dd9ba8c712
+msgid "netplan.io"
+msgstr ""
+
+#: ../../22.04/2.md 03bd0bfa26a242edb2c7de164de95f34
+msgid "[1988447](https://bugs.launchpad.net/bugs/1988447)"
+msgstr ""
+
+#: ../../22.04/2.md 7396f99a0a9d4ecc9d9401564ab42730
+msgid "Backport netplan.io 0.105-0ubuntu2 to 22.04"
+msgstr ""
+
+#: ../../22.04/2.md 1de5f8202b594b0c913d229afb5e67ee
+msgid "apache2"
+msgstr ""
+
+#: ../../22.04/2.md 95f7789bb8b24bb0a35b37ed396f3c5e
+msgid "[1988224](https://bugs.launchpad.net/bugs/1988224)"
+msgstr ""
+
+#: ../../22.04/2.md b687091bb3514b9abe5e4d7696dc6df8
+msgid ""
+"d/p/fix-a-possible-listener-deadlock.patch, d/p/handle-children-killed-"
+"pathologically.patch:  Fix situation where Apache fails to start its "
+"child processes after a certain number of requests, causing requests for "
+"new pages to freeze."
+msgstr ""
+
+#: ../../22.04/2.md 8925fb0ac0574b45bb84fa8dc743ef0e
+msgid "ceph"
+msgstr ""
+
+#: ../../22.04/2.md cfcc7cc0b4fb479481b771bb85f421fb
+msgid "[1986747](https://bugs.launchpad.net/bugs/1986747)"
+msgstr ""
+
+#: ../../22.04/2.md 7a1c477864374e838df96274dc45994e
+msgid ""
+"d/p/lp1986747-fix-osd-class-dir.patch: Partially revert upstream change "
+"that breaks classpath loading."
+msgstr ""
+
+#: ../../22.04/2.md 2dda2403c66c46fb840a8c8762e1b309
+msgid "rsync"
+msgstr ""
+
+#: ../../22.04/2.md 255c9a734d9540a7b09480891fe0ef05
+msgid "[1965076](https://bugs.launchpad.net/bugs/1965076)"
+msgstr ""
+
+#: ../../22.04/2.md 3859f6664a994d82bfa329433acf1c2e
+msgid ""
+"d/p/avoid_spurious_is_newer_messages_with_update.patch: New patch from "
+"upstream"
+msgstr ""
+
+#: ../../22.04/2.md 3fc141003fad4794adad0e3364c5a45f
+#: fb6c3e47e0684b3a9d3e0d6afd6c9a72
+msgid "nfs-utils"
+msgstr ""
+
+#: ../../22.04/2.md 7394f0da192a4d13a7bd986c560310d7
+msgid "[1979885](https://bugs.launchpad.net/bugs/1979885)"
+msgstr ""
+
+#: ../../22.04/2.md 572274d6bd9a4b669fed052c45c59bb8
+msgid ""
+"d/p/blkmapd-fix-invalid-free.patch: fix blkmapd crash due to invalid "
+"free()"
+msgstr ""
+
+#: ../../22.04/2.md 1bdbdb0353414ebb933772c906640b40
+msgid "nvme-cli"
+msgstr ""
+
+#: ../../22.04/2.md df70f463175a44118e46262333b51f0e
+msgid "[1980820](https://bugs.launchpad.net/bugs/1980820)"
+msgstr ""
+
+#: ../../22.04/2.md 48c557e52bc64745ab3951bddb8cf545
+msgid ""
+"Fix broken tab completions: Collapse declaration and attribute assignment"
+" and fix malformed _cmd"
+msgstr ""
+
+#: ../../22.04/2.md bccfab90d9d744dabd78c4c23228f73c
+msgid "[1990302](https://bugs.launchpad.net/bugs/1990302)"
+msgstr ""
+
+#: ../../22.04/2.md 12b5862ce92b4f9a93c3c7a43bc0dd9c
+msgid ""
+"d/p/0049-Preserve-file-position-when-php-temp-switches.patch: PHP "
+"provides a temporary data stream, php://temp, whose contents are moved to"
+" a temporary file when a predefined size limit is hit. In jammy, the file"
+" position is set to the end of the file, which results in "
+"corrupted/unwanted data. Fix this by preserving the file position in this"
+" situation."
+msgstr ""
+
+#: ../../22.04/2.md 13a69b932c824239a7b043f42fabb4c5
+#: 815e5fd666bf4b37ae62ce687875153c
+msgid "[1996645](https://bugs.launchpad.net/bugs/1996645)"
+msgstr ""
+
+#: ../../22.04/2.md 76ff7ff298f849efa72106bcfa952347
+msgid "Upstream snapshot based on 22.4.2 upstream release."
+msgstr ""
+
+#: ../../22.04/2.md 8de568c6dff44d0daad54f2916728485
+msgid ""
+"[1997559](https://bugs.launchpad.net/bugs/1997559) "
+"[1844191](https://bugs.launchpad.net/bugs/1844191)"
+msgstr ""
+
+#: ../../22.04/2.md 4ab6459d35404feda8c69cc28018fd98
+msgid "Includes (LP: #1997559, #1844191) not present in 22.4.0."
+msgstr ""
+
+#: ../../22.04/2.md 570ff5d58b284aa18ae7b88b745e015d
+msgid ""
+"Upstream snapshot based on 22.4 upstream release. List of changes from "
+"upstream can be found at https://raw.githubusercontent.com/canonical"
+"/cloud-init/22.4/ChangeLog"
+msgstr ""
+
+#: ../../22.04/2.md d3592869849e412fbfcefd00913c2077
+msgid "samba"
+msgstr ""
+
+#: ../../22.04/2.md e9535de576554e039c79a494a34a30f2
+msgid "[1993934](https://bugs.launchpad.net/bugs/1993934)"
+msgstr ""
+
+#: ../../22.04/2.md ad6f35f5aca741bb972782f62631b819
+msgid "d/p/win-22H2-fix.patch: fix interoperability with Windows 22H2 clients"
+msgstr ""
+
+#: ../../22.04/2.md ed4d79e6f55348b4bed4dd458449625b
+msgid "[1995289](https://bugs.launchpad.net/bugs/1995289)"
+msgstr ""
+
+#: ../../22.04/2.md cc16141e9ce34e2aae39d036e63ca7b2
+msgid "New upstream point release 2.17.3."
+msgstr ""
+
+#: ../../22.04/2.md bf12ddcfeaf3488db953dd932d4850ba
+msgid "[1981109](https://bugs.launchpad.net/bugs/1981109)"
+msgstr ""
+
+#: ../../22.04/2.md f858d4e7ddd64ba88d3ee566f006b85f
+msgid "Remove fwupd, modemmanager, and udisks2 from the cloud images."
+msgstr ""
+
+#: ../../22.04/2.md b2fa1141973f4f27b798772be214f0c1
+msgid "[1998229](https://bugs.launchpad.net/bugs/1998229)"
+msgstr ""
+
+#: ../../22.04/2.md 8c98bb97eae640429e6a991349097e55
+msgid "feat: Add metadata on ubuntu-oci image."
+msgstr ""
+
+#: ../../22.04/2.md 8fc068d7aea246b8ad3e6ce74e8698e3
+msgid "[1993304](https://bugs.launchpad.net/bugs/1993304)"
+msgstr ""
+
+#: ../../22.04/2.md bde7db2285fa413997344ea01c9a713f
+msgid ""
+"d/p/u/lp-1993304-apparmor-allow-getattr-on-usb-devices.patch: prevent "
+"apparmor denials on USB forwarding"
+msgstr ""
+
+#: ../../22.04/2.md a1213169c89549da9dc795ff3243481e
+msgid "[1996176](https://bugs.launchpad.net/bugs/1996176)"
+msgstr ""
+
+#: ../../22.04/2.md 46c7aede9f2f43ab9fdb6f98253117c2
+msgid ""
+"d/p/u/lp-1996176-nodedev-ignore-EINVAL-from-libudev-in-"
+"udevEventHandl.patch: tolerate the impact of too large udev data avoiding"
+" a busy loop"
+msgstr ""
+
+#: ../../22.04/2.md a97b00df43ee418fa6a3beb443b090f2
+#: bfe4544c75da454986649f42178aa0ea
+msgid "cyrus-sasl2"
+msgstr ""
+
+#: ../../22.04/2.md 4e75169eba204edabf6da5ccf28cdd57
+msgid "[1912256](https://bugs.launchpad.net/bugs/1912256)"
+msgstr ""
+
+#: ../../22.04/2.md c04baffb6f6f4707b80c415466ea78e5
+msgid "Add SASL channel binding support for GSSAPI and GSS-SPNEGO:"
+msgstr ""
+
+#: ../../22.04/2.md 604635f62401459fb610adc679b2cf23
+msgid "[1677781](https://bugs.launchpad.net/bugs/1677781)"
+msgstr ""
+
+#: ../../22.04/2.md 60c5c1ef5d1d4e8c915c046cf42308e9
+msgid "Add some DEP8 tests:"
+msgstr ""
+
+#: ../../22.04/2.md cc61c271393d48be8412e18ebdd93d02
+msgid "fence-agents"
+msgstr ""
+
+#: ../../22.04/2.md 05d2108daff44c4dbd0d6cb7395b7375
+msgid "[1990316](https://bugs.launchpad.net/bugs/1990316)"
+msgstr ""
+
+#: ../../22.04/2.md c3008ba6833e4744b0c06903036ab73d
+msgid ""
+"Update the Azure fencing agent (fence_azure_arm) to support Azure SDK "
+">=15, since this is required by python3-azure in Jammy and this fence "
+"agent doesn't work without this update."
+msgstr ""
+
+#: ../../22.04/2.md d1657e7ea40c4da5a1140d858022f969
+msgid "openssh"
+msgstr ""
+
+#: ../../22.04/2.md 26db48ff724948acba89231f5aaf6523
+msgid "[1986521](https://bugs.launchpad.net/bugs/1986521)"
+msgstr ""
+
+#: ../../22.04/2.md 53cc31ce208d4fd0a0d80bb7773a315c
+msgid ""
+"d/p/fix-poll-spin.patch: Fix poll(2) spin when a channel's output fd "
+"closes without data in the channel buffer."
+msgstr ""
+
+#: ../../22.04/2.md 3fbe6a71df57447d9dd5b93972a248ce
+#: 4fdaff608863411a881570f77ae21620 8126e82a6cf145d2927f87052468cae3
+#: b588f4f5c205401d9e119207a34e54af d473d9a225c14b5e9b09b6aa070cc13a
+#: e7a9ff7c6848421d848f871f1c65fee8
+msgid "s390-tools"
+msgstr ""
+
+#: ../../22.04/2.md 1aa391709ff44094a30ba0f4507f04b4
+#: 7b3a85ed5ca947e8a71aedf4223b8e83
+msgid "[1974109](https://bugs.launchpad.net/bugs/1974109)"
+msgstr ""
+
+#: ../../22.04/2.md c5d7ca0b4bcb47939606e68377ec69f3
+msgid ""
+"Fix zipl segfaults when \"parameters=\" is missing with: d/p/6ff8202f-"
+"zipl-Add-missing-check-for-a-nullpointer.patch"
+msgstr ""
+
+#: ../../22.04/2.md 639fe300752144ec8ebbd12ac7d9ba89
+#: bce04935f3054f2b9d294401b9cc75df
+msgid "[1959987](https://bugs.launchpad.net/bugs/1959987)"
+msgstr ""
+
+#: ../../22.04/2.md 696d7e26c857456490bf1685724cb85c
+msgid ""
+"Add KVM Secure Execution Attestation Userspace Tool to enhance secure "
+"execution (hardware feature: FC 115) exploitation with: d/p/38639269"
+"-libpv-New-library-for-PV-tools.patch d/p/3ab06d77-pvattest-Create-"
+"perform-and-verify-attestation-measu.patch d/p/26148740-pvattest-tools-"
+"Add-tool-for-attestation.patch"
+msgstr ""
+
+#: ../../22.04/2.md 017dfce0832141bab91eb088cad0ff6a
+#: afb455ca2f9242b6a1aa27bc6de0557f
+msgid "[1990520](https://bugs.launchpad.net/bugs/1990520)"
+msgstr ""
+
+#: ../../22.04/2.md 73d04f9a17fb424ca8fa03564e5d0db7
+msgid ""
+"Fix re-enciphering of EP11 identity key of KMIP plugin with: d/p/4e2ebe03"
+"-libseckey-Fix-re-enciphering-of-EP11-secure-key.patch"
+msgstr ""
+
+#: ../../22.04/2.md 0a047c11cfeb455b9c173e87a6d8b8d9
+#: 6dffb3c29479440dbb7d56e4a9c09113
+msgid "[1990524](https://bugs.launchpad.net/bugs/1990524)"
+msgstr ""
+
+#: ../../22.04/2.md 7054e0db778b4076ba4cb276b957c0c2
+msgid ""
+"Fix KMIP plugin fails to connection to KMIP server with: d/p/6c5c5f7e-"
+"libseckey-Adapt-keymgmt_match-implementation-to-Open.patch"
+msgstr ""
+
+#: ../../22.04/2.md 5358cbcabff1472595bf20f4d4571823
+#: f42c21b1ff0e4ec1b53aa671f9f42491
+msgid "[1996069](https://bugs.launchpad.net/bugs/1996069)"
+msgstr ""
+
+#: ../../22.04/2.md 25a33a8ee95d4c95bf48c8a026fc9bf9
+msgid ""
+"d/p/5768d55-zipl-boot-add-secure-boot-trailer.patch Add secure boot "
+"trailer in zipl stage 3 to keep compatibility with upcoming IBM zSystems "
+"firmware updates."
+msgstr ""
+
+#: ../../22.04/2.md 9183a5b01efc4aa187458d5b6d472a6d
+#: fae19f385de84dc29422c2a719792d69
+msgid "[1996477](https://bugs.launchpad.net/bugs/1996477)"
+msgstr ""
+
+#: ../../22.04/2.md f168d6e0e3744a33afafd5f684332bbd
+msgid ""
+"Add d/p/92b8409-dbginfo.sh-ensure-type-commands-compatible-with-"
+"dash.patch and d/p/9f93af6-dbginfo.sh-ensure-compatibility-with-bin-"
+"dash.patch to achieve dbginfo.sh compatibility with /bin/dash shell."
+msgstr ""
+
+#: ../../22.04/2.md 41aa0dd93b5e45ec9439423d7cd68eb4
+#: a6ec34b5cee44542840ceb2c9f406666 ab037c56bd174d4597d1585795d3a943
+#: c92f9fedcdaf43c0844318f2c7b19bef e0a68dd23b3d4282a840e2c37a542f2d
+#: e3922ec2391a4f2e87b4935655476a82
+msgid "s390-tools-signed"
+msgstr ""
+
+#: ../../22.04/2.md 0059ac237d0f47ce92113dafd5eab06b
+#: 1cb7ff75d1bb4813999efbfb99daf3c7 7ce886205cf24d01b71725454c1529ce
+#: 820ebc7c790b4fb391c330d7b78b9f54 8f304f23afc346fab18dc39dd4e44aec
+#: aaa515c5bc7e4a9eb91b86315e08050d
+msgid "Rebuild against 2.20.0-0ubuntu3.2: , , , , ,"
+msgstr ""
+
+#: ../../22.04/2.md e5f817bf7d604c4ba37d6f6fe5d51305
+msgid "horizon"
+msgstr ""
+
+#: ../../22.04/2.md c13d402239054f9e8ead8f08a24b88da
+msgid "[1827120](https://bugs.launchpad.net/bugs/1827120)"
+msgstr ""
+
+#: ../../22.04/2.md d143e172033a4015867c3a7ec7dd3641
+msgid ""
+"d/p/lp1827120.patch: Fix missing project_id in application credential "
+"create when user has both project+domain admin role."
+msgstr ""
+
+#: ../../22.04/2.md 6e7c950b825c4ac392a1c3688550ed5f
+msgid "postgresql-14"
+msgstr ""
+
+#: ../../22.04/2.md fb724d5b952f488d88b7f2c16df0d0f3
+msgid "[1996770](https://bugs.launchpad.net/bugs/1996770)"
+msgstr ""
+
+#: ../../22.04/2.md 62a0b276bf2342feb099b65985c0c997
+msgid "neutron-vpnaas"
+msgstr ""
+
+#: ../../22.04/2.md 4f7a08f263f048e18218423d47d4caa2
+msgid "[1995861](https://bugs.launchpad.net/bugs/1995861)"
+msgstr ""
+
+#: ../../22.04/2.md b0477eb3aaec41f094ad8f2aaed4ac8b
+msgid "barbican"
+msgstr ""
+
+#: ../../22.04/2.md 649b6f78d37448de9c9fbc062fa87890
+msgid "[1998545](https://bugs.launchpad.net/bugs/1998545)"
+msgstr ""
+
+#: ../../22.04/2.md 88dc04fc882e47e2a4b0dc7b1d6c2cff
+msgid "google-compute-engine-oslogin"
+msgstr ""
+
+#: ../../22.04/2.md 6d45da4a7c904f528a6fe718d1124440
+msgid "[1995620](https://bugs.launchpad.net/bugs/1995620)"
+msgstr ""
+
+#: ../../22.04/2.md f6056a75a9cc4a4e8b07ad0cd5931979
+msgid "google-osconfig-agent"
+msgstr ""
+
+#: ../../22.04/2.md 00076b9c07154b35a7666474dd48f3c9
+msgid "[1996735](https://bugs.launchpad.net/bugs/1996735)"
+msgstr ""
+
+#: ../../22.04/2.md a5e11572262540a88b5f5f23802f8bb0
+msgid "mysql-8.0"
+msgstr ""
+
+#: ../../22.04/2.md a92258f578c34d5c9711138b7c1756a1
+msgid "[2003835](https://bugs.launchpad.net/bugs/2003835)"
+msgstr ""
+
+#: ../../22.04/2.md a1c1eab835594d449382c6b5c16504ba
+msgid "SECURITY REGRESSION: Regression with PyMySQL"
+msgstr ""
+
+#: ../../22.04/2.md 63473dacf9f843c4ba4ec86f58cf959a
+#: e3f2037e69fe4af895668849294c00d9
+msgid "[2004030](https://bugs.launchpad.net/bugs/2004030)"
+msgstr ""
+
+#: ../../22.04/2.md 8dcbbc9dc7aa4ad7843956aedb3c0d1b
+msgid "swift"
+msgstr ""
+
+#: ../../22.04/2.md 5e9db3c1e24a4c0ba32897743e23faff
+msgid "[2006534](https://bugs.launchpad.net/bugs/2006534)"
+msgstr ""
+
+#: ../../22.04/2.md 0a72b088cbb0484c9bad51f0c254a3b4
+msgid "squid"
+msgstr ""
+
+#: ../../22.04/2.md 2bf42af2662c4898949e50e47e3ac5d7
+msgid "[1989380](https://bugs.launchpad.net/bugs/1989380)"
+msgstr ""
+
+#: ../../22.04/2.md 1532845e9385466b88502ce8db24dace
+msgid ""
+"d/p/close-tunnel-if-to-server-conn-closes-after-client.patch: Close "
+"tunnel \"job\" after to-server client connection closes, fixing memory "
+"leak."
+msgstr ""
+
+#: ../../22.04/2.md:190 09b8447379fd4c929e12e4616b3d0398
+msgid "Base platform fixes"
+msgstr ""
+
+#: ../../22.04/2.md:192 d9e6dfc3df794cf698f6813930345531
+msgid ""
+"These changes affect the core fundamental components of all the Ubuntu "
+"flavors."
+msgstr ""
+
+#: ../../22.04/2.md 030fb97323a9418d8efc4eb9f368889e
+#: 32bec14327624697a23218d64d4e2973 32ca407a6df24c1eb391f4410b1b3dce
+#: 40077006fb464cbba2a53b91e44d76d6 60fd03475e7a4d97aeb13257bda96d3a
+msgid "snapd"
+msgstr ""
+
+#: ../../22.04/2.md af2dba1591354eb4bb0839d9e1c0f54a
+msgid "[1983528](https://bugs.launchpad.net/bugs/1983528)"
+msgstr ""
+
+#: ../../22.04/2.md 2f28b1aaa91143a3b9a884b8a227af69
+msgid ""
+"Cherry pick https://github.com/snapcore/snapd/pull/12011 to fix launching"
+" snaps OEM install"
+msgstr ""
+
+#: ../../22.04/2.md dc447107fb4b46f2b40a2af8ea09e06b
+msgid "[1974147](https://bugs.launchpad.net/bugs/1974147)"
+msgstr ""
+
+#: ../../22.04/2.md 0c1406bfd6df4cdc8311c74df621f8f4
+#: 2e4c0b0013624900bb41da4c2bbdb7dd ad2a010995f44812a1c979b2a792cf7a
+#: b2c29863d1ab4f13a042e6c063e83b0c
+msgid "New upstream release,"
+msgstr ""
+
+#: ../../22.04/2.md ad8706419bcf4c20a84d27c63521da15
+msgid "cryptsetup"
+msgstr ""
+
+#: ../../22.04/2.md 502dbc9c72484718be457a3faea94a5d
+msgid "[1979159](https://bugs.launchpad.net/bugs/1979159)"
+msgstr ""
+
+#: ../../22.04/2.md 5339ac054faa459bb4eeec029cbdecf8
+msgid ""
+"d/initramfs/hooks/cryptroot: Include OpenSSL legacy.so for ripemd160 and "
+"whirlpool hash algorithms"
+msgstr ""
+
+#: ../../22.04/2.md b3db35b9b5604de9ba5b0d91056693a3
+#: fa62844d0ea6484a826f1fdda693fb10
+msgid "llvm-toolchain-13"
+msgstr ""
+
+#: ../../22.04/2.md 042dad4044a74bc49e4580da55fdab69
+msgid "[1973037](https://bugs.launchpad.net/bugs/1973037)"
+msgstr ""
+
+#: ../../22.04/2.md 4189a185756144ef94b56d614c69388a
+msgid "Backport D115098 for Rust 1.59"
+msgstr ""
+
+#: ../../22.04/2.md ce1faa91099d486b9f96f503b441ca7d
+msgid "[1973041](https://bugs.launchpad.net/bugs/1973041)"
+msgstr ""
+
+#: ../../22.04/2.md f937e899fa0446b6bc2bffcfe862047c
+msgid ""
+"d/p/risc/riscv-insn-support.patch: Backport assembler .insn support on "
+"riscv64 for rustc 1.59.0"
+msgstr ""
+
+#: ../../22.04/2.md 06e14fef0d0342458934ffee511b4b3a
+#: 0ef714914eaf453da5fed2810a48922d 19d78ac1ed23473e9bedfebfe54bcca0
+#: 1c86e758be5240e7ac95ce1935f15167 1cee5be0cacf4536b53b86423cb16d74
+#: 2364da2fffbd430591cc8f50853eca35 3327cab9c3b14701b5b5d9165ca80a4d
+#: 38ef4dea2797456882117e5f895bb9cc 3a9033d03df04af492413b3a064e247c
+#: 450868aec57246d9a012ecff8d1d255f 4c89417e89294598b207bdf55eb31260
+#: 5e4166bcee12430298e3480d4d9d1cf4 5ecac6f961a849ffa71071b682265056
+#: 620c150cec99474892ff9dc4be811771 6267d8c382f14efba8df5de417b2e7d5
+#: 71f28ca475ee4c33b1c6ddbd31e4157d 73a6a75e011d4e7f974d6bcd584d4217
+#: 785c3fc3ee404a54b06a46b332fadeab 8256390f06374ecdb4b45e5812fa752d
+#: 85201d960ce1430088b07477e9433aa4 8815490cc1af4e3fbeec6caa8898d316
+#: 9650445adb224a3eadc94156a3ac4c4f a05c15cce3d346869ce9b13eb286cc15
+#: a2b321d8968749ed8d6983b4ad215adc b4340824ff1f438ba6c246c7b5bed9f6
+#: bd23942ce49c40abba2e9916755fea35 ccd12e938ef444d88c38ba740ccdfdb5
+#: ceb6359155b94b20b225a8df8bebf30b d83cbb60b01e433881006cbe5007fc0d
+#: db72ca30eac04817a1fa0de0a875345f ebfdef6c7230496484596cf6ba70120f
+#: ec230c72e8f04680b30542afca2873c4
+msgid "ubuntu-advantage-tools"
+msgstr ""
+
+#: ../../22.04/2.md 917dd72b60374293ae05a6d8d57a48e3
+#: 976c500795a047a9b09990e3fd3c8f7d
+msgid "[1980990](https://bugs.launchpad.net/bugs/1980990)"
+msgstr ""
+
+#: ../../22.04/2.md 01ef16f3211241199aad7faf11a3f774
+#: 37f9e8b04d8342159206cf59addac954 7e159486505046098728e9bc7a772528
+#: 9040c9da5bdc4117b4e9f6c6bc62976f b499f04b53cb4c6e9eb0fb90e75cab7b
+#: e190605a9bce4997b432fd125b8f81a7
+msgid "Backport new upstream release: to jammy"
+msgstr ""
+
+#: ../../22.04/2.md 3cd2a20f4def483a84571e9102fdfbc0
+msgid "New upstream release 27.10"
+msgstr ""
+
+#: ../../22.04/2.md 64c8683c62374cc49b9f9a45cf928331
+msgid "[1980865](https://bugs.launchpad.net/bugs/1980865)"
+msgstr ""
+
+#: ../../22.04/2.md c487acd4cbec43c780b99949615de75c
+msgid "daemon: do not try enabling daemon during auto-attach"
+msgstr ""
+
+#: ../../22.04/2.md 2890af77480a47a799ac5885b4dada64
+#: 6869275dfa4542268cb42959e6a70674 6d72bc0923a64ce2993defaec1b778fe
+#: 8fcdc638481844b19c6b0281581afcb5 b8df1103b81d479aa50101a6a6242084
+#: bbac3d6dddea425b8c02794336dc9012
+msgid "tzdata"
+msgstr ""
+
+#: ../../22.04/2.md 6a1f8840675f4bb99807aaf30707b25a
+msgid "[1986984](https://bugs.launchpad.net/bugs/1986984)"
+msgstr ""
+
+#: ../../22.04/2.md 44a409bb50784d1c9f6f83d8f7505635
+msgid "gcc-12"
+msgstr ""
+
+#: ../../22.04/2.md 05d4cf07a2bc4820ae4c4d16d886f531
+#: 07f61fbe856c4b999e3f9812c74bdf22 3038b9d97d54407696b1d41a20a23d86
+#: 40075f86976c418a97144943cc56d390
+msgid "[1970233](https://bugs.launchpad.net/bugs/1970233)"
+msgstr ""
+
+#: ../../22.04/2.md b570e39991f446fa96c67e2122b7a35a
+msgid "SRU: . Backport GCC 12.1.0 to 22.04 LTS."
+msgstr ""
+
+#: ../../22.04/2.md 8508f95be44947698d88a85284bfa1d7
+msgid "gcc-12-cross"
+msgstr ""
+
+#: ../../22.04/2.md d8d4f1f62d164246b5addb4076c6cf84
+msgid "SRU: : Build using GCC 12.1.0 for 22.04 LTS."
+msgstr ""
+
+#: ../../22.04/2.md 2d27ee4378d445eaabee7057f834dea5
+#: 4ffa0819e86742b0becfd180d98eb5cb 5a919a24f0154bf78d68df3cd87fd955
+#: 66a8d6e245714236b44d8cb262a0ff1a 81141d5e50dd48f88931020a46025645
+#: 94575838a855420d849a015254461402 97538e463f4b4ed884231ec5ebbcebd4
+#: 9898c59f0ce846859e1afca8848697f4 f08bce007bd54b3eb526a62f61aeef83
+msgid "systemd"
+msgstr ""
+
+#: ../../22.04/2.md 90c4925c1bc34ca69fcc8c41250fcf85
+msgid "[1988994](https://bugs.launchpad.net/bugs/1988994)"
+msgstr ""
+
+#: ../../22.04/2.md c726ea1e7c2346e385e9155657f5d9ba
+msgid ""
+"Deny-list TEST-58-REPART on ppc64el File: debian/patches/lp1988994-Deny-"
+"list-TEST-58-REPART-on-ppc64el.patch https://git.launchpad.net/~ubuntu-"
+"core-"
+"dev/ubuntu/+source/systemd/commit/?id=d2ed3cc1d223bf35015b15ff83b50156b58f0f38"
+msgstr ""
+
+#: ../../22.04/2.md 7a7c53e226574c019d54db81b42fbf92
+msgid "[1975667](https://bugs.launchpad.net/bugs/1975667)"
+msgstr ""
+
+#: ../../22.04/2.md e1a1d1b9db8a4275a2ad69866f0c5bbc
+msgid ""
+"Ensure dns_search_domain_unlink_marked removes all marked domains File: "
+"debian/patches/lp1975667-Ensure-dns_search_domain_unlink_marked-removes-"
+"all-marked.patch https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=919d5ddedd5bb8b45ab9437bf42d66c2821bb074"
+msgstr ""
+
+#: ../../22.04/2.md e93caf49e3484c8f889fcb1d62c701f3
+msgid "[1981042](https://bugs.launchpad.net/bugs/1981042)"
+msgstr ""
+
+#: ../../22.04/2.md 74061d38814b491ab41f7df977cea46a
+msgid ""
+"core,firstboot: workaround timezone issues on Ubuntu Core Thanks to "
+"Robert Ancell for preparing the patch. File: debian/patches/lp1981042"
+"-core-firstboot-workaround-timezone-issues-caused-by-Ubunt.patch "
+"https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=b15546361b549217908fb6ca5d473be23d7fa757"
+msgstr ""
+
+#: ../../22.04/2.md 6896b5f00ac347128ba1eb3f5820b0af
+msgid "[1979951](https://bugs.launchpad.net/bugs/1979951)"
+msgstr ""
+
+#: ../../22.04/2.md 64017e075e714df08dc0726e1321e03f
+msgid ""
+"network: do not remove localhost address File: debian/patches/lp1979951"
+"-network-do-not-remove-localhost-address.patch https://git.launchpad.net"
+"/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=2cd88391cce9fe95a486ae6dd214c12f236f3881"
+msgstr ""
+
+#: ../../22.04/2.md 78d7623d67f045d6a1c6a6874edb24ed
+msgid "[1982462](https://bugs.launchpad.net/bugs/1982462)"
+msgstr ""
+
+#: ../../22.04/2.md 5a80f7fb29004c3488a1514b9c10591d
+msgid ""
+"units: remove the restart limit on the modprobe@.service File: "
+"debian/patches/lp1982462-units-remove-the-restart-limit-on-the-"
+"modprobe-.service.patch https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=8f0acd1b2fbb8eed1259c34963e5e9b201bef900"
+msgstr ""
+
+#: ../../22.04/2.md a03038872c2846719c73841dcec25a31
+msgid "[1981622](https://bugs.launchpad.net/bugs/1981622)"
+msgstr ""
+
+#: ../../22.04/2.md 0c5ed079cbc14fa495e83041a4556ee4
+msgid ""
+"pstore: do not try to load mtdpstore File: debian/patches/lp1978079-efi-"
+"pstore-not-cleared-on-boot.patch https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=15225032c3657f5906ee49d48929f9295a8664a0"
+msgstr ""
+
+#: ../../22.04/2.md 38682e846e87445b80ef2c4414c3ae75
+msgid "[1979952](https://bugs.launchpad.net/bugs/1979952)"
+msgstr ""
+
+#: ../../22.04/2.md 4d64caaf73c245b19f68c814d2570d59
+msgid "core/mount: downgrade log level about several mkdir failures Files:"
+msgstr ""
+
+#: ../../22.04/2.md 16a72989b4234182bad050eb40d35891
+msgid "[1988078](https://bugs.launchpad.net/bugs/1988078)"
+msgstr ""
+
+#: ../../22.04/2.md 0457467db7294256a70b5a63b737aea3
+msgid "hwdb: implement --root option for systemd-hwdb query Files:"
+msgstr ""
+
+#: ../../22.04/2.md 4adb019ce53c4a848d27253768ddf124
+msgid "[1897932](https://bugs.launchpad.net/bugs/1897932)"
+msgstr ""
+
+#: ../../22.04/2.md d3478b1f803442d7a2b95668b51fc0a3
+msgid ""
+"Enable systemd-repart and ship it in a new systemd-repart package. Add "
+"fdisk as test dependency, needed by test-repart which calls sfdisk. Add "
+"libfdisk-dev/libssl-dev as dependencies, needed for systemd-repart. "
+"Author: Luca Boccassi Files:"
+msgstr ""
+
+#: ../../22.04/2.md 9c53b6fb029a448f870abae3d34901e4
+msgid "gzip"
+msgstr ""
+
+#: ../../22.04/2.md 7642a118655743bfada32657b5acc77c
+msgid "[1966849](https://bugs.launchpad.net/bugs/1966849)"
+msgstr ""
+
+#: ../../22.04/2.md 2330fdb86c4147989ca76bc824f3e8f4
+msgid ""
+"Cherry-pick upstream patch to use more portable alignment to resolve "
+"failure to execute on WSL1. https://github.com/microsoft/WSL/issues/8219"
+msgstr ""
+
+#: ../../22.04/2.md ded3f204c49d42bfb2c7fb5cb784e2a6
+msgid "[1990684](https://bugs.launchpad.net/bugs/1990684)"
+msgstr ""
+
+#: ../../22.04/2.md 615819aa54294cd3b204e3ecaf497a65
+msgid "Check state of dependency, not dependee in dependency keep back"
+msgstr ""
+
+#: ../../22.04/2.md 0737a2d5596c4ff7adefbdfda376fa7e
+msgid "[1990586](https://bugs.launchpad.net/bugs/1990586)"
+msgstr ""
+
+#: ../../22.04/2.md ac5713ba9e9f4c61abb0ed59b5b68ee1
+msgid "full-upgrade: Mark phased upgrades for keep before anything else"
+msgstr ""
+
+#: ../../22.04/2.md 24a540351b1f4c9990dc1726f569cfb3
+#: 257e9af3866e4ccd9803fdeff193e144 4af3b4154e7e4e899be1261214867bfe
+#: 6da4b01d8b894849b7f322700b892a34 76f49d15041c4896937319e8a6eab4b2
+#: d52d242ec8844066adc655b9200700f0 eda7d39a43b84c148c7c3fd4e4260a92
+#: fa0e5ca0773d442f90c60fe59adf4e98
+msgid "adsys"
+msgstr ""
+
+#: ../../22.04/2.md d061baf1cca94bcf941d293285ea9acd
+msgid "[1982330](https://bugs.launchpad.net/bugs/1982330)"
+msgstr ""
+
+#: ../../22.04/2.md 879b0a1e293b46d09cec19c6c2c9680c
+msgid "Fix loading policy content from uppercase folders"
+msgstr ""
+
+#: ../../22.04/2.md 31efae95e98442f08a0fc223de4d2390
+msgid "[1982349](https://bugs.launchpad.net/bugs/1982349)"
+msgstr ""
+
+#: ../../22.04/2.md 04b721eca7504279b4901f1bd21899f1
+msgid "Add GSettings power management keys"
+msgstr ""
+
+#: ../../22.04/2.md b54becb6330b4cfe9eb8cf72852f2d18
+msgid "[1982342](https://bugs.launchpad.net/bugs/1982342)"
+msgstr ""
+
+#: ../../22.04/2.md 044cba8189e949368a2c15952c72e00c
+msgid "Allow parsing policy entries with empty values"
+msgstr ""
+
+#: ../../22.04/2.md 3ff5d49de02848baa9db7f5f69e1a31f
+msgid "[1982343](https://bugs.launchpad.net/bugs/1982343)"
+msgstr ""
+
+#: ../../22.04/2.md a09e6bd56a974bbb94fedab7f8162569
+msgid "Allow parsing policies with unsupported types"
+msgstr ""
+
+#: ../../22.04/2.md cae99a4442f741a885e2cec6e29a7f92
+msgid "[1982345](https://bugs.launchpad.net/bugs/1982345)"
+msgstr ""
+
+#: ../../22.04/2.md 58ff2def6cd7488584f743b6517823d9
+msgid "Allow parsing policy entries with no data"
+msgstr ""
+
+#: ../../22.04/2.md 461f0aee38524af5b5c70e01270b91ef
+msgid "[1982347](https://bugs.launchpad.net/bugs/1982347)"
+msgstr ""
+
+#: ../../22.04/2.md 3964800df4734413b3f28651b021f13d
+msgid "Lowercase target name when normalizing"
+msgstr ""
+
+#: ../../22.04/2.md 0ab852830bea404ba61314d2b1f7130f
+msgid "[1982348](https://bugs.launchpad.net/bugs/1982348)"
+msgstr ""
+
+#: ../../22.04/2.md 04b2cac75a624b7aabccfcf1367c5335
+msgid "Annotate policies that require Ubuntu Pro"
+msgstr ""
+
+#: ../../22.04/2.md 00775dff359043e8b6423168abb31e27
+msgid "[1982351](https://bugs.launchpad.net/bugs/1982351)"
+msgstr ""
+
+#: ../../22.04/2.md fb2b3d07488742c2857aaf8f5f6d7ca4
+msgid "Add Active Directory Watch Daemon - adwatchd:"
+msgstr ""
+
+#: ../../22.04/2.md 47f34b4f48c54370947e82bb81a348eb
+msgid "[1977745](https://bugs.launchpad.net/bugs/1977745)"
+msgstr ""
+
+#: ../../22.04/2.md 1528bf81410c4d4397c4a76492b2940b
+msgid "rpc.svcgssd fixes and improvements:"
+msgstr ""
+
+#: ../../22.04/2.md 0c7ef0b1c6704a94861e1f2381ab8511
+#: f32ed7177fec495b965fe967bb670ae2
+msgid "[1991173](https://bugs.launchpad.net/bugs/1991173)"
+msgstr ""
+
+#: ../../22.04/2.md 61276d1f830246da9bcc3bfb0c1b8839
+msgid "New upstream release 27.11.2:"
+msgstr ""
+
+#: ../../22.04/2.md a65193b8c98744baae41cf120f88e8cd
+msgid "[1990907](https://bugs.launchpad.net/bugs/1990907)"
+msgstr ""
+
+#: ../../22.04/2.md 68a00a8671e2498aaf131d7e20c8f65a
+msgid "New upstream release 27.11.1:"
+msgstr ""
+
+#: ../../22.04/2.md a4815b05347d45289c5e3b324c466c38
+msgid "[1989279](https://bugs.launchpad.net/bugs/1989279)"
+msgstr ""
+
+#: ../../22.04/2.md 8f6be08f1a494be3943e40c9dc95f91a
+msgid "New upstream release 27.11"
+msgstr ""
+
+#: ../../22.04/2.md e5c5bfdb03c94c178f40d44defb3e163
+msgid "[1985863](https://bugs.launchpad.net/bugs/1985863)"
+msgstr ""
+
+#: ../../22.04/2.md ef6ee1a5963149a0b17ab2ce2f9f58fc
+msgid "fix apt auth line replacement"
+msgstr ""
+
+#: ../../22.04/2.md 4b44cf47d6774a608910caf6c8184e63
+msgid "sosreport"
+msgstr ""
+
+#: ../../22.04/2.md 2f89e0be1696423793984c2857392ec1
+msgid "[1986611](https://bugs.launchpad.net/bugs/1986611)"
+msgstr ""
+
+#: ../../22.04/2.md 238da841cdcd41ab872e39c6e3a44276
+msgid "New 4.4 upstream."
+msgstr ""
+
+#: ../../22.04/2.md b5beb9b97eee4f6199f224f6a00bc6a5
+msgid "`sudo`"
+msgstr ""
+
+#: ../../22.04/2.md 2ff75fa4da704b068f28306db7c82a0c
+msgid "[1958055](https://bugs.launchpad.net/bugs/1958055)"
+msgstr ""
+
+#: ../../22.04/2.md 2d03e27cb2d8481db1c68599d54b5bd0
+msgid ""
+"Add XDG_CURRENT_DESKTOP to initial_keepenv_table for Qt to determine the "
+"correct theme"
+msgstr ""
+
+#: ../../22.04/2.md 35f82be1642140df902b7b45d37862c3
+#: 57f56869871149bbaacaa4ac74eb1e03
+msgid "[1983035](https://bugs.launchpad.net/bugs/1983035)"
+msgstr ""
+
+#: ../../22.04/2.md d91b1231f5054342bd5b0075602f3e51
+msgid "gcc-11"
+msgstr ""
+
+#: ../../22.04/2.md a94f2224c4a24678a3961faf51febf75
+msgid "SRU: . Backport GCC 11.3.0 to 22.04 LTS."
+msgstr ""
+
+#: ../../22.04/2.md 3470f72b9d9d4ec2a6eac835c1a828a9
+msgid "gcc-11-cross"
+msgstr ""
+
+#: ../../22.04/2.md 4fc54b9f472343dcb549ca5daf712fc3
+msgid "SRU: : Build using GCC 11.3.0 for 22.04 LTS."
+msgstr ""
+
+#: ../../22.04/2.md 30c55d80da6845c08191e50c6dcfe201
+#: ac7c7c23ff8d4794b12f8e1b272eeffd cfdf53f961544259874881a960432429
+msgid "binutils"
+msgstr ""
+
+#: ../../22.04/2.md b1548de71a934b05b485767589c020dc
+msgid "[1982105](https://bugs.launchpad.net/bugs/1982105)"
+msgstr ""
+
+#: ../../22.04/2.md 51f0000fa42244d483a2f07167afb117
+msgid "SRU: . Update from the binutils 2.38 branch:"
+msgstr ""
+
+#: ../../22.04/2.md 365950269e3949078461f289fcf7f615
+msgid "[1974115](https://bugs.launchpad.net/bugs/1974115)"
+msgstr ""
+
+#: ../../22.04/2.md bf83a7f11a61478abe42e744801219e1
+msgid "IBM zSystems: Add support for z16 as CPU name. ."
+msgstr ""
+
+#: ../../22.04/2.md d1af18178ef14e2fa0c0fbeae3d3f418
+msgid "[1978129](https://bugs.launchpad.net/bugs/1978129)"
+msgstr ""
+
+#: ../../22.04/2.md 0e48c6fedfce4573abeb6be8cbcdfd7a
+msgid "PowerPC64 DT_RELR relative reloc addresses. ."
+msgstr ""
+
+#: ../../22.04/2.md cd366065c72c4275aa04981909a2fb26
+msgid "edk2"
+msgstr ""
+
+#: ../../22.04/2.md b1839c6a4e4645519440dcf353c15e51
+msgid "[1986692](https://bugs.launchpad.net/bugs/1986692)"
+msgstr ""
+
+#: ../../22.04/2.md 50e666ea9d4d437fa12686a8f1df408c
+msgid ""
+"Enroll snakeoil keys w/ EnrollDefaultKeys.efi --no-default, fixing a "
+"regression introduced with the transition to edk2-vars-generator.py. ."
+msgstr ""
+
+#: ../../22.04/2.md 767d575b9eaf498e840f415afce97a21
+msgid "sssd"
+msgstr ""
+
+#: ../../22.04/2.md 676e3518e3fb4a619c6cfa58089b5dd8
+msgid "[1989356](https://bugs.launchpad.net/bugs/1989356)"
+msgstr ""
+
+#: ../../22.04/2.md 4b5d506a87cf463eaf5bf3e3dcd2cedc
+msgid ""
+"d/p/initialize-uid-gid-main-functions.patch: Initialize UID/GID variables"
+" in \"main\" functions, preventing inadvertent changes in p11_child.log "
+"file permissions."
+msgstr ""
+
+#: ../../22.04/2.md b53069b397444532a2353695b7678f1c
+msgid "[1992692](https://bugs.launchpad.net/bugs/1992692)"
+msgstr ""
+
+#: ../../22.04/2.md d68345db51794783848ddd855f8e8c33
+msgid "New upstream releases:"
+msgstr ""
+
+#: ../../22.04/2.md ad0df6465526442f8dcea22499b58caa
+msgid "[1969671](https://bugs.launchpad.net/bugs/1969671)"
+msgstr ""
+
+#: ../../22.04/2.md 2dd619dbdbbf4a14b6c6e027ff495a19
+msgid "Simplify three Ukraine zones into one."
+msgstr ""
+
+#: ../../22.04/2.md 1609520fc6da4551979f9bd87242f15e
+msgid "distro-info-data"
+msgstr ""
+
+#: ../../22.04/2.md dffb756d2a49463ba0b51ba64400ca2e
+msgid "[1993667](https://bugs.launchpad.net/bugs/1993667)"
+msgstr ""
+
+#: ../../22.04/2.md 70518dcb1ebf4cdc8fabf4d98e1c96ee
+msgid "Add Ubuntu 23.04, Lunar Lobster"
+msgstr ""
+
+#: ../../22.04/2.md c590ce266d574cf2aa06da307ec8ac9d
+msgid "[1995209](https://bugs.launchpad.net/bugs/1995209)"
+msgstr ""
+
+#: ../../22.04/2.md 4a3d02379804469899b32e19b6989412
+msgid "[1993006](https://bugs.launchpad.net/bugs/1993006)"
+msgstr ""
+
+#: ../../22.04/2.md fb7a0b40bdb045fdba13f1edcd8f7c9e
+msgid "[1995601](https://bugs.launchpad.net/bugs/1995601)"
+msgstr ""
+
+#: ../../22.04/2.md 1fb02a40d5f04ebfb96a05b57060f169
+msgid "Update ICU data to 2022f"
+msgstr ""
+
+#: ../../22.04/2.md 5e37c760df6b4a9d80532b4c9a8bc82c
+msgid "runc"
+msgstr ""
+
+#: ../../22.04/2.md 2420182e9b2e41549547a4200889daf2
+msgid "[1993221](https://bugs.launchpad.net/bugs/1993221)"
+msgstr ""
+
+#: ../../22.04/2.md 4f5bf4dba4494f3b994329e60f5282ba
+msgid ""
+"d/p/fix_cpuset_range_byte_order.patch: fix byte order while parsing "
+"cpuset range to bits"
+msgstr ""
+
+#: ../../22.04/2.md 00ccd726d4854e2e938e1f83f988e071
+#: 16a0574a546d48ac8bb9d598803048f5 509fcef2707b448cbbc0f4ccb8254350
+#: 564ffb30de3b4c2db0d9aa1c91892e60 60ecaf20cf004366a8c9cdfc72c76c43
+#: 6304959fac0f469ba6a752cf1cbc0fe2 88715fd12fd64a3dbcb3019cb4b568bd
+#: 95f3b1fa9a8040a48021296c0ca39a74 c62e85c64bb04abf9a23abbf38a060a8
+#: fd62553c11c2495c96c4b1f24f7c5ffe
+msgid "apport"
+msgstr ""
+
+#: ../../22.04/2.md 935aad01d03f460e91acb3391d6b56e6
+msgid "[1962454](https://bugs.launchpad.net/bugs/1962454)"
+msgstr ""
+
+#: ../../22.04/2.md 991be6c7b4e3417f982a399a68ba6363
+msgid "Grab a slice of JournalErrors around the crash time"
+msgstr ""
+
+#: ../../22.04/2.md cbbf9f9cfac94b3f9c68bda0b2c8a64b
+#: fd4571cf92b444fa8a43ae3b7452b02b
+msgid "[1989467](https://bugs.launchpad.net/bugs/1989467)"
+msgstr ""
+
+#: ../../22.04/2.md f97a0c6ef2514dca8fcb73dfa514818c
+msgid "Initialize error log as first step"
+msgstr ""
+
+#: ../../22.04/2.md 3468b9fbd33e4ddeb03390389deb64c3
+msgid "[1982487](https://bugs.launchpad.net/bugs/1982487)"
+msgstr ""
+
+#: ../../22.04/2.md bd0da5406bdb457d9b6890d3436b544b
+msgid "Fix PermissionError for setuid programs inside container"
+msgstr ""
+
+#: ../../22.04/2.md f6913a56e79b4ff4b479888b8967a247
+msgid "[1982555](https://bugs.launchpad.net/bugs/1982555)"
+msgstr ""
+
+#: ../../22.04/2.md c08ea7ff93364e7e80f703ab2cbf2d24
+msgid "Fix reading from stdin inside containers"
+msgstr ""
+
+#: ../../22.04/2.md e0651a0b706146e3ab7f2402f80d1595
+msgid "Fix autopkgtest test case failures:"
+msgstr ""
+
+#: ../../22.04/2.md fc3f2d4e5e4a4aee87bcc460a48e0d72
+msgid "golang-1.17"
+msgstr ""
+
+#: ../../22.04/2.md 388c941948ab4e3f9ad1f96e3a847dc6
+msgid "[1990893](https://bugs.launchpad.net/bugs/1990893)"
+msgstr ""
+
+#: ../../22.04/2.md eaf4957a9e434346b32ad3a7c648dab7
+msgid "Merge from Debian unstable. Remaining changes:"
+msgstr ""
+
+#: ../../22.04/2.md 098543bcb94f4fadb33fb8ccbabbeeb2
+#: 33746d445e564db1bd7c17bbfca527da
+msgid "[1996424](https://bugs.launchpad.net/bugs/1996424)"
+msgstr ""
+
+#: ../../22.04/2.md 12b687301670463da01843a86bc6d2dd
+msgid "New upstream release 27.12:"
+msgstr ""
+
+#: ../../22.04/2.md ae5fce399a094cd99de467fc3a5add4a
+msgid "ca-certificates"
+msgstr ""
+
+#: ../../22.04/2.md f720b4435e8041998588bfcf371134d1
+msgid "[1998785](https://bugs.launchpad.net/bugs/1998785)"
+msgstr ""
+
+#: ../../22.04/2.md 33bd24f75436453dafecf3b5ca0c699a
+msgid "Add Trustcor root certificates to `mozilla/blacklist.txt`:"
+msgstr ""
+
+#: ../../22.04/2.md 437a27da295e4929946f5bf42fad1784
+msgid "python3.10"
+msgstr ""
+
+#: ../../22.04/2.md 5c65281edddb4e69a4501e29d30a3fd5
+msgid "[1995197](https://bugs.launchpad.net/bugs/1995197)"
+msgstr ""
+
+#: ../../22.04/2.md 92c5578ace7840e9bfcc5ffd4abac1fa
+msgid ""
+"debian/patches/CVE-2022-37454.patch: fixes buffer overflow in "
+"Modules/_sha3/kcp/KeccakSponge.inc."
+msgstr ""
+
+#: ../../22.04/2.md 3c24a9981b6a4324b28b682f6f275d4f
+msgid "[1998321](https://bugs.launchpad.net/bugs/1998321)"
+msgstr ""
+
+#: ../../22.04/2.md 133af27423a846b2bbe547b978aba4fe
+msgid "Update the ICU timezone data to 2022g"
+msgstr ""
+
+#: ../../22.04/2.md f47ca13206cf4a4da935164fdec2015b
+msgid "python-tz"
+msgstr ""
+
+#: ../../22.04/2.md 5d2452e3d7524826bfefddbff5977cde
+msgid "[1995864](https://bugs.launchpad.net/bugs/1995864)"
+msgstr ""
+
+#: ../../22.04/2.md 91a8398d02604c4cb5dfc0b08ef9ce7c
+msgid "Update timezones to tzdata 2022f"
+msgstr ""
+
+#: ../../22.04/2.md 9a1c4072de854fbaaa994c24dfb92de0
+msgid "initramfs-tools"
+msgstr ""
+
+#: ../../22.04/2.md 0ae72974374d44b58dfc395c867c41c0
+msgid "[1981385](https://bugs.launchpad.net/bugs/1981385)"
+msgstr ""
+
+#: ../../22.04/2.md 6986fd7db9b24d1c887785891680e119
+msgid ""
+"Backport pmem support from kinetic by adding the nvdimm, dax, and nfit "
+"modules"
+msgstr ""
+
+#: ../../22.04/2.md 0c3b4b576ab84c77bb3aa6c126c04632
+msgid "[1947425](https://bugs.launchpad.net/bugs/1947425)"
+msgstr ""
+
+#: ../../22.04/2.md 23533d418e444df7a4618dc9848ff4f9
+msgid "Replace deprecated 'imp' module"
+msgstr ""
+
+#: ../../22.04/2.md 5e315b4803724fd9957f6534f5aa3178
+msgid "[1964828](https://bugs.launchpad.net/bugs/1964828)"
+msgstr ""
+
+#: ../../22.04/2.md 20030cc2678745369d44376f9bf84014
+msgid "Fix KeyError: 'CasperMD5json'"
+msgstr ""
+
+#: ../../22.04/2.md dc556f7975de48b9933ba27a79944ec4
+msgid "[1967965](https://bugs.launchpad.net/bugs/1967965)"
+msgstr ""
+
+#: ../../22.04/2.md e666e3678574490195895ad2e28effe7
+msgid "apport-kde: Fix inverse order of choices"
+msgstr ""
+
+#: ../../22.04/2.md 1031dceafa1545e3a19a361f8be30f51
+msgid "[1889443](https://bugs.launchpad.net/bugs/1889443)"
+msgstr ""
+
+#: ../../22.04/2.md 42d8e0039ea44eef8cad2408d993759d
+msgid "apport-unpack: Fix ValueError: ['separator'] has no binary content"
+msgstr ""
+
+#: ../../22.04/2.md 25dfa9059eaf4ed6a92267c75ea402e0
+msgid "[1992172](https://bugs.launchpad.net/bugs/1992172)"
+msgstr ""
+
+#: ../../22.04/2.md 8a7e9de45d70484498fa47bec760de6e
+msgid "Determine source package dynamically in test_run_crash_kernel"
+msgstr ""
+
+#: ../../22.04/2.md 0930e2f5331143518b9f8411f87aea21
+#: 3ed747342b8b403ebe10dff1d10bdd8a 65820346c1304fb9a17f69e339fb18e7
+#: 8273b089fcf24ed79130e62f9c379b70 e03c8a85332f45239724931b5f00be67
+msgid "update-notifier"
+msgstr ""
+
+#: ../../22.04/2.md 93a1c2badbf5429480f9939b1f34e038
+msgid "[1999567](https://bugs.launchpad.net/bugs/1999567)"
+msgstr ""
+
+#: ../../22.04/2.md f6f2a4c6dfde439bbb2138023470dd8b
+msgid "bring translations from Launchpad"
+msgstr ""
+
+#: ../../22.04/2.md 074c855db6c34202877e0dccb92fd39c
+msgid "[1991030](https://bugs.launchpad.net/bugs/1991030)"
+msgstr ""
+
+#: ../../22.04/2.md c7949af951644001bfc179d43832adc8
+msgid "Modify ua status call to pro status"
+msgstr ""
+
+#: ../../22.04/2.md 290144e20380409e9e2043974b84c6f4
+msgid "[1980368](https://bugs.launchpad.net/bugs/1980368)"
+msgstr ""
+
+#: ../../22.04/2.md 895c38c8b8f7448f8e00cda9f0268dae
+msgid "Update the ESM service name and description for the apt_check.py script."
+msgstr ""
+
+#: ../../22.04/2.md 6cdbdcb1e22a435c931bfa31d74973cd
+#: b376a6f0bdb846b5a66b0b68618fdcac
+msgid "ca-certificates-java"
+msgstr ""
+
+#: ../../22.04/2.md 1b86f93ee8bc4b1192ba90ff15602c13
+#: 766717b3888a479d9d47773db913c7d9
+msgid "[1998065](https://bugs.launchpad.net/bugs/1998065)"
+msgstr ""
+
+#: ../../22.04/2.md d6869340a0374abcab47b192dc613675
+msgid ""
+"debian/jks-keystore.hook: Support locating Java 18-21 to avoid java not "
+"found message."
+msgstr ""
+
+#: ../../22.04/2.md d540e36daa73441a9f95eb95e49a8d15
+msgid ""
+"debian/postinst: Support locating Java 18-21. Use setup_path() from "
+"20220719. (Closes )"
+msgstr ""
+
+#: ../../22.04/2.md 1131ace9442e43d49a9990f24dd7eaa6
+#: 5ccf76f659b14ae5bb796ce1eae44153
+msgid "[2003018](https://bugs.launchpad.net/bugs/2003018)"
+msgstr ""
+
+#: ../../22.04/2.md 430349203e904a65999d946d01266621
+msgid "[1990378](https://bugs.launchpad.net/bugs/1990378)"
+msgstr ""
+
+#: ../../22.04/2.md ccba9cf2a8ea4c7a9c7321a55011aeac
+msgid "remove unauthenticated esm repos from Xenial systems"
+msgstr ""
+
+#: ../../22.04/2.md c35755bfef47495d9bd6306983dca94f
+msgid "New upstream release 27.13"
+msgstr ""
+
+#: ../../22.04/2.md f3cd3ae38b5e439997d0c54d91e2a786
+msgid "[1997514](https://bugs.launchpad.net/bugs/1997514)"
+msgstr ""
+
+#: ../../22.04/2.md e163c10993784e1f99e74c69113cdcde
+msgid "attach: support attaching without being able to install snapd"
+msgstr ""
+
+#: ../../22.04/2.md 98055ca2ac924457935f8ccfee182e6e
+msgid "[1994480](https://bugs.launchpad.net/bugs/1994480)"
+msgstr ""
+
+#: ../../22.04/2.md 73816bcc035c4c6e8495714d5b814968
+msgid "messaging: do not fail if the apt-hook executable is not present"
+msgstr ""
+
+#: ../../22.04/2.md 7c4b361109e143cea52c4e5d74608413
+msgid "[2002407](https://bugs.launchpad.net/bugs/2002407)"
+msgstr ""
+
+#: ../../22.04/2.md bec3259435ba4cbab0a531463d9c5aef
+msgid "redesign output to properly show support"
+msgstr ""
+
+#: ../../22.04/2.md 4523faccef584775bc9a4e46c465d955
+#: ffaf336453dd4feebedf5b9c24886c58
+msgid "[2003977](https://bugs.launchpad.net/bugs/2003977)"
+msgstr ""
+
+#: ../../22.04/2.md ed344e0f2c9d4da28eb020724675660c
+msgid ""
+"avoid a dpkg conf prompt if the only change to the original config file "
+"was to the apt_news flag"
+msgstr ""
+
+#: ../../22.04/2.md 4b615e7a279b4519bd3b5a13fe75719b
+msgid "[2004057](https://bugs.launchpad.net/bugs/2004057)"
+msgstr ""
+
+#: ../../22.04/2.md 7bc43b1a8a9c499e8161860f1eddff9d
+msgid ""
+"only run the pro client pre-update hook services when the apt update is "
+"executed as root user"
+msgstr ""
+
+#: ../../22.04/2.md f13e934921964844967a313cfdc1822f
+msgid "[1998462](https://bugs.launchpad.net/bugs/1998462)"
+msgstr ""
+
+#: ../../22.04/2.md 666445e9a02e40ce95063907e328e77f
+#: b9acccbdf9f64f899bb044fd008d80db
+msgid "[2004130](https://bugs.launchpad.net/bugs/2004130)"
+msgstr ""
+
+#: ../../22.04/2.md 153b8124ad59477c98df129bbb2962e0
+#: 9daac5d8053f45a2bf82a0e569bed1ab
+msgid "Backport new upstream release: ( and ) to jammy"
+msgstr ""
+
+#: ../../22.04/2.md 3bfcd55188194c1593ab7b839df72d16
+#: 43c888c83d5e42f5b47905fd78e15940
+msgid "[2004279](https://bugs.launchpad.net/bugs/2004279)"
+msgstr ""
+
+#: ../../22.04/2.md 18b5e7314df440538078ce1b57aa17cd
+msgid "d/ubuntu-advantage-tools.preinst:"
+msgstr ""
+
+#: ../../22.04/2.md c15faefbb6f142c8bdb4279298a26e4e
+msgid ""
+"Catch errors when esm.ubuntu.com is unreachable to avoid causing crash "
+"reports and degraded systemd status from this non-critical service"
+msgstr ""
+
+#: ../../22.04/2.md 07750ae0bff646038f1d8ead316d95c4
+msgid "[2003543](https://bugs.launchpad.net/bugs/2003543)"
+msgstr ""
+
+#: ../../22.04/2.md b9a2a925de3d4a9f9a190a4a5653ff42
+msgid ""
+"po/*.po: do not translate template variable needed for package-data-"
+"downloader script"
+msgstr ""
+
+#: ../../22.04/2.md 3cf70ff6b1fc4682bafc308dce643d0e
+msgid "[2002168](https://bugs.launchpad.net/bugs/2002168)"
+msgstr ""
+
+#: ../../22.04/2.md eb6aa2dfcd3a4fb6bedd3cf5412c0a00
+msgid "Rely on the Pro Client apt esm cache to check for esm updates"
+msgstr ""
+
+#: ../../22.04/2.md 924cec05eff44ffcb891d283d9a112a3
+msgid "[2006765](https://bugs.launchpad.net/bugs/2006765)"
+msgstr ""
+
+#: ../../22.04/2.md ffc32b863b4640b0b0851e1bdcbd87bb
+msgid "fix version for cleaning the esm-apps stale unauthenticated files"
+msgstr ""
+
+#: ../../22.04/2.md d9f862477c5a47c1807b6a347960d503
+msgid "[2004193](https://bugs.launchpad.net/bugs/2004193)"
+msgstr ""
+
+#: ../../22.04/2.md c15fbf05dbd847439bdcf7994d42350f
+msgid "remove stale esm-apps unauthenticated caches"
+msgstr ""
+
+#: ../../22.04/2.md b4bff7a402634775a266c58f8f4e1df6
+msgid "[2006510](https://bugs.launchpad.net/bugs/2006510)"
+msgstr ""
+
+#: ../../22.04/2.md 511ff2e7a318438ab439cccb49bfbcf3
+msgid ""
+"Change esm-apps advertisement message on apt upgrade to make it clearer "
+"that the service is providing more upgrades and not restricting user to "
+"only get updates if esm-apps is enabled"
+msgstr ""
+
+#: ../../22.04/2.md 7e7efe28861342a98ba1d6c685d62946
+msgid "[2006351](https://bugs.launchpad.net/bugs/2006351)"
+msgstr ""
+
+#: ../../22.04/2.md 744810a111b1430e8bc321a638493a1f
+msgid ""
+"make code aware that the effective date is not a required field in the "
+"machine-token.json file"
+msgstr ""
+
+#: ../../22.04/2.md bbda332726724e4e85d5477bfa2d5e94
+msgid "[2006508](https://bugs.launchpad.net/bugs/2006508)"
+msgstr ""
+
+#: ../../22.04/2.md 9c95f049065740c890a628173b6191f6
+msgid "do not fail if we cannot extract information from /etc/os-release file"
+msgstr ""
+
+#: ../../22.04/2.md f992d38d8ddf42d7b95aa4a6dcd78ddb
+msgid "[2006049](https://bugs.launchpad.net/bugs/2006049)"
+msgstr ""
+
+#: ../../22.04/2.md 92407744b19747dfa08676eda518c31a
+msgid "consider packages without a candidate as 'unknown'"
+msgstr ""
+
+#: ../../22.04/2.md 8b130036162f4ed9a0d3c4a9276a3b8d
+msgid "[2004650](https://bugs.launchpad.net/bugs/2004650)"
+msgstr ""
+
+#: ../../22.04/2.md 1a982a052ac142a3a3f5eb84e768c417
+msgid "treat null effective contract dates as unknown/expired"
+msgstr ""
+
+#: ../../22.04/2.md 940bed81a0314b3a916aee109847c99a
+msgid "[2006261](https://bugs.launchpad.net/bugs/2006261)"
+msgstr ""
+
+#: ../../22.04/2.md b901bf5e1a7b47108286ee4ce5903feb
+msgid "recycle invalid jobs-status.json file if we detect it is corrupted"
+msgstr ""
+
+#: ../../22.04/2.md 0319873e221b4ad4af9fed70ce028a14
+#: 1a415618761e41a3aa1bee82911d8e9a
+msgid "grub2-unsigned"
+msgstr ""
+
+#: ../../22.04/2.md 2aef7662c30645cfa73bf74892109e76
+#: 46ab3d46b4ab4d258078a86565d871ba 4b3b2691e0d44825b1818783339ddd39
+msgid "[1842320](https://bugs.launchpad.net/bugs/1842320)"
+msgstr ""
+
+#: ../../22.04/2.md 6ee0a2487fa44d45ae7c94b3e7b93b19
+msgid "Allocate initrd > 4 GB"
+msgstr ""
+
+#: ../../22.04/2.md 157441f90de2451aa28b9a1a6bdc2026
+msgid "Cherry-pick all the 2.12 memory management changes"
+msgstr ""
+
+#: ../../22.04/2.md ba811820f1554a199f820bd481a84cbb
+#: c72ab40e685f44ea964926e00f9be1ee
+msgid "grub2-signed"
+msgstr ""
+
+#: ../../22.04/2.md 2cb65ed6409643589af2f23ac02471ef
+msgid "Build against grub2 2.06-2ubuntu14.1"
+msgstr ""
+
+#: ../../22.04/2.md 49af4bc1b1ec4cb0a6e754befd88da26
+msgid "fwupd-efi"
+msgstr ""
+
+#: ../../22.04/2.md c5e1916b6fab440b8c1d7cfc785e67ba
+#: f8b1121c0bf74dd990dc56706ce7eb7f
+msgid "[2003365](https://bugs.launchpad.net/bugs/2003365)"
+msgstr ""
+
+#: ../../22.04/2.md 86ffd230376e4b7781d3fe618165d83f
+msgid "No-change rebuild for 2022v1 resigning"
+msgstr ""
+
+#: ../../22.04/2.md 672c52fbc90b40298cf3328ebbd49438
+msgid "fwupd-signed"
+msgstr ""
+
+#: ../../22.04/2.md 250af85b0f8346b5b7dcb93f77ab7b7a
+msgid "Rebuild for 2022v1 resigning"
+msgstr ""
+
+#: ../../22.04/2.md de47d616f1b44c1c9947185c1ff26850
+msgid "cd-boot-images-amd64"
+msgstr ""
+
+#: ../../22.04/2.md 7eae6c12ea1047ecb542ae85435578fb
+#: af90a07370174f039c71a538ccd73d58 bf4d026066f24b3d8f2a376918a70838
+#: ec35b338c8d941719bcda3aa11d8c7fd
+msgid "[2004164](https://bugs.launchpad.net/bugs/2004164)"
+msgstr ""
+
+#: ../../22.04/2.md 1c4ede539bd348ac80d7402648832208
+#: 81f3c986d83c4e09a6c4fc25b06f1cdf
+msgid "shim 1.51.3+15.7-0ubuntu1"
+msgstr ""
+
+#: ../../22.04/2.md daece6c57ee44691a25e4055800c0646
+msgid "cd-boot-images-arm64"
+msgstr ""
+
+#: ../../22.04/2.md 1b26dee0cba54c249e6d6b1c6cbbc833
+msgid "cd-boot-images-ppc64el"
+msgstr ""
+
+#: ../../22.04/2.md 7a931536c3b34341b13d0571b6ae885c
+msgid "Rebuild against grub2 2.06-2ubuntu7.2."
+msgstr ""
+
+#: ../../22.04/2.md 19962c107ca14bd5aa4588be4dfd6d04
+#: 427a895aba9a42deb6b92826e8dd42bf
+msgid "cd-boot-images-riscv64"
+msgstr ""
+
+#: ../../22.04/2.md bd98c16178554f2bad1cdd38bdc5a886
+msgid "Rebuild against latest grub2 and u-boot."
+msgstr ""
+
+#: ../../22.04/2.md 3f9864e1b5c947d2a953062c42b8e579
+msgid "ubuntu-advantage-desktop-daemon"
+msgstr ""
+
+#: ../../22.04/2.md 6b3bd757750d4a0798ff9fda0dd85cc1
+msgid "[1990368](https://bugs.launchpad.net/bugs/1990368)"
+msgstr ""
+
+#: ../../22.04/2.md fb75c73da4ab49aabb97aa217ede820d
+msgid "Rename 'Ubuntu Advantage' to 'Ubuntu Pro'"
+msgstr ""
+
+#: ../../22.04/2.md:311 4abfdd8fc9f64895a519f628edb573a1
+msgid "Kernel and Hardware support updates"
+msgstr ""
+
+#: ../../22.04/2.md:313 c2e00dcbacf54ed3a0c5195229fa49c8
+msgid ""
+"Considerable work has been done on improving support for many specific "
+"items of hardware."
+msgstr ""
+
+#: ../../22.04/2.md d6a32a82927c409b9a1d6ccc6558ae32
+msgid "linux-restricted-modules-aws"
+msgstr ""
+
+#: ../../22.04/2.md 1d2a252d64e540efaacc279d1a3365c8
+#: 5aec3118dd6246c898be202a8b48d816 a7284d738e95465a82d0a7776f1785b3
+#: b617bf1f290a4fd59b4ad5abff4a41c6
+msgid "[1980240](https://bugs.launchpad.net/bugs/1980240)"
+msgstr ""
+
+#: ../../22.04/2.md 102235cfe3484ac69248bd3dbc1c4109
+#: 1b6fd381d9484e368a4dff8b9fad988e 374549a0999b41b7adb76032d1bca984
+#: f43b19501612445aaca46abdde6f2a3e
+msgid "Enable arm64 LRM builds if missing"
+msgstr ""
+
+#: ../../22.04/2.md c8a416b14a2d419ca32e602f3b10ed57
+msgid "linux-restricted-modules-azure"
+msgstr ""
+
+#: ../../22.04/2.md 2c06004065ea41419c8e427a31e059e5
+msgid "linux-restricted-modules-gcp"
+msgstr ""
+
+#: ../../22.04/2.md 1f1aa555bbb14131a418d4db7544058f
+#: 28c7b638220c498e9f2bd5794416ed7e 33e6995c8eb145e99985b63f657681d7
+#: 3dc7e99dff4c4f588021837db4538039 4aaac3eeffd54e8ea6af1eb9c8620ad2
+#: 5a22932218a442859dde4fdb30f2e6b6 6f01205033a14a28aea8805c9cbd2f83
+#: 78cdbed185fd4c4e801f1c3ca222e4fa 8973f8db16874262a65dd5efce120cc7
+#: d00d8e65abbe42589c7bdad61a0f742c d1a01b48b8784c3080792155cab15015
+#: e2de14f24f374c888ef7db634e4c2e86
+msgid "linux-intel-iotg"
+msgstr ""
+
+#: ../../22.04/2.md 7372220863314c30981e03c613c0ecd2
+#: ad382c118d7948278f4b3a20b15779d3 dba844ebd13847d484a5086d0baff133
+msgid "[1971699](https://bugs.launchpad.net/bugs/1971699)"
+msgstr ""
+
+#: ../../22.04/2.md 188be63bf7f74dbcadd5b35124c05dac
+#: 1d270b9bed8c48d8b1960bd17f4ac270 2e0322d8685b4a3c957c0d78fd34e4e7
+msgid "disable Intel DMA remapping by default"
+msgstr ""
+
+#: ../../22.04/2.md 208882cf5f5d4deabe319e5d527e0283
+#: 946146443a98444996b9fe230af74878
+msgid "[1964983](https://bugs.launchpad.net/bugs/1964983)"
+msgstr ""
+
+#: ../../22.04/2.md 1b945cdfd8a6468f9fdf546d52fd8ada
+#: d70e13fcbea948fbb8a1b1865f637c6a
+msgid "IPU6 camera has no function on Andrews MLK"
+msgstr ""
+
+#: ../../22.04/2.md dc82727f71ab4d69a24240c3eac7330f
+msgid "[1978610](https://bugs.launchpad.net/bugs/1978610)"
+msgstr ""
+
+#: ../../22.04/2.md 670a283a756f4c26889909426fecce0d
+msgid "jammy/linux: 5.15.0-40.43 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 217da43844e9465898b7a8b5cee812d5
+msgid "[1972899](https://bugs.launchpad.net/bugs/1972899)"
+msgstr ""
+
+#: ../../22.04/2.md 2360e6c75ea84394bcc26571e0673d06
+msgid "Regression] Real-time Kernel Build Failure"
+msgstr ""
+
+#: ../../22.04/2.md bb0d0757bddd475685ec6ebea9d7c585
+msgid "linux-restricted-modules-oracle"
+msgstr ""
+
+#: ../../22.04/2.md 01197369a9ee4d40999bb87b28e8c8e4
+#: 0d6fa4a570b54ffd82c510043ac01bc7 1bf98890fc5b49fe82562d8e26e34d16
+#: 342d6510637545ac99c87daf4ba1f3c4 5ab120017da043019b52ea27f1d07abd
+#: 5c646305cfa5404ea50a863d66892896 7629eaa24f4242aa83ffc364d40ce71f
+#: 928a211fc9ad4737bd626821a5fb0f9e 93391c15b91f43589d91a14784da5849
+#: 9e4a2dcbcb8543c5977fd6c9370b7d06 a3cd4875d3044264abcbb2ecef3ce064
+#: a8847c1faf3947f189d02f2c342c8606 c64bbb8c4c774c869f64ef217a5e0f1a
+#: c77f4e0c8a6a401f8d6378a4380f6c7f cbbbb12313754e0ebe6467f3e9a61e1f
+msgid "linux-firmware"
+msgstr ""
+
+#: ../../22.04/2.md 49e52440b4504422ac138178634019b3
+msgid "[1981922](https://bugs.launchpad.net/bugs/1981922)"
+msgstr ""
+
+#: ../../22.04/2.md 74cbd188d3494275948f35f9cd69ef26
+msgid "Upgrade yellow carp DMCUB firmware to fix suspend failure"
+msgstr ""
+
+#: ../../22.04/2.md a2cbe52ff0dc452b9b38530b00a68886
+msgid "thermald"
+msgstr ""
+
+#: ../../22.04/2.md 46894e70c0fd42deab5a91da13fbbc67
+msgid "[1981525](https://bugs.launchpad.net/bugs/1981525)"
+msgstr ""
+
+#: ../../22.04/2.md 3c89fa499ce84ef88efc0b7ece9ed137
+msgid "Add support for Raptor Lake CPUs."
+msgstr ""
+
+#: ../../22.04/2.md 0187692556824243b47e4ea318f7cf40
+#: 27e3c5ba657e4d7883807af50f6fb67a
+msgid "kdump-tools"
+msgstr ""
+
+#: ../../22.04/2.md 2f5dfb390a0f479dabc6b495451e81b7
+msgid "[1978333](https://bugs.launchpad.net/bugs/1978333)"
+msgstr ""
+
+#: ../../22.04/2.md 8610fc41ee204c3395e3007fcc6654c6
+msgid "debian/rules: Remove \"ata_piix.prefer_ms_hyperv=0\""
+msgstr ""
+
+#: ../../22.04/2.md 2824b98baed7424aae1bca56b66bce61
+#: 2b4639f2a860425198a691ed7bcf9211 aaeb33e2a29447fcb13bbab67e78761b
+#: aea8b474367a4d97a834e0b8e0abd198 af52b969ef0f45179f718c46d84dc665
+#: c359e45a2a51434cba9fbc94fd960abf
+msgid "linux-allwinner-5.17"
+msgstr ""
+
+#: ../../22.04/2.md 4a9e449c419146a586eb446bd52280fb
+msgid "[1983904](https://bugs.launchpad.net/bugs/1983904)"
+msgstr ""
+
+#: ../../22.04/2.md 896e961ac4af4468b86772fbc2a66e1b
+msgid "jammy/linux-allwinner-5.17: 5.17.0-1005.5 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md d2db3529b9d84b40a1ce5ffcb109d089
+msgid "[1980594](https://bugs.launchpad.net/bugs/1980594)"
+msgstr ""
+
+#: ../../22.04/2.md 68e03b543cda457085d3bf6075f8f5ec
+msgid "/usr/lib/u-boot/qemu-riscv64_smode/uboot.elf cannot be booted with KVM"
+msgstr ""
+
+#: ../../22.04/2.md 923a622b0e914b9c85b89d397d0ec9ae
+#: a3f23d1cd0db4aac966c6becf120389f d8c8fbd837ed42bb8cd707f128cc6e54
+msgid "[1983907](https://bugs.launchpad.net/bugs/1983907)"
+msgstr ""
+
+#: ../../22.04/2.md 968cc62a686d4eb6aca41a3e3f725b4e
+#: b5bdc3ac302841478035ca4cb9aea772 db987bcb57c54a2faf465553566a80f6
+msgid "jammy/linux-hwe-5.17: 5.17.0-8.8~22.04.8 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 475e6b8f2bde4bc19959f04953ec552a
+#: 57352877e5e0462f907076499c68d354 73ad61719a2d499d927f6b2a8afe26dd
+#: bde82645a23d4562843ddd6f325b62fc fcb0bf94a1bb417bab0f0280007087dd
+msgid "linux-starfive-5.17"
+msgstr ""
+
+#: ../../22.04/2.md e3ed35cd9f0840378a60998ca9d277ae
+msgid "[1983906](https://bugs.launchpad.net/bugs/1983906)"
+msgstr ""
+
+#: ../../22.04/2.md aa42aad6877b4dd39861df22cde375de
+msgid "jammy/linux-starfive-5.17: 5.17.0-1007.8 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 59e557638b454ca181f417a3cdbbc555
+msgid "autofs"
+msgstr ""
+
+#: ../../22.04/2.md 739368a1d9744c8a97ce6266d66b0535
+msgid "[1982219](https://bugs.launchpad.net/bugs/1982219)"
+msgstr ""
+
+#: ../../22.04/2.md bb65a049a4f9422db8c79a34f783830f
+msgid ""
+"`d/p/autofs-5.1.8-ldap-kerberos-leads-to-automount-hang-p.patch`: fix "
+"lock imbalance"
+msgstr ""
+
+#: ../../22.04/2.md 16d3af10bb734085a402c016a642e453
+#: 210798e022e745f1884afa3a99ba6ae5 297d134d2df44a57a03b86c94473a108
+#: 2bd6402a66974b448ae0828e3215fbf7 340605a77ab1466898c5e292795bbd37
+#: 446f0bf63e42457eaee27258a73d4535 4dcc7c05f65e4e62923efe984a396304
+#: aa1ad3852d884b87b8d3212d80c9066c beab16f1546b44c5a9938d5b1983197e
+#: c95e40427edf4c5cbf8fd83f48d5ae26 de073b056ef64d4a8c9cae493dff349a
+#: e5b9a5ce234a4664a5f68593a8846674
+msgid "linux-oem-5.17"
+msgstr ""
+
+#: ../../22.04/2.md 807dc055dd94461a9e3cbdd4304536ff
+msgid "dmidecode"
+msgstr ""
+
+#: ../../22.04/2.md 53a2298843b842c288df93903d3c3d69
+msgid "[1986852](https://bugs.launchpad.net/bugs/1986852)"
+msgstr ""
+
+#: ../../22.04/2.md 1583501d4a5d4c25bcc2a9f2c3b4cd36
+msgid "Support SMBIOS 3.4 and 3.5 for Hardware Enablement in 22.04 LTS"
+msgstr ""
+
+#: ../../22.04/2.md df459929ed324c1ba4cfdc606477007b
+msgid "[1986743](https://bugs.launchpad.net/bugs/1986743)"
+msgstr ""
+
+#: ../../22.04/2.md 40f84208028a47e7928c173867a07285
+msgid "REQUEST add meson vdec firmware to arm64 linux-firmware package"
+msgstr ""
+
+#: ../../22.04/2.md 7293177e886f4a4a86524b37b48c517f
+msgid "[1983291](https://bugs.launchpad.net/bugs/1983291)"
+msgstr ""
+
+#: ../../22.04/2.md 48d5c16b2fbf460cad73226ffa7aba6b
+msgid "Update firmware for DCN316/GFX1037"
+msgstr ""
+
+#: ../../22.04/2.md 6184e0ed36664299a4167afbba4cfca9
+msgid "[1984004](https://bugs.launchpad.net/bugs/1984004)"
+msgstr ""
+
+#: ../../22.04/2.md c2a1e91bf13041cc81d7bc331b45348e
+msgid "Linux Firmware drops AMD RX6650 XT Performance"
+msgstr ""
+
+#: ../../22.04/2.md 0023dea07aab4efa851d0a2118e6510b
+#: 606b4bb4fb724d7ba7a0affadbcacbf8
+msgid "systemd-hwe"
+msgstr ""
+
+#: ../../22.04/2.md 679b08b3a5394368a6c2c9ea5805dea7
+msgid "[1981599](https://bugs.launchpad.net/bugs/1981599)"
+msgstr ""
+
+#: ../../22.04/2.md 51272148c32a4faa91e77b827352e382
+#: a07e293c78944d5090621b8fd6d38c6f be046a64b7364d51a4f37b4ac97067f2
+#: c6d614994e8a465db0b54b709dc2f5c7
+msgid "Initial release."
+msgstr ""
+
+#: ../../22.04/2.md f768893cf2324691a55ffab0d09e36ed
+msgid "[1981971](https://bugs.launchpad.net/bugs/1981971)"
+msgstr ""
+
+#: ../../22.04/2.md 25a183ab9e9a4ca28500801c592650ef
+msgid ""
+"IOTG][EHL][ICL-D] Gstreamer media failures on Ubuntu 20.04 LTS Desktop "
+"Alpha Image"
+msgstr ""
+
+#: ../../22.04/2.md 394d9e52a64c49d4a3a533bd723ee543
+#: e92b5de445ae44a58af0f23edb6d3370
+msgid "[1964770](https://bugs.launchpad.net/bugs/1964770)"
+msgstr ""
+
+#: ../../22.04/2.md 1aebe68092624752b3d083e361cc02a6
+msgid "EHL] Implement PWM support for Elkhart Lake (out-of-tree patches)."
+msgstr ""
+
+#: ../../22.04/2.md 57c1b4a22e6845c5980e7d27e380f1b6
+msgid "[1964743](https://bugs.launchpad.net/bugs/1964743)"
+msgstr ""
+
+#: ../../22.04/2.md 18daebf60562469f9d55fda7b54aeb12
+msgid "TGL] EDAC support OOT patches"
+msgstr ""
+
+#: ../../22.04/2.md 8767792c486c414bb2ada166fa4dea0a
+msgid "[1972136](https://bugs.launchpad.net/bugs/1972136)"
+msgstr ""
+
+#: ../../22.04/2.md 1e359a63ceb941589765d82cab5aeb9d
+msgid "iotg][22.04LTS][server][CBRD] call trace message for dwmac_intel module."
+msgstr ""
+
+#: ../../22.04/2.md 048e505a08aa4586b882c3e78c949146
+#: 06e0c16c49af40d89af843136778e530 07b3d7ebc0f542589369b574d664fed2
+#: 10399a9bb4ef431b909a814ec0f3bc65 15ad830ed6024d4da156a4cdac4eda15
+#: 1cc01f0df3ee4179878c94cb61862be1 1f04cb0c86074f8d809a653e02d229d7
+#: 24043878c6584fa0982ec8dfed1e0894 25021021ca58435fa8210071a584157a
+#: 2631cee8629a4dcb9c3e9eced902544b 2bb7211127d34a9ab65c6247c2f4d830
+#: 35856b6b7c344684a5ccc5091798cb3f 365fba7def0e4788be9e54ea44b99481
+#: 65007c49e1e84acf8754a286d8b4436f 764d3372b94e4bdb959c3f76e27ea454
+#: 7b5f6e030636464aa4d7024dde9d4a4c 86a2d10d29754b39b053c81e2079cbfc
+#: 8e050712068b47bba19c9854f707f1a1 a75e7b3bfa9240f0b77df31cec57f0e0
+#: b44dd14190cd43cfb09600db09eb4624 b942cd218da14156b6f61d1751834b97
+#: b95d8c9f4af24ef9947b6a13ad12d7f6 c51e1c482bde43b69bf698406b0f0d48
+#: cf0bcbeeec9049488f91a0c05fcef70d e5395d7e793048be9d8af0b3d4c84e82
+#: e80918d635714739938b090268df7158 eb0133e42f1f49e9a1ae8252b0295a17
+#: ee4a4932bd16414bb2605d652fc3b972 f01fe3d35ce14c0fb386f66e0abc1773
+#: f9b580ecd0f14d14b82c864c7486987f
+msgid "linux-azure-fde"
+msgstr ""
+
+#: ../../22.04/2.md c9166fb4ab324c50b3705dbb0cd9e408
+msgid "[1987553](https://bugs.launchpad.net/bugs/1987553)"
+msgstr ""
+
+#: ../../22.04/2.md 00a767cb7f444bec968547acf97b702b
+msgid "jammy/linux-azure-fde: 5.15.0-1019.24.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 232299e4c88e468684eb8f2df62a36b5
+#: 4247bb5cd4594e85ad40da3cd9db2771 5194c6d8188c4b1db5202a281820de9a
+#: 985ef3de6f4c4304a507d628113c396f b148b7ef68844031a518c5f6fbe65aa4
+#: b72e5f172d6140fbb29668f8fc9a0123 bfb715eb6ab24b25aec4e56d45d80e71
+#: eddc44c930b24ff29d896d9815bc9b2b
+msgid "linux-azure"
+msgstr ""
+
+#: ../../22.04/2.md 1b776594d7d04fbcb0f00e8058a03620
+msgid "[1986713](https://bugs.launchpad.net/bugs/1986713)"
+msgstr ""
+
+#: ../../22.04/2.md 6c5c94de417c40cf8430011dd23d0b0c
+msgid "azure: Replace hyperv_fb with hyperv_drm"
+msgstr ""
+
+#: ../../22.04/2.md 2ab221a28cdf489bbf615c8f8d0b67db
+#: 6165609bb7f6432db3bb10d62d78aafe 928e091067a741dd8a2e990f9829f6b6
+msgid "[1987779](https://bugs.launchpad.net/bugs/1987779)"
+msgstr ""
+
+#: ../../22.04/2.md 9292b456a019468eb78bf4ffdaa0900a
+#: 9c25284256414340bc8cb6be576b6df0 aef7ebe3fa41400782926944d224f8a5
+msgid "jammy/linux-hwe-5.17: 5.17.0-9.9~22.04.8 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 4144aa69615f43a580cc110a9a63655f
+msgid "[1990350](https://bugs.launchpad.net/bugs/1990350)"
+msgstr ""
+
+#: ../../22.04/2.md baa7c4db665b4f48985838db11ef65ee
+msgid "jammy/linux-oem-5.17: 5.17.0-1018.19 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 0034f161532c46ffb5ed97c52f8748be
+#: 47c9f8b09ed24dd5aa895e72296eb848 82703c95190d424690d27a690c016614
+#: 8bfafe195b4f4c748fa097dd6835bb25 9bd11f1f3cac4e59bc41cd473b1318e3
+msgid "[1988461](https://bugs.launchpad.net/bugs/1988461)"
+msgstr ""
+
+#: ../../22.04/2.md 0a2b97fc54d24ff192ef0704397e80a8
+#: 1ba7b3919eca4dc988484b63b48a153d 2c34f3160d414a4a98a148cdc3e370fe
+#: 4a0f49d5ef894cb9bc57b08acc7b3415 7f3b9f4420414e26a306f5352e4c1cb8
+msgid "intel_pmc_core not load on Raptor Lake"
+msgstr ""
+
+#: ../../22.04/2.md 2dedbcf8887f46a1a1a3d054136f1b2f
+#: 55bf02bcaa3c42d9843eee3416d41059 6114d99b39e844e48c68110b9c4ac29c
+msgid "linux-nvidia"
+msgstr ""
+
+#: ../../22.04/2.md c09ce7635c414ed5976742a594807d5b
+msgid "Implement PWM support for Elkhart Lake"
+msgstr ""
+
+#: ../../22.04/2.md 7f74bb40ef984625a884ddad74a81521
+msgid "[1987049](https://bugs.launchpad.net/bugs/1987049)"
+msgstr ""
+
+#: ../../22.04/2.md e66135665efa4f888ed54b99294fa40e
+msgid ""
+"LAN devices are not visible after suspend, resume and appear only after "
+"driver is reloaded"
+msgstr ""
+
+#: ../../22.04/2.md 52d94b0fa1594cd4a4c3beee7f94d918
+#: 5358891561ed418091a301249756cf84 5cbbf20f46634888a22e04ced4e80a18
+msgid "flash-kernel"
+msgstr ""
+
+#: ../../22.04/2.md 9e569da8e1d24e4da6e1a93ec1207cba
+msgid "[1986517](https://bugs.launchpad.net/bugs/1986517)"
+msgstr ""
+
+#: ../../22.04/2.md 1a82cfa1908241c283409bb3209908f7
+msgid "Add Mediatek AIoT i1200 board support"
+msgstr ""
+
+#: ../../22.04/2.md f3b813fe4edd4cbab4ab710e407c697e
+msgid "[1990167](https://bugs.launchpad.net/bugs/1990167)"
+msgstr ""
+
+#: ../../22.04/2.md ca9e7c13389f4838a3dbfda3fbce533f
+msgid "cma alloc failure in large 5.15 arm instances"
+msgstr ""
+
+#: ../../22.04/2.md b69eaba9a1e24567a9d9149c07d33eb4
+msgid "[1989787](https://bugs.launchpad.net/bugs/1989787)"
+msgstr ""
+
+#: ../../22.04/2.md aa9c63a3feed49a883776fec331bea03
+msgid "jammy/linux-oem-5.17: 5.17.0-1019.20 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 1b4dc70aa32542d99c3ee0b84afd79fb
+msgid "[1989647](https://bugs.launchpad.net/bugs/1989647)"
+msgstr ""
+
+#: ../../22.04/2.md 37283719ddec49468df832c5ea2d3b21
+msgid ""
+"Fix AMDGPU: No video output and system freezes with two monitor (dGPU: "
+"W6400)"
+msgstr ""
+
+#: ../../22.04/2.md 15fe576b8c4c421eb90c985f47e00fd9
+msgid "[1990330](https://bugs.launchpad.net/bugs/1990330)"
+msgstr ""
+
+#: ../../22.04/2.md 619d51918eab449eb076c81b8d52c8f3
+msgid "System freeze during S3 test"
+msgstr ""
+
+#: ../../22.04/2.md 055aa09c928e4cc1b95d2cb5f05e8748
+#: 80a6532e1a0f48279cde63da5552d941 88e7b1ace9a04255a22772c7bb0d215a
+#: cda67cd60dcb4ae8a1ec72d640583834
+msgid "nvidia-graphics-drivers-515"
+msgstr ""
+
+#: ../../22.04/2.md 9107cd4ad23f4f56963c368206730958
+msgid "[1990835](https://bugs.launchpad.net/bugs/1990835)"
+msgstr ""
+
+#: ../../22.04/2.md 727ce39014d64ccea21c17f460e28117
+#: fca93db0f41447d59893b677a4304082
+msgid "[1993041](https://bugs.launchpad.net/bugs/1993041)"
+msgstr ""
+
+#: ../../22.04/2.md ea50b42b798e45f09e33c1cbba623721
+msgid "Revert to the 515.65.01 version."
+msgstr ""
+
+#: ../../22.04/2.md 46c6512888dc461094b272312791f694
+msgid "[1990945](https://bugs.launchpad.net/bugs/1990945)"
+msgstr ""
+
+#: ../../22.04/2.md f0976e2bbf9f4fbdb882b3d567b64d41
+msgid "i915: Add GuC v70.1.1 for all platforms"
+msgstr ""
+
+#: ../../22.04/2.md 259dc55437ac4e67aa9da9ea7b51fd2c
+#: 9c6891e1e7c74b8fafcc1ce70f59f158 ac352c6933904adcb25540883648fe01
+msgid "fwupd"
+msgstr ""
+
+#: ../../22.04/2.md 14128f5691e940558220492250ce1bdd
+msgid "[1982103](https://bugs.launchpad.net/bugs/1982103)"
+msgstr ""
+
+#: ../../22.04/2.md be9d6384d6f2416ba06cfdb97e968d09
+msgid "Properly fall back to use DMI instead of /sys/class/dmi interface."
+msgstr ""
+
+#: ../../22.04/2.md 0d356890d6244cf7a003f832fd776df0
+msgid "[1966364](https://bugs.launchpad.net/bugs/1966364)"
+msgstr ""
+
+#: ../../22.04/2.md 09869315bdb04ef29e19d439ba484cbd
+msgid "Don't stderr-fail the autopkgtest on modprobe error as they are optional."
+msgstr ""
+
+#: ../../22.04/2.md 820cc72b3ea34d9eaa2655be2e790818
+msgid "[1969976](https://bugs.launchpad.net/bugs/1969976)"
+msgstr ""
+
+#: ../../22.04/2.md a8caca0f6fa548e3a7ce23f1c486141c
+msgid ""
+"Run fwupd-refresh under a dedicated fwupd-refresh user. This is fixed in "
+"1.7.7, so it's automatically included."
+msgstr ""
+
+#: ../../22.04/2.md aceaf6d6e03f425b9b57f29f1bbd91b9
+msgid "[1955353](https://bugs.launchpad.net/bugs/1955353)"
+msgstr ""
+
+#: ../../22.04/2.md 6e37f6b21e8f45258eabf3dffd1c0fe7
+msgid ""
+"Change FK_FORCE_CONTAINER to FK_FORCE and cleanly exit if running in a "
+"chroot environment"
+msgstr ""
+
+#: ../../22.04/2.md 753adeb387f6436db748c55dc8fc786c
+msgid ""
+"Actually revert \"debian/templates/dkms_nvidia.conf.in: drop "
+"buildfix_kernel_6.0.patch\"."
+msgstr ""
+
+#: ../../22.04/2.md 1339797dff0247f59dad78b381705172
+#: 5e28c2b540e24e8aabec8745fae5eab4 e40097dd76944c2285697e13ffa648d5
+msgid "libfprint"
+msgstr ""
+
+#: ../../22.04/2.md fea770da14bd40cbb5310ed3a5d16311
+msgid "[1989314](https://bugs.launchpad.net/bugs/1989314)"
+msgstr ""
+
+#: ../../22.04/2.md 3d3f08934788483781f200ff8bea9297
+msgid "Add support for latest elanmoc devices"
+msgstr ""
+
+#: ../../22.04/2.md 6c9b158f689540f4917e6c0051adb44b
+#: f7569e0145144803ad5bf360db6d69d0
+msgid "nvidia-graphics-drivers-510"
+msgstr ""
+
+#: ../../22.04/2.md a7596e1e082648019f3c906a3ab88774
+msgid "[1988429](https://bugs.launchpad.net/bugs/1988429)"
+msgstr ""
+
+#: ../../22.04/2.md 47e77a005860425581f38183db8d7212
+msgid "Add support for Linux 6.0."
+msgstr ""
+
+#: ../../22.04/2.md bbf6acc69ad142178b700d3498cb1e2c
+msgid "nvidia-graphics-drivers-520"
+msgstr ""
+
+#: ../../22.04/2.md 98df061f95964a0bb0b8ec5fc548a24e
+msgid "[1992669](https://bugs.launchpad.net/bugs/1992669)"
+msgstr ""
+
+#: ../../22.04/2.md cde6120e07da4496819c9d3896a52947
+msgid "[1992020](https://bugs.launchpad.net/bugs/1992020)"
+msgstr ""
+
+#: ../../22.04/2.md 2c4b716e8f5f4e4e856639f2936adcab
+msgid "jammy/linux-oem-5.17: 5.17.0-1021.22 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 3958667e3bc34da3bbee4d8ecd58e4d3
+#: 4ee85640039141d3825b8bd4c4c7d705 5de00f49c1324e599ddb737b959b3afc
+#: 817a8a3fd1fe47c1a18ec977d0592ed7 ede0202243454e56983d22749b0f27fe
+msgid "[1995453](https://bugs.launchpad.net/bugs/1995453)"
+msgstr ""
+
+#: ../../22.04/2.md 1594551a9ebf46ac90afa7035104cb1b
+#: 2405137f2af245ddaaba0d2caccb395a 7cffa68434f341c8b231d0d58781f574
+#: eb15e2ee51ab4c63b897bc80ecdf0689 fbf91164a404490aaa0234753f24108b
+msgid "Add some ACPI device IDs for Intel HID device"
+msgstr ""
+
+#: ../../22.04/2.md 31cf91407c234e4f8b0476fb07a4c40e
+#: 5be8e9f2cc1b4980a2d67053cc5e98f4 bec01cf208d54e3e8561c471f6ea2800
+msgid "[1992022](https://bugs.launchpad.net/bugs/1992022)"
+msgstr ""
+
+#: ../../22.04/2.md 0618549c8d7b494481a4a8471e8d4b42
+#: 2a8b2ad67a964b6a9309c372854b7de3 d00b7a7c136849a2abe6170f7ac5b8fb
+msgid "jammy/linux-hwe-5.17: 5.17.0-11.12~22.04.8 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md a3b72e9c9d404b8ebab8668f8d85f1ca
+#: f17ed7bd1dd64d59b4d2fceee728ece6
+msgid "nvidia-graphics-drivers-470-server"
+msgstr ""
+
+#: ../../22.04/2.md cec379f3517a4749a6d0e8c5349b3190
+msgid "[1993665](https://bugs.launchpad.net/bugs/1993665)"
+msgstr ""
+
+#: ../../22.04/2.md 065d6fd509d347b6af3e16ed08ade253
+#: 3c31374087cf436199915b83a0b61e6d 5c61c9a51a1f4b3d96e0ed9c07a609ad
+#: 634ab014246f40bcba97c81e76dd84bb 6f0f13719dae4450951333a44fd952c2
+#: 890255adc24a4ee8bcb983dc54dc8012 9cabeca6fc4843f4b80a7b8df04e9dbd
+#: b7d94222161149f98f9df0e0b165ed2c bec60e6d3953496883bf6e0cc41e5ae4
+#: ea720b2cb796436bbdfc72ea32cdb768 edf4385b3abf407c8668f2ee4e4328f5
+msgid "New upstream release."
+msgstr ""
+
+#: ../../22.04/2.md 091178c7ddeb47579446b74adb07af27
+msgid "[1991134](https://bugs.launchpad.net/bugs/1991134)"
+msgstr ""
+
+#: ../../22.04/2.md 8d8dd420c77f4e758e988f539d17d7ff
+msgid "Azure: PCI: Fix synchronization"
+msgstr ""
+
+#: ../../22.04/2.md 042079f6910640d5a7aaea60509f4aca
+#: 29905a54b3dc45c6beec59e0f5543b33 3417230bec744c9b8561b74b96e960e2
+#: 395ed82a2f0f456e9bf758d9dc0e586c 3ffadd450f664cbbbf0a2ee01d5bbab7
+#: 42e138aa09e748e398361c17234519fa 44da104469e840c3b38da14a6cfaf101
+#: 49ddc17dd5b74905946d30477b04bd6d 4aa383179d834d919acf11dcb0ae8397
+#: 4ff7537a14a846bda774c4625c8a175d 56c4705ebfd045f4a7f3722f8cb6703b
+#: 5d9be45eadc14aa099f0f72a60a8ae5b 68838a02921d4a07b30ee22f74f1bcae
+#: 83a8134f88bf4ca4b85b26d34ff9785a 8bccfc5f5c264d85be20ad9610bb3085
+#: 8c689b059e92414a97233af8138e3ca6 963534e23cc249b5ad51de92dcad0d9c
+#: b543d2ec6e034cf1b29513d5bdc425f9 b9536eeeadde4e3ea23de5a3b9e0fde3
+#: bb36a60719534b1c88cb65c104f63dfd d38603893934422fbfc9d7c75ace5e55
+#: e4c108626bbb4db2bbebb73c355680dd e50856d74a934288bfe67f1d6fb8cddc
+#: eac3ebe4d900469a97aba94a0fbc0ca6
+msgid "linux-oem-6.0"
+msgstr ""
+
+#: ../../22.04/2.md a86ce10936964d3c8a0855d94b9eaa03
+msgid "[1992023](https://bugs.launchpad.net/bugs/1992023)"
+msgstr ""
+
+#: ../../22.04/2.md ca1b0b5cceaa4f0fbf2995bf5ceccebb
+msgid "jammy/linux-oem-6.0: 6.0.0-1007.7 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 254b50f526284613b03a3b32f0fee800
+#: 5d4c14b80b7147b5bc8d9e73b1340693 6245eb9cfecc4c4486691fbe6134f482
+#: ae342991cc3440eba32cc8cd2acc1791 f6c252d879c845729df6e99230473766
+msgid "[1993715](https://bugs.launchpad.net/bugs/1993715)"
+msgstr ""
+
+#: ../../22.04/2.md 26be38c82c1148408be6e31145a8b48b
+#: b4ab7310d8ca4c5e947d0159cc078904 d9a0573f932c49488dc8d69a008ac586
+#: d9afcdaf1c2f4c08a74f9fc9a8601328 f0e80405b5e94b4da6e97f28d5863315
+msgid "AMD Cezanne takes 5 minutes to wake up from suspend"
+msgstr ""
+
+#: ../../22.04/2.md 373243fbc1724c0d97444fa89bcc1374
+#: 51005240fce7444aa49e2e06726ef9fe
+msgid "[1989041](https://bugs.launchpad.net/bugs/1989041)"
+msgstr ""
+
+#: ../../22.04/2.md 0cbd1e8bfc5341d082a26f58d3effbae
+#: 302e2ecff7d14a998584acd7091cb6be
+msgid "Add iommu passthrough quirk for Intel IPU6 on RaptorLake"
+msgstr ""
+
+#: ../../22.04/2.md 1035b252c99a40709716fb74791c535f
+#: cea7fe36434749c6939936d46cdf6ea5
+msgid "[1992714](https://bugs.launchpad.net/bugs/1992714)"
+msgstr ""
+
+#: ../../22.04/2.md 6471cfd85c5d46ed87844650ff3c9f2d
+msgid "SRU] SoF for RPL platform support"
+msgstr ""
+
+#: ../../22.04/2.md 0720568a77a04fb7b2196f580f6961b2
+msgid "[1991609](https://bugs.launchpad.net/bugs/1991609)"
+msgstr ""
+
+#: ../../22.04/2.md c52af91120be4cafb82e852ff974d3eb
+msgid "Add support for AMD PMF Cool and Quiet Framework (CnQF)"
+msgstr ""
+
+#: ../../22.04/2.md d31b691a45de494397590ed6a24a3272
+msgid "[1994038](https://bugs.launchpad.net/bugs/1994038)"
+msgstr ""
+
+#: ../../22.04/2.md a463ea60474b428d8ef6e59198b8b04c
+msgid "Jammy update: v6.0.3 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md d9a25e1e726b425aa4e5d7edb5090805
+msgid "[1993028](https://bugs.launchpad.net/bugs/1993028)"
+msgstr ""
+
+#: ../../22.04/2.md dce4a53b2b7e4c9db5cc7b208899eabd
+msgid "Jammy update: v6.0.2 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 62814cc8ab4d477eb22e0368575204bd
+msgid "[1992976](https://bugs.launchpad.net/bugs/1992976)"
+msgstr ""
+
+#: ../../22.04/2.md 8d62b6d40ca24f329618430bddb6f322
+msgid "Jammy update: v6.0.1 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 1d77d3e19e724eeba63487199e734b75
+msgid "[1989194](https://bugs.launchpad.net/bugs/1989194)"
+msgstr ""
+
+#: ../../22.04/2.md 08e8750a0ec642e1b32677254d2ed77b
+msgid ""
+"Rename FK_FORCE_CONTAINER into FK_FORCE as its role was extended to also "
+"support chroot."
+msgstr ""
+
+#: ../../22.04/2.md c7d4729b469c41779e2738a8919c88da
+msgid "firmware-sof"
+msgstr ""
+
+#: ../../22.04/2.md 6f6d1ba9e6fc4d81a73bea04cb3311c7
+msgid ""
+"Intel released v2.2.2 firmware to support both adl and rpl, and the rpl "
+"firmware are just symbolic links to adl firmware. The new firmware are "
+"suggested to be used together with v5.18+ kernel, so to prevent current "
+"adl platforms from being impacted, copy the firmware for rpl only, and "
+"leave the adl firmware untouched."
+msgstr ""
+
+#: ../../22.04/2.md ef2eaf7e13a3465495eec1f162c247c3
+msgid "dkms"
+msgstr ""
+
+#: ../../22.04/2.md 8942cbf7a21344a599e57f9e00cce066
+#: e11f40cf2c594d92b0f370d24dcc6a5c
+msgid "[1991664](https://bugs.launchpad.net/bugs/1991664)"
+msgstr ""
+
+#: ../../22.04/2.md ca970e6b9ff74280a1b4da92302a7c1f
+msgid ""
+"Cherry-pick patches from kinetic/stable to address building dkms modules "
+"correctly for HWE kernels:"
+msgstr ""
+
+#: ../../22.04/2.md 5984cc6db75042f1a4cdbe980bca203c
+msgid "[1995654](https://bugs.launchpad.net/bugs/1995654)"
+msgstr ""
+
+#: ../../22.04/2.md 1b3cf115830548e5b2167af65a55cf7a
+msgid "jammy/linux-nvidia: 5.15.0-1010.10 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 4fd2aca75fdb48c0a498c72bcd1e61c2
+msgid "[1993589](https://bugs.launchpad.net/bugs/1993589)"
+msgstr ""
+
+#: ../../22.04/2.md ff9c224d7ccc4428a1c9a5b6f8080423
+msgid "jammy/linux-nvidia: 5.15.0-1009.9 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 58d23b0efc70407ba92a728e6938eb28
+#: 7feea62d48a24aa0b83971c4f1434378
+msgid "opensbi"
+msgstr ""
+
+#: ../../22.04/2.md 7f8726fb40454dd1b10207157e7a3fd7
+msgid "[1995261](https://bugs.launchpad.net/bugs/1995261)"
+msgstr ""
+
+#: ../../22.04/2.md 905c6fa8bb4b48ce9e85b40e4b8e61b7
+msgid "[1995860](https://bugs.launchpad.net/bugs/1995860)"
+msgstr ""
+
+#: ../../22.04/2.md d7826e6638314ed1b5afc279f0f658ea
+msgid ""
+"Fix emulation of fence.tso hanging in endless loop on Allwinner D1 d/p"
+"/lib-sbi_illegal_insn-Fix-FENCE.TSO-emulation-infinit.patch"
+msgstr ""
+
+#: ../../22.04/2.md b1ca44cca6dc4929bbdfb039652ab21c
+msgid "libpfm4"
+msgstr ""
+
+#: ../../22.04/2.md 6e8723ae9c73419b994a2374669a01ca
+msgid "[1960118](https://bugs.launchpad.net/bugs/1960118)"
+msgstr ""
+
+#: ../../22.04/2.md fabe999964af4411bd58e80badebcbd8
+msgid ""
+"Add d/p/lp-1960118-s390-Update-counter-definition-for-IBM-z16.patch to "
+"add new CPU-MF counters for new IBM zSystems hardware."
+msgstr ""
+
+#: ../../22.04/2.md 866299411b40435caa70d07d54c1d024
+#: a556e9c40dfb40f3978f21ed0aac5b09
+msgid "[1996817](https://bugs.launchpad.net/bugs/1996817)"
+msgstr ""
+
+#: ../../22.04/2.md abf16946cc274f7cafde093988bb592f
+#: d96a8f59d2ea40ac813671c8979f88b3
+msgid "jammy/linux-azure: 5.15.0-1024.30 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 263ae5a2d0e449acb858f8b36fa9cd06
+#: 2f1d34f41e884830bd7c838237147a7d 32e3f01fa1d14f7a94f8b97ac48f551e
+msgid "[1996806](https://bugs.launchpad.net/bugs/1996806)"
+msgstr ""
+
+#: ../../22.04/2.md 248b78c6a19d45f59293ab928b45bab9
+#: c2b1609c9b88426c934818d733916708 d6703c8556414f3cb8f56b0361c6f5e7
+msgid "Azure: Jammy fio test causes panic"
+msgstr ""
+
+#: ../../22.04/2.md 302c603b97a747f9bc06a4faf30ef35a
+#: 531f8621a7a541478e77d57cca8832a7 752fd5e4821a41f6b4b61dc5bc901899
+#: a8d7e07d38cb43f4af7ad280b5e5e7c2 cb93b14a1bb647059fc9ff9c97cdf1e0
+msgid "[1996814](https://bugs.launchpad.net/bugs/1996814)"
+msgstr ""
+
+#: ../../22.04/2.md 4239901a7b4c4bfa9f1e151b55e94e9b
+#: a78351aac13a42119db32289290f8a86 b5b65b7914cb4f44a1643ac2267fada8
+#: f383e5f76bba4feb8f146ab0c94e9c04 fd82653848754adc841b34b14dd4c97c
+msgid "jammy/linux-azure-fde: 5.15.0-1024.30.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 368bf8fea23346a598b5e30813b18b57
+#: 43c91fe116da4b9eae7aae6325d10c9a 4b769ac9f93941a19c16b8640b98a421
+#: 51f19d8e762a4fbd9c4e78803804ca9a 52453b030d2443d1a32b086e963ab216
+msgid "[1991980](https://bugs.launchpad.net/bugs/1991980)"
+msgstr ""
+
+#: ../../22.04/2.md 29613960238443c1a369f792d8d7b290
+#: 3bbe938a4c234940a44b23506e69cefc a181b98208954ea29f7a643750d9b6df
+#: abca35caacbe493eb0a621ca00f651b2 ee291595389b4dc8b8665c8d94dc30e8
+msgid "jammy/linux-azure-fde: 5.15.0-1022.27.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 35d12182079a44feb9504dbce3269a69
+msgid "[1971712](https://bugs.launchpad.net/bugs/1971712)"
+msgstr ""
+
+#: ../../22.04/2.md 13304aecef10452893f553c8ffb6cad4
+msgid "Add support for Intel DG2"
+msgstr ""
+
+#: ../../22.04/2.md a10d463057f54ff99c4ad0c4cb12e847
+msgid "[1993223](https://bugs.launchpad.net/bugs/1993223)"
+msgstr ""
+
+#: ../../22.04/2.md be073c436c8d406896c5793a34b2c0bb
+msgid "MIssing GPU firmware for AMD Ryzen 7000 desktop on Jammy 22.04"
+msgstr ""
+
+#: ../../22.04/2.md a505d8f04cb34c29bad1864d26c4c23b
+#: bbdb05384a2141b7bd8b479aeb438c95
+msgid "[1987595](https://bugs.launchpad.net/bugs/1987595)"
+msgstr ""
+
+#: ../../22.04/2.md 81df86beb8c64eb68e7485fc20d31096
+#: ad0d0ae852034f298e2d7327c78be4c5
+msgid "Support Intel IPU6 MIPI camera"
+msgstr ""
+
+#: ../../22.04/2.md 26603f2a1b504292a89a760e8f6ef9f1
+msgid "[1995046](https://bugs.launchpad.net/bugs/1995046)"
+msgstr ""
+
+#: ../../22.04/2.md cb6fcead63484be18f430ff3a4898853
+msgid "Realtek 8852c WiFi/BT firmware support"
+msgstr ""
+
+#: ../../22.04/2.md 1539fc640832403e8a4b84410d2a8289
+#: 2213845a58a2422cb6f83a7cf7a751c0 e37925b98c8f484f9b2500b2e5c76b04
+msgid "[1997084](https://bugs.launchpad.net/bugs/1997084)"
+msgstr ""
+
+#: ../../22.04/2.md b38be21e7cf041e09af1443c357c51ba
+#: bad87eda5d2247fd8a8ab7f1c92c898f c5c2f72fb2de442885a6561dc8357833
+msgid "jammy/linux-hwe-5.17: 5.17.0-14.15~22.04.8 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 0341bd7473204f6da87f6e7063e62fb4
+msgid "[1997371](https://bugs.launchpad.net/bugs/1997371)"
+msgstr ""
+
+#: ../../22.04/2.md 2b5f985cf6de4faaa64b6f5d6ddd5f99
+msgid "Add Sipeed Lichee RV Dock and Microchip PolarFire-SoC Icicle Kit"
+msgstr ""
+
+#: ../../22.04/2.md d6044bec72324e88a0e89fc05db86dcf
+msgid "u-boot"
+msgstr ""
+
+#: ../../22.04/2.md acd67748b55d4ca3ae122b35ac1eb4d5
+msgid "[1995848](https://bugs.launchpad.net/bugs/1995848)"
+msgstr ""
+
+#: ../../22.04/2.md 8e7a2f63670a407c84c53ae4e961404d
+msgid "Add package u-boot-microchip"
+msgstr ""
+
+#: ../../22.04/2.md 32b1f266fbf548ca878249571845276d
+msgid "[1990209](https://bugs.launchpad.net/bugs/1990209)"
+msgstr ""
+
+#: ../../22.04/2.md 7fb79d075aba4777a75d65307ec9b9b6
+#: c55707a04c9f47fcb25e0ddd49a3c268
+msgid "Add new goodix IDs ( )"
+msgstr ""
+
+#: ../../22.04/2.md b9fd04c0df4b419b9dad98f357b1c1ad
+msgid "[1989313](https://bugs.launchpad.net/bugs/1989313)"
+msgstr ""
+
+#: ../../22.04/2.md 037d1fe60000456aa87bf0ca5a17de0f
+#: d1f848cc41934a6299ea9d5b567656be
+msgid "nvidia-graphics-drivers-525"
+msgstr ""
+
+#: ../../22.04/2.md 11357b9e31844bda9e4a71661661b4ea
+#: 207b32a1ae584c10a59c9d338069c226 41996b3c58414d5eaa3da832cdb7f228
+#: 60875a8a3f1e44cb874f4a7bb6db6055 6786df05c5254ce2adbe7cc239355026
+#: 74439640196f46209b5fb1e3e822c1c2 8419b5121ab14ce18198e53be9013e1a
+#: 9aa65c09863e4242a6da21cd77d08845 a670df09099b42a08df23e0104d094cd
+#: e8abcfa0a4484bad845fff3c5ecedd1a
+msgid "[1997087](https://bugs.launchpad.net/bugs/1997087)"
+msgstr ""
+
+#: ../../22.04/2.md 7ad00a83a2ed4f5a8d3d2ddba69c0a40
+msgid "nvidia-graphics-drivers-515-server"
+msgstr ""
+
+#: ../../22.04/2.md 4b2cb4a944944859a950d7f7b83445bd
+msgid "nvidia-graphics-drivers-470"
+msgstr ""
+
+#: ../../22.04/2.md 90a6e1f2f17640f892a1dd611fef2301
+msgid "nvidia-graphics-drivers-450-server"
+msgstr ""
+
+#: ../../22.04/2.md d8d71536d8904d3c808848fdfcb877fc
+msgid "nvidia-graphics-drivers-390"
+msgstr ""
+
+#: ../../22.04/2.md a8207aa6e61f4919838fef5769a531b3
+msgid "libnvidia-nscq-515"
+msgstr ""
+
+#: ../../22.04/2.md 703f5ec802904758a493f5e94615aee9
+msgid "fabric-manager-515"
+msgstr ""
+
+#: ../../22.04/2.md 694bb50e46c846638e49a18b76581621
+msgid "linux-meta-oem-5.17"
+msgstr ""
+
+#: ../../22.04/2.md 90fa5043c9f944df9f4ac9f1ecf5ac46
+msgid "[1997505](https://bugs.launchpad.net/bugs/1997505)"
+msgstr ""
+
+#: ../../22.04/2.md 2f2df7d3925148fd8f595b76dd8945de
+msgid "Unattended-Upgrade will upgrade 1020-oem kernel without nvidia-driver"
+msgstr ""
+
+#: ../../22.04/2.md 5b5ebfdb9b7b43a9847763fa522dc9c5
+msgid "[1996347](https://bugs.launchpad.net/bugs/1996347)"
+msgstr ""
+
+#: ../../22.04/2.md 5d9421af3fb04ae681136a3a8dbe8af0
+msgid "jammy/linux-oem-6.0: 6.0.0-1008.8 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 1a232fef66854842a56ac3086236dfe1
+msgid "[1993242](https://bugs.launchpad.net/bugs/1993242)"
+msgstr ""
+
+#: ../../22.04/2.md c541f71c2c24464b827aea1db429ea4a
+msgid "Fix a race condition with AMD PMF and Thinkpad-ACPI"
+msgstr ""
+
+#: ../../22.04/2.md 0f2dbcfc593b4e6dab9633978f9509e4
+#: 3ec6d7eb547f40398d647749a687b0c0 9100f1123607480fac30174c67da716e
+#: 95692bb476df4784817c5cda690f0dec f6f9098e46454b8d9d0a4342996a3248
+msgid "[1990700](https://bugs.launchpad.net/bugs/1990700)"
+msgstr ""
+
+#: ../../22.04/2.md 70007e436b0e493e82b75dcc4a0c5179
+#: 79478f1979fe42acae42f99154ff2fb8 9e6b5e4a5c514fb6890b7f7a0c651c63
+#: e83a41b342d746cd85f05cc5d5f2f60e f27d8b0659ce4811a8c4ef7ecae19532
+msgid "Fibocom WWAN FM350-GL suspend error (notebook not suspend)"
+msgstr ""
+
+#: ../../22.04/2.md a505fc5e0a504fdf8119a0f726caf261
+msgid "[1993240](https://bugs.launchpad.net/bugs/1993240)"
+msgstr ""
+
+#: ../../22.04/2.md 74ec1d860f324cae96128ac066d79b22
+msgid "amd_sfh modprobe fails when no sensor reported from AMD MP2"
+msgstr ""
+
+#: ../../22.04/2.md 000fd644b09848f59eb76d6eddb7a57e
+msgid "[1996785](https://bugs.launchpad.net/bugs/1996785)"
+msgstr ""
+
+#: ../../22.04/2.md 53297cfb2fbd4f6aae5ed26864558607
+msgid "Jammy update: v6.0.9 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 5676f62617ee4fec8d639347ff0a6c96
+msgid "[1996783](https://bugs.launchpad.net/bugs/1996783)"
+msgstr ""
+
+#: ../../22.04/2.md 6255f171431b4e49989f963dee47ceaa
+msgid "Jammy update: v6.0.8 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 28dce2bc6c554a778a516d10369d7c31
+msgid "[1996084](https://bugs.launchpad.net/bugs/1996084)"
+msgstr ""
+
+#: ../../22.04/2.md b8f5ea21388147d8a0b4012479a63d31
+msgid "Jammy update: v6.0.7 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 1391533f33654ee1a2f1d87ce6b29b96
+#: 799d72747b7f4d3dbbc08005cd383f9c
+msgid "[1996083](https://bugs.launchpad.net/bugs/1996083)"
+msgstr ""
+
+#: ../../22.04/2.md e5ff9043038648218094f836cbd7518b
+msgid "Jammy update: v6.0.6 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 2ceaa272fd82429f9a39966b64f8f3a3
+msgid ""
+"UBSAN: array-index-out-of-bounds in /build/linux-"
+"9H675w/linux-5.15.0/drivers/ata/libahci.c:968:41 // Jammy update: v6.0.6 "
+"upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md c3e942bb718c416cb220d561272f0f71
+msgid "[1996081](https://bugs.launchpad.net/bugs/1996081)"
+msgstr ""
+
+#: ../../22.04/2.md ebef049f820841d8b45249d3b7020b10
+msgid "Jammy update: v6.0.5 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md fedc49986cc44823a643b0282d5bfd17
+msgid "[1996080](https://bugs.launchpad.net/bugs/1996080)"
+msgstr ""
+
+#: ../../22.04/2.md f3677a276d314eba9d43e99a598cf7ab
+msgid "Jammy update: v6.0.4 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 1f36c6032cf44707ba01b7ba59e88448
+#: 3fb00b422fdb455bba5bfc8c90e05914 444f5b758bca4af89d4c5a13a628eeae
+#: b228dc6e4e504d74b8983db519422a61
+msgid "[1998844](https://bugs.launchpad.net/bugs/1998844)"
+msgstr ""
+
+#: ../../22.04/2.md 8be434e897164cdeb003b43597ccc6da
+#: 9abf496314bf469c9dbd3e5a1dac8400 a94312d303ed4358926a2f0f2d0b4ff3
+#: c635a6b5aee34207a3ff5d8977a15c57
+msgid "jammy/linux-azure-fde: 5.15.0-1029.36.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 0e6d5caae3cf44c4a0ed4cf2433bde7c
+#: 17a8f2ce0a5b4d51960887a2c0674e60 1926074085db430ab7cf68425717d489
+#: c211dbec51f04317aabb16f7265590a8
+msgid "[1989751](https://bugs.launchpad.net/bugs/1989751)"
+msgstr ""
+
+#: ../../22.04/2.md 38455887166e4c488a123ba46176e9f7
+#: 69db8235795e4328b5ebc6c7cdca12ee 7e6085a4ecb843338b21e6bef1f33087
+#: 8621c2d9fa6f402fa6ba8145232f8b16
+msgid "jammy/linux-azure-fde: 5.15.0-1021.26.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 16a5ffd3f8e446f9b3f56ce2c06079f3
+#: 65d783b3a2554f7596a0cc374955f09e 6e798af95122466287077171352907e6
+#: a8b13ebccd9e4ccf981f978062bceae4
+msgid "[1987741](https://bugs.launchpad.net/bugs/1987741)"
+msgstr ""
+
+#: ../../22.04/2.md 06e88e39e0f14e9ea77899a35c6248de
+#: 21e62e916516439f960c9f37bff05c69 8e71244e838a4ff9ae6fc143ec0ed92a
+#: ef3e48496ff54578b37264ac71322ce4
+msgid "jammy/linux-azure-fde: 5.15.0-1020.25.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md ab31d5387a79406a9913619b0bdf84c1
+msgid "[1982582](https://bugs.launchpad.net/bugs/1982582)"
+msgstr ""
+
+#: ../../22.04/2.md 1cb76b6204de4ade8f7cb477f3b3e7b2
+msgid ""
+"Modifed ucf call in d/kdump-tools.postinst to use option '--debconf-ok' "
+"to fix a package install issue."
+msgstr ""
+
+#: ../../22.04/2.md eb24bb2823944cdc9d531e2777a593a4
+msgid "[1997233](https://bugs.launchpad.net/bugs/1997233)"
+msgstr ""
+
+#: ../../22.04/2.md d08e6dffd0bf4e619247199ee2e40341
+msgid "Backporting patches to support new RISC-V platforms"
+msgstr ""
+
+#: ../../22.04/2.md 1908fddb099847bca55d73cc22cd623c
+msgid "[1999041](https://bugs.launchpad.net/bugs/1999041)"
+msgstr ""
+
+#: ../../22.04/2.md 837d4b8cb69d4862a430b91d7696e1bd
+msgid "jammy/linux-oem-6.0: 6.0.0-1009.9 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 96d0a6f26e2540afb817748ade685161
+#: f8f4c202d17849bdb4b1fb3333d93dcf
+msgid "[1998419](https://bugs.launchpad.net/bugs/1998419)"
+msgstr ""
+
+#: ../../22.04/2.md 11bc20b2ab8f4a55b299d5b6c7761f29
+#: e4215fef987c402e975f47e4baeb6155
+msgid "Gnome doesn't run smooth when performing normal usage with RPL-P CPU"
+msgstr ""
+
+#: ../../22.04/2.md 48028e5b61ff43c7b4af7d733bd27a3d
+#: 5beeff91f8ca4f1dbb5abc45df6ee92c
+msgid "[1998727](https://bugs.launchpad.net/bugs/1998727)"
+msgstr ""
+
+#: ../../22.04/2.md 545e982e3c18466684f3859a1907f924
+#: c5a8effe949b495d851f69b9d8912c5a
+msgid "Fix System cannot detect bluetooth after running suspend stress test"
+msgstr ""
+
+#: ../../22.04/2.md 0805ecfdf7584745bf7801aa622aa49b
+msgid "[1999491](https://bugs.launchpad.net/bugs/1999491)"
+msgstr ""
+
+#: ../../22.04/2.md 22750250e50d4d79ada039f8ac9398f4
+msgid ""
+"Fix The Bluetooth connection cannot be established between two Ubuntu "
+"22.04 LTS systems with Realtek 8821"
+msgstr ""
+
+#: ../../22.04/2.md c40cc174a781488e80e55d63db4262fe
+msgid "[1998468](https://bugs.launchpad.net/bugs/1998468)"
+msgstr ""
+
+#: ../../22.04/2.md 0cb59a71722e401e9b65113e26b06733
+msgid "New DMCUB FW for AMD amdgpu DCN 3.1.6"
+msgstr ""
+
+#: ../../22.04/2.md 7a35279cb3f24348a5746401e5360f69
+msgid "nvidia-graphics-drivers-525-server"
+msgstr ""
+
+#: ../../22.04/2.md cc7dced6bdb342569f4865a33d391153
+msgid "[1999530](https://bugs.launchpad.net/bugs/1999530)"
+msgstr ""
+
+#: ../../22.04/2.md 27158a036be147f78bf42aeb745a1275
+#: 4d107635e99e4e25b2aa4ea6c2230392 cc4ec73a915441ba979756683673fa8d
+msgid "[1999439](https://bugs.launchpad.net/bugs/1999439)"
+msgstr ""
+
+#: ../../22.04/2.md 299dfa58a04e44d39099ce1e51f973e0
+#: 951fbe9eb2c84ef9b5ec03f4f924734d fe90cf336d614b4d9a9f2302abeb9ae7
+msgid "jammy/linux-azure-fde: 5.15.0-1030.37.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 01a67513aa844d0aa9e5f7edc921c539
+#: 217290a6c97c408a9c8b760f34adef33 2336b1c4815e4b8bb01ec721810dc24c
+#: 4c246646c7ae44e990561b4096f44216 4e28b5ba25854143897f5b2acc97d360
+#: 4f2851c45ed945e18ccb58e38d6e8a9a 7330d1a9ca744552afeb83c39ecdd539
+#: 89be1c55e4ec49018749ae57ae92edcd a1ea66d934ab4782b0243a50a13df02e
+#: b7259e73268e4558bbdcb27bcc119fb6 b8a6103c825c4ce28501dbda9e7e1652
+#: b9ba310dbb36470ea8576295908f1375 bf223d66a24e4c10a7b56ba975b6b43c
+#: d1cd0499ac114993a1df36a9dc2bfb14 e355cf69f65c41599389284b2bec858f
+#: e8062b52607b4ae2a922034962190da6 eb8df8ad75db470aafbe2d20e7f70776
+msgid "linux-oem-6.1"
+msgstr ""
+
+#: ../../22.04/2.md d10f1066f1964427a23c0331fe074499
+msgid "[2001678](https://bugs.launchpad.net/bugs/2001678)"
+msgstr ""
+
+#: ../../22.04/2.md 44cc92ef52d842a28198384a020a01b4
+msgid "jammy/linux-oem-6.1: 6.1.0-1004.4 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 01619901fae84761b0bce571094ba96a
+#: 3a5f322b0f62415eb0beb246961ebd67 692d1d0018cb402e844101a684718ee2
+#: cd4ff478a18b4b9180a953b7f7361419 e9cd279279d74d3181db5533ed8a6f06
+msgid "[1996112](https://bugs.launchpad.net/bugs/1996112)"
+msgstr ""
+
+#: ../../22.04/2.md 423088056346407fbf88d9bf57c0fd96
+#: 7bff2ffc9f7c4a878a9b024ec98c6eb5 87651c670de747c394ed9f77199ee4c2
+#: 99c2bd0e29d642d4b5137d58bbfe4c0f e8e86e583e6f404a9d4342c7e73df881
+msgid "Virtual GPU driver packaging regression"
+msgstr ""
+
+#: ../../22.04/2.md 54f8756998494e61adfba5b6a7b3695d
+msgid "[2000704](https://bugs.launchpad.net/bugs/2000704)"
+msgstr ""
+
+#: ../../22.04/2.md 34f923514f454a2ea88f688b10aa9cd7
+msgid "lunar/linux: 6.1.0-11.11 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 7f867e7558ea4f558afd9c26833cd357
+msgid "[2000706](https://bugs.launchpad.net/bugs/2000706)"
+msgstr ""
+
+#: ../../22.04/2.md e863775d303f4bdeade017b88e42d862
+msgid "Lunar update: v6.1.1 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 4c774fa2b7cc4f94be90936d8bb938f1
+#: 80caa0479f914a5ea17f5f959377c298 91dfda9b60c442feb01d7744c062f44b
+#: d3c60f094c434dde867e07d9e61e6db5 f8716546a6904049ac084b79a8c5191f
+msgid "[1993148](https://bugs.launchpad.net/bugs/1993148)"
+msgstr ""
+
+#: ../../22.04/2.md 3b3345b51a264cf9b4311563455509ac
+#: 65f790aaa07646ef9395cae32228f48c 87615831f2b24870a6510a92a93fca87
+#: daf55298437f4c00aa6fa466c2bc94c1 f8dcf8968f7c483a92cc27d6274b895b
+msgid "Support Icicle Kit reference design v2022.10"
+msgstr ""
+
+#: ../../22.04/2.md 1da52ff97dd549a1aafdc9d82ce4aad5
+#: 40f03f917caa462ba62df3df7fab1f5e 45a75e8c451e4903b8e0a6dc9975ff57
+#: 5d2a5b9531b247459de993333dd30e11 a496f6f375444c459011ca7061b2cc96
+#: ae00b7544e764c54ae2d36ccde7f281d
+msgid "[1994179](https://bugs.launchpad.net/bugs/1994179)"
+msgstr ""
+
+#: ../../22.04/2.md 079bbd10f98b4ad1b48758fc3f299127
+#: 7da8337e3f164433a5bf4eee3c35b77d d8e6cd8a1c124bd9975356e7f75e7643
+#: edb43b8980894b6da39a1601c9cee2b5 f1a6317b39424ca79027c60ed0db1a06
+msgid "Kinetic update: v5.19.17 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 2834ab08a78e43d0b4a039c189c413f1
+#: c82a27632a044798b7d04306db06161b cb7930e3b1e441eaaf099c0ed439e54a
+#: f4e5601f44d444ec965948b7b7767fef f927c8a56c6f41c09f2e2c20ec2645ed
+#: feb77d50fd5745009c9775225f4d6cb8
+msgid "[1994078](https://bugs.launchpad.net/bugs/1994078)"
+msgstr ""
+
+#: ../../22.04/2.md 02e9c9ec0dc349e095eb632c7030197c
+#: 05ad9c53d8ff40538558035af49f6eea 90410db925ac4012ac9a5284b7bc1bf2
+#: b5b5b54989844d9191b2ecf0d7a16246 e2567636e5774d608d20f4c247256c4d
+msgid "Kinetic update: v5.19.15 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 807b0edfc3384fcda0f4cf60366437ac
+msgid "[1937004](https://bugs.launchpad.net/bugs/1937004)"
+msgstr ""
+
+#: ../../22.04/2.md b394396824094e928747dd06c2139fce
+msgid "Add additional Mediatek MT7921 WiFi/BT device IDs"
+msgstr ""
+
+#: ../../22.04/2.md 0e9b90e5d9ea4525857f0ab2844c0471
+msgid "[1919321](https://bugs.launchpad.net/bugs/1919321)"
+msgstr ""
+
+#: ../../22.04/2.md 6f6b86fd7fdd4d298699b2bbda6c71e6
+msgid "Fix system sleep on TGL systems with Intel ME"
+msgstr ""
+
+#: ../../22.04/2.md 3c5193b245a64b5a89db1751d6c5bf03
+msgid "[1999556](https://bugs.launchpad.net/bugs/1999556)"
+msgstr ""
+
+#: ../../22.04/2.md eb2692cae9424555a20b48357608fa00
+msgid ""
+"commit cf58599cded35cf4affed1e659c0e2c742d3fda7 seems to be missing in "
+"<!-- vale Canonical.400-Enforce-inclusive-terms = off -->kinetic "
+"master<!-- vale Canonical.400-Enforce-inclusive-terms = on --> to remove "
+"\"hio\" reference from Makefile"
+msgstr ""
+
+#: ../../22.04/2.md 49dccd35e4cf4b17be944f1fcb97f6ff
+msgid "[1999569](https://bugs.launchpad.net/bugs/1999569)"
+msgstr ""
+
+#: ../../22.04/2.md 75ef97344ad3417e8dbcbc8a68c49970
+msgid "lunar/linux: 6.1.0-10.10 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 049522becf6644a7afe4ec39087dc98f
+#: 0c861f187c9848e185f539cae1d3cec6 0fda93b75ba641fdb66118a848b3603b
+#: 1ed2bfb935c74b38a3e989381c6fed48 1fa1b5e54eda42d58f82f71903a9e968
+#: 2149aa51bdde43189d6709d321557670 281fdee5b9294e839bfc697895854c6d
+#: 29af6f5b564c4b6780f933d8658b8654 2c9b22a9ef734997a478ee8d206554dc
+#: 2cd592e477ec4fc99ba84425921b208d 3329dc8d0ecb45f69268006499b62834
+#: 34fedfdedda64637888384d9a136358a 3832dfbf375d4701a01abbae52a652ff
+#: 392c1844153046ab8840e574e7f06094 3c68970a87e2429786653ce9ae3e6546
+#: 45964d63de1a44b6963e4c211d36ea24 4a55b8849c3641f38a120fe72899875d
+#: 4be1ea79755f4bb98b80fba55d9ad70a 4cf901f0a3164815ad5e55347ddec175
+#: 5176199908ea46db9383db9a8503173b 55cd86eac4b34e8ba6a949a544f0a841
+#: 562ea963de6e4381ad14ce3989690b7f 601b9c05de8d4c808d9f0d302804bc1b
+#: 77233cab9c154a97996209e1dbe1d168 781629455fdb4e52988c4d0012c34741
+#: 7b4bd5ee7ed44da0a1d212ad6ea3287e 83a4d3b07a024a7d860e0f2c06e1fd6c
+#: 887492e2d1bb456585c9f76f5174996c 8a0451736a854c6aa1b0240887480e9f
+#: 9be39544c17e4d348fbfa20428a3bde6 9cde4d8027a14cecae5313831289e60b
+#: 9f4faeeecc704768be7672e1486975ea a11d65a513134829adb924ae7f8db5ce
+#: a5e1a45402f4488a8a864ee7e05d7242 a69ec2156c274893a388b25c9fcd9118
+#: a848d3db6f5049eb8edf9048d7919971 adb9b9e66c784ca7b44ff16bd582f429
+#: b0296b85e7e544888044a684b774518c b49360e0d9dd4f8a9eebd648cd3e8e2d
+#: b8fc6422430048f6b93e6bf2769b613d b9cfc8ca8cb845bc8fb2dfca610bb46d
+#: bdbb445e6c044875842ce8eefe36bf8a c37f2580a27343dea8810bffdeed37ea
+#: ccf86f2bb31745b3b97d82e3b6aad353 ce2f47ffea6f407c97a218e95e246d6c
+#: d4ca29ff216340e6b949fac4b0aad131 d5e261db943840ca90cc261ac0cc0ea7
+#: d665685fbc4a4d8e9eaf342f892414f5 df21aeb59398439eb50c380e0ba365e8
+#: e0e63e6a05974897a7df97ed599cc25a e25e3e4af7b0400baa8091bb6ad91291
+#: e578d2a75f35444f9984314576c8fef1 ef4e9ec6120349e79615bbe5b8f23aff
+#: f9104c891d8041248627b3970971e344 fb01b4ab58b24b0492c20b316af82c03
+#: fde6badc5e9a410db51100f0795ae2ef
+msgid "linux-hwe-5.19"
+msgstr ""
+
+#: ../../22.04/2.md 42406e8bf66b42c6a86d913660e30ce5
+#: 4f83f3a91c704840948a37949d0c6df3 c9c281f7df184e9aa75ee5f48c115ff6
+#: e1b53a47cd4d41229459012dc1d21dc2
+msgid "[1999746](https://bugs.launchpad.net/bugs/1999746)"
+msgstr ""
+
+#: ../../22.04/2.md 524a151f1a4843a5abe2ff63b219040f
+#: 893c51fde3ff41b297cc15faf7f9cb13 ab3b8c77d9b348b08fb94d83bf0bdbe0
+#: ee65c06437b440f299fba7c082e69853
+msgid "kinetic/linux: 5.19.0-28.29 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 12069d54a1bb4030a289b6e1ab4764df
+#: 306d43e1684747518c024f4d3c99b733 45de9623ab374d5d917f59d3f544cf60
+#: c9c1175846564bb09f0ab36652ba0384
+msgid "[1999094](https://bugs.launchpad.net/bugs/1999094)"
+msgstr ""
+
+#: ../../22.04/2.md 330ce545a77f407ba496fa194fe58fd1
+#: 6a1ffe4174bb457d9ac064579f753ce5 a21fb5ab2db24fbfa315e0613f650342
+#: c711cd6108c542ac8e8f449753b1d82b
+msgid ""
+"mm:vma05 in ubuntu_ltp fails with '[vdso] bug not patched' on "
+"kinetic/linux 5.19.0-27.28"
+msgstr ""
+
+#: ../../22.04/2.md 0947402c0198435aa1aafe2bef60b2bf
+#: 2b3167c5c87d4c189c18dab9a8308e34 c1235872b61a4ab9b1cbb79fc0652fde
+msgid "[1997794](https://bugs.launchpad.net/bugs/1997794)"
+msgstr ""
+
+#: ../../22.04/2.md 607ee540d1974d28b550129775ebafbb
+#: 78fae4cc195d423dbdfe99d2f97ae38b 8319352024d14c698d06173e78a03bb9
+msgid "kinetic/linux: 5.19.0-27.28 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 7703972e87b94f46b9a08f0b114cbc2d
+#: b7ad3c4eeb864accb594431cd0a75479 e9dd1e02df1245608660a33734d1b983
+msgid "[1996536](https://bugs.launchpad.net/bugs/1996536)"
+msgstr ""
+
+#: ../../22.04/2.md 76f5e1aaca8b441eaa42a19c33f5bcac
+#: a515fdfefce74f468fb334b65259162b a53b77bd3a4b42079486cc8852777556
+msgid "selftests/.../nat6to4  breaks the selftests build"
+msgstr ""
+
+#: ../../22.04/2.md 23cb030e675a4300aa2bd3f452e65379
+#: 89cd218f30a644d884c8ceab15917b3f c417030926c44c01b229a70565ea9d9f
+#: ea6446d2765349b8a9cc757712a0794a
+msgid "[1994164](https://bugs.launchpad.net/bugs/1994164)"
+msgstr ""
+
+#: ../../22.04/2.md 06b49b6754394bd9a0e0464969dcb9f2
+#: 3a7f7f501b024e769a76729f70206184 50a9c695e3794acaae55ed53a4bc5a93
+#: a770695d32614809b8d3891ea38418d4
+msgid "Kinetic update: v5.19.16 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 20606c4dda7d4fbfbba7a1ee0a4f9d25
+#: 2fec2f9964ef4dc692d36724276e1df8 377801f644b046ab892ea08fd4f157ad
+#: ddc359c122004c96bcc0d5cddfcc7010
+msgid "[1994076](https://bugs.launchpad.net/bugs/1994076)"
+msgstr ""
+
+#: ../../22.04/2.md 8d44b4da3482403abe8ea4bbfe953194
+#: bf63062da47d4e6b9421c5a8b8cdd089 c927f1aa6a734285b806489640aa2bc9
+#: e102d5f9579745afb71ad98bd4d13297
+msgid "Kinetic update: v5.19.14 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 0c5ba469d9064193ba309bd4364a40c9
+#: 497931b8542c494cb2d55b83200d463b 6bdf4ea8f0754425969c380995517550
+#: a197c9d69cb54b27a0116ebb257bc0a6
+msgid "[1994075](https://bugs.launchpad.net/bugs/1994075)"
+msgstr ""
+
+#: ../../22.04/2.md 047c9621001742e19358c24f01c454b1
+#: ad1bf897c7844156bc6e0d9fc4d6701d b4f394ddf83d40e0b774fa41707c3b54
+#: d9e81db2f0ce406ca84706b3e7ed8a61
+msgid "Kinetic update: v5.19.13 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 3503d56de3464379a89b8faec5783ba6
+#: 82a6ce225a2044f0a3a891339312c4d4 8c270fadb8d34f9db95f2a056f4fa78f
+#: ce4b6db72c8e4f05901d9bfc1e82ae94 ee69f7a3e5eb4fe39773d127b2d3c9a5
+msgid "[1994074](https://bugs.launchpad.net/bugs/1994074)"
+msgstr ""
+
+#: ../../22.04/2.md 19a64fd61aa74b8193e2828664a750e2
+#: b2d57151ba3a460dbae68a6437c9b3f9 c6ae0947ceaf4216ba6c78dee197b35e
+#: f8b02098fe154475b436d4860857875c
+msgid "Kinetic update: v5.19.12 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md a2e99869c7d44aca836a2979b09615b2
+#: c3b80b56cd854bf9a46b8f991e044974 d6af909b2b2d4db9b5a8f29c4fd4a294
+#: fbc302d4adae4617affdcf93c6c3549f
+msgid "[1994070](https://bugs.launchpad.net/bugs/1994070)"
+msgstr ""
+
+#: ../../22.04/2.md 37c7db6716ce436aab2a7ed0ac057424
+#: 84ce015c338a40a1be57e9dbdfa0458f e8088479a4c545dab7a4e26f95a1c110
+#: f3e56a240348429da883b46cd96e55e4
+msgid "Kinetic update: v5.19.11 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 28480abd61a240a7bf284db423982b77
+#: 2f8efe7e0a7c41eb976f0c37a8c89ee6 5d27eb8898784e689dc56c89449326f6
+#: 9449dfe7e4d14352a420361c44bbb1b9
+msgid "[1994069](https://bugs.launchpad.net/bugs/1994069)"
+msgstr ""
+
+#: ../../22.04/2.md 98747ee9c9bb4ee68863204facfa3323
+#: b1faf2a59cca4b81848ec5b30fc97567 f7ed849b21794963ae0a19e0bc8e3942
+#: fea2a5a65dc04db3bb0bceefc4e8ab99
+msgid "Kinetic update: v5.19.10 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 26f22c1648f445ee93b32e3f9d10c5ef
+#: 8b51da3f27a4420ab1d03ce2f904488c dc622b6981d6438faa9ec037a0615570
+#: e3792c8113b347fe83ef6497952c18bb f4286a66f518429eb00d15ddf3a835df
+msgid "[1994068](https://bugs.launchpad.net/bugs/1994068)"
+msgstr ""
+
+#: ../../22.04/2.md 43a2df192e6f4241b9f7ce6a4cc4bbf0
+#: 5692cebd04ac4a3d85ab6ecf1c65bf4d bb676a14a1174a1e8d28551b991b0ce3
+#: e689d18268bb47d9bc2ce86b4bee196c
+msgid "Kinetic update: v5.19.9 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 679ff98f74a249a18f3b28dbe15a63aa
+#: 6fb36d16b8eb4e4cbcf3c1cb6c09de78 8e217b8345ea4c5a91cf417d89154892
+#: f0b2efe83bad430081aa697223e3a1a5
+msgid "[1994061](https://bugs.launchpad.net/bugs/1994061)"
+msgstr ""
+
+#: ../../22.04/2.md 0af15049071c4a949b9ecc33aeef88a3
+#: 0eac72aabaf64a49b957c6101bf36c66 8283bd24d5e546c4bcd3fedd9f57ea50
+#: cc370b20845b414f997b44a4c381095f
+msgid "Kinetic update: v5.19.8 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 172820728e6c402891718e731ad2dd6b
+#: 25ddc667119347dfa31b29048b1c0ec8 7325d9987430400f97e5933219c94d66
+#: f4e0ee0b983b40099366e254c3481dbd
+msgid "[1988711](https://bugs.launchpad.net/bugs/1988711)"
+msgstr ""
+
+#: ../../22.04/2.md 2c40b938a38042f089af1439c98fcc13
+#: 570d53b61fcd42db8b3a063c97308d0c 7137c7ffbc1a4738b3b2910fa4b035ba
+#: f6b786d765304bbdb6568f0d4a47a75f
+msgid "Update Broadcom Emulex FC HBA lpfc driver to 14.2.0.5 for Ubuntu 22.04 LTS"
+msgstr ""
+
+#: ../../22.04/2.md 32750d350bd94019836610728f9f731f
+msgid "[1996300](https://bugs.launchpad.net/bugs/1996300)"
+msgstr ""
+
+#: ../../22.04/2.md 631f0dbd70a24c118701d6b28a9580a2
+msgid "jammy/linux-hwe-5.19: 5.19.0-24.25~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md f22ff9f08b394acdb1c9d5e4b213fd58
+msgid "[1996301](https://bugs.launchpad.net/bugs/1996301)"
+msgstr ""
+
+#: ../../22.04/2.md b80bd5af81b84b45872826bf5500e467
+msgid "kinetic/linux: 5.19.0-24.25 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md c399b5c0b6c44ca7a37b883697427cd8
+msgid "[1992639](https://bugs.launchpad.net/bugs/1992639)"
+msgstr ""
+
+#: ../../22.04/2.md 27752b18166844418ba2108250a8c8a2
+msgid "kinetic/linux: 5.19.0-21.21 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 651926a4a6a54811b4ba3a71620aedbf
+msgid "[1991691](https://bugs.launchpad.net/bugs/1991691)"
+msgstr ""
+
+#: ../../22.04/2.md d73dd7095e4c43ef8394f7d079b7b186
+msgid "cannot change mount namespace"
+msgstr ""
+
+#: ../../22.04/2.md a75fbb0d3bd34575af6d47acbae5abde
+msgid "[1992408](https://bugs.launchpad.net/bugs/1992408)"
+msgstr ""
+
+#: ../../22.04/2.md f9d1c6323972475bb8565bd8716ef34c
+msgid "kinetic/linux: 5.19.0-20.20 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 07d14be782644891aae9f2a09662d544
+msgid "[1991704](https://bugs.launchpad.net/bugs/1991704)"
+msgstr ""
+
+#: ../../22.04/2.md bbb003220e2849f19679dec85b850ad9
+msgid "Kinetic kernels 5.19.0-18/19-generic won't boot on Intel 11th/12th gen"
+msgstr ""
+
+#: ../../22.04/2.md c568ddc44ea248c591e64641f369fe93
+msgid "[1967130](https://bugs.launchpad.net/bugs/1967130)"
+msgstr ""
+
+#: ../../22.04/2.md af37b3360a3e4f06a0b3e2737099a19b
+msgid "rcu_sched detected stalls on CPUs/tasks"
+msgstr ""
+
+#: ../../22.04/2.md 209633ce6fbe454eb3c59bd0d1982533
+msgid "[1988984](https://bugs.launchpad.net/bugs/1988984)"
+msgstr ""
+
+#: ../../22.04/2.md bc2cd2d413fc4c109a5c18f165de2a89
+msgid "earlyconsole prints question marks on 5.19.0-1002-generic"
+msgstr ""
+
+#: ../../22.04/2.md 3a0d9932d794402b8dcee07228ccf701
+msgid ""
+"backport dkms fixes to build modules correctly for hwe-5.19+ kernels with"
+" custom compiler"
+msgstr ""
+
+#: ../../22.04/2.md 859e2441d4844839990de27d7d9d16cc
+msgid "[1990964](https://bugs.launchpad.net/bugs/1990964)"
+msgstr ""
+
+#: ../../22.04/2.md 2c9d8ae91bf74affaf15b3932d8725d2
+msgid "FTBFS on kinetic"
+msgstr ""
+
+#: ../../22.04/2.md 62dcc834d4dd4bccb3624ab02759e436
+msgid "[1852741](https://bugs.launchpad.net/bugs/1852741)"
+msgstr ""
+
+#: ../../22.04/2.md da3abb16e07841659880859a4429056f
+msgid "22.10 FEAT] zKVM: Crypto Passthrough Hotplug - kernel part"
+msgstr ""
+
+#: ../../22.04/2.md 07d0858f7a79445b9378362fc56f6c45
+msgid "[1990960](https://bugs.launchpad.net/bugs/1990960)"
+msgstr ""
+
+#: ../../22.04/2.md 078b17616904451fba8e66e04e3bdfbe
+msgid "kinetic/linux: 5.19.0-19.19 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 5248319943274f78aa312f05d7035a59
+msgid "[1997946](https://bugs.launchpad.net/bugs/1997946)"
+msgstr ""
+
+#: ../../22.04/2.md 7e52d65cc22645b9b474c3ac4f3a2fa3
+msgid "Backport patch for speaker AMP-ALC1318 support."
+msgstr ""
+
+#: ../../22.04/2.md f39acc82c8714a6bbd64ffaac9f42cd8
+msgid "[2000465](https://bugs.launchpad.net/bugs/2000465)"
+msgstr ""
+
+#: ../../22.04/2.md 0fabf22efa944eb8a8e8f7bbdd5c286f
+msgid "fix microphone recording on rt715"
+msgstr ""
+
+#: ../../22.04/2.md 5a893f9afcc04386a422b2bd58e4c7c3
+msgid "[2001703](https://bugs.launchpad.net/bugs/2001703)"
+msgstr ""
+
+#: ../../22.04/2.md 554338e5fbdf4f708c02d201ae766fae
+#: 58381cb06c4e4c999c794f631a073e6c 6979ec1ff98a4c01836ef5c86ae709ed
+#: dc054757cee342279b08d9419ccb338b
+msgid "linux-riscv-5.19"
+msgstr ""
+
+#: ../../22.04/2.md 4269166b787d41979d19203de9474d3e
+msgid "[2002588](https://bugs.launchpad.net/bugs/2002588)"
+msgstr ""
+
+#: ../../22.04/2.md adcb7a0aa2e04c7f9cfaa9e9b0db41a1
+msgid "jammy/linux-riscv-5.19: 5.19.0-1012.13~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md c9f9c9fce8c74f06b8b5d4a558383c54
+msgid "[1999743](https://bugs.launchpad.net/bugs/1999743)"
+msgstr ""
+
+#: ../../22.04/2.md 618cff13cacb4da7ae2d4db733085fb8
+msgid "kinetic/linux-riscv: 5.19.0-1011.12 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 149446791abf439389713e8f1cb12def
+msgid "[1999782](https://bugs.launchpad.net/bugs/1999782)"
+msgstr ""
+
+#: ../../22.04/2.md 7fafdc51ffb6407aaeca03073b60feaf
+msgid "Add ACCEL_LOCATION=base property for Dell clamshell models"
+msgstr ""
+
+#: ../../22.04/2.md 3f4f571941a14e659292f2167c45e595
+#: 4460d7660f534a02a58a92bdc7a5811e
+msgid "[2001629](https://bugs.launchpad.net/bugs/2001629)"
+msgstr ""
+
+#: ../../22.04/2.md 3c5ff8f962274917980c23fb2785f59f
+#: 771a0b732f694f67aac14beabe27d824
+msgid "jammy/linux-azure-fde: 5.15.0-1031.38.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md da48569f451d41e58f899e915101165f
+msgid "[2002373](https://bugs.launchpad.net/bugs/2002373)"
+msgstr ""
+
+#: ../../22.04/2.md c71803190eb648e49618039651ef1b04
+msgid "Backport patch to fix micmute LED."
+msgstr ""
+
+#: ../../22.04/2.md 25647025ff2d4d4ea3293611ef3855bc
+msgid "[2001896](https://bugs.launchpad.net/bugs/2001896)"
+msgstr ""
+
+#: ../../22.04/2.md 5f62c10e11724c9db52db0b3aadcac68
+msgid "Backport patch to fix capture switch default value."
+msgstr ""
+
+#: ../../22.04/2.md afcda66d808f44d2a98fa9c4f4038366
+msgid "linux-signed-oem-6.0"
+msgstr ""
+
+#: ../../22.04/2.md 0d9b85fd1c2c4e848b18855d6ee4cb39
+#: 2908a671017546d4b2a121d0c420bbbb 2cda9811c65b46dfa30d614c0ae273c4
+#: 31e42ca328c74648ae1ff7413037283a 52da5dfc50b042d58079ef75e8ffc027
+#: 552deb48b6c04d49845a005a8ea02d7e 5cee40974a014948af8f08f828a086f4
+#: 5d6baccf5933450ea116d0fcc54a87a3 62806befbe394813a6e5d75a95d54b56
+#: 66aae17d5cc34751ae9a1beb13e43401 68c84fec9668471cb55bae4356a96756
+#: 7ee706340c134f4384e371eb16cdb143 ad88cd1eb96e4e308cc77a9111717ff6
+#: b9461a927df34e74b8f1b57af87deba1 d175c45f829f4ee9b1f3d57f6afdcfdc
+#: dad6a8380acd4432ba3c41a75ed70089 de01885f95fc49eb905d8c79dd36ef75
+msgid "[1989705](https://bugs.launchpad.net/bugs/1989705)"
+msgstr ""
+
+#: ../../22.04/2.md 19d98118ac9a4ea8823f8dac1d69f03c
+#: 492f3631cad349589450ee1bccf42b7f 52a291d6dd6c45bcabf5f0da86c8cd15
+#: 63cf6fc88661434a8196b3bf641b7cf2 6d410e5d454e46558f3d871ba1d37472
+#: 71e933599ef24997a3946e282378bf1a 75a79400ffb447878cd8cff0ce9baa6e
+#: 7832ce4b53f04559b92902f7736d9113 78983a82c30144f5b732f7e8781dafbb
+#: 7a94a75eaaa54b168ebef331eddc6dea 95b84050ac434eeda76fc90cda952a3b
+#: b005cd832f48465dab80546de352fe11 b72fdc9dfbc8455c85a4a96274b7e2bb
+#: ba12e66b8ecd49618c3da9a99d28186f ce7f0c3886744d059b3aab9f3046db89
+#: d9a05d8f132247ae82aaec000c01d293 f0512f0d46424ba6862d61b5da8a6291
+msgid "SIGNEDv3: add a linux-generate ancillary package"
+msgstr ""
+
+#: ../../22.04/2.md 6409253d25f243638a8bacaaa2362b5f
+msgid "[2002096](https://bugs.launchpad.net/bugs/2002096)"
+msgstr ""
+
+#: ../../22.04/2.md 72a98357d4a5464e85ee6e37d640a9ed
+msgid "lunar/linux: 6.1.0-12.12 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 83f221824e5648c7917aa380d4da109f
+msgid "[2002079](https://bugs.launchpad.net/bugs/2002079)"
+msgstr ""
+
+#: ../../22.04/2.md 26030292980c42ebb792c53068dc0a7b
+msgid "Lunar update: v6.1.2 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md 122cf51b948b4009b188366f113fc614
+msgid "linux-signed-oem-6.1"
+msgstr ""
+
+#: ../../22.04/2.md 5184832e8fad444a818fe9430d5376e0
+msgid "linux-signed"
+msgstr ""
+
+#: ../../22.04/2.md a2c20d2995474eafa2f5384eae0d1a1d
+msgid "linux-signed-azure"
+msgstr ""
+
+#: ../../22.04/2.md 1005c2af1c8446aea602064bfc5c4f68
+msgid "linux-signed-gke"
+msgstr ""
+
+#: ../../22.04/2.md 216975ef8848409e992bdacf1a06afb7
+msgid "linux-signed-ibm"
+msgstr ""
+
+#: ../../22.04/2.md d1c3065ddd374c789aad971d26cb39e8
+msgid "linux-signed-kvm"
+msgstr ""
+
+#: ../../22.04/2.md 4fc4de04ce7d468a9cc2260780c737f3
+msgid "linux-signed-lowlatency"
+msgstr ""
+
+#: ../../22.04/2.md 3715643998e34af982783511fa70a0aa
+msgid "[2003452](https://bugs.launchpad.net/bugs/2003452)"
+msgstr ""
+
+#: ../../22.04/2.md 7a29c9558db64db1b961766338f687d9
+msgid "jammy/linux-hwe-5.17: 5.17.0-15.16~22.04.8 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md db9b4315394d4d5eb6e8b2a26b9e0c45
+msgid "linux-signed-oem-5.17"
+msgstr ""
+
+#: ../../22.04/2.md f8a0f433165844979112b17c8449b1d7
+msgid "linux-signed-oracle"
+msgstr ""
+
+#: ../../22.04/2.md 5399a3d090034b32a341fe0df786baba
+msgid "[1999375](https://bugs.launchpad.net/bugs/1999375)"
+msgstr ""
+
+#: ../../22.04/2.md 0c06c292b4c34072be3625e0992041fb
+msgid "Update dg2_dmc to 2.08"
+msgstr ""
+
+#: ../../22.04/2.md 1e1a0f737bf94a16ae7f1a4fc5e4f256
+msgid "[1999406](https://bugs.launchpad.net/bugs/1999406)"
+msgstr ""
+
+#: ../../22.04/2.md 07b8598ea8374bd284db91c08733f005
+msgid "Update firmware for hwe/oem kernel migrations"
+msgstr ""
+
+#: ../../22.04/2.md bb7c54cb43e14205b27cb58d44ae87f8
+msgid "[2000133](https://bugs.launchpad.net/bugs/2000133)"
+msgstr ""
+
+#: ../../22.04/2.md a351b8105ce24af3b03b292f19bfb66d
+msgid "amdgpu: missing firmware for navi31"
+msgstr ""
+
+#: ../../22.04/2.md c4dea6454e3c40029a5564d18025c06f
+msgid "[2003846](https://bugs.launchpad.net/bugs/2003846)"
+msgstr ""
+
+#: ../../22.04/2.md 11fcdd4de25d40ed83ffdf34c056a66c
+msgid "amdgpu: missing firmware for navi33"
+msgstr ""
+
+#: ../../22.04/2.md 7c6fe01362674994a99802e1922f74a3
+msgid "[2006102](https://bugs.launchpad.net/bugs/2006102)"
+msgstr ""
+
+#: ../../22.04/2.md 08275bea1e3d4a14be325d799d86e192
+msgid "Backport patch to fix micmute LED (soundwire)."
+msgstr ""
+
+#: ../../22.04/2.md e8683ad20a7448759deeb63f079c293e
+msgid "linux-signed-aws"
+msgstr ""
+
+#: ../../22.04/2.md 0161d024d32843a7bcc9f7daa07000b0
+#: 0a43425c83a442c58361507d51c35f78 1c94bff9f468421e86f9fb9d1e1eea2c
+#: 1f08f7e8919d44cda5538f8fbd5ab126 29bc0531202f4046a6cefbba3c92a543
+#: 2e00438e59994f36aae093b8afa6ac02 37841fb5e7ca445fb4d3b51dcb896b6c
+#: 412fa56bafa84303a71209d3da20e24e 44db0eb3b8904e2b9a9d93c97b3d4aac
+#: 530a46aee06746cda4097f6448b98e39 6313d67a6b3b40e2a647be78cc0b8ccd
+#: 6dc207fd635b4a62b106c7395ef439b0 78e5fa5b0acd4672b2b3e817dd45abe5
+#: 806d016f31484adb95d2cf2c000a7290 8099a56014f345149f59650b2f40fa5e
+#: 90730d6e2b104947aca462b04e8ffc0a a7f52ed200fa415aad4e8f0215c3032a
+#: a9bc08bb82c44027afc24c48bcee37f1 b163845003804c64ac3332e2be919e25
+#: b808d4fc27ee40169edaaaad0f5225bc c8422441377b4e86bb1075066f794c54
+#: ca58ddce63cb4c9894374f065b271c35 d074c5ca37bb4b099865c823059a7125
+#: d0cce647703a4f6d96b18c01a595fd31 d49d39f95317404fbd517299b44e8550
+#: d5e2e56064944d08802ad256ba9174b2 d6d49f64bc2947c2ac2522130d62750a
+#: d7da79fdfbf94ec5a7fb5ad75df898aa e442039cc2d64c65a0ff0dc4b5d8addf
+#: e52865138c3541839c8d797ba5322b1d e92df8070c6344bfbe0caab8fae28ab8
+#: ea43aaa7576643f1b3dbe66af8b347bd f00cf421d6bf42ffaa40dcd957c9441e
+#: fbef5617e03f47dc979e428cbe6e7fdb feb357726e0e42dc8ab505337792f03b
+#: fee74b07a6394ecf94d126630bc26752 fefd20fb4bc44dce82ddd7cc21d128a4
+#: ff6a66a28cca46ea9ba5621205a857ad
+msgid "linux-aws-5.19"
+msgstr ""
+
+#: ../../22.04/2.md 0feb01ad90a24e1480199570980c4f0f
+msgid "[2003412](https://bugs.launchpad.net/bugs/2003412)"
+msgstr ""
+
+#: ../../22.04/2.md aa201c98de5d4b9aa8cb30e841e880fb
+msgid "jammy/linux-aws-5.19: 5.19.0-1019.20~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 10038cc5ad1f4aa4af253f8b12930f95
+msgid "[2003413](https://bugs.launchpad.net/bugs/2003413)"
+msgstr ""
+
+#: ../../22.04/2.md 185b1246491a4806b0ec9d95cb86a2f0
+msgid "kinetic/linux-aws: 5.19.0-1019.20 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md a03bb6228f5744aba0a5cb14cae4981e
+#: bc191a3092954663aa4b0864e8810b1c ff6ec9ba79b047249149e7f83e30659f
+msgid "[2003423](https://bugs.launchpad.net/bugs/2003423)"
+msgstr ""
+
+#: ../../22.04/2.md 9dac9fe27aab484388836ef1d4be39fb
+#: daeb164cd3aa4fa2b172d2515b85b818 e88950537c624525965682d3b117cd30
+msgid "kinetic/linux: 5.19.0-31.32 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 3eda293e48324808b0bcde38fafda050
+#: 3edfe55dc67b41c881d00250e5425452 b3f0940daa1d40a9aa5164301967a8c4
+msgid "[2003524](https://bugs.launchpad.net/bugs/2003524)"
+msgstr ""
+
+#: ../../22.04/2.md 013c6b555ef3470ba4930ccd2aa6213b
+#: 255d323a908d48879b5c86d96b78d1b4 36d1aa8d1860469ea1fb7c12482918b1
+msgid ""
+"amdgpu: framebuffer is destroyed and the screen freezes with unsupported "
+"IP blocks"
+msgstr ""
+
+#: ../../22.04/2.md 90bf47a04e6d49ddba99ed11af875cbf
+msgid "[2001742](https://bugs.launchpad.net/bugs/2001742)"
+msgstr ""
+
+#: ../../22.04/2.md 81d817d346a4471f99fdfa02ab0e79d2
+msgid "jammy/linux-aws-5.19: 5.19.0-1018.19~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 4f532bbaeeb945d595c01a3c8d6f2e23
+msgid "[2001743](https://bugs.launchpad.net/bugs/2001743)"
+msgstr ""
+
+#: ../../22.04/2.md 22e7613a4cf141218a6f7946c3268ee5
+msgid "kinetic/linux-aws: 5.19.0-1018.19 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 1d49c87182674274903322732311c2f3
+#: 3d3138d2785b4eab947a8b1fe72a6a57 42a67457f4a74543a5e066b09db56848
+#: 5e36a9152ee14170907e0e332810efbc 9bf5b40600034c97acda74e463211bad
+msgid "[1996540](https://bugs.launchpad.net/bugs/1996540)"
+msgstr ""
+
+#: ../../22.04/2.md 1dadca8fff944ae4b8c1e6747daa1ca1
+#: 72f6eb78adf24b8988807acca273813c a1002fcd2f234e0a917405631adf8a90
+#: ab9e9553aa904c0c96fda21b5c016c5a e317523f51804a87b508b10625ecdfa0
+msgid "Kinetic update: upstream stable patchset 2022-11-14"
+msgstr ""
+
+#: ../../22.04/2.md 17784a93845d496c9e803f2f3b8b8cee
+#: 3795f09c02d340ad82025dd101713b7d a26b7e6f37c24e13a0631bb56dccc5ce
+msgid "[2001756](https://bugs.launchpad.net/bugs/2001756)"
+msgstr ""
+
+#: ../../22.04/2.md 02ba0f6d5a284e10abda4fea0ebd80e2
+#: 1077cdaaed9f48cdb93963ba0bf52a28 a2b4b124361f4f04ae801ab82a08584a
+msgid "kinetic/linux: 5.19.0-30.31 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 4d1b19f218d14a1ba4c0862c44c3e91f
+#: bb56215bcccc4841b6c8199e892bd3fe c6b7f0cc484b4ca4a5309d26a3014637
+msgid "[2001618](https://bugs.launchpad.net/bugs/2001618)"
+msgstr ""
+
+#: ../../22.04/2.md 1a4878c07b0644eab5dab7a1238ab675
+#: 8a67708b6e8141769248725a987b4bba e22eb38334bf49c496e8f79ea296937b
+msgid "BPF_[AND"
+msgstr ""
+
+#: ../../22.04/2.md 0515e8b6f92b4b95b8b942ca299befc1
+#: a3e832be245940cd9d7dc6367fc0b271 e40df971c5ef44a58b84a03b3b8bda43
+msgid "[1999828](https://bugs.launchpad.net/bugs/1999828)"
+msgstr ""
+
+#: ../../22.04/2.md 26f46d12c9e442fa9a34a1b4df39bd66
+#: c66770153efd4488aa468c12541c86c0 eebd2f0db97649e38440ce30f7e5f9ae
+msgid "Kinetic update: upstream stable patchset 2022-12-15"
+msgstr ""
+
+#: ../../22.04/2.md 63a7631066304b06bd552754bbdfca76
+#: 7039f4b69a364482a371f07b103661ec c33df3e7309348baa97e3c0cc91c1541
+msgid "[1999079](https://bugs.launchpad.net/bugs/1999079)"
+msgstr ""
+
+#: ../../22.04/2.md ae2f6bcd678b4809a2f98466f47787b6
+#: bd94d7d2235643109cd2117bbf61c21f bdaa4e9da9954276a7a9da355bc037b1
+msgid "Kinetic update: upstream stable patchset 2022-12-07"
+msgstr ""
+
+#: ../../22.04/2.md 6864a58c5b964abca7bb6df311c90574
+#: 700c098029b14add9196007ed24234cc 94b7b3e7fc16438c8250fb6584d3d323
+msgid "[1998398](https://bugs.launchpad.net/bugs/1998398)"
+msgstr ""
+
+#: ../../22.04/2.md 0455b413af8e4a23b011223e7b827184
+#: 7aef8c6373884cff9bec1c9a34d8952e d0da274e6cbf417c8331c6ff30a410c7
+msgid "Kinetic update: upstream stable patchset 2022-11-30"
+msgstr ""
+
+#: ../../22.04/2.md 2751e5ad1a9c4af1954c9f457aef61f3
+#: 2f9b6104ef5f40ed829a07c61b87e92e 62465de6827b4f58925bdd026493f247
+#: a334305dad844a05be6d1ce18bb05530
+msgid ""
+"Kinetic update: v5.19.9 upstream stable release // Kinetic update: "
+"v5.19.12 upstream stable release // Kinetic update: v5.19.15 upstream "
+"stable release // Kinetic update: v5.19.17 upstream stable release"
+msgstr ""
+
+#: ../../22.04/2.md ea10f4399cbe4aab880477359bb19b93
+msgid "linux-signed-aws-5.19"
+msgstr ""
+
+#: ../../22.04/2.md 701bc76f63e74b4f9826617ae4a41100
+msgid "linux-azure-5.19"
+msgstr ""
+
+#: ../../22.04/2.md 2bc38ade0835459d9c9b7b0faad14789
+msgid "[2004084](https://bugs.launchpad.net/bugs/2004084)"
+msgstr ""
+
+#: ../../22.04/2.md bc48565aae39453797f4361a20f8d26c
+msgid "jammy/linux-azure-5.19: 5.19.0-1020.21~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 62d1472a3c8d4a68a36ea7f3d3c4e1a1
+msgid "[2003425](https://bugs.launchpad.net/bugs/2003425)"
+msgstr ""
+
+#: ../../22.04/2.md 99767e3ef5f8400599c9a6f307ad5ca7
+msgid "jammy/linux-azure-fde: 5.15.0-1033.40.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md a36d1eb38ee445d7bad018813f533b8a
+msgid "[2001760](https://bugs.launchpad.net/bugs/2001760)"
+msgstr ""
+
+#: ../../22.04/2.md a1d2b426a41845f0a8912c57e9fb35ef
+msgid "jammy/linux-azure-fde: 5.15.0-1032.39.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 80a5f4546cb94f18b6cb6ab98137fdd4
+msgid "linux-signed-azure-fde"
+msgstr ""
+
+#: ../../22.04/2.md e7022b1a3e2a444b89e8bafb3b18c017
+msgid "linux-signed-gcp"
+msgstr ""
+
+#: ../../22.04/2.md bbc821d9c500418c925a20e82b23078d
+msgid "nvidia-graphics-drivers-418-server"
+msgstr ""
+
+#: ../../22.04/2.md 62beb383113b40738e7d86c4f27a1cc7
+msgid "[1993328](https://bugs.launchpad.net/bugs/1993328)"
+msgstr ""
+
+#: ../../22.04/2.md 7afd2b05e7e04c979b7e66843cf767f9
+msgid "Add support for Linux 5.19."
+msgstr ""
+
+#: ../../22.04/2.md 2a6272e8397c4edaaee33afbbac9270f
+msgid "zfs-linux"
+msgstr ""
+
+#: ../../22.04/2.md 65db890bce794becb87716c2b3a4fb8c
+msgid "[2003174](https://bugs.launchpad.net/bugs/2003174)"
+msgstr ""
+
+#: ../../22.04/2.md 2568c976fbed4e92b9c1c441ddca7138
+msgid "No change, rebuild with the jammy toolchain."
+msgstr ""
+
+#: ../../22.04/2.md 01851ca58c3e4fc288ddf3e5d101b4c6
+msgid "linux-signed-intel-iotg"
+msgstr ""
+
+#: ../../22.04/2.md d09afe2ed51c4b6792ba60be4a8f7145
+#: d5a09f2636c940089ae255ea98284f4a e0c73455ec394254ac3b540fe2f52908
+msgid "bcmwl"
+msgstr ""
+
+#: ../../22.04/2.md a20016ed13d640eab7dde161a12515a5
+msgid "[1998039](https://bugs.launchpad.net/bugs/1998039)"
+msgstr ""
+
+#: ../../22.04/2.md a242725463b4498ca9f23b6f142df563
+msgid "debian/dkms.conf.in, debian/patches/0041-dev-addr-access.patch:"
+msgstr ""
+
+#: ../../22.04/2.md 823409f2381949629d92a3a73d2a31cc
+msgid "[1999009](https://bugs.launchpad.net/bugs/1999009)"
+msgstr ""
+
+#: ../../22.04/2.md dc61b0a07a92417aa9221e1f0574f0bb
+msgid "debian/dkms.conf.in, debian/patches/0042-add-support-for-linux-6.x.patch:"
+msgstr ""
+
+#: ../../22.04/2.md d6fb8d5e97114409aef52c5b31278271
+msgid "[1981968](https://bugs.launchpad.net/bugs/1981968)"
+msgstr ""
+
+#: ../../22.04/2.md 3d3aae9ab30c4ea487d82b25a0e5eee5
+msgid "debian/dkms.conf.in, debian/patches/0040-add-support-for-linux-5.18.patch:"
+msgstr ""
+
+#: ../../22.04/2.md ed56d90055c44a50ba68afe946f755f1
+msgid "linux-signed-hwe-5.19"
+msgstr ""
+
+#: ../../22.04/2.md 0c13c94d859f499a94b21bfd268928e7
+#: 0d5ae6f4eb4d46cfb5d82a5bfda422c1 18507296c95c4fba82f077ff73b9be31
+#: 1be7d932d4cd425b914fcfd4eb8b7234 20b4b986fd5f46a09899d27a5f220924
+#: 298d65fec197427dadb37487b0b6c5a0 38c9f8d70a0f497c977221515ce9285f
+#: 46c9d18b0fa54b9ba55c2506c63016d9 470f413aee8c4e12b06c1706737d966f
+#: 5266f77735fa4e41b9683ab92d546bca 571c2ae23c7c4fb38698c11eb0731af7
+#: 6d730a0a5cdf416d910098a4c5881cf6 6e5ad344f5ce48509d66048364250def
+#: 70f7310c812d4157936645b6f3c3efdf 769c9834c65442ca8af7ace9d5270598
+#: 77655d9b979341428b98dc37e25b010c 77cfb67ea9974124ab6c7fda7d0af083
+#: 7b8b063091ac417a98d606f7911c9b6f 7dba93fc3e0c4e558ba08b41514dbe61
+#: 8211c39e4de14f218e889669bc8dbb34 850a295c8d184a5ba569319e0530bf4e
+#: 85a2dc5fa60546c3801c5eeecb96f99d 87df93add201485c9deed476d6dfd6c4
+#: 956fc00b7b754fa1bb10ff6d44296e71 98301f5616e14d1eb36d8e0e08d74e23
+#: 9e4628ddfb84438682391f2aadf73b48 a64dbf67f31946428b2fcde1cb389d11
+#: b93d5388400b4187bf67c6cc1cc8e197 b9af9e75c2514c82b6800baa897ae818
+#: c0299a611d9242afbf45feda8fbde1f4 c253adbe306942159fb652de55802cc6
+#: c47ab0bef2a545719600eb393533277b d699a51c9f4c4a62ae2542ba7c0f1a21
+#: e1709827884e429b86b928c2d88cb051 e479920ce93e496e82e64cd6cd2fa30b
+#: e69aad4b1cd64d6da54737137b75ae9f ee64043347c3498f8c989a417bedb3e9
+#: fa391820dfce4a64b8b22fc028d272f2 fb552e219dbc4385a1479bd055348674
+msgid "linux-lowlatency-hwe-5.19"
+msgstr ""
+
+#: ../../22.04/2.md 4ecacf6537fa447896c229f7301b3754
+msgid "[2003419](https://bugs.launchpad.net/bugs/2003419)"
+msgstr ""
+
+#: ../../22.04/2.md 0dc2a8cf73674262803ee14bf0c85b57
+msgid "jammy/linux-lowlatency-hwe-5.19: 5.19.0-1017.18~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md b2cb224873bd4f89899bc2443414001b
+msgid "[2003420](https://bugs.launchpad.net/bugs/2003420)"
+msgstr ""
+
+#: ../../22.04/2.md 46b575ce5dbb44af93e70e934d5181e6
+msgid "kinetic/linux-lowlatency: 5.19.0-1017.18 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md d3be71168fa84f00ac11abba4056a914
+msgid "[2001750](https://bugs.launchpad.net/bugs/2001750)"
+msgstr ""
+
+#: ../../22.04/2.md 3fbde27e29a842508701cd9bb5f2c38d
+msgid "kinetic/linux-lowlatency: 5.19.0-1016.17 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md c1131fab9c41406dbab875057c1dceea
+msgid "[1999739](https://bugs.launchpad.net/bugs/1999739)"
+msgstr ""
+
+#: ../../22.04/2.md a9c229fa08584ac1bece18e44ff729d6
+msgid "jammy/linux-lowlatency-hwe-5.19: 5.19.0-1014.15~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 22e2df18db5949188a3cbf057f71f000
+#: 4e059b67fa1d4466b201528500653a16
+msgid "[1989334](https://bugs.launchpad.net/bugs/1989334)"
+msgstr ""
+
+#: ../../22.04/2.md 1c53f445e1154339a093ec3224500c37
+#: e97d53c9d7264e19b4053ba72cc6b678
+msgid "remove circular dep between linux-image and modules"
+msgstr ""
+
+#: ../../22.04/2.md f324f7941ef2437983dd1c0f8c1814c7
+msgid "[1999740](https://bugs.launchpad.net/bugs/1999740)"
+msgstr ""
+
+#: ../../22.04/2.md 1b3c278f21c340459f612412fb255bc6
+msgid "kinetic/linux-lowlatency: 5.19.0-1014.15 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md fb18e0121b9241138800a846a6659367
+msgid "[1997786](https://bugs.launchpad.net/bugs/1997786)"
+msgstr ""
+
+#: ../../22.04/2.md b30cfd0713234b988989e2847179b8d6
+msgid "jammy/linux-lowlatency-hwe-5.19: 5.19.0-1013.14~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 7f0bbc1d505c416bbe4daff1fe9ce5da
+msgid "[1997787](https://bugs.launchpad.net/bugs/1997787)"
+msgstr ""
+
+#: ../../22.04/2.md 042d59d1e69a415da81538a4b5f7bb3b
+msgid "kinetic/linux-lowlatency: 5.19.0-1013.14 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/2.md 8f39b88f8588473bb0d8935db72550ab
+msgid "linux-signed-lowlatency-hwe-5.19"
+msgstr ""
+
+#: ../../22.04/2.md:664 a55eb05f25ff4b58b76d1f6781016573
+msgid "Unsorted changes"
+msgstr ""
+
+#: ../../22.04/2.md a2cc50aa41164b56bd13f4f4b19fafc8
+msgid "xdg-utils"
+msgstr ""
+
+#: ../../22.04/2.md feeea679da2d428683ed0e1b942e7cd3
+msgid "[1967963](https://bugs.launchpad.net/bugs/1967963)"
+msgstr ""
+
+#: ../../22.04/2.md 779b6c305d784441b168ba12e2eec0f3
+msgid "Update a distro patch from the corresponding upstream merge request"
+msgstr ""
+
+#: ../../22.04/2.md 758aae378ade4a87a37a963ac62322fc
+msgid "cmake"
+msgstr ""
+
+#: ../../22.04/2.md d2149980f8fd4d7c989480327d30a54e
+msgid "[1986665](https://bugs.launchpad.net/bugs/1986665)"
+msgstr ""
+
+#: ../../22.04/2.md 637ed6e191624267b359629ef288092d
+msgid "Cherry pick upstream change to fix FindGTest for Gmock"
+msgstr ""
+
+#: ../../22.04/2.md 4316600dfbb1452d84f34913669d7c16
+msgid "zlib"
+msgstr ""
+
+#: ../../22.04/2.md f8888acb8fe64cd3806a9ac521b81772
+msgid "[1961427](https://bugs.launchpad.net/bugs/1961427)"
+msgstr ""
+
+#: ../../22.04/2.md 3ab0127ec29f49d1b73ebf252150687e
+msgid ""
+"d/p/410-lp1961427.patch ported from zlib #410, fixing compressBound() "
+"with hw acceleration.  Thanks to Ilya Leoshkevich <iii@linux.ibm.com>. In"
+" addition a patch is needed for bedtools."
+msgstr ""
+
+#: ../../22.04/2.md 6ad5077696b04362bac24ad001060326
+msgid "[1982571](https://bugs.launchpad.net/bugs/1982571)"
+msgstr ""
+
+#: ../../22.04/2.md 51094a3fee0e4d1dbee5edee89518aad
+msgid ""
+"meta/gadget.yaml: use loader1 and loader2 instead of their capitalized "
+"versions for the u-boot partitions. This is then consistent with our "
+"preinstalled images."
+msgstr ""
+
+#: ../../22.04/2.md b0beb97d252e436c9030bcfb53e34f0d
+msgid "autopkgtest"
+msgstr ""
+
+#: ../../22.04/2.md abf9d2fcd7ee499c87646777f33311aa
+msgid "[1988527](https://bugs.launchpad.net/bugs/1988527)"
+msgstr ""
+
+#: ../../22.04/2.md d5bf1cb39a94428a9a8722337555609c
+msgid ""
+"qemu: fix the ppc64le arch name in kvm_compatible(). Upstream cherry-pick"
+" (93fd5ea9)."
+msgstr ""
+
+#: ../../22.04/2.md 7a0a99b0674a4cf2bf2c5732a6d19e4f
+msgid "gdb"
+msgstr ""
+
+#: ../../22.04/2.md c9677d970c71480783cf28487200c75f
+msgid "[1971474](https://bugs.launchpad.net/bugs/1971474)"
+msgstr ""
+
+#: ../../22.04/2.md 16492ba479c84251addb1732a2f5a158
+msgid "SRU: : Update to the final 12.1 release in 22.04 LTS."
+msgstr ""
+
+#: ../../22.04/2.md 748770542d694e52825d3bed1cf733ee
+msgid "libp11"
+msgstr ""
+
+#: ../../22.04/2.md a497302ce0b14febb703d4eae5b07967
+msgid "[1987938](https://bugs.launchpad.net/bugs/1987938)"
+msgstr ""
+
+#: ../../22.04/2.md 352bf0ff2b094da19d5e3a10bb819ad9
+msgid ""
+"d/p/0001-When-a-PIN-explicitly-provided-use-a-PIN-regadless-o.patch: Use "
+"a PIN when explicitly provided regardless of the security login flag."
+msgstr ""
+
+#: ../../22.04/2.md 42f065cb76f046ddb356b1dae6d0cbea
+msgid "debootstrap"
+msgstr ""
+
+#: ../../22.04/2.md 16745f80fed048c7bcfe4c7c2e6726fb
+msgid "[1995612](https://bugs.launchpad.net/bugs/1995612)"
+msgstr ""
+
+#: ../../22.04/2.md 01940d6cc94a4749bf6b6b81ae305c26
+msgid "Add (Ubuntu) lunar as a symlink to gutsy."
+msgstr ""
+
+#: ../../22.04/2.md d1651902217940948386c5a62a84dbe0
+msgid "lintian"
+msgstr ""
+
+#: ../../22.04/2.md f06ef5cb125144b58e97bda73e0368f4
+msgid "[1996085](https://bugs.launchpad.net/bugs/1996085)"
+msgstr ""
+
+#: ../../22.04/2.md f004876136a247f7a4c0412cea69f33b
+msgid "Add \"lunar\" as a known Ubuntu distribution."
+msgstr ""
+
+#: ../../22.04/2.md 55683a88840a4f648b0c60abe86d8cc9
+msgid "[1991812](https://bugs.launchpad.net/bugs/1991812)"
+msgstr ""
+
+#: ../../22.04/2.md a810725fd0284a3b9c399339c3fcffa8
+msgid ""
+"d/frr.postinst: don't change log ownership if the syslog user doesn't "
+"exist. Thanks to Alessandro Ratti <alessandro.ratti@exoscale.ch> for the "
+"fix."
+msgstr ""
+
+#: ../../22.04/2.md 119e6fd9a2cc428b8487d2a98c1310ff
+msgid "tmux"
+msgstr ""
+
+#: ../../22.04/2.md 9e85cc35852b42ae9adf24ffb54652d6
+msgid "[1976110](https://bugs.launchpad.net/bugs/1976110)"
+msgstr ""
+
+#: ../../22.04/2.md e3bc69737d8c447f8a3ddc5151b492e2
+msgid ""
+"d/p/lp1976110-respect-sizing.diff: Add patch to only use client for "
+"sizing when not detached."
+msgstr ""
+
+#: ../../22.04/2.md 8b58444c36104aa18c27e2fd22fc7b80
+#: d56b781a6f424c91806e7d24f9660725
+msgid "python-apt"
+msgstr ""
+
+#: ../../22.04/2.md b7149b6f77e14e9cad92bce8bef076dc
+msgid "[1998265](https://bugs.launchpad.net/bugs/1998265)"
+msgstr ""
+
+#: ../../22.04/2.md a98490320ffd44a78db71c5624b536cb
+msgid "AcquireFile: Handle large files"
+msgstr ""
+
+#: ../../22.04/2.md c56432bc52a947f2910f3f47a152d063
+msgid "[1998488](https://bugs.launchpad.net/bugs/1998488)"
+msgstr ""
+
+#: ../../22.04/2.md 9253bd1218c64fc1b9d121c3f693b8e8
+msgid "apt: fix mypy in apt.progress.text.AcquireProgress"
+msgstr ""
+
+#: ../../22.04/2.md 2bfb0e45855d43818d5dc7ad4ee34a52
+msgid "kbd"
+msgstr ""
+
+#: ../../22.04/2.md e2fbeaf2f66b447495d87989e95b4be5
+msgid "[1996619](https://bugs.launchpad.net/bugs/1996619)"
+msgstr ""
+
+#: ../../22.04/2.md 803552e190a840ecaaacf2cd4e6a7250
+msgid ""
+"d/p/libkfont-Use-only-KDFONTOP.patch: Fixes error thrown in syslog from "
+"deprecated setfont"
+msgstr ""
+
+#: ../../22.04/2.md b51afa53895e4382b8b8d767727f034a
+msgid "[1997779](https://bugs.launchpad.net/bugs/1997779)"
+msgstr ""
+
+#: ../../22.04/2.md d231679f75694434a4a3385bbbc0218a
+msgid "Source debconf in postinst script"
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/22.04/3.po
+++ b/docs/locale/ja/LC_MESSAGES/22.04/3.po
@@ -1,0 +1,3871 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../22.04/3.md:2 4e1abfbdb5964241853319e897e0d0aa
+msgid "Changes in Ubuntu 22.04.3"
+msgstr ""
+
+#: ../../22.04/3.md:4 727def0cb2c04715aafe48c5da8bca95
+msgid ""
+"This is a brief summary of bugs fixed between Ubuntu 22.04.2 and 22.04.3."
+" **This summary covers only changes to packages in *main* and "
+"*restricted*, which account for all packages in the officially-supported "
+"images; there are further changes to various packages in *universe* and "
+"*multiverse*.** Some of these fixes were by Ubuntu developers directly, "
+"while others were by upstream developers and backported to Ubuntu. For "
+"full details, see the individual package changelogs."
+msgstr ""
+
+#: ../../22.04/3.md:6 f58eebd9e1be43aca35a307f8d9e0bb1
+msgid ""
+"In addition to the bugs listed below, this update includes all security "
+"updates from the [Ubuntu Security Notice "
+"list](https://ubuntu.com/security/notices?order=newest&release=jammy&details=)"
+" affecting Ubuntu 22.04.1 LTS that were released up to and including "
+"August 3, 2023. The last update included was USN-6275-1."
+msgstr ""
+
+#: ../../22.04/3.md:8 a4804ae875c44ed48ebf38cf32346d7d
+msgid "Installation bug fixes"
+msgstr ""
+
+#: ../../22.04/3.md:10 571b607e5b2249e49e3ed680e0eeed22
+msgid ""
+"Updated CD images are provided with this release, including fixes for "
+"some installation bugs. (Many installation problems are hardware-"
+"specific; for those, see “Hardware support bugs” below.)"
+msgstr ""
+
+#: ../../22.04/3.md 2e4a3fe19e0042f08b6cf86827c3c2e3
+#: 3a7c8964e62c40799b6e1a49b40a5011 4edc7de43970474595bdbaf0634f65e0
+#: 6bca62c222a546fc91bb8fa11cb52661 9c01278bbf404f4eb9a43a3c9f6a2bf3
+#: aaf4d8f456764b35bc33274889fabdb0
+msgid "Source Package"
+msgstr ""
+
+#: ../../22.04/3.md 0616f61d44a6499299a47928e76f37c2
+#: 2566fcdbbb3f4881a1794b16594a3910 317cfa17568c4ab0a750632cafe7508d
+#: 69a0794162dc4b3e880ed7e901401b67 7a3b913bd1d447a7b8f2a1f74da761c6
+#: fb0e057e69134122ad1146e8575cfb57
+msgid "Bug #"
+msgstr ""
+
+#: ../../22.04/3.md 0e796eed22fd45bf9fb931571e597d50
+#: 7a0a0a9749354dff820e1eba3d513961 7cc47fe75f884f67adf2ac3528b1cdf5
+#: 9565e567191a429b856c251bdbc0a54f a431426a523045dcb22eb969f1f6ac1c
+#: a6a451946e954b349f268dbf12cbf2f5
+msgid "Description"
+msgstr ""
+
+#: ../../22.04/3.md d3692386089f4f098ec20c0bdf37b191
+msgid "casper"
+msgstr ""
+
+#: ../../22.04/3.md a52bdf6035bd4ce9880f778df8d560de
+msgid "[1986781](https://bugs.launchpad.net/bugs/1986781)"
+msgstr ""
+
+#: ../../22.04/3.md e7a1ac2c6b1c4278a84d82111f810397
+msgid ""
+"d/casper.casper-md5check.service: order it After=multi-user.target. This "
+"should allow us to reach multi-user.target sooner, especially for users "
+"where the md5 check is slow."
+msgstr ""
+
+#: ../../22.04/3.md 51904111769b482ba63a05c91283568b
+#: 9204414552e846d491476cf09a323ec7 a2b45d89b2dc434bbbf87a4313284e5c
+#: dfc8a2b47bcf4f3eac58109c626d7efd
+msgid "ubiquity"
+msgstr ""
+
+#: ../../22.04/3.md 0084a46c1e9a41f8b7625c423eb059fe
+msgid "[1925265](https://bugs.launchpad.net/bugs/1925265)"
+msgstr ""
+
+#: ../../22.04/3.md 46ef9cafb86e42e8abf095f73983fb97
+msgid ""
+"Whenever removing packages, use apt-get autoremove --purge instead of "
+"apt-get purge so that no-longer-used dependencies are removed together "
+"with the package in question, and we do not leave behind any packages "
+"that will be reported as autoremovable later."
+msgstr ""
+
+#: ../../22.04/3.md 2b29aaeaf34c4a2cb69c555b429f9173
+msgid "[1978931](https://bugs.launchpad.net/bugs/1978931)"
+msgstr ""
+
+#: ../../22.04/3.md cc164279b59b466aacf4108073a41948
+msgid ""
+"Use dpkg-divert /sbin/start-stop-daemon unconditionally instead of just "
+"renaming it conditionally."
+msgstr ""
+
+#: ../../22.04/3.md c716d9f14bee4853b911c091d2553595
+msgid "[1993318](https://bugs.launchpad.net/bugs/1993318)"
+msgstr ""
+
+#: ../../22.04/3.md b7164bdaa33645388394d606f6c9fa1c
+msgid "zsys-setup: generate correct zfs-list.cache for target"
+msgstr ""
+
+#: ../../22.04/3.md 50bca6bc7b2045d6bf639b9cfd2f8be3
+msgid "[2022965](https://bugs.launchpad.net/bugs/2022965)"
+msgstr ""
+
+#: ../../22.04/3.md b40d686ff86e413592ccd2ac62de995c
+msgid "tests: modify test_city_entry to adapt to tzdata update"
+msgstr ""
+
+#: ../../22.04/3.md:20 19eed0f918fa400fbdb5ad75ae2ad801
+msgid "Desktop fixes"
+msgstr ""
+
+#: ../../22.04/3.md:22 0f0062143fc84d84baf1eb4ad89c2f1f
+msgid ""
+"These changes mainly affect desktop installations of Ubuntu, Kubuntu, "
+"Ubuntu MATE and other Ubuntu-based systems."
+msgstr ""
+
+#: ../../22.04/3.md 28c25a990b9c465fac911fc7f69919ee
+#: c62e3d66ad91445f96cd61782e3ae6ab d75b3e2758d14b0c800d29283c75ba41
+msgid "apport"
+msgstr ""
+
+#: ../../22.04/3.md 40c1ea1c26e246a892b2d3688a9233de
+msgid "[1780767](https://bugs.launchpad.net/bugs/1780767)"
+msgstr ""
+
+#: ../../22.04/3.md 7e0732e8fae64afb96337fd3e853b0f7
+msgid ""
+"tests: Fix GTK UI race condition and reduce timeout again, saving five "
+"minutes test execution time"
+msgstr ""
+
+#: ../../22.04/3.md 49fce4b39da74aefa7130419e0355bef
+msgid "[1973470](https://bugs.launchpad.net/bugs/1973470)"
+msgstr ""
+
+#: ../../22.04/3.md d859ba462eab41d1aa35e8faa6966ccc
+msgid "apport-bug: Add /snap/bin to PATH for Firefox snap on Lubuntu"
+msgstr ""
+
+#: ../../22.04/3.md 8166fba5e0e54032bde18685ec926bca
+msgid "[1978301](https://bugs.launchpad.net/bugs/1978301)"
+msgstr ""
+
+#: ../../22.04/3.md c5820b45c2a74d529785af430b708b63
+msgid "apport-gtk: Exclude trailing dot from URL links"
+msgstr ""
+
+#: ../../22.04/3.md 3bcd88b520574a06abdb44abc1c8eb37
+msgid "evince"
+msgstr ""
+
+#: ../../22.04/3.md 62798339862943fc99f07e6dfdb2b217
+msgid "[1915910](https://bugs.launchpad.net/bugs/1915910)"
+msgstr ""
+
+#: ../../22.04/3.md 1c10c75a1c114795b0be364b0940d913
+msgid ""
+"allow access to the libproxy helper pxgsettings which is needed on some "
+"configuration to access remote printers"
+msgstr ""
+
+#: ../../22.04/3.md 3aa2f21c26c049ca89b8c08e23996fea
+#: 4d485be429e343438b2e816676510db4 746e8e33e8c6461c9bb69c8f56049a17
+msgid "gdm3"
+msgstr ""
+
+#: ../../22.04/3.md b4004eb0a4bb4f8c9a7d3b3b1df3ee86
+msgid "[1999884](https://bugs.launchpad.net/bugs/1999884)"
+msgstr ""
+
+#: ../../22.04/3.md 414815f1a5f44226875c340a216d3454
+msgid ""
+"debian/gdm3-gdm-smartcard*: Do not fail if pam_succeed_if succeeded. We "
+"were not handling the success case in pam_succeed_if.so, and so even if "
+"other modules were successful, gdm-smartcard was failing with a "
+"permission denied error, because the pam_succeed_if default was bad, and "
+"this was applied to the success case too. Alternatively we could even "
+"just use success=ignore here, but it's better to be consistent with other"
+" usages."
+msgstr ""
+
+#: ../../22.04/3.md 2ab18e2c0f2e41798408444e3797ae03
+msgid "[2006059](https://bugs.launchpad.net/bugs/2006059)"
+msgstr ""
+
+#: ../../22.04/3.md fc1b9226c0ef452bb2176516a12ccec1
+msgid ""
+"Add local-display-factory-Fix-typo-in-supported-session-types.patch: To "
+"fix unreliable session type selection"
+msgstr ""
+
+#: ../../22.04/3.md 4ccfd5cede324bc5a2661377b9fd608b
+msgid "[2020641](https://bugs.launchpad.net/bugs/2020641)"
+msgstr ""
+
+#: ../../22.04/3.md 89929953b9c14c6ca478522b8b7a7950
+msgid ""
+"clear signal handlers after udev settle to avoid unexpected session "
+"logouts, thanks Ghadi Rahme (lp: #2020641)"
+msgstr ""
+
+#: ../../22.04/3.md 1c3ce00f17844a619c3c9b194ed707f6
+#: 2ae6cdaa809d423db8f28f24084d4df1 d50227bd20f54e8c816cbf783873f2ba
+#: ed035182d9d447c88699ae01a2b7deb5
+msgid "gjs"
+msgstr ""
+
+#: ../../22.04/3.md 73c1bc140e2244499d9305ffdd056ac3
+#: da0b8a63402941f7b4ac216d1c5a47c1
+msgid "[1974293](https://bugs.launchpad.net/bugs/1974293)"
+msgstr ""
+
+#: ../../22.04/3.md 3cdbb730d335451ab67d90f410f7176a
+msgid "Add context-Clear-all-vectors-of-JS-Heap-on-dispose.patch"
+msgstr ""
+
+#: ../../22.04/3.md d6547d05443f4a8c82e6f215bebecdcf
+msgid ""
+"debian/patches: Refresh teardown patch, replacing it with the one landed "
+"upstream"
+msgstr ""
+
+#: ../../22.04/3.md de9600cf9ac3464ab37e7a10641c8812
+msgid "[2012978](https://bugs.launchpad.net/bugs/2012978)"
+msgstr ""
+
+#: ../../22.04/3.md d351106309cf4a25950f42b3305e2238
+msgid "debian/patches: Cherry-pick upstream fixes to address various memory leaks"
+msgstr ""
+
+#: ../../22.04/3.md 6284a327083a4a1b92f39914559a63e6
+msgid "[2023572](https://bugs.launchpad.net/bugs/2023572)"
+msgstr ""
+
+#: ../../22.04/3.md 14f22ea1944d410a90fe3624347b8dd9
+#: 1ab8711757954da286d348ed93e0e8fe 23a44bda0f0f45908f69966c2ee0cd72
+#: 25659c2ba39e465688d9d0dd45949b7f 328b7aa641a44f77a0d2dd0af66ccf9d
+#: 33efb57fcc8345e797e8ecdd78e70c25 38887d8ca7ea41a6bbd98779e6d18733
+#: 4a70e7eea77d402eaeba91c86cc79b70 5afb8dc498bc47cfbd66a23f7b8f8d0c
+#: 5dc995c0951c40ccb3f5a5ae067584c6 69366edf46d14716adac781ee47b9f33
+#: 6fd0aa37ff5d4de1bc124e24d32df23c 8395c445b3a940d2bff6664d724d3894
+#: 86d1877a2fc84c858deb11643ca7c285 877f1fe034634433b09f3dbd30394105
+#: 8f2fd1c7fd86431497fa5465c745f585 94eeb06db0d54e63bdf44a97401d3538
+#: 99f52b16b8a247678baa0d3929ef29e6 a5386199948f44a08a9b7f530a275f16
+#: d6e27a5d55ec45dfb4ae884b69ee89f8 e68b0179020747c3b2383d32bb894804
+#: e9069f7dded644a7b6aad7f470bad51e e995f0a9ab9a44778d3b827d7feba022
+#: f8be6bf2919f4e71998f017d283aa46d fea6cee0cbe8433e9fcb774e685a44fe
+msgid "New upstream release"
+msgstr ""
+
+#: ../../22.04/3.md 93636f63484246a1b1390b6f5af91a5e
+msgid "glib2.0"
+msgstr ""
+
+#: ../../22.04/3.md 8f803f5faa4646c2b1896055ababdbbf
+msgid "[1998267](https://bugs.launchpad.net/bugs/1998267)"
+msgstr ""
+
+#: ../../22.04/3.md 3004b6c7e52b49ab8ec78ecb6495f4ed
+msgid "Make portal support aware of snaps"
+msgstr ""
+
+#: ../../22.04/3.md ff8aa77c19b846d58620ad4f20117a6f
+msgid "gnome-control-center"
+msgstr ""
+
+#: ../../22.04/3.md 604f4b4ec14249069b96a724f0e5bef5
+msgid "[2026228](https://bugs.launchpad.net/bugs/2026228)"
+msgstr ""
+
+#: ../../22.04/3.md 722e867f03514839a700419b5a1e31f5
+msgid ""
+"Cherry-pick 3 patches to fix mirror mode crash when resolution of the 2 "
+"monitors don't match"
+msgstr ""
+
+#: ../../22.04/3.md 9135cfcceb5c4245bc6412f6acbdd29a
+msgid "gnome-desktop"
+msgstr ""
+
+#: ../../22.04/3.md 0057fd8842e445c3b15529e4da2a1c24
+msgid "[2023923](https://bugs.launchpad.net/bugs/2023923)"
+msgstr ""
+
+#: ../../22.04/3.md 27043d8759d142b49c62d5e7d692528e
+#: 5e7a1d5da9da4f7a824df1977faead70
+msgid "gnome-initial-setup"
+msgstr ""
+
+#: ../../22.04/3.md 846d2976783e4a1da30941e4514026c9
+msgid "[2004037](https://bugs.launchpad.net/bugs/2004037)"
+msgstr ""
+
+#: ../../22.04/3.md d4508c4583bf4806b3a8450ce3de4580
+msgid "fix an incorrect pointer use in the connectivity callback (lp: #2004037)"
+msgstr ""
+
+#: ../../22.04/3.md 567361d167bd4bf1a319e2878c6c3794
+msgid "[2004518](https://bugs.launchpad.net/bugs/2004518)"
+msgstr ""
+
+#: ../../22.04/3.md c38e111ff33c44bfb3597b078860c02e
+msgid "fix a crash in the dispose handler (lp: #2004518)"
+msgstr ""
+
+#: ../../22.04/3.md 2382dedd560447919089448f90dc4307
+msgid "gnome-settings-daemon"
+msgstr ""
+
+#: ../../22.04/3.md 5064ca6a00d544d3a3a5ba6ecacbb573
+msgid "[2011770](https://bugs.launchpad.net/bugs/2011770)"
+msgstr ""
+
+#: ../../22.04/3.md 287d6828bbd340e2baf5e3d95c956a5f
+msgid ""
+"cherrypick a change proposed upstream to fix airplane mode on some Lenovo"
+" laptops (lp: #2011770)"
+msgstr ""
+
+#: ../../22.04/3.md fe005861ac6b41668babbd118e141741
+msgid "gnome-shell"
+msgstr ""
+
+#: ../../22.04/3.md bebfdd7ec9994f0d917122c1f7b168f3
+msgid "[2023913](https://bugs.launchpad.net/bugs/2023913)"
+msgstr ""
+
+#: ../../22.04/3.md 28a069f111f44f58a078746c370d81ac
+#: 37e3e72b4f5a426bbe7a18135770b1fb 42d7e97acfdd4c6198d6640e1509db86
+#: 47bda45d0e4a45ef87b350366bb6595a 53efd902e6b34706bf6d800c3fc85a20
+#: 94efe71ff138480d9d61b17d88786243 affff53b9d73438eb899105dd4bd670a
+#: dd593a309ec44afdb7f60cac8dc8c5e7
+msgid "gnome-shell-extension-ubuntu-dock"
+msgstr ""
+
+#: ../../22.04/3.md 6e181e3701f04d978fc28db9e3c78e03
+msgid "[1965208](https://bugs.launchpad.net/bugs/1965208)"
+msgstr ""
+
+#: ../../22.04/3.md 161c86cbbb7d483fb6f6a5edee7bdfb4
+msgid ""
+"docking: Ensure we perform the startup animation completely on docks "
+"updates"
+msgstr ""
+
+#: ../../22.04/3.md 2342a4a31f8f4c0492c14ff00dd9297e
+msgid "[1979096](https://bugs.launchpad.net/bugs/1979096)"
+msgstr ""
+
+#: ../../22.04/3.md 993884c49c464a9b81e56bbacb8c52c5
+msgid "Keep shell overview always visible and usable"
+msgstr ""
+
+#: ../../22.04/3.md a53a50612ab448d78f893d2eef02336e
+#: dcf6457daed840b1a460d05d8e106506
+msgid "[1983130](https://bugs.launchpad.net/bugs/1983130)"
+msgstr ""
+
+#: ../../22.04/3.md a1e4899a2574409f83aa58221376774b
+msgid "Do not hide the dock when menus are closed"
+msgstr ""
+
+#: ../../22.04/3.md 962f746e5d7b4c52a45d03f46c177b71
+msgid "docking: Ignore hover changes if overview is visible"
+msgstr ""
+
+#: ../../22.04/3.md 767e8525764c49818c23ba979ff7c906
+#: e93104966eb543a3996ef0afe5a2c90b
+msgid "[1992847](https://bugs.launchpad.net/bugs/1992847)"
+msgstr ""
+
+#: ../../22.04/3.md 5cc8a675c71c4e9192b419d60094e2ad
+msgid "docking: Also reduce the app grid area when in auto-hide mode"
+msgstr ""
+
+#: ../../22.04/3.md 51b97f3a5b304a1d906d62516d651426
+msgid "docking: Keep overview controls layout proportions when resizing it"
+msgstr ""
+
+#: ../../22.04/3.md 0fab98015da147b0a868bc33de08e4a1
+#: 5a666eb5f29c4036abba5b969e1e7463
+msgid "[2019751](https://bugs.launchpad.net/bugs/2019751)"
+msgstr ""
+
+#: ../../22.04/3.md 7f2610cdb6fa47bea3aab12c1184ad0c
+msgid "Ensure startup animations are performed on monitor changes"
+msgstr ""
+
+#: ../../22.04/3.md d6c2795dca104476b7b84d2a38d533e8
+msgid "docking: Handle when dash is destroyed during the login animation"
+msgstr ""
+
+#: ../../22.04/3.md 6126c0719788463c968a57f3aa0aedba
+#: dabee8a611034353b6a7ef412662d66f
+msgid "gtk4"
+msgstr ""
+
+#: ../../22.04/3.md cc161b77c34e47e6871e73af325fcb77
+msgid "[2027986](https://bugs.launchpad.net/bugs/2027986)"
+msgstr ""
+
+#: ../../22.04/3.md e625433f2061464d895da858067d9f48
+msgid "debian/patches: Properly handle gtk scale adjustment property"
+msgstr ""
+
+#: ../../22.04/3.md 41f7e7d516d14b0384a6c83419fb8439
+msgid "[2028005](https://bugs.launchpad.net/bugs/2028005)"
+msgstr ""
+
+#: ../../22.04/3.md 8f8433311a514a29a9cbe40e3d09f351
+msgid "libadwaita-1"
+msgstr ""
+
+#: ../../22.04/3.md 424e0135189349108059cac573fcff26
+msgid "[2023548](https://bugs.launchpad.net/bugs/2023548)"
+msgstr ""
+
+#: ../../22.04/3.md 1285d866bb7e40d997ee63bb4765e70d
+msgid "libcanberra"
+msgstr ""
+
+#: ../../22.04/3.md c3e12bdd1ba64981bd776037235b255b
+msgid "[1983794](https://bugs.launchpad.net/bugs/1983794)"
+msgstr ""
+
+#: ../../22.04/3.md 04f81e19f02e4ef0855e30687bdb9cf8
+msgid ""
+"d/p/gtk-module-Handle-display-closing-gracefully: Do not leak objects on "
+"destruction. As per previous fix for lp:1949200 we were leaking Gtk "
+"Widgets when they were manually destroyed, because we never released the "
+"reference that we added previously. Thanks to Alberts Muktupāvels for "
+"providing the test case and some analysis."
+msgstr ""
+
+#: ../../22.04/3.md b1b60dff9bc14f3f953750fd23ff0c76
+msgid "libfprint"
+msgstr ""
+
+#: ../../22.04/3.md 4ae3aeebfa774840bc500399e2fe097b
+msgid "[2008067](https://bugs.launchpad.net/bugs/2008067)"
+msgstr ""
+
+#: ../../22.04/3.md 062a298efd3d460bbfc0ed0264065070
+msgid "debian/patches/elanmoc-add-PID-0x0c82.patch"
+msgstr ""
+
+#: ../../22.04/3.md 10adb188ea5b4396a8fec281e705da50
+msgid "libidn"
+msgstr ""
+
+#: ../../22.04/3.md daa06e0cf5c8427681e5825d7a790c7a
+msgid "[1971715](https://bugs.launchpad.net/bugs/1971715)"
+msgstr ""
+
+#: ../../22.04/3.md 472757b90e55492990d7e30a9bae0fcf
+msgid "Fix handling of non-ASCII characters"
+msgstr ""
+
+#: ../../22.04/3.md 7c622d0b9d7f4677834b85ef9f6975cd
+msgid "libmbim"
+msgstr ""
+
+#: ../../22.04/3.md 1f75614df849400b8f2b1307196bf13c
+#: 8afe4a4a514f40ce9df6d4860b1b9cf2 cc0c9ff6eb68478bbf5023fdf2a7c116
+msgid "[1950282](https://bugs.launchpad.net/bugs/1950282)"
+msgstr ""
+
+#: ../../22.04/3.md 0331d3e945844bae99ae9d06efede839
+#: 745864050a7a4b739b67c9ae1f8f049d cf23521e045540c69fe8be8a43feb360
+msgid ""
+"Backport the newer modemmanager stack to the LTS as part of new hardware "
+"enablement including FM350 modems (lp: #1950282)"
+msgstr ""
+
+#: ../../22.04/3.md deaba50d313b4c88a8fed3c996d49560
+msgid "libqmi"
+msgstr ""
+
+#: ../../22.04/3.md fc80aed2bc3d484a8512f2e5cb886d75
+msgid "libreoffice"
+msgstr ""
+
+#: ../../22.04/3.md 4ce2aab59cff467eb595ea02460a7777
+msgid "[2003335](https://bugs.launchpad.net/bugs/2003335)"
+msgstr ""
+
+#: ../../22.04/3.md bdf6615d5f0a4262ab2fe0b8660fef6c
+msgid "Cherry picked bug fixes release"
+msgstr ""
+
+#: ../../22.04/3.md 03f6ef086b614c2ea9c60f7dbd837668
+#: 08f7c755899c4e60b0687eca73132b85 0b05e7a9f01741d995fba532187baf6b
+#: 12a54a58be8243febdbf75e379753edc 19aa1281b1d24907b7a659e7a214f728
+#: 763090f0df694defbb63a2427160b3dd fda2c2a946774129aec0f0b17ba86024
+msgid "mesa"
+msgstr ""
+
+#: ../../22.04/3.md 7309de8612e7495b94874deb26debbb7
+msgid "[1990089](https://bugs.launchpad.net/bugs/1990089)"
+msgstr ""
+
+#: ../../22.04/3.md 319980afa21641a0923c6c438cec5f3d
+msgid "patches: Fix a freeze with iris under stress test."
+msgstr ""
+
+#: ../../22.04/3.md 97826a5e4e80408fb4048095568196a7
+msgid "[1991761](https://bugs.launchpad.net/bugs/1991761)"
+msgstr ""
+
+#: ../../22.04/3.md 2b70618cb9a14a6b97acd5d3d0c55341
+#: 7ed0864ac1454e868a669c9026369f8f df20747e1e4541acb021fc512346ddff
+msgid "Backport to jammy."
+msgstr ""
+
+#: ../../22.04/3.md 1886a2654f78442fbe80976a0143929f
+msgid "[2003339](https://bugs.launchpad.net/bugs/2003339)"
+msgstr ""
+
+#: ../../22.04/3.md fcc3aeb310644fac865708cfac474c72
+msgid "patches: Revert two commits causing kwin to eventually crash."
+msgstr ""
+
+#: ../../22.04/3.md 4cf81125ad3242cab57027d4fab78e00
+msgid "[2017142](https://bugs.launchpad.net/bugs/2017142)"
+msgstr ""
+
+#: ../../22.04/3.md 667fd06816f14ea6b9c6c6ea3975606a
+msgid "patches: Fix VA-API on DCN 3.1.4."
+msgstr ""
+
+#: ../../22.04/3.md 5dfeb3743457495c82178a55988de709
+#: fa59c854a44147759b870a3ee1532959
+msgid "[2019212](https://bugs.launchpad.net/bugs/2019212)"
+msgstr ""
+
+#: ../../22.04/3.md aece82cbe03444b59e932762cdf205af
+msgid "Backport to 22.04."
+msgstr ""
+
+#: ../../22.04/3.md d924546259b04b15af56851bcaece2aa
+msgid "[2020604](https://bugs.launchpad.net/bugs/2020604)"
+msgstr ""
+
+#: ../../22.04/3.md c185b6bd721f4fbba22f6a8f2856f2fe
+msgid "rules: Set VERSION so that it also includes the packaging revision."
+msgstr ""
+
+#: ../../22.04/3.md 0da9861c814d41dcbbd2d884016cee92
+msgid "[2021948](https://bugs.launchpad.net/bugs/2021948)"
+msgstr ""
+
+#: ../../22.04/3.md 478482ce7a6041f890a9a6a78f3dde11
+msgid "New upstream release."
+msgstr ""
+
+#: ../../22.04/3.md cdd8cdb6bcaa43209b939071c7feb64d
+msgid "mesa-amber"
+msgstr ""
+
+#: ../../22.04/3.md 9d4b9efa5aeb43c1bce12fbe5474808e
+#: a3a4e4efe3ee4342a53055173add2b16
+msgid "modemmanager"
+msgstr ""
+
+#: ../../22.04/3.md a27b4a05623d4d65acff297e2d5fd6dc
+msgid "[2023746](https://bugs.launchpad.net/bugs/2023746)"
+msgstr ""
+
+#: ../../22.04/3.md 82a1edad94104f99ad9951782da5618d
+msgid ""
+"Backport the newer modemmanager commits from 1.20.4 to the LTS as part of"
+" new hardware enablement including EM05-G/EM05-CN modems (lp: #2023746)"
+msgstr ""
+
+#: ../../22.04/3.md 2f0a4bcb4fde4d268dee02ce4c51a0ea
+#: 58f2b303e2fb4bf58c5f2cb82c7d8476 7f0d1dea26ff443d85c773f32a3e52b2
+#: c3bcbffc893f416eb447dfe3c542622e eff392151fbc4f389177cab9d2239db2
+msgid "mutter"
+msgstr ""
+
+#: ../../22.04/3.md c8b489254a01461987ecd42017a17d0a
+msgid "[2020782](https://bugs.launchpad.net/bugs/2020782)"
+msgstr ""
+
+#: ../../22.04/3.md c3439b87479147dca88305f9a7da9152
+msgid ""
+"Add backends-x11-Return-zero-Hz-instead-of-nan-Hz-for-incompl.patch so "
+"that incomplete graphics mode definitions are reported as having a "
+"refresh rate of 0 Hz instead of -nan Hz. This also fixes the behaviour of"
+" the 'Revert Settings' button"
+msgstr ""
+
+#: ../../22.04/3.md 425ee2dc709145c5abc29748af9b2a9d
+msgid "[2023766](https://bugs.launchpad.net/bugs/2023766)"
+msgstr ""
+
+#: ../../22.04/3.md 334026968ce54db3a3d4ade5c5406a01
+msgid ""
+"Add clutter-frame-clock-Avoid-rapidly-toggling-dynamic-max-re.patch to "
+"avoid cursor stutter"
+msgstr ""
+
+#: ../../22.04/3.md 37257403a17a45be8f08b1ad4e8e726e
+msgid "[2026887](https://bugs.launchpad.net/bugs/2026887)"
+msgstr ""
+
+#: ../../22.04/3.md 0ad250b99c984c6ca5354ad18757eb60
+msgid ""
+"Add Revert-data-udev-Don-t-disable-KMS-modifiers-on-newer-i91.patch to "
+"fix rendering failures on older kernels (5.15) when run on newer hardware"
+" (Intel Alder Lake)."
+msgstr ""
+
+#: ../../22.04/3.md 1353118b1df247b3b256e72b09441ece
+msgid "pango1.0"
+msgstr ""
+
+#: ../../22.04/3.md 4f2dcaff9f8f4427a14a8aef62aa651a
+msgid "[2006756](https://bugs.launchpad.net/bugs/2006756)"
+msgstr ""
+
+#: ../../22.04/3.md 920f291ec45b4d9085d6fea531882e06
+msgid "Cherry-pick fix for vertical color lines showing with composite emoji"
+msgstr ""
+
+#: ../../22.04/3.md 3afacc22eff1498b85175737bb183448
+#: 836e25a11af04423a885757f1a934f50 acc15fe96780408b804b9f4475cc2903
+#: ddcb5a6cc22f4b9d8b4641b4095e37be
+msgid "software-properties"
+msgstr ""
+
+#: ../../22.04/3.md c25d6f5be39e459f8810c5004c2d7135
+msgid "[2003996](https://bugs.launchpad.net/bugs/2003996)"
+msgstr ""
+
+#: ../../22.04/3.md da940cf5d8b14ab4bcaf1a3c3a924bcc
+msgid "Catch exceptions to wait (lp: #2003996)"
+msgstr ""
+
+#: ../../22.04/3.md 640c909a27154e59aae573dbed08414c
+msgid "[2004245](https://bugs.launchpad.net/bugs/2004245)"
+msgstr ""
+
+#: ../../22.04/3.md 128ea9ba5b7b469581e08dde735efeb5
+msgid "Initialize pin as empty string (lp: #2004245)"
+msgstr ""
+
+#: ../../22.04/3.md 8abd59fbf6164228829ce276ca019ace
+msgid "[2004634](https://bugs.launchpad.net/bugs/2004634)"
+msgstr ""
+
+#: ../../22.04/3.md 78e7c31576c54575878b053457057c5c
+msgid ""
+"Disable the Ubuntu Pro UI with an explanation when not connected (lp: "
+"#2004634)"
+msgstr ""
+
+#: ../../22.04/3.md 9d11357cd09a4ca994ed8b6e2180f7ba
+msgid "[2018457](https://bugs.launchpad.net/bugs/2018457)"
+msgstr ""
+
+#: ../../22.04/3.md 9748ea1c45024b1abbffb564fa78b038
+msgid "cloudarchive: Enable support for the Bobcat Ubuntu Cloud Archive on 22.04"
+msgstr ""
+
+#: ../../22.04/3.md 8b57b2b205eb4fe98b56ab522b9788ad
+msgid "speech-dispatcher"
+msgstr ""
+
+#: ../../22.04/3.md 9d9f347360da435aa5c4f8f4a9ebca54
+msgid "[1991022](https://bugs.launchpad.net/bugs/1991022)"
+msgstr ""
+
+#: ../../22.04/3.md 5191ac3b25b242f6877cf1ab66b19931
+msgid ""
+"Enables activating Speech Dispatcher via a Systemd socket, it's needed "
+"for confined clients to be able to activate the service"
+msgstr ""
+
+#: ../../22.04/3.md 0a51a5b70e1c436589ab1b5029e4d3ae
+msgid "ubuntu-advantage-desktop-daemon"
+msgstr ""
+
+#: ../../22.04/3.md 8444e5d887d4429c99b9d37752bbbd8a
+msgid "[1990368](https://bugs.launchpad.net/bugs/1990368)"
+msgstr ""
+
+#: ../../22.04/3.md 0370653743844323bdb656219caa5a83
+msgid "Rename 'Ubuntu Advantage' to 'Ubuntu Pro' (lp: #1990368)"
+msgstr ""
+
+#: ../../22.04/3.md 5ff6694993c24637b992d5f4b58cadc2
+msgid "update-notifier"
+msgstr ""
+
+#: ../../22.04/3.md b28622f87f9d4c41a21b9327561d0b18
+msgid "[2008212](https://bugs.launchpad.net/bugs/2008212)"
+msgstr ""
+
+#: ../../22.04/3.md a2a05f331fcc4d06bb959184ee1a90b1
+msgid "Isolate creation of the esm apt cache in apt-check"
+msgstr ""
+
+#: ../../22.04/3.md 0a1e49bd0ef84bceadfaf0f95e2646ec
+#: 810f1ab79bf6413a84252a758282c965
+msgid "xorg-server"
+msgstr ""
+
+#: ../../22.04/3.md 086e4bf31f2d4197bbbfaf44f80e23b0
+msgid "[1993621](https://bugs.launchpad.net/bugs/1993621)"
+msgstr ""
+
+#: ../../22.04/3.md cb0c359a7c604ca48639c69dea32abe2
+msgid "patches: Force update LEDs after device state update."
+msgstr ""
+
+#: ../../22.04/3.md 1b9d4194320043eea830ee590c51e761
+msgid "[2009767](https://bugs.launchpad.net/bugs/2009767)"
+msgstr ""
+
+#: ../../22.04/3.md 154b843b96af4fbe9a322074eefa91bd
+#: 4c7ecff6cadc4a87996d4a837aa0467e 51a6942804f34583884c9d53ff161990
+#: 585cd4eb9749479cba3b4ff76c5a7c95 6f125220a5104c6a8c871b51e2bc3afd
+#: 7dfe891c1bb34ccd8b56562dabdd6a8e f6d65f5b9e4c48f9a4cc9180b8e55168
+msgid "yaru-theme"
+msgstr ""
+
+#: ../../22.04/3.md 3e2fb59376a4489997fe8e113fff2f38
+msgid "[1966167](https://bugs.launchpad.net/bugs/1966167)"
+msgstr ""
+
+#: ../../22.04/3.md 4d0f5e709889419d97bc12420d836879
+msgid "dock: Fix margins making the dock show-apps clickable"
+msgstr ""
+
+#: ../../22.04/3.md 43ebcd23672a4a8fb6a1c65e85bea10b
+msgid "[1979037](https://bugs.launchpad.net/bugs/1979037)"
+msgstr ""
+
+#: ../../22.04/3.md 61dab31815994d34958fcf9834d45c1a
+msgid "Add osd monitor labels theming"
+msgstr ""
+
+#: ../../22.04/3.md 2eb321f604f74ae598902190b99bc589
+msgid "[2008791](https://bugs.launchpad.net/bugs/2008791)"
+msgstr ""
+
+#: ../../22.04/3.md 7544aabefdfc4d46b263b2e9020751ca
+msgid "nautilus: Ensure disk-space-display items are themed"
+msgstr ""
+
+#: ../../22.04/3.md f165930ee1d64ef1bed19e7624a0bc92
+msgid "[2019475](https://bugs.launchpad.net/bugs/2019475)"
+msgstr ""
+
+#: ../../22.04/3.md 323135530e394053ba4ca79ada3a0ddd
+msgid "Fix slider states"
+msgstr ""
+
+#: ../../22.04/3.md b07d0d1fac2644d891a120d70bf2eab3
+msgid "[2019476](https://bugs.launchpad.net/bugs/2019476)"
+msgstr ""
+
+#: ../../22.04/3.md 110ad170293146d1a3bedd88ffbbeea9
+msgid "Gtk3: fix invisible check and radio in selected row"
+msgstr ""
+
+#: ../../22.04/3.md 053512f8bf0c47c98eca88f755406501
+msgid "[2019477](https://bugs.launchpad.net/bugs/2019477)"
+msgstr ""
+
+#: ../../22.04/3.md 769283a15e9b43f599df8a9fc78fc36f
+msgid "Gtk3: fix marks scale visibility on hover"
+msgstr ""
+
+#: ../../22.04/3.md 5370f28b40044dbba152267d612655a3
+msgid "[2019479](https://bugs.launchpad.net/bugs/2019479)"
+msgstr ""
+
+#: ../../22.04/3.md f16e9dae125f4af0b76d391629010d03
+msgid "Fix uncentered cursors"
+msgstr ""
+
+#: ../../22.04/3.md:92 e5073c44e54f4a8da92f53bc924d0658
+msgid "Server and Cloud related fixes"
+msgstr ""
+
+#: ../../22.04/3.md:94 baebe1c1d03346bfb18937b7f3d94b12
+msgid ""
+"These changes mainly affect installations of Ubuntu on server systems and"
+" clouds."
+msgstr ""
+
+#: ../../22.04/3.md c5264aa59b1c4bc9957bddfff6de1598
+msgid "aodh"
+msgstr ""
+
+#: ../../22.04/3.md 80937b3571224bd6adacf017e42ef2b9
+msgid "[1974682](https://bugs.launchpad.net/bugs/1974682)"
+msgstr ""
+
+#: ../../22.04/3.md 3e95448fb7ab49debc459177d6f3f519
+msgid "gnocchi: Use Dynamic Aggregates API"
+msgstr ""
+
+#: ../../22.04/3.md 55fc36bae4d94969a47112d316cc7dec
+#: edda756d134e47e8887c8615b338b2e6
+msgid "apache2"
+msgstr ""
+
+#: ../../22.04/3.md d60440e2a3a54561bafe5b5e0018c6cf
+msgid "[1998311](https://bugs.launchpad.net/bugs/1998311)"
+msgstr ""
+
+#: ../../22.04/3.md 20044a6a44d0438f99662c9b15a93ba1
+msgid ""
+"d/p/mod_proxy_hcheck_jammy_fix_to_detect_support.patch: Fix issue where "
+"enabling mod_proxy_hcheck results in error"
+msgstr ""
+
+#: ../../22.04/3.md 259516ee66c44a7eb16c16b29dfb7eb5
+msgid "[2003189](https://bugs.launchpad.net/bugs/2003189)"
+msgstr ""
+
+#: ../../22.04/3.md 88fe4bdc4f424f3eab8922b56b9196ea
+msgid ""
+"d/p/reenable-workers-in-standard-error-state-jammy-apache2.patch: fix "
+"issue with workers in apache2 which could not recover from its error "
+"state"
+msgstr ""
+
+#: ../../22.04/3.md a7eff6058c604d9fbddfbfb9c115f442
+#: b30642a4954e485fbe368cda7a8e2e24 c0ea2420bc0b4e6ebff341155af427fd
+msgid "ceph"
+msgstr ""
+
+#: ../../22.04/3.md a035cb69109845f5b510942d2ec8db98
+msgid "[1998958](https://bugs.launchpad.net/bugs/1998958)"
+msgstr ""
+
+#: ../../22.04/3.md 5912152d4a374f6d8d518a8f5c970dc9
+#: 6e599f6368fe4e4ea0c2731ae4271239 b63eec41c4834088aa58de1815127ded
+msgid "New upstream point release"
+msgstr ""
+
+#: ../../22.04/3.md 19db7e879bbf46a1b2f4c89c3b596078
+msgid "[2003530](https://bugs.launchpad.net/bugs/2003530)"
+msgstr ""
+
+#: ../../22.04/3.md c2f1f19f85e34adfb06d4485397750c9
+msgid "Fix: add the mgr.nfs package to the core modules"
+msgstr ""
+
+#: ../../22.04/3.md 9ae0aa5ca9674b4d9ae68bd29f412bcb
+msgid "[2018929](https://bugs.launchpad.net/bugs/2018929)"
+msgstr ""
+
+#: ../../22.04/3.md 99e1f80622a148b3a1f1f89b0c25fe1d
+#: d80f8065ff4246769968f2c3d61cf761 dc33428afb5849c7811cb7e852433764
+#: e95bc181e9e44c7c96f20d4f049d20ac f6ee5f6d354b4b26b282ed6fddf7da72
+msgid "cloud-init"
+msgstr ""
+
+#: ../../22.04/3.md a4d0a380a5dd4d90b6648d89a764b3df
+msgid "[1724623](https://bugs.launchpad.net/bugs/1724623)"
+msgstr ""
+
+#: ../../22.04/3.md 73783b0616884e16a234752d2a7da5bb
+msgid ""
+"d/apport-general-hook.py: Add general apport hook to append cloud type, "
+"image and instance size information to bug reports"
+msgstr ""
+
+#: ../../22.04/3.md b2fa077cde3746e9a86565d7cc458f62
+msgid "[1956788](https://bugs.launchpad.net/bugs/1956788)"
+msgstr ""
+
+#: ../../22.04/3.md 193720b3e49549d587c47cda9e902fc1
+msgid ""
+"d/cloud-init.preinst: Oracle to remove vestigial /etc/cloud.cloud.cfg.d/ "
+"99-disable-network-config.cfg because system config is now honored before"
+" datasource config"
+msgstr ""
+
+#: ../../22.04/3.md 04c91bedf5504203b4066cf458c07b3c
+msgid "[2008230](https://bugs.launchpad.net/bugs/2008230)"
+msgstr ""
+
+#: ../../22.04/3.md d0b1815ce688473c80dd9a1b88ff3002
+msgid "Upstream snapshot based on 23.1.1."
+msgstr ""
+
+#: ../../22.04/3.md af5ce1d909e24b608f4ff800568f8115
+msgid "[2023110](https://bugs.launchpad.net/bugs/2023110)"
+msgstr ""
+
+#: ../../22.04/3.md 10dfdccdd6ff453ca39fb3a734032901
+msgid "Upstream snapshot based on 23.2."
+msgstr ""
+
+#: ../../22.04/3.md 6570c89929c845729f90dbf813ea8078
+msgid "[2025180](https://bugs.launchpad.net/bugs/2025180)"
+msgstr ""
+
+#: ../../22.04/3.md 492382bc30f841c2abedf251f1aa242e
+msgid "Upstream snapshot based on 23.2.1."
+msgstr ""
+
+#: ../../22.04/3.md 90a7e9fb633f4696a10ce59c470eb6ef
+#: ea10dd2ed2654f54988425a95d5812e9
+msgid "containerd"
+msgstr ""
+
+#: ../../22.04/3.md a3090b0f1f124034baedd5cd72f90a3b
+msgid ""
+"[1996909](https://bugs.launchpad.net/bugs/1996909) "
+"[1996534](https://bugs.launchpad.net/bugs/1996534)"
+msgstr ""
+
+#: ../../22.04/3.md 81863e9c1f60492eafd18d453cb47e16
+msgid "Backport version 1.6.12-0ubuntu1 from Lunar"
+msgstr ""
+
+#: ../../22.04/3.md 48da0d8064284283a96e8a87da294133
+msgid "[2022390](https://bugs.launchpad.net/bugs/2022390)"
+msgstr ""
+
+#: ../../22.04/3.md c2c7c2406a104afeb88920221910f55e
+msgid "Do not provided the containerd binary package anymore"
+msgstr ""
+
+#: ../../22.04/3.md f506ab0aebdc40cda664559cb503e5db
+msgid "cyrus-sasl2"
+msgstr ""
+
+#: ../../22.04/3.md 51025203290e48bf936fccd651cee88a
+msgid "[1988730](https://bugs.launchpad.net/bugs/1988730)"
+msgstr ""
+
+#: ../../22.04/3.md bedbd0ba47f54e7a822cb077c87d3e86
+msgid ""
+"d/control, d/libsasl2-modules-gssapi-mit.install, "
+"d/libsasl2-modules.install: move the SCRAM mechanism to the "
+"libsasl2-modules package"
+msgstr ""
+
+#: ../../22.04/3.md 868c6721ff344be79dd98d3ce7b9c811
+msgid "dovecot"
+msgstr ""
+
+#: ../../22.04/3.md 014ec316652c4eb38664faef58bf6ffc
+msgid "[1991564](https://bugs.launchpad.net/bugs/1991564)"
+msgstr ""
+
+#: ../../22.04/3.md 91f1412df7bd42f7a41e12089e26896e
+msgid "Backport fix + refactoring for handling ssl settings"
+msgstr ""
+
+#: ../../22.04/3.md 34ff2ff6c23b419b9143acb6b6928565
+msgid "dpdk"
+msgstr ""
+
+#: ../../22.04/3.md 6fcf70664d6a48ae99ed4d7584c690db
+msgid "[2002404](https://bugs.launchpad.net/bugs/2002404)"
+msgstr ""
+
+#: ../../22.04/3.md 744e35402dad45bc84c0d8dbcc9079ee
+msgid "Merge LTS stable release 21.11.3"
+msgstr ""
+
+#: ../../22.04/3.md 1870f439a6fd41e4addca379d48ec752
+#: 8419b94b1faa42bba770e21d412a7e8b 94a15b0d9c854c5abffda4691a7016e9
+msgid "ec2-hibinit-agent"
+msgstr ""
+
+#: ../../22.04/3.md 69b26c3132a64123aa30dfa0d528dd86
+msgid "[1941785](https://bugs.launchpad.net/bugs/1941785)"
+msgstr ""
+
+#: ../../22.04/3.md 6473b7bf638b4314a5b0f4e09993130f
+msgid ""
+"d/p/lp1941785-Add-support-for-IMDSv2.patch: allow hibernation of AWS EC2 "
+"instances with IMDSv2"
+msgstr ""
+
+#: ../../22.04/3.md 22ca79f26fab4a4ab3f85cd1eec96c0b
+msgid "[2023924](https://bugs.launchpad.net/bugs/2023924)"
+msgstr ""
+
+#: ../../22.04/3.md c0bccdbc769948489c2eec4d8165cd09
+msgid ""
+"d/p/lp2023924-remove-quotes-from-state-dir.patch: fixes an issue where a "
+"weird directory would be created in root"
+msgstr ""
+
+#: ../../22.04/3.md 9bd832c08b8b4904a07e3f07494ed7fd
+msgid "[2024505](https://bugs.launchpad.net/bugs/2024505)"
+msgstr ""
+
+#: ../../22.04/3.md fd13c12835e34f62abd65531c434cce5
+msgid ""
+"d/p/lp2024505-fix-locale-issue.patch: fixes an issue where certain "
+"locales can cause an error when trying to decode the output of `df -P`"
+msgstr ""
+
+#: ../../22.04/3.md 67c091d83c3f4c0398894c55f76e9bff
+#: e119f8e9ca6d480a9a49d1371f414fc3
+msgid "freeipmi"
+msgstr ""
+
+#: ../../22.04/3.md 8b6a848d0fa74418ab0c5fc629e3eafa
+msgid "[2019147](https://bugs.launchpad.net/bugs/2019147)"
+msgstr ""
+
+#: ../../22.04/3.md 7d0fee557e0d4d9c994e84d857284515
+msgid ""
+"d/p/add-initial-support-for-xilinx.patch: enable Xilinx OEM data parsing "
+"in ipmi-fru"
+msgstr ""
+
+#: ../../22.04/3.md 784e05d80b0c4f54a45a09803701f3db
+msgid "[2025177](https://bugs.launchpad.net/bugs/2025177)"
+msgstr ""
+
+#: ../../22.04/3.md 444b6df4015d4d1393748ba8551636b0
+msgid "Fix missing header file in libfreeipmi-dev package"
+msgstr ""
+
+#: ../../22.04/3.md 32b56e464db9488aa91040a5a5d6c595
+msgid "gce-compute-image-packages"
+msgstr ""
+
+#: ../../22.04/3.md c2be4a7bf2454ef6941d31cacb4436c2
+msgid "[2020770](https://bugs.launchpad.net/bugs/2020770)"
+msgstr ""
+
+#: ../../22.04/3.md 716c0f1300e749c1b2b018e062fa9942
+msgid "New upstream version 20230328.00."
+msgstr ""
+
+#: ../../22.04/3.md f9d854ee527a48b986982dcd99a407fe
+msgid "gdnsmasq"
+msgstr ""
+
+#: ../../22.04/3.md f6be64997261476fb78aac8d1cf3df84
+msgid "[1981794](https://bugs.launchpad.net/bugs/1981794)"
+msgstr ""
+
+#: ../../22.04/3.md 75b168513ccc432ab7b90ecbe82e1954
+msgid ""
+"src/forward.c: Do not refuse retries from client DNS queries. Behaviour "
+"to stop infinite loops when all servers return REFUSED was wrongly "
+"activated on client retries, resulting in incorrect REFUSED replies to "
+"client retries. The code added here is a cherry pick released in upstream"
+" version 2.87, originating at "
+"https://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commit;h=2561f9fe0eb9c0be"
+msgstr ""
+
+#: ../../22.04/3.md a7d8ab3746544706a7b5eb215b9807d5
+msgid "google-guest-agent"
+msgstr ""
+
+#: ../../22.04/3.md b785844d858745b5abdb66244b7ea182
+msgid "[2019089](https://bugs.launchpad.net/bugs/2019089)"
+msgstr ""
+
+#: ../../22.04/3.md 77f2395ff8f04646898b08679b2c1cb0
+msgid ""
+"d/rules: Add --no-stop-on-upgrade for upgrade path to enforce no stop of "
+"the services on package upgrade. This has the desired side-effect of not "
+"stopping, starting or restarting the services as a part of the upgrade"
+msgstr ""
+
+#: ../../22.04/3.md c6cedfe89ada4349bc926ee3609ddd77
+msgid "google-osconfig-agent"
+msgstr ""
+
+#: ../../22.04/3.md aa2f9fe43b3b4280a2da4402d3496e0b
+msgid "[2020762](https://bugs.launchpad.net/bugs/2020762)"
+msgstr ""
+
+#: ../../22.04/3.md cfbde8c3e99948eea04dd89775ddd7f8
+msgid "New upstream version 20230504.00."
+msgstr ""
+
+#: ../../22.04/3.md 270ee1301e6c40e7b554dcd5744351a9
+#: d194c2eccc9542089613b2ac6a7ef6c9
+msgid "heat"
+msgstr ""
+
+#: ../../22.04/3.md e322dec03cf6453c9bf89cbefa5f6586
+msgid "[1999665](https://bugs.launchpad.net/bugs/1999665)"
+msgstr ""
+
+#: ../../22.04/3.md cf387f899a5c43838067b0ded2fcc0fb
+msgid ""
+"d/p/honor-hidden-parameter.patch: Ensure get_environment() masks hidden "
+"parameters"
+msgstr ""
+
+#: ../../22.04/3.md 585093ae067340de961a9c801b525a71
+msgid "[2012073](https://bugs.launchpad.net/bugs/2012073)"
+msgstr ""
+
+#: ../../22.04/3.md b77aed6f8bba48e3807a5bafdcd5c5cf
+msgid "d/p/lp2012073.patch: Decode UTF-8 body data in SwiftSignal"
+msgstr ""
+
+#: ../../22.04/3.md 8e1077fbbba5444a927446bc998c8540
+#: b5605ba9d8c843ceafd882bb5272804f
+msgid "hibagent"
+msgstr ""
+
+#: ../../22.04/3.md 9656c897b7ec48309169d311eb974aa4
+msgid "[1896638](https://bugs.launchpad.net/bugs/1896638)"
+msgstr ""
+
+#: ../../22.04/3.md d1f52ae2d94e43ef81b7b12d6df917a4
+msgid ""
+"d/p/lp1896638-set-resume-device-by-partition-uuid: Set resume device by "
+"PARTUUID instead of by name. Thanks to Tony Nie <zirann@amazon.com>."
+msgstr ""
+
+#: ../../22.04/3.md 87613ba94af74e0d8955c7d21f0b3d80
+msgid "[2013336](https://bugs.launchpad.net/bugs/2013336)"
+msgstr ""
+
+#: ../../22.04/3.md ad7899184538458a89a4d6a917bed0e9
+msgid ""
+"d/p/lp2013336-do-not-modify-GRUB-config-on-GRUB2-systems: Do not attempt "
+"to modify non existent GRUB config file. Thanks to Robert Schweikert "
+"<rjschwei@suse.com>."
+msgstr ""
+
+#: ../../22.04/3.md 28b86cbef564446fbeb5a94eee77b788
+#: a742bc99e20440f6ade58b959e8eb891
+msgid "isc-dhcp"
+msgstr ""
+
+#: ../../22.04/3.md 5d413149df2a4c159d26a3bd0feb9cec
+msgid "[1926139](https://bugs.launchpad.net/bugs/1926139)"
+msgstr ""
+
+#: ../../22.04/3.md 76c3dd2da9ab4ce6aab0fce830c8b2ca
+msgid ""
+"Prevent race condition that might ignore DHCP OFFERs/ACKs when dhclient "
+"receives DHCP traffic noise."
+msgstr ""
+
+#: ../../22.04/3.md cedfe48c74d24a66b74dd7e87881954e
+msgid "[1937110](https://bugs.launchpad.net/bugs/1937110)"
+msgstr ""
+
+#: ../../22.04/3.md c31089fed86f4273a6c8db9487fb4598
+msgid ""
+"Include /etc/dhcp/dhclient-exit-hooks.d/rfc3442-classless-routes in the "
+"initramfs."
+msgstr ""
+
+#: ../../22.04/3.md e0aad7be018b4e41afff62b08f0d364d
+msgid "libinput"
+msgstr ""
+
+#: ../../22.04/3.md cea3244ca6d64cbe930dd5a79c0e87cd
+msgid "[2023623](https://bugs.launchpad.net/bugs/2023623)"
+msgstr ""
+
+#: ../../22.04/3.md fd3fdccb82ad482d8e6176b4bbf011f0
+msgid "Disable pressure for Precision5680 2nd source touchpad"
+msgstr ""
+
+#: ../../22.04/3.md f6cff93dbc46414988d8610f448bb71f
+msgid "libvirt"
+msgstr ""
+
+#: ../../22.04/3.md faba8e9fe757407eac7e13cf79f3b992
+msgid "[2024114](https://bugs.launchpad.net/bugs/2024114)"
+msgstr ""
+
+#: ../../22.04/3.md cb764f9513d44bdfbed75a7c1665aa68
+msgid ""
+"d/p/u/lp-2024114-Avoid-memleak-in-virNodeDeviceGetPCIVPDDynamicCap.patch:"
+" fix memory leak PCI devices with VPD data"
+msgstr ""
+
+#: ../../22.04/3.md 73481785df414c418250d6c4593563f8
+msgid "mdadm"
+msgstr ""
+
+#: ../../22.04/3.md 41e64fd6ccde495fb72d132f61bde997
+msgid "[1993541](https://bugs.launchpad.net/bugs/1993541)"
+msgstr ""
+
+#: ../../22.04/3.md a29b1580b60d46a9b6b8d93dfe0de492
+msgid "Add scripts/init-top/00_mount_efivarfs, mounting efivarfs."
+msgstr ""
+
+#: ../../22.04/3.md 5b22b6c043ea43f4b2ef17736d7d0123
+msgid "[1985089](https://bugs.launchpad.net/bugs/1985089)"
+msgstr ""
+
+#: ../../22.04/3.md a5145dd372ed4d9a8522c5505cd6ee03
+msgid "Fix high memory and lagginess when resizing side-by-side tiled windows"
+msgstr ""
+
+#: ../../22.04/3.md 62ecc960219b4b51aa79e550cc6b8249
+msgid "[1998286](https://bugs.launchpad.net/bugs/1998286)"
+msgstr ""
+
+#: ../../22.04/3.md 5b58dab38bcd4866afd0a1b7d5a097a2
+#: aa281a808f8949e8915443ce92adab78 b33ecc26020f46c583cf03a31ec91957
+msgid "mysql-8.0"
+msgstr ""
+
+#: ../../22.04/3.md 16f11c0d2d33443aafede52cb1f62286
+msgid "[1980466](https://bugs.launchpad.net/bugs/1980466)"
+msgstr ""
+
+#: ../../22.04/3.md b78f2eff8a96449aa7ba19d5a68cc5d4
+msgid ""
+"d/p/mysql_secure_installation-remove-root-pw-creation.patch: Fix "
+"mysql_secure_installation by removing root password creation"
+msgstr ""
+
+#: ../../22.04/3.md cb3884030a1b47e0b38c19ed7ecc5722
+msgid "[2019203](https://bugs.launchpad.net/bugs/2019203)"
+msgstr ""
+
+#: ../../22.04/3.md 447fa6c4824d416ea5f9cbcc999d5960
+msgid "Fix crash on startup on armhf"
+msgstr ""
+
+#: ../../22.04/3.md 5ff270144d804c29b23b8766f163d219
+msgid "[2020910](https://bugs.launchpad.net/bugs/2020910)"
+msgstr ""
+
+#: ../../22.04/3.md 54862e5e154842f8bb13dc5a4975ad13
+msgid "d/t/upstream: Ignore upstream tests due to s390x failure"
+msgstr ""
+
+#: ../../22.04/3.md bcb514c2c5694961a494317958e16b22
+#: e57efd11addb4fdea182a2ed5f991a91
+msgid "net-snmp"
+msgstr ""
+
+#: ../../22.04/3.md 62b4272262ed4a60a433cb59bb0812ac
+msgid "[1998461](https://bugs.launchpad.net/bugs/1998461)"
+msgstr ""
+
+#: ../../22.04/3.md 0bfbfe2fd7d143e18d619c14a1079039
+msgid ""
+"d/p/restore-support-for-long-dns-names.patch: Fix snmp requests for "
+"domains longer than 63 characters"
+msgstr ""
+
+#: ../../22.04/3.md 816bfb6e1676448fa22181e27a63672a
+msgid "[1999711](https://bugs.launchpad.net/bugs/1999711)"
+msgstr ""
+
+#: ../../22.04/3.md da4f25589f684fe2923bbc2950738171
+msgid "Fix snmptrapd reconnection issue after hitting MySQL wait_timeout"
+msgstr ""
+
+#: ../../22.04/3.md 2a203c53caed452fb530d38a57e5d34f
+#: 387bebfc62ad49c8bfe1a0448df5c350
+msgid "netplan.io"
+msgstr ""
+
+#: ../../22.04/3.md 7aec39e3b9db4a01af5668f1249e7710
+#: 9e10cc9670b84863ad05fc6bfa50d678
+msgid "[1997467](https://bugs.launchpad.net/bugs/1997467)"
+msgstr ""
+
+#: ../../22.04/3.md a3b0c8f427294292ace3fe3800a415b8
+msgid "Fix and improvements for the DBus integration"
+msgstr ""
+
+#: ../../22.04/3.md f72d2b1655c24406b588a4aa8bd53f6d
+msgid "d/p/lp1997467: set only specific origin-hint if given"
+msgstr ""
+
+#: ../../22.04/3.md bb8005c9d9a74e5eaba95d166aa2714c
+msgid "neutron"
+msgstr ""
+
+#: ../../22.04/3.md 4e6d11aa62d84a048cac5adde945037e
+msgid "[2025505](https://bugs.launchpad.net/bugs/2025505)"
+msgstr ""
+
+#: ../../22.04/3.md 3ea1c87ffb9448b9805ae4a7ac462a4a
+#: f6f52fe2d8d24ce9a2ff92ddf7b51138
+msgid "New stable point release for OpenStack Yoga"
+msgstr ""
+
+#: ../../22.04/3.md 0d09338d5fa84d17a2c949f08d47d3a7
+msgid "nginx"
+msgstr ""
+
+#: ../../22.04/3.md e90722d7327e4203be2c5793b6519bdc
+msgid "[1957320](https://bugs.launchpad.net/bugs/1957320)"
+msgstr ""
+
+#: ../../22.04/3.md 50ddc8cf9dac4b71bc7fcf92f64236a8
+msgid ""
+"d/p/lp1957320-jammy-fixed-sigquit-issue-with-unix-sockets.patch: Fix "
+"SIGQUIT by replacing the custom socket closing code in the "
+"ngx_process_cycle.c file by calling another function."
+msgstr ""
+
+#: ../../22.04/3.md 0d066b97084c48238332b5082ff239e0
+msgid "nova"
+msgstr ""
+
+#: ../../22.04/3.md 8939c415669f41a3bcc7d44b2ca63e79
+msgid "[1890244](https://bugs.launchpad.net/bugs/1890244)"
+msgstr ""
+
+#: ../../22.04/3.md f58d0ec9679c4594af1bae0765e8ce53
+msgid "Backport fix to ignore deleted server groups"
+msgstr ""
+
+#: ../../22.04/3.md 5d00c38bc9d04f45a2aa142dc408d82e
+msgid "open-vm-tools"
+msgstr ""
+
+#: ../../22.04/3.md 8d8e4be6de7141a1b8f82d1e21847e66
+msgid "[1998558](https://bugs.launchpad.net/bugs/1998558)"
+msgstr ""
+
+#: ../../22.04/3.md cb6293ee595d44caa0c9581126c7a3aa
+msgid "Backport recent open-vm-tools release v12.1.5"
+msgstr ""
+
+#: ../../22.04/3.md 129d410d4a5842508ea28af263e6b9fa
+#: 7c40dac939de418f98442938b12b9d99 85ddabf1616542dea5fadf5216ea7cf0
+msgid "openldap"
+msgstr ""
+
+#: ../../22.04/3.md 3a59ec512116421c86f1f1173454801d
+msgid "[2000817](https://bugs.launchpad.net/bugs/2000817)"
+msgstr ""
+
+#: ../../22.04/3.md 7359875f5cb446b29414aaad1d5bd57e
+msgid ""
+"Build the passwd/sha2 contrib module with -fno-strict-aliasing to avoid "
+"computing an incorrect SHA256 hash with some versions of the compiler"
+msgstr ""
+
+#: ../../22.04/3.md b84dcd457d56474a8dfd8c9b4af916b8
+msgid "[2007625](https://bugs.launchpad.net/bugs/2007625)"
+msgstr ""
+
+#: ../../22.04/3.md be45f3006dde42f5bcf5eafce5ff4265
+#: e1aa28f3ef2248fab7f01bc21ef1c443
+msgid "New upstream version"
+msgstr ""
+
+#: ../../22.04/3.md 7f9369f8b2b64551835a9c9d16c2ef60
+msgid "[2027079](https://bugs.launchpad.net/bugs/2027079)"
+msgstr ""
+
+#: ../../22.04/3.md a198eb2c4f9741de88c3c5b09997fc3a
+msgid "openvswitch"
+msgstr ""
+
+#: ../../22.04/3.md 5a15277c1a0f42ec860c7c95c7187013
+msgid "[2025323](https://bugs.launchpad.net/bugs/2025323)"
+msgstr ""
+
+#: ../../22.04/3.md b4380cc9ae9a4e739c0a777ad6fae947
+msgid "New upstream version 2.17.7"
+msgstr ""
+
+#: ../../22.04/3.md 2a25610ca48d4423a19e31f65731f0fb
+#: 6a0f5ab179f44b9595bab505481609cf 87a2ccbd926143d485af1d65f523f49e
+#: 8c1aca114ba845c68aa69a499e971a16 e02afc510e6a4e42a23000d684f95c93
+msgid "ovn"
+msgstr ""
+
+#: ../../22.04/3.md 26d947cd49c540aeb42a82ace54ae8b8
+#: bbedc2f38ffb41ef95f8ce97d36dc7a0
+msgid "[1971178](https://bugs.launchpad.net/bugs/1971178)"
+msgstr ""
+
+#: ../../22.04/3.md fd081fb390a94051b16dba265af8f354
+msgid "d/ovn-common.install: Add missing ovn_detrace.py binary"
+msgstr ""
+
+#: ../../22.04/3.md 634a5805dc4d4c7d94a132c41e75fb2e
+msgid "d/rules, d/ovn-common.install: Properly fix the ovn-detrace binary"
+msgstr ""
+
+#: ../../22.04/3.md 78c04e6d443b4677a5957057a4bde4a6
+msgid "[1980809](https://bugs.launchpad.net/bugs/1980809)"
+msgstr ""
+
+#: ../../22.04/3.md a85e2510f6a44311a7dd4b33a417fc3e
+msgid "[1982454](https://bugs.launchpad.net/bugs/1982454)"
+msgstr ""
+
+#: ../../22.04/3.md 32ece6a24cff47509c918a077dc3ac60
+msgid "d/p/lp-1982454-northd-stateless-nat-fix.patch"
+msgstr ""
+
+#: ../../22.04/3.md 20f6f32df6014f5fb361d4be923e2a2e
+msgid "[2003056](https://bugs.launchpad.net/bugs/2003056)"
+msgstr ""
+
+#: ../../22.04/3.md 9eae78783da849d6865c6031e042971c
+msgid "New upstream version 22.03.2"
+msgstr ""
+
+#: ../../22.04/3.md 02b278bc94794ea5b90cf5bc748ab7b3
+msgid "pacemaker"
+msgstr ""
+
+#: ../../22.04/3.md fe6772fc0ab14a95b7891a58cb90440b
+msgid "[2012740](https://bugs.launchpad.net/bugs/2012740)"
+msgstr ""
+
+#: ../../22.04/3.md bfa6bd53012046d0bd47851ce3b4f968
+msgid ""
+"d/p/jammy-avoid-double-free-during-notify-operation.patch: Fix a "
+"regression introduced by 31c7fa8, causing a double-free in notify "
+"operations"
+msgstr ""
+
+#: ../../22.04/3.md 214842030b56454cb2a61b7bbc3a9c4e
+#: 3efc5752bb48405b901bead8e52605cb
+msgid "postfix"
+msgstr ""
+
+#: ../../22.04/3.md e9e6f3ff99aa4543aa662e548fbbbefc
+msgid "[1995312](https://bugs.launchpad.net/bugs/1995312)"
+msgstr ""
+
+#: ../../22.04/3.md 4c33f440247c46c29336c0463538df5a
+msgid ""
+"d/p/1995312-unexpected-eof-fix.patch: Workaround for a breaking change in"
+" OpenSSL 3: always turn on SSL_OP_IGNORE_UNEXPECTED_EOF, to avoid warning"
+" messages and missed opportunities for TLS session reuse. This is safe "
+"because the SMTP protocol implements application-level framing, and is "
+"therefore not affected by TLS truncation attacks. Fix by Viktor Dukhovni"
+msgstr ""
+
+#: ../../22.04/3.md 89103150326d4521aa7b7b08d4808959
+msgid "[1996524](https://bugs.launchpad.net/bugs/1996524)"
+msgstr ""
+
+#: ../../22.04/3.md a66449acad854d39a69c91483e951545
+msgid "d/p/1996524-Linux6-support.patch: Adding LINUX6 support for portability"
+msgstr ""
+
+#: ../../22.04/3.md 7a3cbc5d142f4e81a9797b805fd0542c
+#: 8c046572e620402ca43ed6dae720a8ab ae5fa00e132b40f6b613e491838afa30
+#: bea7dc3b25744b38ab961b7f26bf3390 c669e3ac68d74877b067b1548662d30f
+#: f38afdb68c1a453299f551d858faf8e0
+msgid "qemu"
+msgstr ""
+
+#: ../../22.04/3.md 4888db287e2347579cb10e4ac5ec8aa4
+msgid "[1994002](https://bugs.launchpad.net/bugs/1994002)"
+msgstr ""
+
+#: ../../22.04/3.md 8ac10a0c5fd142cd9c0b9d7e0368e35e
+msgid ""
+"d/p/u/lp1994002-migration-Read-state-once.patch: Fix for libvirt error "
+"'migration was active, but no RAM info was set'"
+msgstr ""
+
+#: ../../22.04/3.md 5fd4accdaf9f492695915ee16206d1e3
+msgid "[2009048](https://bugs.launchpad.net/bugs/2009048)"
+msgstr ""
+
+#: ../../22.04/3.md 186a55331b9843ed915ac414ca05288c
+msgid ""
+"d/p/u/lp2009048-vfio_map_dma_einval_amd_iommu_1tb.patch: Add hint to "
+"VFIO_MAP_DMA error on AMD IOMMU for VMs with ~1TB+ RAM"
+msgstr ""
+
+#: ../../22.04/3.md e3f7d48f5c294c7f9951b08e91a2c8ca
+msgid "[2011832](https://bugs.launchpad.net/bugs/2011832)"
+msgstr ""
+
+#: ../../22.04/3.md 50368b65d610476094366580032f37d7
+msgid "d/p/u/lp-2011832-*: fix emulation issues in mips and powerpc"
+msgstr ""
+
+#: ../../22.04/3.md 8d68ac461c3846b4b75177653d81ddce
+msgid "[2018733](https://bugs.launchpad.net/bugs/2018733)"
+msgstr ""
+
+#: ../../22.04/3.md 47fba29b9ad3492c87d3a85fe44dccb1
+msgid ""
+"d/p/u/allow-repeating-hot-unplug-requests.patch: Allow repeating hot-"
+"unplug requests by making ACPI PCI able to requeue them."
+msgstr ""
+
+#: ../../22.04/3.md da85881d5dfd4fe0b2b3202470778d20
+msgid "[2019766](https://bugs.launchpad.net/bugs/2019766)"
+msgstr ""
+
+#: ../../22.04/3.md 4c530d74fa90471886f26334cc88ffe5
+msgid ""
+"d/p/u/lp-2019766-target-arm-kvm-Retry-KVM_CREATE_VM-call-if-it-"
+"fails-.patch: ARM: Retry KVM_CREATE_VM when it returns EINTR"
+msgstr ""
+
+#: ../../22.04/3.md e5e6f877c19d4beda0db28776e3e609d
+msgid "[2025591](https://bugs.launchpad.net/bugs/2025591)"
+msgstr ""
+
+#: ../../22.04/3.md 93eeff5923ab4805905df95b5975b00b
+msgid ""
+"d/p/u/lp2025591-block-use-the-request-length-for-iov-alignment.patch: Fix"
+" boot error on the HWE 6.2 kernel with direct IO (eg, cache=none) if the "
+"logical block size is smaller than in the host"
+msgstr ""
+
+#: ../../22.04/3.md b72d081663004d329c55a0dcb2d0dacb
+msgid "rabbitmq-server"
+msgstr ""
+
+#: ../../22.04/3.md c767d3670c6b41d9b1b8421176e54cd0
+msgid "[1999816](https://bugs.launchpad.net/bugs/1999816)"
+msgstr ""
+
+#: ../../22.04/3.md 61c4bdb890ce42f1947eccd7ed6390de
+msgid ""
+"d/p/lp1999816-fix-rabbitmqctl-status-disk-free-timeout.patch: Fix "
+"rabbitmqctl status when free disk space cannot be determined"
+msgstr ""
+
+#: ../../22.04/3.md 5832f5bbeb7a4d14a5e7e38682a35ce1
+#: d9836fbde3b34941ba3a0bf9ba7f2e76
+msgid "resource-agents"
+msgstr ""
+
+#: ../../22.04/3.md b9707d9eceaf4f6a8fed4e13be82778a
+msgid "[1981598](https://bugs.launchpad.net/bugs/1981598)"
+msgstr ""
+
+#: ../../22.04/3.md f647056c8c8a4503b5999712400bda1f
+msgid "d/control: breaks/replaces for file reorg"
+msgstr ""
+
+#: ../../22.04/3.md cdaffaae29cc4a299c58e6a1ab74d378
+msgid "[2013084](https://bugs.launchpad.net/bugs/2013084)"
+msgstr ""
+
+#: ../../22.04/3.md 76ffc5fdc5ce4a6d95cb2aff1be242d1
+msgid ""
+"d/p/pgsql-heartbeat-postgresql-issue-jammy.patch: walreceiver name is "
+"changed to make the check for running wal receiver process compatible "
+"with PostgreSQL >= 11"
+msgstr ""
+
+#: ../../22.04/3.md 25f70e40bd7f4414b7328bbd40813bc3
+#: 337fd898c55c4e8ba7549af3dcf12018 b4f30ac114834689af4f5e246a9cc10b
+msgid "runc"
+msgstr ""
+
+#: ../../22.04/3.md 85ab137fb82a486daff2a2b2aeaa6ef3
+msgid "[1996909](https://bugs.launchpad.net/bugs/1996909)"
+msgstr ""
+
+#: ../../22.04/3.md 2be39afaeb9b45279648bb9ab395b653
+msgid "Backport version 1.1.4-0ubuntu1 from Lunar"
+msgstr ""
+
+#: ../../22.04/3.md 3e89323dcbbc4c9dbe1d559b08bf6921
+msgid "[2013318](https://bugs.launchpad.net/bugs/2013318)"
+msgstr ""
+
+#: ../../22.04/3.md 93fb142db8f24cfca54adbc732350ed1
+msgid ""
+"d/p/lp2013318-fix-device-files-in-containers.patch: Fix inability to use "
+"device files such as /dev/null in containers"
+msgstr ""
+
+#: ../../22.04/3.md 3bb743b98a3d4da2b59a200d44bde678
+msgid "[2023694](https://bugs.launchpad.net/bugs/2023694)"
+msgstr ""
+
+#: ../../22.04/3.md 8634dfef32454cc3884966e2ba39337a
+msgid "Backport version from Mantic to Jammy"
+msgstr ""
+
+#: ../../22.04/3.md cdcc17b393cc4c7c9ae6f16f72965af7
+msgid "spamassassin"
+msgstr ""
+
+#: ../../22.04/3.md 99b417f8b2734e6cb13f4b473dc7430e
+msgid "[1799185](https://bugs.launchpad.net/bugs/1799185)"
+msgstr ""
+
+#: ../../22.04/3.md 331bea0ca2d242dc8d115bdcc12436ad
+msgid ""
+"d/p/fix-mkpath-untainted.patch: fix spamd running with virtual-config-dir"
+" mkdir error"
+msgstr ""
+
+#: ../../22.04/3.md 4d9aa20578894e0d91e4b607f65f76df
+msgid "squid"
+msgstr ""
+
+#: ../../22.04/3.md ed3e40871b7d4f9588b7ef8a6f223f05
+msgid "[1989380](https://bugs.launchpad.net/bugs/1989380)"
+msgstr ""
+
+#: ../../22.04/3.md b409f01164ae420c98ae970b885dd8f4
+msgid ""
+"d/p/close-tunnel-if-to-server-conn-closes-after-client.patch: Close "
+"tunnel \"job\" after to-server client connection closes, fixing memory "
+"leak."
+msgstr ""
+
+#: ../../22.04/3.md ab321bd274d04c1ca9cf02f26d000b84
+msgid "swift"
+msgstr ""
+
+#: ../../22.04/3.md 793a59f69742487c9b4fd8fee6599426
+msgid "[2006534](https://bugs.launchpad.net/bugs/2006534)"
+msgstr ""
+
+#: ../../22.04/3.md 0d23b4d750a24b27bb750054fdcce057
+msgid "tcpdump"
+msgstr ""
+
+#: ../../22.04/3.md efc9994793a44d70ab342709cb36ad3b
+msgid "[1667016](https://bugs.launchpad.net/bugs/1667016)"
+msgstr ""
+
+#: ../../22.04/3.md 36b42afb6b3a4b2aa6bd78219c766adb
+msgid ""
+"debian/usr.sbin.tcpdump: allow tcpdump printing to stdout/stderr when "
+"running from a container"
+msgstr ""
+
+#: ../../22.04/3.md:174 dedc718f43ba44c98b92a06dab80098b
+msgid "Base platform fixes"
+msgstr ""
+
+#: ../../22.04/3.md:176 2931c681e1744dcbb7d69d6f63fbf915
+msgid ""
+"These changes affect the core fundamental components of all the Ubuntu "
+"flavors."
+msgstr ""
+
+#: ../../22.04/3.md fad4c4f67787409db0be71a1372d0129
+msgid "apparmor"
+msgstr ""
+
+#: ../../22.04/3.md 0cf352c9b54948c79922401a81e9add3
+msgid "[1993353](https://bugs.launchpad.net/bugs/1993353)"
+msgstr ""
+
+#: ../../22.04/3.md d303f6017ce840d399b89235ab2ba7ef
+msgid "Add mqueue patches."
+msgstr ""
+
+#: ../../22.04/3.md b9661ab9ad8c46dd8d883694869bbd54
+msgid "apt"
+msgstr ""
+
+#: ../../22.04/3.md e795089bff634b309ce47fe314804c24
+msgid "[1995247](https://bugs.launchpad.net/bugs/1995247)"
+msgstr ""
+
+#: ../../22.04/3.md 64c46d86f2614c758038f6a1b3852acc
+msgid "Actually delete temporary apt-key.*.asc helper files"
+msgstr ""
+
+#: ../../22.04/3.md 896caeae99a8474da5ef27d4538f6d38
+msgid "binutils"
+msgstr ""
+
+#: ../../22.04/3.md a91b9d0ad9cc48b5a414c96ceaff3e6a
+msgid "[2022845](https://bugs.launchpad.net/bugs/2022845)"
+msgstr ""
+
+#: ../../22.04/3.md d6faed777eec42a7a5aa330c5d867ac9
+msgid "Update from the binutils 2.38 branch:"
+msgstr ""
+
+#: ../../22.04/3.md 288e426720a9421595f1def9bc1baf12
+msgid "ca-certificates"
+msgstr ""
+
+#: ../../22.04/3.md b5022473df6a4ae2bfcfee8ddbf5f4d2
+msgid "[2020089](https://bugs.launchpad.net/bugs/2020089)"
+msgstr ""
+
+#: ../../22.04/3.md 480561dc648d47bdb313935349169445
+msgid "Update ca-certificates database to 20230311"
+msgstr ""
+
+#: ../../22.04/3.md 0a4672232e2b4b8cb7323f774093c6a7
+msgid "ca-certificates-java"
+msgstr ""
+
+#: ../../22.04/3.md ae59542ac9eb421d820c589e05716dc8
+msgid "[2019908](https://bugs.launchpad.net/bugs/2019908)"
+msgstr ""
+
+#: ../../22.04/3.md 5e00afec97e147db9326f8ee6bb507ed
+msgid ""
+"REGRESSION UPDATE: ca-certificates-java can fail to install with "
+"openjdk-17"
+msgstr ""
+
+#: ../../22.04/3.md 7e12f84e2b74450d97a22a5370e3c6c7
+msgid "distro-info"
+msgstr ""
+
+#: ../../22.04/3.md 3e59f690ffe242b49028dc044d30549e
+#: cd14ecc9980e4a02b602547f420f239b da6c37d1a35f4f19a07623105b1b88ff
+#: f484f8f2fe394e6f8f966cb44aec1f68
+msgid "[1991606](https://bugs.launchpad.net/bugs/1991606)"
+msgstr ""
+
+#: ../../22.04/3.md d839c47239434acbb66f80a7dce547dd
+msgid "python: Use PEP440 compliant version in setup.py"
+msgstr ""
+
+#: ../../22.04/3.md 3a37a864c83a4828997c2f4d2ae3e6e6
+#: f83458a4a28f4084afae128bc715cc5a
+msgid "distro-info-data"
+msgstr ""
+
+#: ../../22.04/3.md 95bf0c954d0141efb6199102388b0048
+msgid "[2003949](https://bugs.launchpad.net/bugs/2003949)"
+msgstr ""
+
+#: ../../22.04/3.md 5dd57a4e29ad48e69a15b36c5601e253
+msgid "Document Ubuntu ESM overlap period"
+msgstr ""
+
+#: ../../22.04/3.md 61c62310be1d48e39c0c80ce1595bc4a
+msgid "[2018028](https://bugs.launchpad.net/bugs/2018028)"
+msgstr ""
+
+#: ../../22.04/3.md 95c256cd7cfb4da7b7a214b9b516e2c9
+msgid "Add Ubuntu 23.10 Mantic Minotaur."
+msgstr ""
+
+#: ../../22.04/3.md 2060f474edc84585b1626bef5dc92265
+#: 902898c064804d1db80121622781f926 a3448a119f9c46888a37af1f92078a36
+#: c48b8b0cc8c143a5a5cb86a6214a8317
+msgid "gcc-11"
+msgstr ""
+
+#: ../../22.04/3.md 72c215088052472ea3ca0b37cb58ab90
+#: a4116f3f669340448960632c96e35aa0 b61c2d11e7df410391f4b22563beddc7
+#: ef707c65578944d7905edec94980ce0d
+msgid "[2002429](https://bugs.launchpad.net/bugs/2002429)"
+msgstr ""
+
+#: ../../22.04/3.md 4b1745bcea2549a2bc6e55721e207b20
+msgid ""
+"Drop debian/patches/gcc-ibmz-plt-revert.diff, the kernel was fixed to "
+"build correct dkms modules on s390x. In turn, this patch is now "
+"preventing livepatch modules to work."
+msgstr ""
+
+#: ../../22.04/3.md afc4c261d9e24b17866ceaf891b463e1
+#: e696d86875e34d44a0ace6bb918853a7
+msgid "Remove the gcc-ibmz-plt-revert patch."
+msgstr ""
+
+#: ../../22.04/3.md 22dc282e2c6b48c2aa43c822a158a396
+#: 80228d254c374309942920f8d30a382a
+msgid "[2019465](https://bugs.launchpad.net/bugs/2019465)"
+msgstr ""
+
+#: ../../22.04/3.md 91553c182d814f799e51a6c7005bead3
+#: e55120da54254c388cb4ebd37cba1e08
+msgid "Backport GCC 11.4 to 22.04 LTS."
+msgstr ""
+
+#: ../../22.04/3.md 2bf633f6938f42b984e3110f4ceb3e53
+#: b36a259917f64426b4e82b2c5a29fe9e
+msgid "gcc-11-cross"
+msgstr ""
+
+#: ../../22.04/3.md 3c9ad18a729a42bbb99f829a771fbb13
+msgid "Build using GCC 11.3.0-1ubuntu1~22.04.1 for 22.04 LTS."
+msgstr ""
+
+#: ../../22.04/3.md 497f9b3b59e2414fbc1f2f31df104ed8
+msgid "gcc-12"
+msgstr ""
+
+#: ../../22.04/3.md 04904a692c724945bdc1502f3b0bf9bd
+#: 81a517a5604545348ddb1acbfcb131b1
+msgid "[1995499](https://bugs.launchpad.net/bugs/1995499)"
+msgstr ""
+
+#: ../../22.04/3.md 0b8459b02f284f4cba3e13b0f0ae2d91
+#: 5391e601207545c395f40dd6a3e7441b
+msgid "Backport GCC 12.3.0 to Ubuntu 22.04 LTS."
+msgstr ""
+
+#: ../../22.04/3.md 27a7f7248a974b8fa404502d0ac1b8cc
+msgid "gcc-12-cross"
+msgstr ""
+
+#: ../../22.04/3.md 6eb6ba0cc11f40a083e6b100e7de6303
+msgid "grub2"
+msgstr ""
+
+#: ../../22.04/3.md fbb21a547b734cb0be20f57e76dd3631
+msgid "[1987567](https://bugs.launchpad.net/bugs/1987567)"
+msgstr ""
+
+#: ../../22.04/3.md 9804f79aee3843f49d90df6a8054e4e5
+msgid "linux_xen: Properly handle multiple initrd files"
+msgstr ""
+
+#: ../../22.04/3.md c640d667159144e58f37742cb48fde60
+msgid "grub2-signed"
+msgstr ""
+
+#: ../../22.04/3.md 3c9a3f609327453082520e0be663aa0a
+#: 44c23fe5b8bb45a3940caca34876cd8f 70d3170a904b43efafbb9bc64d4dd62f
+msgid "[1842320](https://bugs.launchpad.net/bugs/1842320)"
+msgstr ""
+
+#: ../../22.04/3.md b7e8574a8b444c97862fd0949495d240
+msgid "Build against grub2 2.06-2ubuntu14.1"
+msgstr ""
+
+#: ../../22.04/3.md 8852baaaeb204f7ea00621399a2f9088
+#: c514c528a0aa4596be115d7b939cf0fb
+msgid "grub2-unsigned"
+msgstr ""
+
+#: ../../22.04/3.md c5f0595192e34aac886834b9cd268cdb
+msgid "Allocate initrd > 4 GB"
+msgstr ""
+
+#: ../../22.04/3.md 70fa574292a242ac8d2c02d8cb758f8e
+msgid "Cherry-pick all the 2.12 memory management changes"
+msgstr ""
+
+#: ../../22.04/3.md 6610fba8b2b04912843beeb6202ef92a
+msgid "initramfs-tools"
+msgstr ""
+
+#: ../../22.04/3.md 101b0e46db7f41e58180e206b29f9649
+msgid "[1983359](https://bugs.launchpad.net/bugs/1983359)"
+msgstr ""
+
+#: ../../22.04/3.md f6f9c296a12b478296c9b2636bb29c07
+msgid "Add char/hw_random drivers"
+msgstr ""
+
+#: ../../22.04/3.md 5ce3347ed76145a9b90cf4fb6b256911
+msgid "iptables"
+msgstr ""
+
+#: ../../22.04/3.md 22bcaf89e9064f44b475ac5c71821cde
+msgid "[1992454](https://bugs.launchpad.net/bugs/1992454)"
+msgstr ""
+
+#: ../../22.04/3.md dfed825ecf004a39a7a276f6d3a9a19e
+msgid "libiptc: Fix for segfault when renaming a chain"
+msgstr ""
+
+#: ../../22.04/3.md c55d930609fe4cd2a5381437e7580fe4
+msgid "mokutil"
+msgstr ""
+
+#: ../../22.04/3.md 9ac7db5aaeb547e8a4789247bf5ef266
+msgid "[2015664](https://bugs.launchpad.net/bugs/2015664)"
+msgstr ""
+
+#: ../../22.04/3.md c525630609c84e7383af3ce6ffb6ee10
+msgid "Backport 0.6.0-2 to jammy"
+msgstr ""
+
+#: ../../22.04/3.md 32d7eb5b0030472682021eb787718673
+#: 829b0bf552134e2a84e3abbb0178081d cf353dd9044b4351b7fc1ae6c9cb2459
+#: dc57d11d528041b2839eed0d0e963891 f3695914175548b0886022740f0ba29b
+msgid "systemd"
+msgstr ""
+
+#: ../../22.04/3.md 00089ef265564ea2a1bba3126c43815d
+msgid "[2000880](https://bugs.launchpad.net/bugs/2000880)"
+msgstr ""
+
+#: ../../22.04/3.md d833df28527f4c21aaa263c71329d3d6
+msgid "network: create stacked netdevs after the underlying link is"
+msgstr ""
+
+#: ../../22.04/3.md 1af8ca67c03d49f09351a65f7983cee5
+#: 4fe8c7e0ead74fc7984848f777cb6daa
+msgid "[2002445](https://bugs.launchpad.net/bugs/2002445)"
+msgstr ""
+
+#: ../../22.04/3.md f256b7cb4a11421ca86cb06f5efca770
+msgid "udev: avoid NIC renaming race with kernel"
+msgstr ""
+
+#: ../../22.04/3.md c2d0d5d2d9ed47059f0893d890b27dc9
+msgid "udev: gracefully handle rename failures"
+msgstr ""
+
+#: ../../22.04/3.md a4f9c5b3fb104f248d9c5c8ec255bcc8
+msgid "[2004478](https://bugs.launchpad.net/bugs/2004478)"
+msgstr ""
+
+#: ../../22.04/3.md d6d1060cbf0b4b98812f5db581f45e4c
+msgid "network/dhcp4: accept local subnet routes from DHCP"
+msgstr ""
+
+#: ../../22.04/3.md 76df06ae0b464309b2cd155b16abe9fe
+msgid "[2009502](https://bugs.launchpad.net/bugs/2009502)"
+msgstr ""
+
+#: ../../22.04/3.md 55add9b11c6148c9b5f4567e5633b31a
+msgid "Enable /dev/sgx_vepc access for the group 'sgx'"
+msgstr ""
+
+#: ../../22.04/3.md 425e935d2fe24bef813fc82ce77c906f
+msgid "systemd-hwe"
+msgstr ""
+
+#: ../../22.04/3.md 4d4b28dd53a740568da4d4dbc274e732
+msgid "[2007032](https://bugs.launchpad.net/bugs/2007032)"
+msgstr ""
+
+#: ../../22.04/3.md 799f50a35b924d2789868021ee00e2ed
+msgid "hwdb: Add Dell G16 that require KEYBOARD_KEY_100150=f20"
+msgstr ""
+
+#: ../../22.04/3.md 0f11cff562af44acaeb56e2feb475687
+#: 0fa2f6a0aafa481c89089f880d606a6a 422ee08706294535a22230bd702566c9
+msgid "tzdata"
+msgstr ""
+
+#: ../../22.04/3.md 278017f727fd48fdaecc6c551442468a
+msgid "[2003797](https://bugs.launchpad.net/bugs/2003797)"
+msgstr ""
+
+#: ../../22.04/3.md a6b2cbd2d8a94bad9ffcc83d239dbf97
+msgid "Build timezones that differ pre-1970"
+msgstr ""
+
+#: ../../22.04/3.md 644f9dc36cc94950a5be8cfe16802603
+msgid "[2012599](https://bugs.launchpad.net/bugs/2012599)"
+msgstr ""
+
+#: ../../22.04/3.md 2cb9da4f78ca493fae11836af4aed168
+msgid "[2017999](https://bugs.launchpad.net/bugs/2017999)"
+msgstr ""
+
+#: ../../22.04/3.md e201e8a5e6b84bd9b293b1f77bfaf64a
+msgid ""
+"Build tzdata with PACKRATLIST=zone.tab. In combination with "
+"PACKRATDATA=backzone (which is used since 2023c-0ubuntu0.22.04.1), time "
+"zones that differ pre-1970 and had been resurrected will not incur "
+"changes to data from 1970 on. This also removes Asia/Hanoi again. Upgrade"
+" Pacific/Enderbury to Pacific/Kanton again."
+msgstr ""
+
+#: ../../22.04/3.md 090aba01fe0647d69f655bc52a9fef32
+#: 0e4fe3c1e3b7419aa042dc957673ae3a 1b1a3cdc98df4e5d9067367d2ba36723
+#: 29db21ebfc3142fba89ac31f78065ae2 36d70596e4534d26a81a622997095a8a
+#: 48db815b77574fbba6f9d91a3cf5adf5 513af1c7343b493690e3037ac28905d6
+#: 5511ca2b5d31454cb2ecc6151f783ba2 5ba512e98516414fa15c30f437898229
+#: 5ef1145528de46efbbada6b8f321edc2 680dcbb8b86a49f1a769ad3dd955684d
+#: 8180697718884ad78473c2570bbfc0ca 85a616daf879490693b15154d0b816db
+#: 9c0e923e82dc4e449084913db86fa892 a63e8f78ac7045d8ad355e0eda8fe20a
+#: a66d324fe52142fb9b8a33e19c03005c abf9489a720f4e52a593309dd64ea9c6
+#: ae40bfada93e4dfa86c75236e2664a95 b54c97deb8cb40c18a4c6f85f21a6168
+#: b9a2f62002ab426eb2b46d57da64e8a5 bbf0df6557f84d9888d81cd89d034ae4
+#: c51ba719a10b48da98748a7b6ccd3292 ceff5395bf714190af9d1a0250244d89
+#: d0e3b236c9e1412fb9e65a77a5105208 e23c42fe59eb4956b85b685a1b4ff666
+#: e320a570bdf64732bd5759e5c2dbc75c e729034efa27469b8dc76559d9fdcbc1
+#: ed3098f57f2f48788291a7afe80506b0 ed915aaae7b849b1a83c4f621cc87ec1
+#: f9cfffb16b654473aee5d342cdb0c5ca fb41d8774bb543c68ac23b33d43ec22c
+#: fccd9ff415e04ee9b9ab8cfa73deaca9
+msgid "ubuntu-advantage-tools"
+msgstr ""
+
+#: ../../22.04/3.md 622192eff16a4d0783bd85524ea210fb
+msgid "[1926182](https://bugs.launchpad.net/bugs/1926182)"
+msgstr ""
+
+#: ../../22.04/3.md 03ccfc1db37744aba57df3d9f92df3fe
+msgid "format the output to be more readable"
+msgstr ""
+
+#: ../../22.04/3.md cc6353571cab40b9a59eb6dca40c342b
+msgid "[1987738](https://bugs.launchpad.net/bugs/1987738)"
+msgstr ""
+
+#: ../../22.04/3.md 85c4a313fa0a4c88809cce2a01de4057
+msgid "notices: new representation on disk as separate files"
+msgstr ""
+
+#: ../../22.04/3.md 8492be1d3bbb456284b1534f2b808760
+msgid "[1994923](https://bugs.launchpad.net/bugs/1994923)"
+msgstr ""
+
+#: ../../22.04/3.md f7d446663c5a4d6583a3f131a8edc6f7
+msgid "better message if no services are available"
+msgstr ""
+
+#: ../../22.04/3.md b11e80be01a24032bad8a74a3c946ff9
+msgid "[1996931](https://bugs.launchpad.net/bugs/1996931)"
+msgstr ""
+
+#: ../../22.04/3.md 333bde30a4874221af9d2bdaa1b902db
+msgid "locks: alert user about corrupted lock files"
+msgstr ""
+
+#: ../../22.04/3.md 75482c2f89ed44c49d59f6b34639ed60
+msgid "[2004018](https://bugs.launchpad.net/bugs/2004018)"
+msgstr ""
+
+#: ../../22.04/3.md ead2cce7b7d045458bad8575e41bdff3
+msgid "only set up the esm cache on supported systems"
+msgstr ""
+
+#: ../../22.04/3.md 61b33f7047854653a83597803614371a
+msgid "[2004193](https://bugs.launchpad.net/bugs/2004193)"
+msgstr ""
+
+#: ../../22.04/3.md b93f762c57a0493abf74e7a71da1bcd6
+msgid "remove stale esm-apps unauthenticated caches"
+msgstr ""
+
+#: ../../22.04/3.md e78cc80b8d16422d8a385d7788d48ca0
+msgid "[2004280](https://bugs.launchpad.net/bugs/2004280)"
+msgstr ""
+
+#: ../../22.04/3.md 6f0e5abb67294fc58eb60768e9f35915
+msgid ""
+"migrate certain settings out of uaclient.conf to a new file managed by "
+"the pro config subcommand"
+msgstr ""
+
+#: ../../22.04/3.md 928b2a44abff466dbbae89794af834b3
+msgid "[2004650](https://bugs.launchpad.net/bugs/2004650)"
+msgstr ""
+
+#: ../../22.04/3.md 81859802eea648b58bc74a71980394ca
+msgid "treat null effective contract dates as unknown/expired"
+msgstr ""
+
+#: ../../22.04/3.md 0992d9094b884fd29f17d339da899bd0
+msgid "[2006049](https://bugs.launchpad.net/bugs/2006049)"
+msgstr ""
+
+#: ../../22.04/3.md 5dd48c2167c640a7b6c757b546b58e87
+msgid "consider packages without a candidate as 'unknown'"
+msgstr ""
+
+#: ../../22.04/3.md d804f5f73ac94857a2cb5c01e01a4405
+msgid "[2006138](https://bugs.launchpad.net/bugs/2006138)"
+msgstr ""
+
+#: ../../22.04/3.md 319596507d944e63abe8dce84fdfc0c6
+msgid "no longer includes warnings about notices when non-root"
+msgstr ""
+
+#: ../../22.04/3.md 17959e6f2f8c4c83903915f1b35d01b2
+msgid "[2006261](https://bugs.launchpad.net/bugs/2006261)"
+msgstr ""
+
+#: ../../22.04/3.md e6befcb717fd42039ec1435662835b98
+msgid "recycle invalid jobs-status.json file if we detect it is corrupted"
+msgstr ""
+
+#: ../../22.04/3.md 99010e78455d48ffbbb440adbbaeefb5
+msgid "[2006351](https://bugs.launchpad.net/bugs/2006351)"
+msgstr ""
+
+#: ../../22.04/3.md e25bf388e6604da6801a9267dbd2f903
+msgid ""
+"make code aware that the effective date is not a required field in the "
+"machine-token.json file"
+msgstr ""
+
+#: ../../22.04/3.md d39174951cf348f9b0a2a13176816cfa
+msgid "[2006508](https://bugs.launchpad.net/bugs/2006508)"
+msgstr ""
+
+#: ../../22.04/3.md 55d44ec88e6c4ca6b6e1418840569d60
+msgid "do not fail if we cannot extract information from /etc/os-release file"
+msgstr ""
+
+#: ../../22.04/3.md 9b891497cd7f44f68b0f77ee1d0913a3
+msgid "[2006510](https://bugs.launchpad.net/bugs/2006510)"
+msgstr ""
+
+#: ../../22.04/3.md 68383637441d4926a2cff132256f747a
+msgid ""
+"Change esm-apps advertisement message on apt upgrade to make it clearer "
+"that the service is providing more upgrades and not restricting user to "
+"only get updates if esm-apps is enabled"
+msgstr ""
+
+#: ../../22.04/3.md 09ef95c17a9446ba97508d20145c9344
+msgid "[2006765](https://bugs.launchpad.net/bugs/2006765)"
+msgstr ""
+
+#: ../../22.04/3.md 9bc1284ac62442c4a7a7a179e8b08b05
+msgid "fix version for cleaning the esm-apps stale unauthenticated files"
+msgstr ""
+
+#: ../../22.04/3.md bf79c1b229574246870ac18f98526551
+msgid "[2007234](https://bugs.launchpad.net/bugs/2007234)"
+msgstr ""
+
+#: ../../22.04/3.md dfe8201f5e914ac1ae5f74dcdf476ce4
+#: ec5c7569b29a40dcbf87cbee6b56ccea
+msgid "yaml: always import distro-provided pyyaml"
+msgstr ""
+
+#: ../../22.04/3.md 7812243197d54fb4ae04a856a0259fbb
+msgid "[2007241](https://bugs.launchpad.net/bugs/2007241)"
+msgstr ""
+
+#: ../../22.04/3.md 9a5248010d5c450ab67deb3c30a8e203
+msgid "[2008280](https://bugs.launchpad.net/bugs/2008280)"
+msgstr ""
+
+#: ../../22.04/3.md 411e05a7bc1f49989d2126a29314a1c3
+msgid "make all calls to esm-cache isolated from system configuration"
+msgstr ""
+
+#: ../../22.04/3.md 779a38172dcc4defbcac454bab9ab506
+#: d1e3275deb5c4716855e094d55972390
+msgid "[2008814](https://bugs.launchpad.net/bugs/2008814)"
+msgstr ""
+
+#: ../../22.04/3.md 6b306f2e38334feeb847b958c85726e0
+#: 8efe23de58934067964155f0bc842bcf ac2712c523e44f0ebe36022b6460377c
+msgid "Backport new upstream release:"
+msgstr ""
+
+#: ../../22.04/3.md 914e52e5bf4949309778c676c3e9e8ee
+msgid ""
+"make sure systems which never ran a pro command get the apt-news message "
+"displayed"
+msgstr ""
+
+#: ../../22.04/3.md 1d090ae8d2b64bebbdea7bf9c1f7d2f2
+#: a6b5e5f1d34d48d9a14a10a41d9245d8
+msgid "[2011477](https://bugs.launchpad.net/bugs/2011477)"
+msgstr ""
+
+#: ../../22.04/3.md e6b45378fc904e50817ecf164d7b786d
+msgid "New upstream release 27.14"
+msgstr ""
+
+#: ../../22.04/3.md 9c2250ad8d834b55af07bf6a1c9ce9d5
+msgid "[2012642](https://bugs.launchpad.net/bugs/2012642)"
+msgstr ""
+
+#: ../../22.04/3.md 7afff406dbbe45dda7252c958dd064ae
+msgid ""
+"apt: fix a configuration leak in the apt.get_pkg_candidate_version "
+"function"
+msgstr ""
+
+#: ../../22.04/3.md 54cec2238c284652bcd78d1ed68fa7cb
+msgid "[2012735](https://bugs.launchpad.net/bugs/2012735)"
+msgstr ""
+
+#: ../../22.04/3.md 05489dc769a44772bdc91677b21b20d8
+msgid "always use dpkg instead of lscpu for fetching architecture information"
+msgstr ""
+
+#: ../../22.04/3.md e7e09cb1ebcd41e7a75c174040e04385
+msgid "[2013409](https://bugs.launchpad.net/bugs/2013409)"
+msgstr ""
+
+#: ../../22.04/3.md 53cfd519a99445d29e4571b262168649
+msgid ""
+"livepatch: prevent livepatch from auto-enabling and subsequently failing "
+"on interim releases"
+msgstr ""
+
+#: ../../22.04/3.md c14310cbf022414da85a32a283e06bf8
+msgid "[2015241](https://bugs.launchpad.net/bugs/2015241)"
+msgstr ""
+
+#: ../../22.04/3.md 712a15e3eda44ac1a8539b69e553873c
+msgid ""
+"livepatch: prevent livepatch from auto-enabling and subsequently failing "
+"on non-amd64 systems"
+msgstr ""
+
+#: ../../22.04/3.md e5c7147b50a84ff6b72e61335b36dcce
+msgid "[2015286](https://bugs.launchpad.net/bugs/2015286)"
+msgstr ""
+
+#: ../../22.04/3.md b7d37bb620c948a788a78292869533c8
+msgid "avoids unnecessary network calls"
+msgstr ""
+
+#: ../../22.04/3.md 7ed24c0369a34db69119834af36eab43
+msgid "[2015302](https://bugs.launchpad.net/bugs/2015302)"
+msgstr ""
+
+#: ../../22.04/3.md e5c53b478fd147fe8023284520cbcc29
+msgid "timer: disable update_contract_info job"
+msgstr ""
+
+#: ../../22.04/3.md 38c32a4792ad4cbfbd090d1dd4fcb08c
+#: 3cb3359c197e491ca069950aef4b847d a8214e8ba778458184473a2b306da542
+msgid "[2017949](https://bugs.launchpad.net/bugs/2017949)"
+msgstr ""
+
+#: ../../22.04/3.md 23eb8c7fd08e4df49087d2e405df95c4
+msgid "New upstream release 28"
+msgstr ""
+
+#: ../../22.04/3.md 58acb64b84044594ab5cef8d1a4708ce
+msgid "New upstream release 28.1"
+msgstr ""
+
+#: ../../22.04/3.md 1380c0d685e74d79a85514f6d9282fbd
+msgid "[2019729](https://bugs.launchpad.net/bugs/2019729)"
+msgstr ""
+
+#: ../../22.04/3.md 22bfb186d0704152ab7ea470587f10c4
+msgid "avoid crashes when processing unicode text"
+msgstr ""
+
+#: ../../22.04/3.md 49e8b25793584adfbbc0cfca0851fd94
+msgid "ubuntu-meta"
+msgstr ""
+
+#: ../../22.04/3.md 425aef993a9c4506a44f2d88b9a637f2
+msgid "[1992688](https://bugs.launchpad.net/bugs/1992688)"
+msgstr ""
+
+#: ../../22.04/3.md cf1065045ae14bb4a6a0e3e380488354
+msgid ""
+"Added firefox to desktop-minimal-recommends [amd64 arm64 armhf], desktop-"
+"recommends [amd64 arm64 armhf] as it provides dpkg alternatives for x"
+"-www-browser and gnome-www-browser."
+msgstr ""
+
+#: ../../22.04/3.md 94211c7539244e1db6c71e4fb9da0be6
+msgid "ufw"
+msgstr ""
+
+#: ../../22.04/3.md 2edda41f6ada47fb92eece79c45e5432
+msgid "[2015645](https://bugs.launchpad.net/bugs/2015645)"
+msgstr ""
+
+#: ../../22.04/3.md ce12904901be49cca744a67fc1debc7f
+msgid "0005-lp2015645.patch: fix for get_ppid() not working on WSL"
+msgstr ""
+
+#: ../../22.04/3.md:247 e8edfdb1495e47498254ef48a5efec55
+msgid "Kernel and Hardware support updates"
+msgstr ""
+
+#: ../../22.04/3.md:249 e1deee6828304f6c9750cce17c914e58
+msgid ""
+"Considerable work has been done on improving support for many specific "
+"items of hardware."
+msgstr ""
+
+#: ../../22.04/3.md 1f925249ae294db086634f65e5578823
+#: 9aa0e6c9a44044459bab489ded6622df cb00f9cdbf84424eb58e1718a68347be
+msgid "bcmwl"
+msgstr ""
+
+#: ../../22.04/3.md a4256926bdc0462d8497c7137c795165
+msgid "[1981968](https://bugs.launchpad.net/bugs/1981968)"
+msgstr ""
+
+#: ../../22.04/3.md 8ae9c9c3a101479b8548489bcfb92ff8
+msgid "debian/dkms.conf.in, debian/patches/0040-add-support-for-linux-5.18.patch"
+msgstr ""
+
+#: ../../22.04/3.md 083d9d242d2d4f1e8c9f322a11be4650
+msgid "[1998039](https://bugs.launchpad.net/bugs/1998039)"
+msgstr ""
+
+#: ../../22.04/3.md 89c2b100e05c4f19aba4383de118b815
+msgid "debian/dkms.conf.in, debian/patches/0041-dev-addr-access.patch"
+msgstr ""
+
+#: ../../22.04/3.md b84ede3702cd4374ac15530082d7b1c8
+msgid "[1999009](https://bugs.launchpad.net/bugs/1999009)"
+msgstr ""
+
+#: ../../22.04/3.md 07ce65ae9abe43008beef772dbc81e15
+msgid "debian/dkms.conf.in, debian/patches/0042-add-support-for-linux-6.x.patch"
+msgstr ""
+
+#: ../../22.04/3.md ee0a4151c72f4e3da74d6393497ac182
+msgid "dkms"
+msgstr ""
+
+#: ../../22.04/3.md 6cd54df0b9f0417faf45c45b0cc6357a
+msgid "[2012612](https://bugs.launchpad.net/bugs/2012612)"
+msgstr ""
+
+#: ../../22.04/3.md fb6202380d5a40ff8f18cafc3d7aaa50
+msgid ""
+"Add new feature BUILD_EXCLUSIVE_CONFIG=\"CONFIG_FOO !CONFIG_BAR\". Patch "
+"imported from kinetic"
+msgstr ""
+
+#: ../../22.04/3.md f93980aad0d943e3b84e833d351e7c74
+msgid "flash-kernel"
+msgstr ""
+
+#: ../../22.04/3.md 76597995c5534427a3976d77cf18e9bb
+msgid "[2006558](https://bugs.launchpad.net/bugs/2006558)"
+msgstr ""
+
+#: ../../22.04/3.md 28d6dcb8432e4df981590f8d49f391eb
+msgid "Add support for Xilinx Versal VCK190"
+msgstr ""
+
+#: ../../22.04/3.md 8c0a15fa60e844b3aeeee04dde9ee6b8
+#: f21807ecd3304e65b5bb61792fb362c8
+msgid "fwupd"
+msgstr ""
+
+#: ../../22.04/3.md ec614d5424c04a138e9fc66c8797ff02
+msgid "[1983451](https://bugs.launchpad.net/bugs/1983451)"
+msgstr ""
+
+#: ../../22.04/3.md 85e6d9758d7d47eea8a9093e7c07ddac
+msgid "Hide inhibited usb4 device in dell-dock plugin"
+msgstr ""
+
+#: ../../22.04/3.md bbea9288cce8410fbc9ad202d0d8ea7b
+msgid "[1994143](https://bugs.launchpad.net/bugs/1994143)"
+msgstr ""
+
+#: ../../22.04/3.md 145cf14408b848e1a641a4db69fb8e4d
+msgid ""
+"d/p/0001_make_sure_mtdram_is_set_up.patch: Upstreamed patch that fix the "
+"false alarm in the autopkgtest"
+msgstr ""
+
+#: ../../22.04/3.md 15f48afcdbbd46dd91711fe6458b17b9
+msgid "fwupd-efi"
+msgstr ""
+
+#: ../../22.04/3.md 3a2d138e80d34cb1b59902a6ab45d1b0
+#: 924f8638ee9c44deb32578da99be702e
+msgid "[2011808](https://bugs.launchpad.net/bugs/2011808)"
+msgstr ""
+
+#: ../../22.04/3.md 074c403d958a41c39c5749cec65982f3
+msgid "Stable release series backport"
+msgstr ""
+
+#: ../../22.04/3.md 16d1bf286f5f497795a5fe710365c939
+#: c846421f7683437482cdf23c3cbddfe4
+msgid "fwupd-signed"
+msgstr ""
+
+#: ../../22.04/3.md d78d5e1a439d4c1889617b58e4289965
+msgid "[2003365](https://bugs.launchpad.net/bugs/2003365)"
+msgstr ""
+
+#: ../../22.04/3.md eb0391cb4c064581bc816cb8c82a358b
+msgid "Rebuild for 2022v1 resigning"
+msgstr ""
+
+#: ../../22.04/3.md d7c3e439fc6648bdbab837e7ee636264
+msgid "Rebuild against fwupd-efi 1:1.4-0ubuntu0.1"
+msgstr ""
+
+#: ../../22.04/3.md d75ca968c6a24cd88e73ae96671c02bf
+msgid "kexec-tools"
+msgstr ""
+
+#: ../../22.04/3.md 11e9d9c7a2d14e0da94aab41613bd8f5
+msgid "[2024479](https://bugs.launchpad.net/bugs/2024479)"
+msgstr ""
+
+#: ../../22.04/3.md 782be8f99a7844ed99c937b103bcbc66
+msgid "Support more than one crash kernel regions for arm64"
+msgstr ""
+
+#: ../../22.04/3.md 2d5793cc85334d73982e1a7f03ee3f01
+#: d2c57ce03db249b2b60b8af940f8771d
+msgid "libnvidia-nscq-515"
+msgstr ""
+
+#: ../../22.04/3.md 0e3e012dcc49432b94c11b731b5c5706
+#: 740e16b3d9aa46ed9a22735334659af4 9bc3d2ff2db64cd290842f7e18ab7203
+#: dc03d102718c4c839f5a541a153d9602
+msgid "[2003995](https://bugs.launchpad.net/bugs/2003995)"
+msgstr ""
+
+#: ../../22.04/3.md a5851f00a8014ca7bbbe3e7c1f33c039
+msgid "Remove leftover install file"
+msgstr ""
+
+#: ../../22.04/3.md 1a56af6f6aff401781f9ebb5dab4a2af
+#: 3111c2679f1649649f8337f5cec84d5e 50ab305ba8f9487c9c9cb8c9b180ae7f
+#: 903b054e3ff7477f9d328a73061675df aa74119251dc46cbaf570dc50b1a3985
+#: ae2626140ca7466bb99c14aab827ff08 c702f3f209204579be732061d8e9f6d5
+#: e41e0f6e8bea4e5fb9bd77c3cb74c208
+msgid "[2012529](https://bugs.launchpad.net/bugs/2012529)"
+msgstr ""
+
+#: ../../22.04/3.md 4c33e14820dd4675a17bd7d476d0204c
+msgid "linux-allwinner-5.19"
+msgstr ""
+
+#: ../../22.04/3.md 2b93fe6283c548fd90e59b067a00cbdb
+#: 2d9a20c09c2745309733566051e5dbd1 6677bf5afad042d18efaa13d3507bd87
+#: 66e6ac3a23134af09c0b815b3b450ef8 83451a35b91e4b8797843e90b3d17cc8
+#: 989df0fd127c4df18024cb08bdff075f c0190ee06d8547529f86cb036e0d22ec
+#: ffe935d5947e4261af288af962cb5a23
+msgid "[1996536](https://bugs.launchpad.net/bugs/1996536)"
+msgstr ""
+
+#: ../../22.04/3.md 00fbab05fc964e97afb414daaf3a84f0
+#: 1e9ba3a1059648fb9a9d42b1da6a1826 4570da069bab4cfca17e7c0b9d6ee8e0
+#: 53e3cc0970dd4fa580105dd39a81dca9 6924d97ad9624f47a9886038bc32ac15
+#: ae8e8ce1b25a4bf6977ff88caad844a5 bb149226605546f08fe36d0129069aa4
+#: d26d4cb27ed34754944e8c82fa89b4ab
+msgid "selftests/.../nat6to4  breaks the selftests build"
+msgstr ""
+
+#: ../../22.04/3.md 1ba1dca28852481ba35d9481f6ad1615
+#: 3b51a4c4ea494479990226e0910ee529 518c7b13483740df96adda1767af1c45
+#: 7ffec7662bf442508b6ec8f7c690053d 9cc07a2860fd4079a8ff7517107bef3e
+#: ca384b84adc6440985fb707b4304a4d1 ce728ae3f0704f948a3fe0a467f70e83
+#: ddc4c90700214e23b0835fe542f65255 e3d942803f6042fea5d107976c42261a
+#: fea49734ec964ee0a4ea7773511fa697
+msgid "linux-aws-5.19"
+msgstr ""
+
+#: ../../22.04/3.md 14ed9394f5c44dc9bbb648c3126a1ce0
+#: 5c99fc16076c4a849af5d175782556ce 9b9f5bac56bd41ae9ee01f3a3d0db375
+msgid "[1988461](https://bugs.launchpad.net/bugs/1988461)"
+msgstr ""
+
+#: ../../22.04/3.md 1790d8c9b0314390852ce9ec1d7a5395
+#: 307f38bbade4460993e3a173a104140f 6ee36b46300d4e42baf25d3e42405765
+msgid "intel_pmc_core not load on Raptor Lake"
+msgstr ""
+
+#: ../../22.04/3.md 6f6a0512dc754475b91f6a0b2937f195
+#: a9bc26c75c27410188ae7a513e5eca48 b090e6b60e0d4dbeae3e9ac52d0f4436
+msgid "[1988711](https://bugs.launchpad.net/bugs/1988711)"
+msgstr ""
+
+#: ../../22.04/3.md 3e0044aeea3c4719b1f0f6cc4c3bd36f
+#: 3fb32731fca84fe6bdf0f3547a702b81 c7e6adfe0ed54d9f8557e6317e5e3187
+msgid "Update Broadcom Emulex FC HBA lpfc driver to 14.2.0.5 for Ubuntu 22.04 LTS"
+msgstr ""
+
+#: ../../22.04/3.md 33c6514fdf954280aa7247a697066cbb
+#: 3a35d5dae2ee4cec9f40dad28e9e9ab2 9d1c4a3f5e2d4f14be231e597700a862
+msgid "[1990700](https://bugs.launchpad.net/bugs/1990700)"
+msgstr ""
+
+#: ../../22.04/3.md 52688ac4c5904ca683ffe1c543c0fe0e
+#: 633fc51551ac41afa0030e328a02a7e4 a5078df164864d3dbf1d3479c1424645
+msgid "Fibocom WWAN FM350-GL suspend error (notebook not suspend)"
+msgstr ""
+
+#: ../../22.04/3.md 3c26d9b4e7514b508059f252b544af46
+#: 511837e1de8344d7a2ea96a667ba6f61 7b5e42c8b9814b5291cab88c7877fb71
+msgid "[1993148](https://bugs.launchpad.net/bugs/1993148)"
+msgstr ""
+
+#: ../../22.04/3.md 1ea1627610064ffcb07b17750d3c2619
+#: 653b50e25d0b400eb0da8a840206d3dd 86d401b40c4f4cec9f423a025965e689
+msgid "Support Icicle Kit reference design v2022.10"
+msgstr ""
+
+#: ../../22.04/3.md 1ada355191e2445caf8d29a90288546a
+#: 2557f86af1af48448b7d265c7f221f3e 2deab53f442b46499e14b76a40e7ef93
+msgid "[1993715](https://bugs.launchpad.net/bugs/1993715)"
+msgstr ""
+
+#: ../../22.04/3.md 10c731506db3407eba20abbe1a8b6a59
+#: 32b4f788c0114e0d8319254c07033cfb 7fbbe80407494ce49155b777bcaa6108
+msgid "AMD Cezanne takes 5 minutes to wake up from suspend"
+msgstr ""
+
+#: ../../22.04/3.md 552230e1eba441ebb8aec4ddc0f85ea7
+#: 88e3193bfab24b629bb6053fc84ed2ce 94e0d3885af44e0a84ac50630fd3007d
+#: b4ea1ec57bfb454bb2e6842096b2f7f3 d8dabde3e4704041b06d524cef953988
+msgid "[1995453](https://bugs.launchpad.net/bugs/1995453)"
+msgstr ""
+
+#: ../../22.04/3.md 31efb0b328064ddbb02507f0a4827df0
+#: 510a01fc79b4417eb9d133aebc589e5e 9292f3b824834a5a96cffb3697ffb3f7
+#: b7137623d67745efb7f2191cd3bb0d0b e1fce104b65a4b59ad21a36a7fbbf919
+msgid "Add some ACPI device IDs for Intel HID device"
+msgstr ""
+
+#: ../../22.04/3.md 1ba8c2c183d84606abd999a4c721500e
+#: 317bbfcc013847c6853434d9cfb022d4 39f19776f5be465e8d5519dbdcd81910
+#: a08d2aca21d947f18faac29a23f4d1c6 f75b3a6f1e5e45889ed9785b799f27fc
+msgid "[1996112](https://bugs.launchpad.net/bugs/1996112)"
+msgstr ""
+
+#: ../../22.04/3.md 1eeeeb8c0414481ba2e4b15e405ce135
+#: 6dce039c352f47c69ec0d9902dfa22a9 90b5c897821844ef90cbe1152d93d782
+#: ae3244f864c7406ab12577b639b32f0f dcdbe231fef94d66935b1ff6b1526d29
+msgid "Virtual GPU driver packaging regression"
+msgstr ""
+
+#: ../../22.04/3.md 15116f5d13d444daa6e268682f5b4057
+#: 21ffa6fb821d45cf98b3e0a24763b29a 77eec38832ea477a8c0bb3cfb1b5316a
+msgid "[1999094](https://bugs.launchpad.net/bugs/1999094)"
+msgstr ""
+
+#: ../../22.04/3.md b209672c6941491b8db518656d950326
+#: b50b7b3c56ab4def99e3fb66d244dc1e ef1f99cd05ac4042bff8d9d164085bd6
+msgid ""
+"mm:vma05 in ubuntu_ltp fails with '[vdso] bug not patched' on "
+"kinetic/linux 5.19.0-27.28"
+msgstr ""
+
+#: ../../22.04/3.md 207f2de3aeba48b88dc9108a05cf3d04
+#: 3c21fd0dab1647768d9662fdff4c6d52 42e98a7999a742f782eb00e84942b15c
+#: b4e798ee79e94edcb29fe79b21f0bfa7 b6d658fd9a7149709776907e6c4e5385
+msgid "[2001618](https://bugs.launchpad.net/bugs/2001618)"
+msgstr ""
+
+#: ../../22.04/3.md 74a4a6c2e996410bac5e46465adf75d9
+#: 789c75bd3d344be881aa9e46353e5656 e8724191b1d4414cbdf3f7f004422ba4
+#: f86bfa04b1324e97967b79c273dd360b f964f393d3f747edb94f70a1c15ebf08
+msgid "BPF_[AND"
+msgstr ""
+
+#: ../../22.04/3.md 2a86582a0d324123bc885826e535d74f
+#: 638bfb295c304911ad4a26638361f2cb
+msgid "linux-azure"
+msgstr ""
+
+#: ../../22.04/3.md 13e7eebde11a429b80e04476a9198dfb
+msgid "[1996806](https://bugs.launchpad.net/bugs/1996806)"
+msgstr ""
+
+#: ../../22.04/3.md 4c65178e6f4546faa651a9f2490293e0
+msgid "Azure: Jammy fio test causes panic"
+msgstr ""
+
+#: ../../22.04/3.md 2653445d63ca461285a603b80a940da0
+#: 2a49a39a65c14ddf9b42f2ff0d4e1496 ee4c5194d1fd4a759c1009a0ad4d7dc7
+msgid "[2016898](https://bugs.launchpad.net/bugs/2016898)"
+msgstr ""
+
+#: ../../22.04/3.md 397d4a0779274137812c809d71a979f5
+#: 48f111baad9045ff9840f8d6c312e8cc c5b1cfed5b5f40cc837a0b7c69a2f42d
+msgid "Azure: Enable MANA Jumbo Frame Support"
+msgstr ""
+
+#: ../../22.04/3.md 368e671ee705471bb00ae59f46682f32
+#: bb695e75bc5d43f39c7163dd7e9dc393
+msgid "linux-azure-5.19"
+msgstr ""
+
+#: ../../22.04/3.md 5580d05800044883b2476b02040ca1a1
+msgid "linux-azure-6.2"
+msgstr ""
+
+#: ../../22.04/3.md 06dbc93421f74d5681a4dbd3da1475c9
+#: 0d0c802b7e684908a932c031a45dafa1 1c14333a679e4e38bcfe33e38b1a7ee3
+#: 27ea3799d4814dd69b64e1a731dce2b6 28212ba8fa4c4c039de0d84b032e67c7
+#: 3b8fe627509a478792fb30ded1c76d5c 48a1414d72d34adb806dca53ddb246a7
+#: 4d094eac08d8417996fd87d30711b2b3 4d5c4edd3c08488fa40dde0c02a39aba
+#: 5bf5a0b4565349e290a145adb60ddc18 6533eb1900e84c1682469424c4f956fc
+#: 72cfa0b90e974aeea4d18d6d984a4213 80abbf1ee5014bb5a30d95371359905a
+#: 886c4f0c94524055bcc630e5a91a3f02 8887a99d846545dc83f4fce3e31cdf8c
+#: c7dc4ae157704416b91876cf295543c3 d18b188ddf5043aba0222d8dc9ada315
+#: e6434bc18a3f455aa40c6fdf45f3e5b2 f9ce2c5b8e0649ed932aaecdc68d75c2
+msgid "linux-firmware"
+msgstr ""
+
+#: ../../22.04/3.md cb85ac6e69c04c038be9af0b16aa7f29
+msgid "[1968604](https://bugs.launchpad.net/bugs/1968604)"
+msgstr ""
+
+#: ../../22.04/3.md e89cdec5382d40489e83acf5ef4c0d93
+msgid "rtl8761b usb bluetooth doesn't work following reboot until unplug/replug"
+msgstr ""
+
+#: ../../22.04/3.md ad680dc7b050416d9fc3f8b697d83032
+#: ad6ccdbee75c4cc8be39d771357426a3
+msgid "[1999375](https://bugs.launchpad.net/bugs/1999375)"
+msgstr ""
+
+#: ../../22.04/3.md 05c19eac923043f0b8fd83fe77adaaf1
+#: 393a057ed04c4b039ee20f50c63d304e
+msgid "Update dg2_dmc to 2.08"
+msgstr ""
+
+#: ../../22.04/3.md e31f5967ccbb467bbafb91b0aed10834
+msgid "[1999406](https://bugs.launchpad.net/bugs/1999406)"
+msgstr ""
+
+#: ../../22.04/3.md 693eceaa83f54b8ebda61073ffdf2ca4
+msgid "Update firmware for hwe/oem kernel migrations"
+msgstr ""
+
+#: ../../22.04/3.md 8bf8ee3ae1b04a0fb97c5057c18beb79
+msgid "[2000133](https://bugs.launchpad.net/bugs/2000133)"
+msgstr ""
+
+#: ../../22.04/3.md c75eca877cd44b1fba9c73e7c35fde4d
+msgid "amdgpu: missing firmware for navi31"
+msgstr ""
+
+#: ../../22.04/3.md 37a81795c3bb4ba7bcf81e4a2ea65563
+msgid "[2003846](https://bugs.launchpad.net/bugs/2003846)"
+msgstr ""
+
+#: ../../22.04/3.md b00d9486549e4e909d2e776bc877746d
+msgid "amdgpu: missing firmware for navi33"
+msgstr ""
+
+#: ../../22.04/3.md 46f68625e5ef4f82a91be09a68a5c0e7
+msgid "[2006458](https://bugs.launchpad.net/bugs/2006458)"
+msgstr ""
+
+#: ../../22.04/3.md 19a6a6d5b925492b9ebec761a9e40bd1
+msgid ""
+"Frequent wakeups on HP Pro x360 435 13.3 inch G9 using Qualcomm "
+"FastConnect 6900"
+msgstr ""
+
+#: ../../22.04/3.md da2820ac58d04ad9b0e9cf3446084700
+msgid "[2007875](https://bugs.launchpad.net/bugs/2007875)"
+msgstr ""
+
+#: ../../22.04/3.md 99b5e8f0eac84248a56d8f0949957f40
+msgid ""
+"Ubuntu 22.04 LTS XPS 13 plus 9320  kernel 6.0 OEM and 5.19 breaks wifi "
+"frequently"
+msgstr ""
+
+#: ../../22.04/3.md 4846ebec978940339c7f5089d7f43a68
+msgid "[2008113](https://bugs.launchpad.net/bugs/2008113)"
+msgstr ""
+
+#: ../../22.04/3.md 8ed16a8e5744476899ee369d0c5a8e5f
+msgid "Add firmware for amdgpu products with GC 11.01"
+msgstr ""
+
+#: ../../22.04/3.md bba6abb616a34082abf89a71a449ffe2
+msgid "[2008217](https://bugs.launchpad.net/bugs/2008217)"
+msgstr ""
+
+#: ../../22.04/3.md 54c1bef6e2eb4f1ca0474556a56f1a21
+msgid "Unsolicited wake from suspend with bluetooth connected (Intel AX211/AX201)"
+msgstr ""
+
+#: ../../22.04/3.md 0f8a5fbf6a3344b5adc28170dff8ccd4
+#: 323cda5cfe2c4440968b2663acc1041a
+msgid "[2009642](https://bugs.launchpad.net/bugs/2009642)"
+msgstr ""
+
+#: ../../22.04/3.md 24a7afe2a89943379ac7a2e8270afd05
+#: e64a043bdde548e78d9c2f5e9df0798c
+msgid "mt7921: add support of MTFG table"
+msgstr ""
+
+#: ../../22.04/3.md f3ce9e6c11e14435a9c15fc71e05473e
+msgid "[2012468](https://bugs.launchpad.net/bugs/2012468)"
+msgstr ""
+
+#: ../../22.04/3.md c7c0791ea5c1466b9a0629bbbd3233e5
+msgid "Add Intel QAT Gen4 firmware"
+msgstr ""
+
+#: ../../22.04/3.md 041d6c3361a8442291372af9e36140a6
+msgid "[2015297](https://bugs.launchpad.net/bugs/2015297)"
+msgstr ""
+
+#: ../../22.04/3.md 93d85f5dc0db470aa7ed8c22b555edae
+msgid "Update GPU F/W for DCN 3.1.4 products to fix S0i3 issue"
+msgstr ""
+
+#: ../../22.04/3.md fc11f935c3434775b069b0ea3902b10f
+msgid "[2020627](https://bugs.launchpad.net/bugs/2020627)"
+msgstr ""
+
+#: ../../22.04/3.md ad0878bcbdfc45eb97d9393784e710b4
+msgid ""
+"upgrade iwlwifi firmware of FW API 72 for WiFi 6E support in Malaysia and"
+" Morocco"
+msgstr ""
+
+#: ../../22.04/3.md 15256272f64947cca36ed2f481f0f3ae
+msgid "[2023193](https://bugs.launchpad.net/bugs/2023193)"
+msgstr ""
+
+#: ../../22.04/3.md 80e66636294d420ab20dad8927adde4d
+msgid "Add firmware files for HP G10 series laptops"
+msgstr ""
+
+#: ../../22.04/3.md 83a23e17ea6042218cc122ebb51a8306
+msgid "[2024427](https://bugs.launchpad.net/bugs/2024427)"
+msgstr ""
+
+#: ../../22.04/3.md 8005c09a564441c59173938e09ced5a5
+msgid "potential S3 issue for amdgpu Navi 31/Navi33"
+msgstr ""
+
+#: ../../22.04/3.md 8a1304fabe13484e925e4187b248ee43
+msgid "[2024774](https://bugs.launchpad.net/bugs/2024774)"
+msgstr ""
+
+#: ../../22.04/3.md ba9b08d07e324ee8bd3b97a5b0163b82
+msgid "AMD Rembrandt / Phoenix PSR-SU related freezes"
+msgstr ""
+
+#: ../../22.04/3.md c099930d55bd43bf919802a82bd81c12
+msgid "[2026253](https://bugs.launchpad.net/bugs/2026253)"
+msgstr ""
+
+#: ../../22.04/3.md 895df83330c447b69001e1c4b44765d3
+msgid "i915: Add DMC/GuC/HuC firmware for Meteor Lake"
+msgstr ""
+
+#: ../../22.04/3.md 762f5be328e6424f9b3f6f5adc8a5031
+msgid "[2027959](https://bugs.launchpad.net/bugs/2027959)"
+msgstr ""
+
+#: ../../22.04/3.md 2e69b8dfb5f24c859009753962631f91
+msgid "Follow-up: potential S3 issue for amdgpu Navi 31/Navi33"
+msgstr ""
+
+#: ../../22.04/3.md bd565984f3f14a4286f0728715d62312
+msgid "[2029396](https://bugs.launchpad.net/bugs/2029396)"
+msgstr ""
+
+#: ../../22.04/3.md 6af1db6adeb2427097606c7e6ba0cf09
+msgid "20230323.gitbcdcfbcf-0ubuntu1.4 borks amdgpu"
+msgstr ""
+
+#: ../../22.04/3.md 0fa018b6ece845549a6e2761ffc67c2b
+#: 1c05b9d051a04eca9f6a4d6c035f05b4 242f637904704bcaa2a9979fd9db2520
+#: 28a8079b7569450387e6de2057f0490a 32abdd516c7e4f768b07fd3e0b0f7b84
+#: 40c53496c3364e3cb37a3d113f9f52ce 4175ab6bfa8044bb8053b5cd052f9feb
+#: 46f1f42fb04f4dcfbc2b72e89cdecae5 5013ca6975634165a61b05ef611b8eac
+#: 501680a9172148fd800b39e22101b6b9 56a95364e4ab4e59bec32a5f2f733a92
+#: 69b3372de87d40e28f47b94f41c155b8 79ed58ddc7bd4af1a1470e8c23579036
+#: 7cb85f40bab348a2929f27226b176728 7ef1b400337d43d3bb169cdcaec1c559
+#: 831575b3021448e988c5381cc8464435 8b50568310de4a0b9afcc42efc53501b
+#: a82353e598ca4ae3906969303b187f2f b65e406316e3499584e3000b18c3ee0a
+#: f768b6a72cc748098b8f2d1640470e66 fbfc0aad36e44cc8ba02dd44c6ab8b59
+#: fe4a0de09a2c44b6b3814f27d0f2cd82 ff132a41a001473bbe319906df3dbe4e
+msgid "linux-gcp-5.19"
+msgstr ""
+
+#: ../../22.04/3.md 785f44f8f6c844bba86385bd76d2d4aa
+msgid "[1941893](https://bugs.launchpad.net/bugs/1941893)"
+msgstr ""
+
+#: ../../22.04/3.md 23d1f8a283ac45e28e558bb002ce7183
+msgid "Improve performance and idle power consumption"
+msgstr ""
+
+#: ../../22.04/3.md 50ecb3d2057944029757ba8275657d86
+msgid "[1951563](https://bugs.launchpad.net/bugs/1951563)"
+msgstr ""
+
+#: ../../22.04/3.md d0dee04bff1641b59daa3dc71c899fdf
+msgid "alsa/sdw: add sdw audio machine driver for several ADL machines"
+msgstr ""
+
+#: ../../22.04/3.md 7dc82d65496c48bdbc9a1d09aa860dce
+msgid "[1953008](https://bugs.launchpad.net/bugs/1953008)"
+msgstr ""
+
+#: ../../22.04/3.md bab17e87c6cd4ab5b45170c162c65a15
+msgid "Support USB4 DP alt mode for AMD Yellow Carp graphics card"
+msgstr ""
+
+#: ../../22.04/3.md 202047874e0844cbb3700ef785cf9d8d
+msgid "[1956780](https://bugs.launchpad.net/bugs/1956780)"
+msgstr ""
+
+#: ../../22.04/3.md 5e7f8d494ce34fd1affe9e11915296f0
+msgid "5.15 stuck at boot on c4.large"
+msgstr ""
+
+#: ../../22.04/3.md 080345a1114842e5b8b167c5f6bb86dd
+msgid "[1959376](https://bugs.launchpad.net/bugs/1959376)"
+msgstr ""
+
+#: ../../22.04/3.md 72bca2fabe8b42bdaac583d93dc85af2
+msgid "rtw88_8821ce causes freeze"
+msgstr ""
+
+#: ../../22.04/3.md f2688635de954e5ba90f1c9c4ce86491
+msgid "[1965766](https://bugs.launchpad.net/bugs/1965766)"
+msgstr ""
+
+#: ../../22.04/3.md 78ab7838fed54f2f9affd5ac8cca2d4c
+msgid "zfcpdump-kernel update to v5.15"
+msgstr ""
+
+#: ../../22.04/3.md 0b5e19bcb0fb4a6d8ddd713e01e33fee
+msgid "[1971699](https://bugs.launchpad.net/bugs/1971699)"
+msgstr ""
+
+#: ../../22.04/3.md 784f5075565c432ba97dfe4bb4fabccc
+msgid "disable Intel DMA remapping by default"
+msgstr ""
+
+#: ../../22.04/3.md db107fa3ec354511831537afb4da2657
+msgid "[1974442](https://bugs.launchpad.net/bugs/1974442)"
+msgstr ""
+
+#: ../../22.04/3.md fbdd68995dd141cbb41e4c10e972de59
+msgid "enable CONFIG_DEVTMPFS_SAFE"
+msgstr ""
+
+#: ../../22.04/3.md cd3ecc460b4545faa22d3f7dfefab8b2
+msgid "[1979647](https://bugs.launchpad.net/bugs/1979647)"
+msgstr ""
+
+#: ../../22.04/3.md ee3c0cc4351b45419ef1e9f8974274f2
+msgid "No RISC-V configuration in the unstable tree"
+msgstr ""
+
+#: ../../22.04/3.md 65f35d22aa60451e87cbc35b67b1d428
+msgid "[1980061](https://bugs.launchpad.net/bugs/1980061)"
+msgstr ""
+
+#: ../../22.04/3.md ea57133a35484f5885a80d3f1174d1fd
+msgid "RISC-V enables CONFIG_COMPAT in the unstable branch"
+msgstr ""
+
+#: ../../22.04/3.md 2ecf978237aa4a10848388f9604827ea
+msgid "[1980484](https://bugs.launchpad.net/bugs/1980484)"
+msgstr ""
+
+#: ../../22.04/3.md ee5f108798994c9eac241489b18bcafc
+msgid "temporarily disable CONFIG_X86_KERNEL_IBT"
+msgstr ""
+
+#: ../../22.04/3.md 8b3840ab3ee849afa41fe9581a28d885
+msgid "[1981437](https://bugs.launchpad.net/bugs/1981437)"
+msgstr ""
+
+#: ../../22.04/3.md d5c11eb2178c4ce2b2c6b22530a4fa9a
+msgid "RISC-V kernel config is out of sync with other archs"
+msgstr ""
+
+#: ../../22.04/3.md 519089d4d3d942d28fa778fc6a40cea2
+#: b9d42487c5b6411894b7d2c562852924 f92ff92918ce4a8793f5bec80f9a0fdb
+msgid "[1989334](https://bugs.launchpad.net/bugs/1989334)"
+msgstr ""
+
+#: ../../22.04/3.md 1ee31f317745406487cf2e88b0daff2b
+#: 5b79d7b7789d44788118f6b66dc4d0d4 a293c895f69745beb68a57ad361bd67d
+msgid "remove circular dep between linux-image and modules"
+msgstr ""
+
+#: ../../22.04/3.md 7482313149e24fbb8615bd8b030f245c
+msgid "linux-gcp-6.2"
+msgstr ""
+
+#: ../../22.04/3.md 062a53dabca44c81822ccecc31092bdd
+#: 06f6cfec935644fc9b5caade1c941210
+msgid "[2015741](https://bugs.launchpad.net/bugs/2015741)"
+msgstr ""
+
+#: ../../22.04/3.md 6bd6c4ae7eaa4980a3c6315e4aa3aec2
+#: add345f180e94dd5ae47332a3aa4fcf9
+msgid ""
+"efivarfs:efivarfs.sh in ubuntu_kernel_selftests crash L-6.2 ARM64 node "
+"dazzle (rcu_preempt detected stalls)"
+msgstr ""
+
+#: ../../22.04/3.md 1f0037cb86724834b56edb0848bc1f1b
+msgid "linux-gke"
+msgstr ""
+
+#: ../../22.04/3.md c6483df90d964b819bf2b81dc6acef2c
+msgid "[2022098](https://bugs.launchpad.net/bugs/2022098)"
+msgstr ""
+
+#: ../../22.04/3.md d2f42af309a640ef84652a6fdd4a304c
+msgid "Severe NFS performance degradation after LP #2003053"
+msgstr ""
+
+#: ../../22.04/3.md 31f3d9782fbf4180a5129f41e9b28186
+#: 72b30f58e441409695f9f181c8a1cf83 76f09b1c56074f9d96048f7b26ee8b85
+#: ea1e9f5357304baabedc67de324a3122
+msgid "linux-hwe-5.19"
+msgstr ""
+
+#: ../../22.04/3.md 4a4ca9621925499382aa1eb1abc99d17
+msgid "linux-intel-iotg"
+msgstr ""
+
+#: ../../22.04/3.md a83f1e9a400a484aa640e2e59b2ca313
+msgid "[2022887](https://bugs.launchpad.net/bugs/2022887)"
+msgstr ""
+
+#: ../../22.04/3.md 23f2b3fea3ca454da3467adf795ca4cf
+msgid "add Fintek F81604 can controller support"
+msgstr ""
+
+#: ../../22.04/3.md 3b56a21472234f5890b2e3b73dda0539
+#: 4bd3f2218e10468d986b167185112a45 4c81893a45dd425187365bcd96a368fd
+#: 682b33b81496453090bb06e028515601 7583063c3d1c47f689799bd1c17ea73e
+#: abfab68242c34368a28f0b6cd8da7593 b84a5e6d55054679a775a5c3f6603f27
+#: d5caa472865d436ea21feac44dd7cc93 d974c1ec629949e98019dd6acbd945f0
+#: dacfc6d231854852bdb434e77fc8337e ec149f61792e470382b9ce4789417f13
+msgid "linux-lowlatency-hwe-5.19"
+msgstr ""
+
+#: ../../22.04/3.md 3d8079839b66418eba02ac7b19aba3e5
+#: 5b55f39fac34411bb768523cd5c6d463 8fe6cf580d114749b56cc300abcb2529
+#: 9a508fbcfac0472d8a17130fc3c0fa02 b99439e8b1584aeeb31555a8caf125f4
+#: c70d4c4d97404830812a7daa54049a38 da9d029ad560424a9be139659464ca54
+#: f0321668e84043008ac39b00915ffe7f
+msgid "linux-lowlatency-hwe-6.2"
+msgstr ""
+
+#: ../../22.04/3.md 23ad1ad56b994c2390120451d86cd28a
+msgid "[2007654](https://bugs.launchpad.net/bugs/2007654)"
+msgstr ""
+
+#: ../../22.04/3.md d1fec41fab6b487b9b1ed040381b06e1
+msgid "enable Rust support in the kernel"
+msgstr ""
+
+#: ../../22.04/3.md 4b94595489294eaa9d0bf10ff6a27f4f
+#: c93c24d5afbb4d8fa48c689128f1e5fc
+msgid "[2012136](https://bugs.launchpad.net/bugs/2012136)"
+msgstr ""
+
+#: ../../22.04/3.md c7d6a925952844b1b98dfe7ec1f6f9a7
+msgid "LSM stacking and AppArmor refresh for 6.2 kernel"
+msgstr ""
+
+#: ../../22.04/3.md be28d63c362448b89386f9acc389ba01
+msgid "kinetic: apply new apparmor and LSM stacking patch set"
+msgstr ""
+
+#: ../../22.04/3.md aa4325b0cb90446ca93c35442f025387
+msgid "[2012776](https://bugs.launchpad.net/bugs/2012776)"
+msgstr ""
+
+#: ../../22.04/3.md df3ae5007e2e434f9a4785d1639144cf
+msgid "Neuter signing tarballs"
+msgstr ""
+
+#: ../../22.04/3.md ca72cdd5bfc246a485a8b4499747981e
+msgid "[2013014](https://bugs.launchpad.net/bugs/2013014)"
+msgstr ""
+
+#: ../../22.04/3.md 7156e31652934ce2970b726ea307a823
+msgid "net:l2tp.sh failure with lunar:linux 6.2"
+msgstr ""
+
+#: ../../22.04/3.md 565940460d404d43974a3974b48e053c
+msgid "[2015361](https://bugs.launchpad.net/bugs/2015361)"
+msgstr ""
+
+#: ../../22.04/3.md 6c4f1f1837eb423b82d3f821b9904e31
+msgid "FTBFS with different dkms or when makeflags are set"
+msgstr ""
+
+#: ../../22.04/3.md 005c749607ee4f5ebf9699ba5d945479
+msgid "linux-meta-azure-fde-5.19"
+msgstr ""
+
+#: ../../22.04/3.md a5c4eda1b4cc4c8ca2c3e6c46855c2b7
+msgid "[2017658](https://bugs.launchpad.net/bugs/2017658)"
+msgstr ""
+
+#: ../../22.04/3.md f854cd59ac3d4c4da33fc0925a7faec0
+msgid "FDE v5.19 edge variant meta packages are incorrectly named"
+msgstr ""
+
+#: ../../22.04/3.md b46196811bfe42e68a05911fa892017e
+msgid "linux-oem-5.17"
+msgstr ""
+
+#: ../../22.04/3.md f2c2ccaaa23c42cb9325cd52ee973cef
+msgid "[2017013](https://bugs.launchpad.net/bugs/2017013)"
+msgstr ""
+
+#: ../../22.04/3.md c7aa0bc621be42ce82cc65f720606ebd
+msgid "net: sched: Fix use after free in red_enqueue()"
+msgstr ""
+
+#: ../../22.04/3.md 0359528c959b4282915a452fcdc47c2d
+#: 2820c75740954ee5bcafacf7b8438b53 3b62f96a4b0c4ac3b6e1589518de59c2
+#: 3dccc92527fb4e24942c4950fada4052 3e5b6c1d2e3b4da3b2d9fb05385b402e
+#: 4c677047e5354198bfa392ac1115f369 4fd67ec781094ae384319ccebca949f2
+#: 821e498d926f4575890b102ffa98be23 87614e15c4cc47f996376d1c6c1cc1c2
+#: 8fccaac3bded44bea3e9f58b00aa7654 9ae8d84b50f14c66b6d82eeffabb2e23
+#: 9d944e6db48d4d63b0cf40775d6d8ea6 a65cad083b914be5bc65eb0dfd158f6a
+#: a8939a6bdf1f4739b59df2f85012556b
+msgid "linux-oem-6.1"
+msgstr ""
+
+#: ../../22.04/3.md c0ca8907e0ff4f65a9caed6e7000fa78
+msgid "[2004429](https://bugs.launchpad.net/bugs/2004429)"
+msgstr ""
+
+#: ../../22.04/3.md 9678c730cfd648058cffc018d9aa21b7
+msgid "Move kernel ADT tests to python3"
+msgstr ""
+
+#: ../../22.04/3.md 6f2f1c5d40fb44568953a359b6cc653f
+msgid "[2006945](https://bugs.launchpad.net/bugs/2006945)"
+msgstr ""
+
+#: ../../22.04/3.md e6b0d4bea6bf471daedd43e4fe4d2bf1
+msgid "New DG2 workarounds"
+msgstr ""
+
+#: ../../22.04/3.md e859b4b607a640a1ba9fb8f601673fb5
+msgid "[2007584](https://bugs.launchpad.net/bugs/2007584)"
+msgstr ""
+
+#: ../../22.04/3.md a8032a901aed41d29036a6eb8c7974db
+msgid "cm32181 module error blocking suspend"
+msgstr ""
+
+#: ../../22.04/3.md 1239cef9871f4020b5b08763ca74fd0c
+msgid "[2008871](https://bugs.launchpad.net/bugs/2008871)"
+msgstr ""
+
+#: ../../22.04/3.md 9e14b809e46d4a60a34b28390be5f5ee
+msgid "Screen backlight keeps in minimized and can't change it with amdgpu"
+msgstr ""
+
+#: ../../22.04/3.md a3bd4f2c9b9f4362bf85c722860439fe
+msgid "[2008882](https://bugs.launchpad.net/bugs/2008882)"
+msgstr ""
+
+#: ../../22.04/3.md e22ed2b47da3473c9ca974ac8e722267
+msgid "Remove all other acpi_video backlight interface on Dell AIO platforms"
+msgstr ""
+
+#: ../../22.04/3.md 4e137206cc5746d1945b7a8333ed8e0d
+msgid "[2009164](https://bugs.launchpad.net/bugs/2009164)"
+msgstr ""
+
+#: ../../22.04/3.md 78d79ed7f5754906b6bdf5f9d667e1a8
+msgid "Fix screen that remains blank forever after it gets locked"
+msgstr ""
+
+#: ../../22.04/3.md 0a968cbf5d8145669f85c98c3e324bc6
+msgid "[2011379](https://bugs.launchpad.net/bugs/2011379)"
+msgstr ""
+
+#: ../../22.04/3.md 4735edb1896242f29d0f91d87cf992ae
+msgid "Speaker / Audio/Mic mute LED don't work on a HP platform"
+msgstr ""
+
+#: ../../22.04/3.md 78ae9211487b43d5b9fe9936a1b6370e
+msgid "[2011768](https://bugs.launchpad.net/bugs/2011768)"
+msgstr ""
+
+#: ../../22.04/3.md b0fcfb2c0cbc45b6a7bd0e3ce1b3f43d
+msgid ""
+"Fix NVME storage with RAID ON disappeared under Dell factory WINPE "
+"environment"
+msgstr ""
+
+#: ../../22.04/3.md a1a2d4ce2d33420e91acb8888d8d7389
+msgid "[2012846](https://bugs.launchpad.net/bugs/2012846)"
+msgstr ""
+
+#: ../../22.04/3.md 5533e73484ef48c5ab0292a676363d98
+msgid "Fix spurious wakeup from S5 when TBT dock is plugged"
+msgstr ""
+
+#: ../../22.04/3.md 8bc590077ae04264986533a6f83c6758
+msgid "[2013114](https://bugs.launchpad.net/bugs/2013114)"
+msgstr ""
+
+#: ../../22.04/3.md 721d229ad5424e1a912007e2a4887b34
+msgid "The panel get blank for too long after disconnecting dock with monitors"
+msgstr ""
+
+#: ../../22.04/3.md 01753ec3fcc644e4afd9e031b8d7b267
+msgid "[2018566](https://bugs.launchpad.net/bugs/2018566)"
+msgstr ""
+
+#: ../../22.04/3.md 92fee9b9fa3d498fb7cb1f62a0aa7e80
+msgid "A deadlock issue in scsi rescan task while resuming from S3"
+msgstr ""
+
+#: ../../22.04/3.md 982e8bcd6c45462b9434c0b4c64894f2
+msgid "[2024199](https://bugs.launchpad.net/bugs/2024199)"
+msgstr ""
+
+#: ../../22.04/3.md df45409c8ae841dba90503617b9dc4bc
+msgid "Resync CI Runner Configuration"
+msgstr ""
+
+#: ../../22.04/3.md b45dac577afb42dfa812b8d123915c80
+msgid "linux-restricted-modules"
+msgstr ""
+
+#: ../../22.04/3.md 03e4047b754a496ba72e443b9187a3a1
+#: 05df875e17c749db9301cc2f8fa01bca 0a84667f77c346b2929967f5070e791b
+#: 0bde4e355a2949b2b1f08c49c36389be 0d3909e2556346b6b98caf9bf7fb80c7
+#: 132a90f0689245d7938d8e3df2725b47 18e7b0bd6e724d73bc2b3e8661c73525
+#: 1cff22fb71a14def887de6e3b8fc6ed0 270d7b63450f4c0d91c161314f905b1a
+#: 2a55b959bf524523add5a1db386b38e7 2ffa76813ed645129acb330ebc6ee06c
+#: 3725c5822aa1465ea6fd99da84fc42d4 3c2a611d631d4ebe8b420af1e97e9312
+#: 3d2110fc7b0c4b21872249f2ae06e704 3e2b6722d56d446e8002c28cd76a74d6
+#: 46cdb72eb95247279fd1df83483491bd 54343892b2a24818aa1ef79edf020fc2
+#: 66ac58d6101d4cacb8bd708412511030 7fd83463dda643b297918451fbe1c31d
+#: 81a9ea28e0164e58a167838361fee02b 8547764ba0b94e9f9b1549d67a9f4f16
+#: a2e3d7a35b1f4eb2bff9ad4c49e24680 a65bf6e19917407b93687526851eb007
+#: b23b7a830372463299a869ccb198f055 c0375c8555f74f0da5aa60ddc273b81e
+#: d146eb6c5f1048658ba40d138e35a557 d98041a44e964a51a2880dfde42fb331
+#: e1dfbe6f7d1b4929848b2bf2de7567f5
+msgid "[1988836](https://bugs.launchpad.net/bugs/1988836)"
+msgstr ""
+
+#: ../../22.04/3.md 019c8914a13a4c3e83ab78ae5c6e1b5b
+#: 0444881908ef4cfca71aeaa835b84122 0aefa2b437284a7a92f24f64f10b16a8
+#: 1e9877b0d4dc472b857668ba043aa4e1 24b8d88a99be4866b41d59ac5e9f09fd
+#: 258cdc88971b435e8d52402abc50b579 2a488480f1c046d6be26af23f09983e0
+#: 2cc651ab141340e6a06f1b48ae603220 2e7100bcbc894069a0a35f9660f6e8df
+#: 2e806704e3754fcb9b40b23a5ee89762 49bf9797e00a4f39a9e407a83caeadb2
+#: 4a034c4022f84fc89dbfd6f308c02ce7 4cad15fc23b64227b718786a647cb028
+#: 52c023b2e37c48a3aad32e5dba83b61c 6b74a5ecb5d44659bb7c356879910937
+#: 74022e8abee94a70b2127ed3450250b7 7d3285474c3247b3bf9254ba194ab0d2
+#: a124cfd542a2453bbe3c3a9c26a972f0 b38eb7a5e3e5469584eb6028f7caffcc
+#: c129617035474b389c27e1522ba32db3 c6694d039cce4810ae8b151ffb782081
+#: cc95811e75e44759bcfd14ab2ebfa94f cf075a26df814899a7515760f72c0f26
+#: e4928e9e8f304ab99f673ca4dad49a24 e9b8d7724b734c9dae46a06667c9221c
+#: e9f68629dbf64c7ead5040f156c07878 ecdd87938fc54f228e0612ffa69a37ab
+#: ef2c6fd967ee40d5a2e21504280a3ebf
+msgid "LRMv7: Enable the open NVIDIA kernel modules"
+msgstr ""
+
+#: ../../22.04/3.md ecd4e6e297c148908ae71c73969eb6f3
+msgid "linux-restricted-modules-aws"
+msgstr ""
+
+#: ../../22.04/3.md fc389682d13c4bb69d4f8d86c7f112bb
+msgid "linux-restricted-modules-aws-5.19"
+msgstr ""
+
+#: ../../22.04/3.md 46e8ad89217741c39ec5eca6bbecf273
+msgid "linux-restricted-modules-azure"
+msgstr ""
+
+#: ../../22.04/3.md 47182142294644909d7a3723bc7e3eb6
+msgid "linux-restricted-modules-azure-5.19"
+msgstr ""
+
+#: ../../22.04/3.md be316a3a565f428c85619c22ebfd3482
+msgid "linux-restricted-modules-gcp"
+msgstr ""
+
+#: ../../22.04/3.md e99ce9ca49084d298b91d3614135d731
+msgid "linux-restricted-modules-gcp-5.19"
+msgstr ""
+
+#: ../../22.04/3.md eb1585f3ffe247e281c133acd40dc0af
+msgid "linux-restricted-modules-hwe-5.19"
+msgstr ""
+
+#: ../../22.04/3.md e9dd785c554247b38fea4d251536adeb
+msgid "linux-restricted-modules-hwe-6.2"
+msgstr ""
+
+#: ../../22.04/3.md 82a1b9b9a2a240738dba2160e9da9bb9
+#: f569a41418384fddae6457943a43a575
+msgid "[1991130](https://bugs.launchpad.net/bugs/1991130)"
+msgstr ""
+
+#: ../../22.04/3.md 0acebcdf7eb342279afbd973b196d7bf
+#: aae394c04e0f4d7ab26e4c460d2585ee
+msgid "Add lrm autogenerated transitional independent of variants"
+msgstr ""
+
+#: ../../22.04/3.md fc97917a1ae840ab921ae21f0f48d464
+msgid "linux-restricted-modules-intel-iotg"
+msgstr ""
+
+#: ../../22.04/3.md 12268616d2f7435c9bff73344f682a00
+msgid "linux-restricted-modules-lowlatency"
+msgstr ""
+
+#: ../../22.04/3.md ee1ce54da0544cd3aa456e56591fc6d4
+msgid "linux-restricted-modules-lowlatency-hwe-5.19"
+msgstr ""
+
+#: ../../22.04/3.md 0d2a45b0b27a4d5dbe0b93e978a61bb2
+#: c725b9d2a4d547ca8828d93e5e92b024
+msgid "linux-restricted-modules-lowlatency-hwe-6.2"
+msgstr ""
+
+#: ../../22.04/3.md 1c2685f225c04f829a931654f4ae5783
+msgid "linux-restricted-modules-oem-5.17"
+msgstr ""
+
+#: ../../22.04/3.md 096a9e08f21943b3b37722b8e553bda3
+msgid "linux-restricted-modules-oem-6.0"
+msgstr ""
+
+#: ../../22.04/3.md c9e2a94d727f4c1e9ad988cc8630ef95
+msgid "linux-restricted-modules-oem-6.1"
+msgstr ""
+
+#: ../../22.04/3.md affcd0fc9f424cb78d8d72c09264b7eb
+msgid "linux-restricted-modules-oracle"
+msgstr ""
+
+#: ../../22.04/3.md 5989613c9aa74a74a764b5c6976e9686
+msgid "linux-restricted-signatures-aws"
+msgstr ""
+
+#: ../../22.04/3.md aa82867aadd7448a96160002dcc550d2
+msgid "linux-restricted-signatures-aws-5.19"
+msgstr ""
+
+#: ../../22.04/3.md 3b11794d396048109b6d7db949ee5f0a
+msgid "linux-restricted-signatures-azure"
+msgstr ""
+
+#: ../../22.04/3.md 062e753b4ce940a29462214003821364
+msgid "linux-restricted-signatures-azure-5.19"
+msgstr ""
+
+#: ../../22.04/3.md 9a53e9d35892469a8754d256f72c56bb
+msgid "linux-restricted-signatures-gcp"
+msgstr ""
+
+#: ../../22.04/3.md c080f62315504428809b5b3bb0559186
+msgid "linux-restricted-signatures-gcp-5.19"
+msgstr ""
+
+#: ../../22.04/3.md 2f49f35581324135b9e646c6d13aebb9
+msgid "linux-restricted-signatures-hwe-5.19"
+msgstr ""
+
+#: ../../22.04/3.md 5a5c67e699b946d1b440febd6f224b47
+msgid "linux-restricted-signatures-intel-iotg"
+msgstr ""
+
+#: ../../22.04/3.md ecedec78732640e79409fcc05956c832
+msgid "linux-restricted-signatures-oem-5.17"
+msgstr ""
+
+#: ../../22.04/3.md a9ae5bbb35f1491d8510835cbe3b7cec
+msgid "linux-restricted-signatures-oem-6.0"
+msgstr ""
+
+#: ../../22.04/3.md 841299d0c5a24a268678dbec2be65337
+msgid "linux-restricted-signatures-oem-6.1"
+msgstr ""
+
+#: ../../22.04/3.md 5fe323ac21974df0862e39da3e5dffcc
+msgid "linux-restricted-signatures-oracle"
+msgstr ""
+
+#: ../../22.04/3.md 28ac1e35b73a4f4c9569220b79d22350
+#: 7ae50df278ef4577b42de802842b884b 80ed092d50114eb2abf3c94d5114da5c
+#: aae245877ac64710ac7c7497f2d634ea
+msgid "linux-riscv-5.19"
+msgstr ""
+
+#: ../../22.04/3.md 8f5c2150aaad4c54a77434ce37c29ec0
+msgid "linux-signed-gcp"
+msgstr ""
+
+#: ../../22.04/3.md a41f55cbfcd945239c7e9552214a53c0
+msgid "[2004010](https://bugs.launchpad.net/bugs/2004010)"
+msgstr ""
+
+#: ../../22.04/3.md 979fecf404a448cebccb733b22209048
+msgid "Missing sbsigntool build-dependency"
+msgstr ""
+
+#: ../../22.04/3.md 3a0d283d10e54a54b51644ba8924fa27
+msgid "linux-starfive-5.19"
+msgstr ""
+
+#: ../../22.04/3.md bacd29c135be43e6a26450f5e28d410b
+msgid "nvidia-graphics-drivers-390"
+msgstr ""
+
+#: ../../22.04/3.md 2e88b77110454a9ba1eab2bc526c356c
+msgid "[2019869](https://bugs.launchpad.net/bugs/2019869)"
+msgstr ""
+
+#: ../../22.04/3.md 4cfbc44ad2d44b91b79e1728a89dce45
+msgid "Better support for linux 6.2"
+msgstr ""
+
+#: ../../22.04/3.md 93132c1a0a114109b25e5c0085d8a184
+msgid "nvidia-graphics-drivers-418-server"
+msgstr ""
+
+#: ../../22.04/3.md 8493b7de28f44be3bdcb7d1c6fc7fb7d
+msgid "[1993328](https://bugs.launchpad.net/bugs/1993328)"
+msgstr ""
+
+#: ../../22.04/3.md 85597f9f018442b695998768a2839b4d
+msgid "Add support for Linux 5.19"
+msgstr ""
+
+#: ../../22.04/3.md 8e8d32b1484c4cefbd76ed4e866566e4
+#: a0e7d6546af845bc987f393b35da84e4
+msgid "nvidia-graphics-drivers-450-server"
+msgstr ""
+
+#: ../../22.04/3.md 3b8b0b03de6d46cfae8d2a95981c39a3
+#: dadd5d51d57c41a08ee73c614b18cd87 ddd3d7b8a50d4080a92ed874e0315d64
+#: dea07c257a514cffa9c57ee9e9adb182 eb48b5c756454ee9b71549652134f912
+#: f4c6cd0c87eb4771ada3d41d55dc57aa
+msgid "[2024675](https://bugs.launchpad.net/bugs/2024675)"
+msgstr ""
+
+#: ../../22.04/3.md 5266111d354f4003993d333050780300
+#: 7182cb4bf5df446d88b365a4af8e3997
+msgid "nvidia-graphics-drivers-470"
+msgstr ""
+
+#: ../../22.04/3.md 76e9a31e34c445159b5cea9caddf4c57
+#: 80fa309a2d784624999d018b3201b502
+msgid "nvidia-graphics-drivers-470-server"
+msgstr ""
+
+#: ../../22.04/3.md 81331f02559240f6ae6ee6980c6ad3cf
+msgid "nvidia-graphics-drivers-515"
+msgstr ""
+
+#: ../../22.04/3.md 4d539b11d00a49efa2d40ba23c991377
+#: fee6e94aaee34200bdde492278d330c6
+msgid "nvidia-graphics-drivers-515-server"
+msgstr ""
+
+#: ../../22.04/3.md f1b7820e791048ca931a413beae8ba27
+msgid "Add Conflicts, Replaces, Provides up to libcuda-11.7-1"
+msgstr ""
+
+#: ../../22.04/3.md 6453fa6e17354aec9d99f1741b4f9865
+#: 9f87cc325f204cc883b5a9a24fdbfff7 a1350377c40346d3ad337248da256566
+#: c1463a246768422b975818139c495075 c2a63ae46000428eb99bcd3b8fd7b8ac
+msgid "nvidia-graphics-drivers-525"
+msgstr ""
+
+#: ../../22.04/3.md df35ec87fec34a28b6e08f402184764f
+msgid "[2006937](https://bugs.launchpad.net/bugs/2006937)"
+msgstr ""
+
+#: ../../22.04/3.md c4d218f2982c4e50a6bad98c4f5909a2
+msgid "[2018979](https://bugs.launchpad.net/bugs/2018979)"
+msgstr ""
+
+#: ../../22.04/3.md 6be9f4cd2dbe4e34b0723718d8d93484
+#: 973e5747a30f49b29fed7fc1654f41fa c9f0774a8bfd4385927d9382d4066e07
+msgid "nvidia-graphics-drivers-525-server"
+msgstr ""
+
+#: ../../22.04/3.md 20ef71812b3c489db079498548b16271
+msgid "nvidia-graphics-drivers-530"
+msgstr ""
+
+#: ../../22.04/3.md b7cd9e4bdd524847962065164f162832
+msgid "[2015491](https://bugs.launchpad.net/bugs/2015491)"
+msgstr ""
+
+#: ../../22.04/3.md 8bccff22a1f3451e92560e7e75cf9ce9
+#: f6d56d30b6cc4c63b029c8b2b91475c4 f9642d8d10f341458839c36c345d2e52
+msgid "Initial release"
+msgstr ""
+
+#: ../../22.04/3.md 16e73971dd6f4aa2859cc780c03dc3d1
+#: 887ec44e6d7645168d6b98e5108a794c
+msgid "nvidia-graphics-drivers-535"
+msgstr ""
+
+#: ../../22.04/3.md 4e0d39e4c79441ca95dbffbc8582dd16
+msgid "[2028125](https://bugs.launchpad.net/bugs/2028125)"
+msgstr ""
+
+#: ../../22.04/3.md a72b1761f3d143d8800ec4073acb54db
+msgid "nvidia-graphics-drivers-535-server"
+msgstr ""
+
+#: ../../22.04/3.md a9bbc33b4cfe4849ad54089285174dd2
+msgid "[2025243](https://bugs.launchpad.net/bugs/2025243)"
+msgstr ""
+
+#: ../../22.04/3.md 1058bce7b0ff4d389a2e92c5cfc06d4d
+#: 296bea222e114430958ed40b40da901a 325151e96c0d4399bfd088815e1a5e98
+#: 3e6d25de3f574b8b902fd8f96ed7cf01 53e382ea714d4ea493d2bf4880677ecf
+#: b8c6f9b8715c4a259531a52aa2ba5d61 b9b6a1d3165546e4b1b297fa57d0a779
+#: e279230e3f7d4ab08c38d910ada921ed
+msgid "thermald"
+msgstr ""
+
+#: ../../22.04/3.md 80fc641542ff457e8970d146e9e15c1d
+msgid "[1981087](https://bugs.launchpad.net/bugs/1981087)"
+msgstr ""
+
+#: ../../22.04/3.md bfbd1e4814d5425f9be1b1a48ece2b6e
+msgid "Fix throttled GPU"
+msgstr ""
+
+#: ../../22.04/3.md 37c46abc4b594f7a8e9390fca67d4de4
+msgid "[1989044](https://bugs.launchpad.net/bugs/1989044)"
+msgstr ""
+
+#: ../../22.04/3.md b5cafd2bffeb4b73ae5b7c337235b217
+msgid "Fix RPL: Add INT3400 base path"
+msgstr ""
+
+#: ../../22.04/3.md 9811fa10990d4144803d5e0809dd3043
+msgid "[1995606](https://bugs.launchpad.net/bugs/1995606)"
+msgstr ""
+
+#: ../../22.04/3.md c80cfbb0b5a84c91ac5c35ccc8116acc
+msgid "Cherry-pick following fixes from thermald 2.5.1 and 2.5.2"
+msgstr ""
+
+#: ../../22.04/3.md 58fb95c24ab04aafb7734e7aa3070efa
+msgid "[2007579](https://bugs.launchpad.net/bugs/2007579)"
+msgstr ""
+
+#: ../../22.04/3.md e19a5a4f4bda4f9f9d9e23103717ed8a
+msgid "Support ITMTv2 for Raptor Lake"
+msgstr ""
+
+#: ../../22.04/3.md 3ef4428404d74ac19c50af07779f6711
+msgid "[2009676](https://bugs.launchpad.net/bugs/2009676)"
+msgstr ""
+
+#: ../../22.04/3.md 6219eb9f3e014e56a709c74dfdb8811a
+msgid "Add support for Raptor Lake S CPUs."
+msgstr ""
+
+#: ../../22.04/3.md d82f68ca66124aa78d71d31c0fa7e575
+msgid "[2012260](https://bugs.launchpad.net/bugs/2012260)"
+msgstr ""
+
+#: ../../22.04/3.md b345da8861b442f2b6747e5582407530
+msgid "Add support for Adler Lake N"
+msgstr ""
+
+#: ../../22.04/3.md 04975c1b7f53456c9504642e1d25b0c2
+msgid "[2018236](https://bugs.launchpad.net/bugs/2018236)"
+msgstr ""
+
+#: ../../22.04/3.md c9740fe673074a5385bc827ffb759218
+msgid "Fix i9-12900k shutdown when run Prime95 and stress-ng"
+msgstr ""
+
+#: ../../22.04/3.md ccdac29ee30c49e88b5d36d2f632fee4
+msgid "[2018275](https://bugs.launchpad.net/bugs/2018275)"
+msgstr ""
+
+#: ../../22.04/3.md d28113e7c3994283934510eab58d6c0b
+msgid "Fix in-motion function doesn't work"
+msgstr ""
+
+#: ../../22.04/3.md 1730c5fb74f94a9cac8f8848171d970a
+#: 6e26cd322f93419eb960d0d9fc6f545a c73b412c30fc40d89af0db9662b0c073
+#: dc193b9e96204b66b28dc746b66cdaf2
+msgid "ubuntu-drivers-common"
+msgstr ""
+
+#: ../../22.04/3.md 92ae0d0b67dd4c3a8746a63e673ed203
+msgid "[1935070](https://bugs.launchpad.net/bugs/1935070)"
+msgstr ""
+
+#: ../../22.04/3.md f62d3b2abc074f48ac71feb0c70fffd8
+msgid "Add some error trapping when aplay is not installed (on servers)"
+msgstr ""
+
+#: ../../22.04/3.md 4b442934cec0414da0ffe41043f3ee3b
+msgid "[1966413](https://bugs.launchpad.net/bugs/1966413)"
+msgstr ""
+
+#: ../../22.04/3.md e8a109579ecc4ebfb8aad5def1f86ccf
+msgid "Fix --no-oem option stored in wrong config variable"
+msgstr ""
+
+#: ../../22.04/3.md 1c309bbc1d5f45e7bf3a7ceb20d185c1
+#: 8668c20138024ab59da034cb0efbdb4f
+msgid "[1993019](https://bugs.launchpad.net/bugs/1993019)"
+msgstr ""
+
+#: ../../22.04/3.md 29a1da427dcb4d8a8a9f06ad5a58f0ac
+msgid ""
+"Fix local variable 'version' being referenced before assignment when "
+"catching ValueError"
+msgstr ""
+
+#: ../../22.04/3.md 9b07ce1c798e415493ef30ec22ccbafb
+msgid ""
+"Update regex and unify package name parsing in the following functions by"
+" using the new NvidiaPkgNameInfo class: "
+"nvidia_desktop_pre_installation_hook, _get_headless_no_dkms_metapackage, "
+"nvidia_desktop_pre_installation_hook, get_linux_modules_metapackage, This"
+" prevents ubuntu-drivers from crashing when dealing with the -open NVIDIA"
+" drivers"
+msgstr ""
+
+#: ../../22.04/3.md:439 5c812bda1d944722a41aad41bc9ad896
+msgid "Unsorted changes"
+msgstr ""
+
+#: ../../22.04/3.md 10fe6e9f63d04d95b12548275465a500
+#: 3f102a947d7d4795904cbec6e6039b27 a98c88ed0fc941e094d9d8948e5dec3d
+msgid "alsa-ucm-conf"
+msgstr ""
+
+#: ../../22.04/3.md 0b051d793fca49489395e98256b16648
+msgid "[2006102](https://bugs.launchpad.net/bugs/2006102)"
+msgstr ""
+
+#: ../../22.04/3.md ed2eead4fd7a4f86876a0f5a26a06583
+msgid "Backport patch to fix micmute LED (soundwire)."
+msgstr ""
+
+#: ../../22.04/3.md 874ff279852642baa8ef62dc172ae207
+msgid "[2012590](https://bugs.launchpad.net/bugs/2012590)"
+msgstr ""
+
+#: ../../22.04/3.md 3b773c8985544dd98b190bb78e1835d1
+msgid "Backport patch to update AMD micmute LED."
+msgstr ""
+
+#: ../../22.04/3.md c211ec7083614009b9ff9c6c9e383c68
+msgid "[2025353](https://bugs.launchpad.net/bugs/2025353)"
+msgstr ""
+
+#: ../../22.04/3.md 6df65b12c7d44a4196f4511973be787d
+msgid "Backport patches to add support AMD ACP RPL and Pink Sardine."
+msgstr ""
+
+#: ../../22.04/3.md 556717feed384b34bf801d490943160a
+msgid "autopkgtest"
+msgstr ""
+
+#: ../../22.04/3.md 91414a54e782416faed39989975eb958
+msgid "[2008026](https://bugs.launchpad.net/bugs/2008026)"
+msgstr ""
+
+#: ../../22.04/3.md 634ff2f6b5984d3680ef3353b8e6321a
+msgid "Backport version 5.28 of autopkgtest.livecd-rootfs"
+msgstr ""
+
+#: ../../22.04/3.md 3d3f2208d02349ffa600923fc2cd8fff
+msgid "cd-boot-images-arm64"
+msgstr ""
+
+#: ../../22.04/3.md 40300c0f7cd34c318b432be3d3fd69f8
+#: 65933bd506d24d139c1773e6491dc6ba ea2ce4f4acce4e46828bae5fd8eed595
+msgid "[2004164](https://bugs.launchpad.net/bugs/2004164)"
+msgstr ""
+
+#: ../../22.04/3.md 2e4a8773e50d4d04a03c2157bbebd641
+msgid "shim 1.51.3+15.7-0ubuntu1"
+msgstr ""
+
+#: ../../22.04/3.md 51f1f0c2a2df4bdc9731d47c58db1c96
+msgid "cd-boot-images-ppc64el"
+msgstr ""
+
+#: ../../22.04/3.md 610e4a9f617f412caabd4a81951e9d41
+msgid "Rebuild against grub2 2.06-2ubuntu7.2"
+msgstr ""
+
+#: ../../22.04/3.md 7644b81d69a8417eaf45f13badeb6ee0
+msgid "cd-boot-images-riscv64"
+msgstr ""
+
+#: ../../22.04/3.md e46b4cb2262e4ba0b9dab5fe054735a2
+msgid "Rebuild against latest grub2 and u-boot"
+msgstr ""
+
+#: ../../22.04/3.md b0ba5895c3ea4792899dfdd5b7375139
+#: b5600662c9c64c6284d443f0efcc1a4d
+msgid "debootstrap"
+msgstr ""
+
+#: ../../22.04/3.md 4832914fa6ae469db249c7235d89db0f
+msgid "[2020530](https://bugs.launchpad.net/bugs/2020530)"
+msgstr ""
+
+#: ../../22.04/3.md f717bfab870244bdbda3180680bc1fd4
+msgid "Remove all the old symlinks that are no longer needed."
+msgstr ""
+
+#: ../../22.04/3.md c23b1894351940f9aa1b6b832c164519
+msgid "[2024483](https://bugs.launchpad.net/bugs/2024483)"
+msgstr ""
+
+#: ../../22.04/3.md 049fcfc77681402582bccee120b15049
+msgid ""
+"Restore the old symlinks removed in the previous SRU.  While not needed "
+"by debootstrap itself, other tools may call debootstrap with the optional"
+" 'script' argument (which was always unnecessary when its value was the "
+"same as the 'suite' argument), and this change broke compatibility with "
+"them."
+msgstr ""
+
+#: ../../22.04/3.md 29fd6ba40adf4fdbbac68fb00bcc54e0
+msgid "dpkg"
+msgstr ""
+
+#: ../../22.04/3.md 481b8792b2424ca3b2eaea53e8308cd4
+msgid "[1960582](https://bugs.launchpad.net/bugs/1960582)"
+msgstr ""
+
+#: ../../22.04/3.md c3513030f5084b20b52ddb31b6b19bbd
+msgid "Cherry-pick 940f86c37f9f from dpkg.git"
+msgstr ""
+
+#: ../../22.04/3.md 66dc11c339c44ef382fcb43fbdffb0cb
+msgid "dput"
+msgstr ""
+
+#: ../../22.04/3.md 817586846be2420b815ee64bca10fdf0
+msgid "Make versions with Ubuntu suffixes compliant with PEP 440"
+msgstr ""
+
+#: ../../22.04/3.md a93a2d406ddc4eb7b8a09c558fdb654d
+msgid "gpgme1.0"
+msgstr ""
+
+#: ../../22.04/3.md cd97a30eb49248d99b9d7d2c1bee4a8a
+msgid "avoid -unknown suffix"
+msgstr ""
+
+#: ../../22.04/3.md ec8bb425c193431889bdb164d2be4d2b
+msgid "im-config"
+msgstr ""
+
+#: ../../22.04/3.md 6c38be88aa0549a6b06f02e6a43faa0b
+msgid "[2007379](https://bugs.launchpad.net/bugs/2007379)"
+msgstr ""
+
+#: ../../22.04/3.md a24310d23c1748e4beda4bad4ddecab2
+msgid "Set GTK_IM_MODULE in Ubuntu on Xorg sessions"
+msgstr ""
+
+#: ../../22.04/3.md e9377b4ebf0f4d039c68283c4454e095
+msgid "iotop"
+msgstr ""
+
+#: ../../22.04/3.md a005cca4c95849b085438f46f86bd077
+msgid "[1932523](https://bugs.launchpad.net/bugs/1932523)"
+msgstr ""
+
+#: ../../22.04/3.md 3dd826bcedfa4b4a94a50095c0decde5
+msgid ""
+"d/p/0001-Workaround-crashes-due-to-non-UTF-8-characters-in-pr.patch: Fix "
+"the crash caused by non-UTF-8 characters by using the Python feature of "
+"replacing non-UTF-characters with the U+FFFD replacement character."
+msgstr ""
+
+#: ../../22.04/3.md f5b1d437a3ed42e0a8100902a081a81c
+msgid "krb5"
+msgstr ""
+
+#: ../../22.04/3.md 726ec5dc390d4f7b89369c3b610fe253
+msgid "[1981697](https://bugs.launchpad.net/bugs/1981697)"
+msgstr ""
+
+#: ../../22.04/3.md 35b4b3c6dedd4e8698bbd8021a3142ac
+msgid ""
+"d/kdc.conf: Do not specify root key type to avoid weak crypto for new "
+"realms. Existing realms will not be changed."
+msgstr ""
+
+#: ../../22.04/3.md 6ce72815b81245908fb7dd95994d4f9b
+#: 7501ad2651054c448ccf753f594c14c3 b3166ffc2b774f88b88075a6b75b84c9
+msgid "livecd-rootfs"
+msgstr ""
+
+#: ../../22.04/3.md e106ad50052c4ad29a2c07d6fad88d55
+msgid "[2006481](https://bugs.launchpad.net/bugs/2006481)"
+msgstr ""
+
+#: ../../22.04/3.md be1d449047ce455d88dff44c1a4d9018
+msgid "Enable the hwe kernel variant for 22.04.2"
+msgstr ""
+
+#: ../../22.04/3.md 7368653594d14fb19b42bd4d85c2726b
+msgid "[2007863](https://bugs.launchpad.net/bugs/2007863)"
+msgstr ""
+
+#: ../../22.04/3.md 8a8450c720974a9295cbef1303707cba
+msgid "Do not offer the hwe kernel for RISC-V server-live images"
+msgstr ""
+
+#: ../../22.04/3.md 64f87624561242b9b14d5027a9b504a4
+msgid "[2009067](https://bugs.launchpad.net/bugs/2009067)"
+msgstr ""
+
+#: ../../22.04/3.md 5d3f0e8b98ee409dbef748359ae31311
+msgid ""
+"auto/config: Add support for Ubuntu Core arm64 generic imagescd-boot-"
+"images-amd64"
+msgstr ""
+
+#: ../../22.04/3.md 910d7978666f44139f871102e3b946b5
+#: b4e918612bbb4963a608b4e537021aeb
+msgid "opensbi"
+msgstr ""
+
+#: ../../22.04/3.md 7ceca33b1ed64e1c8f265b01070a9bad
+msgid "[1995860](https://bugs.launchpad.net/bugs/1995860)"
+msgstr ""
+
+#: ../../22.04/3.md 7dcb013c7ee2469192d1871fdbedcd5d
+msgid ""
+"Fix emulation of fence.tso hanging in endless loop on Allwinner D1 d/p"
+"/lib-sbi_illegal_insn-Fix-FENCE.TSO-emulation-infinit.patch"
+msgstr ""
+
+#: ../../22.04/3.md f3d037f465a74eea9fcbb0e4d625abd4
+msgid "[2026588](https://bugs.launchpad.net/bugs/2026588)"
+msgstr ""
+
+#: ../../22.04/3.md a49b1f16322b45ae9b5fcdd53f424410
+msgid "SRU OpenSBI 1.3 to Jammy"
+msgstr ""
+
+#: ../../22.04/3.md 0919d909c5914590b3cde085622c6001
+msgid "pcsc-lite"
+msgstr ""
+
+#: ../../22.04/3.md 0848b4cf2c1842c98b474d2c81bfc77f
+msgid "[1971984](https://bugs.launchpad.net/bugs/1971984)"
+msgstr ""
+
+#: ../../22.04/3.md f0d15572f1e84f18b69c1c27d21325d2
+msgid "Fix dh_installsystemd doesn't handle files in /usr/lib/systemd/system."
+msgstr ""
+
+#: ../../22.04/3.md 4f26e8cf30e84abd96990ac538dd66e1
+msgid "py-macaroon-bakery"
+msgstr ""
+
+#: ../../22.04/3.md c75b1737ad504ae1b20ff8fdf525454a
+msgid "[1970267](https://bugs.launchpad.net/bugs/1970267)"
+msgstr ""
+
+#: ../../22.04/3.md 589f8ffa1cc2476482c5cfafc429bc37
+msgid ""
+"d/p/0001-gh88-fix-saving-macaroons-in-mozillacookie-jar.patch: Fix saving"
+" cookies to MozillaCookieJar() under python-3.10"
+msgstr ""
+
+#: ../../22.04/3.md 99f02d57a92a4fceb9d601e1f6f034d4
+msgid "pyroute2"
+msgstr ""
+
+#: ../../22.04/3.md cccb7581a26846f290cc70894a4fa609
+msgid "[1995469](https://bugs.launchpad.net/bugs/1995469)"
+msgstr ""
+
+#: ../../22.04/3.md f851d6078a254292beef6f497f62da00
+msgid ""
+"d/p/iproute-linux-try-to-improve-flags-when-sending-del-msgs.patch: "
+"Cherry-picked from upstream 0.6.10 to fix delete operations that fail "
+"with 'Operation not supported'"
+msgstr ""
+
+#: ../../22.04/3.md 890d16584e18415f8baac88792d62192
+msgid "python-debian"
+msgstr ""
+
+#: ../../22.04/3.md eaf9167d25c4469ebf265f35291bd12c
+msgid "Make Python version PEP440 compliant"
+msgstr ""
+
+#: ../../22.04/3.md a191fa44bba34b3b946a6f48affc8b2f
+msgid "python-tz"
+msgstr ""
+
+#: ../../22.04/3.md d8dea3a66ede4fe0ad6447dc17a94a81
+msgid "[207604](https://bugs.launchpad.net/bugs/207604)"
+msgstr ""
+
+#: ../../22.04/3.md ada010eb2aa146ea8715fbc70cde4a35
+msgid "Dynamically determine list of available and common timezones"
+msgstr ""
+
+#: ../../22.04/3.md 509958651e204513841910221d9cbf39
+#: 8fb75aedc2da45a483194e863a0eaa40
+msgid "swtpm"
+msgstr ""
+
+#: ../../22.04/3.md bb80cf45ca184750b5bc2b51f549a7a7
+msgid "[1992377](https://bugs.launchpad.net/bugs/1992377)"
+msgstr ""
+
+#: ../../22.04/3.md c30d8c76a5df49f08bac5bea0bd21d69
+msgid ""
+"d/usr.bin.swtpm: Update apparmor profile to match swtpm upstream In "
+"between adding the apparmor profile to Ubuntu and merging upstream "
+"additional rules were used to cover more common use cases."
+msgstr ""
+
+#: ../../22.04/3.md c96634bbd1294ae7997d7ec5327c9771
+msgid "[2016744](https://bugs.launchpad.net/bugs/2016744)"
+msgstr ""
+
+#: ../../22.04/3.md b0d40635cbe14268ac9ef759672baa9c
+msgid ""
+"d/p/create-user-config-files-use-correct-swtpm-localca.patch: Fix the "
+"path to swtpm-localca used in swtpm-create-user-config-files"
+msgstr ""
+
+#: ../../22.04/3.md f86be9e6f60a432abb40d3e8f3720456
+msgid "wpebackend-fdo"
+msgstr ""
+
+#: ../../22.04/3.md e884928302cc40b695829cf466b0c884
+msgid "[2015543](https://bugs.launchpad.net/bugs/2015543)"
+msgstr ""
+
+#: ../../22.04/3.md 397df3a390b3415ab616da1198419b44
+msgid "New bugfix version (lp: #2015543)"
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/22.04/4.po
+++ b/docs/locale/ja/LC_MESSAGES/22.04/4.po
@@ -1,0 +1,6396 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../22.04/4.md:2 436b1f932a5143ad85ddb7813e9a5f7a
+msgid "Changes in Ubuntu 22.04.4"
+msgstr ""
+
+#: ../../22.04/4.md:4 1581777b7f194b728f23ca7a5a052ef2
+msgid ""
+"This is a brief summary of bugs fixed between Ubuntu 22.04.3 and 22.04.4."
+" **This summary covers only changes to packages in *main* and "
+"*restricted*, which account for all packages in the officially-supported "
+"images; there are further changes to various packages in *universe* and "
+"*multiverse*.** Some of these fixes were by Ubuntu developers directly, "
+"while others were by upstream developers and backported to Ubuntu. For "
+"full details, see the individual package changelogs."
+msgstr ""
+
+#: ../../22.04/4.md:6 4aef562447264ba7927bf207ca8db07e
+msgid ""
+"In addition to the bugs listed below, this update includes all security "
+"updates from the [Ubuntu Security Notice "
+"list](https://ubuntu.com/security/notices?order=newest&release=jammy&details=)"
+" affecting Ubuntu 22.04.3 LTS that were released up to and including "
+"February 15, 2024. The last update included was [USN-6640-1: shadow "
+"vulnerability](https://ubuntu.com/security/notices/USN-6640-1)."
+msgstr ""
+
+#: ../../22.04/4.md:8 08cfeb242238452baa8770a3b3f82daa
+msgid "Installation bug fixes"
+msgstr ""
+
+#: ../../22.04/4.md:10 e74fc3980d664f3ba8178457c523eee6
+msgid ""
+"Updated CD images are provided with this release, including fixes for "
+"some installation and image building bugs. (Many installation problems "
+"are hardware-specific; for those, see “Hardware support bugs” below.)"
+msgstr ""
+
+#: ../../22.04/4.md:12 6ee30e8309ea4c8e8ef51b4fc7e3236b
+msgid ""
+"For changes in the server installer (subiquity), please see "
+"https://github.com/canonical/subiquity/releases/tag/24.02.1 ."
+msgstr ""
+
+#: ../../22.04/4.md 11822a9d35e14457a7a23cb84c1a19ad
+#: 131c1405c5ff49659f84402a1d44e9cd 26585a64e9794b3a8002b96614833c06
+#: bf0227503d2540d7a2368bdc6b0f6b38 c240bb92243e4958acaa7380766f49a2
+#: c5338a0583e6477ba2d35539f3709f48 ea02bfb004bd4ec58bf859e0d2699eb9
+#: fc1726b512b9405eaef546958aa0e112
+msgid "Source Package"
+msgstr ""
+
+#: ../../22.04/4.md 26e518b9bb8f4004ae00109162dca771
+#: 7db8e0ffb3344ad0b75704373b1a8313 7fe0719b6b1744df82a5d280a8aa2227
+#: 86486870b80148918e600cdaf4222502 9129d7a0a1f1488b971ac37e206d2e81
+#: 968429eaaca345a285857c221ca9be66 d05ab9e6673943f9b33a214c71311022
+#: e9f3f1d6180340b08ccc22d5c75a7c78
+msgid "Bug #"
+msgstr ""
+
+#: ../../22.04/4.md 0bd4696573724b07b2cc2a9eebdb4099
+#: 34eb5e82bd1649548d7a9574ae4b10fd 39236264da674bb9a60c5fda98852069
+#: 609a96a8f817447f99c7cfa765cd95b8 9e79f75e8a214d428d97f84ec5ed461f
+#: d18a3f05c7034cef8f29e858ea37e7d4 d1f17b4377ac436b9b91df36783e8fa4
+#: eef01d5faf8b41e7a50d261f6d1a7ed6
+msgid "Description"
+msgstr ""
+
+#: ../../22.04/4.md 0aa0f6415fcf42c894af2e501667c272
+#: 14319d9f44d145fd9994474c0003c36f 2c2703475a3c4c15b2990249c3957de6
+#: 2d716c6affe6418bbdc36f094677bfb8 423df4e79e534791824e3c8863dc9a04
+#: 4df7e290919c4f8494df5d9ded948466 5482a2b039864f4b92a34cf433244565
+#: a8734b2952d8475489127b9d471d7471 bcf5d4cc1f9a4a3291d6571f37169a01
+#: c4470d27180140d8bbb19e6fd263b627 cab2f2ba1fc04bcc9ea54edb178f565d
+#: cafc4c73f21c46b2974d1b44844099d3 cbb39bcf7a914528a214ddad9239b680
+#: cd8e69dd3e7147da9140514c82bf3d52 d161f576d97f4983aa00c0e6ca4a57f9
+#: d1da02edb42744ee8780210e70e27b4a ec9c4b559fbe4ea881c4069ddaa299f7
+#: f0775498117b42fa9f64dc1dbf026e2d f78e907ec98f4d47ab61150c1cbe5334
+#: f8cffbd8807943789d773781aaccf5ba fd8e05fafafa4e42bb95c50ab5c1ff3e
+msgid "livecd-rootfs"
+msgstr ""
+
+#: ../../22.04/4.md bc701b3857974c9ab4b223bccd01d61d
+msgid "[2028862](https://bugs.launchpad.net/bugs/2028862)"
+msgstr ""
+
+#: ../../22.04/4.md d484817544db4438acd07ee9ab3aa3f3
+msgid ""
+"Remove additional dependencies from subiquity units as they are now "
+"interfering with the boot process. (LP: #2028862)"
+msgstr ""
+
+#: ../../22.04/4.md cfe869cf8443471691f43e2f3e4debfc
+msgid "[2034253](https://bugs.launchpad.net/bugs/2034253)"
+msgstr ""
+
+#: ../../22.04/4.md 342c941bc5634adab40f4a0890ff3fc1
+msgid ""
+"Set GRUB_DISTRIBUTION in 50-builddimg-settings.cfg to ensure EFI is "
+"installed in the right place (LP: #2034253)"
+msgstr ""
+
+#: ../../22.04/4.md 9a911131ae6144b2a5e123d1188827cb
+msgid "[2045797](https://bugs.launchpad.net/bugs/2045797)"
+msgstr ""
+
+#: ../../22.04/4.md 9b86e7f458d74ecab89504172afc8ea0
+msgid ""
+"Use losetup instead of kpartx to resolve race conditions in riscv64 image"
+" builds.  LP: #2045797."
+msgstr ""
+
+#: ../../22.04/4.md ab228bedc0564be1884df575554bf6a7
+#: cd235440987647deb8f03562354f8012
+msgid "[2036725](https://bugs.launchpad.net/bugs/2036725)"
+msgstr ""
+
+#: ../../22.04/4.md d514e843286a448896aa7fcdd516ffd0
+msgid "unminimize: Use `lxd-installer` to install LXD itself (LP: #2036725)"
+msgstr ""
+
+#: ../../22.04/4.md a4d770b3e1c7404590a2bf72e4cf6403
+msgid "[2036730](https://bugs.launchpad.net/bugs/2036730)"
+msgstr ""
+
+#: ../../22.04/4.md 12eb0b8d13c9444db1494f53bd979801
+msgid "arm: fix console parameter for ARM cloud-images (LP: #2036730)"
+msgstr ""
+
+#: ../../22.04/4.md 89fa455138284b71bd082777e6aeb1f6
+msgid "[2037567](https://bugs.launchpad.net/bugs/2037567)"
+msgstr ""
+
+#: ../../22.04/4.md b057ba8102854eaca3d7881f73678b64
+msgid ""
+"fix: add 6.5 kernel apparmor features to livecd-rootfs based on features "
+"of 6.5 in ubuntu/mantic. This will roll as HWE. (LP: #2037567)"
+msgstr ""
+
+#: ../../22.04/4.md afd50b54b70a409fa152bb6f7580eb7e
+msgid "[2038957](https://bugs.launchpad.net/bugs/2038957)"
+msgstr ""
+
+#: ../../22.04/4.md 1cf403184d4840ad80d567fbc6d99816
+msgid ""
+"Enable snap preseeding with ppc64el images where /boot/vmlinux is used "
+"instead of /boot/vmlinuz. (LP: #2038957)"
+msgstr ""
+
+#: ../../22.04/4.md 83a11f15a8d4475c8b608f2cc038b6ca
+msgid "[2036195](https://bugs.launchpad.net/bugs/2036195)"
+msgstr ""
+
+#: ../../22.04/4.md ee50f50b6bd74e93a222f07171d8756e
+msgid ""
+"The chroot tmpfs mount should only be /var/lib/apt/lists, not "
+"/var/lib/apt; the latter breaks changes to /var/lib/apt/extended_states. "
+"(LP: #2036195)."
+msgstr ""
+
+#: ../../22.04/4.md 8e909b39896f42d89c0428907707ce82
+msgid "[1996489](https://bugs.launchpad.net/bugs/1996489)"
+msgstr ""
+
+#: ../../22.04/4.md ac4cecb3ba644ca39ca1bee4f97e3477
+msgid "Fix unminimize to correctly list packages. (LP: #1996489)"
+msgstr ""
+
+#: ../../22.04/4.md 909d5300f4ab4230b8d819ffc306afc3
+msgid "Install LXD snap from `stable/ubuntu-<version>` channel. (LP: #2036725)"
+msgstr ""
+
+#: ../../22.04/4.md 7bbd99880efd4735929f112d066f6fd4
+msgid "[1968873](https://bugs.launchpad.net/bugs/1968873)"
+msgstr ""
+
+#: ../../22.04/4.md 89c6b6eac6ba48ea9260dda107349b59
+msgid ""
+"Do not modify /etc/ssh/sshd_config for ubuntu-cpc project builds (LP: "
+"#1968873)"
+msgstr ""
+
+#: ../../22.04/4.md 9cd968d84c6e4da6bdbc2b1a5c5fd0b6
+msgid "[2049373](https://bugs.launchpad.net/bugs/2049373)"
+msgstr ""
+
+#: ../../22.04/4.md f1a8834cd4344677abe1f19958185131
+msgid ""
+"For raspi preinstalled builds, use a per-series dedicated gadget branch. "
+"(LP: #2049373)"
+msgstr ""
+
+#: ../../22.04/4.md f24c3a29a6ce4479925c8a2e96826280
+msgid "[2050209](https://bugs.launchpad.net/bugs/2050209)"
+msgstr ""
+
+#: ../../22.04/4.md 3f00346c515c41ce975b53b0a888d339
+msgid ""
+"Add a largemem subarch for ubuntu-server that ships a 64k kernel variant "
+"by default (LP: #2050209)"
+msgstr ""
+
+#: ../../22.04/4.md be90bedd768441fe9d7453857b75a6d1
+msgid "[2049723](https://bugs.launchpad.net/bugs/2049723)"
+msgstr ""
+
+#: ../../22.04/4.md 051092b14781497685aaf4cdaa6cfaeb
+msgid ""
+"fix: Fix for calling unminimize if `lxd-installer` package not installed."
+" (LP: #2049723)"
+msgstr ""
+
+#: ../../22.04/4.md ea53c67b36fc41dd98420352b6baceb9
+msgid "[2049860](https://bugs.launchpad.net/bugs/2049860)"
+msgstr ""
+
+#: ../../22.04/4.md 4d42b7b152dc47499bbfe3e9d73f9b93
+msgid ""
+"Use correct /etc/ssh/sshd_config.d/ filename so cloud-init overrides via "
+"cloud-config works. (LP: #2049860)"
+msgstr ""
+
+#: ../../22.04/4.md 34b277bf3d0c497e8ac53cf282b9f313
+msgid "[2045586](https://bugs.launchpad.net/bugs/2045586)"
+msgstr ""
+
+#: ../../22.04/4.md 5181225de3474215bc2fc7b93726a83b
+msgid ""
+"Use flock to avoid races with systemd-udevd that cause loop device "
+"partitions to briefly disappear. (LP: #2045586)"
+msgstr ""
+
+#: ../../22.04/4.md 1c8e2591ebdf49b4bbe0c44300a1bd4c
+#: 392f455f13d243a39ff54688e7e21910 e05d2d33cc644cdabcf21e1d53db5df2
+msgid "flash-kernel"
+msgstr ""
+
+#: ../../22.04/4.md e7349b9744d04eed985018c7be47516b
+msgid "[2054304](https://bugs.launchpad.net/bugs/2054304)"
+msgstr ""
+
+#: ../../22.04/4.md c82d35fc173f421aa7e18e343d36fc35
+msgid ""
+"Use \"any\" kernel flavor for allwinner-based RISC-V boards, as the new "
+"kernel is a \"-generic\" flavor (LP: #2054304)"
+msgstr ""
+
+#: ../../22.04/4.md 0a868d9b1a024440aa5ebb8d62ca6cfa
+msgid "[2054412](https://bugs.launchpad.net/bugs/2054412)"
+msgstr ""
+
+#: ../../22.04/4.md 45e44cf5af3e4b7793b7f8e4a9ea682c
+msgid ""
+"Handle the allwinner kernel in the same way as we handle generic. This "
+"change seems to been missed, as it was present in noble. (LP: #2054412)"
+msgstr ""
+
+#: ../../22.04/4.md:37 a7b516ff7b434ef4ad663163938ac89c
+msgid "Upgrade bug fixes"
+msgstr ""
+
+#: ../../22.04/4.md:39 8804be777a804b9b8f9a2876777fad48
+msgid ""
+"These changes fix upgrade issues, smoothing the way for future upgrades "
+"to later releases of Ubuntu (and not only)."
+msgstr ""
+
+#: ../../22.04/4.md 56269c6346be4e8483280053b113e968
+#: 6a98709f5f6f4738b31e691c0f88a0fc 71ad920c418c4f639c735fee1f2db357
+#: 8ff4e48c4bce4388ad246741df12f144 993d5b497d9d411d845487bfb2cb4a79
+#: a46906247f5a4b62a27287915bdedef8 b2ac3fb8feea4bba943bb579955a4604
+#: d3760238eab84f63960fc2caa8221ccb
+msgid "update-manager"
+msgstr ""
+
+#: ../../22.04/4.md 8131508a5608433ea447b60b43e7c0cc
+msgid "[2043425](https://bugs.launchpad.net/bugs/2043425)"
+msgstr ""
+
+#: ../../22.04/4.md 2e39776a0231495eb429e0d6f2bbf4ee
+msgid ""
+"Fix incorrect available version for Ubuntu Pro updates in unattached case"
+" (LP: #2043425)."
+msgstr ""
+
+#: ../../22.04/4.md 0938f71397034a27812076dcc63ff238
+#: 1ef79a62457a4949badf9e2ea7171849 a7e5e552ebeb4bd3bdf8e1b0ea9ffcfe
+#: c9bdbe279adc45be9138fb2a137b53fa d87fd26e4a06431f8979bb7386222928
+#: fdf236c9ba86484bbbb1136ee1ba6ca2
+msgid "[1990450](https://bugs.launchpad.net/bugs/1990450)"
+msgstr ""
+
+#: ../../22.04/4.md 26eb5876110c48a2bc4a1e314a6c6c25
+#: c08fa2f9966741d498cb633a01b5ff77 da7b1457b41c45ed85d21ecdeb350a48
+msgid "Ubuntu Pro (LP: #1990450):"
+msgstr ""
+
+#: ../../22.04/4.md 0c773c82dd5d401a81a03d72906dfe65
+msgid ""
+"Fix Ubuntu Pro updates checkbox and expander widget from overlapping (LP:"
+" #1990450)"
+msgstr ""
+
+#: ../../22.04/4.md d47191a125be445495d256d770dc8822
+msgid "Update of the parsing for pro client changes (lp: #1990450)"
+msgstr ""
+
+#: ../../22.04/4.md 98779f23d22e46568192e3b0684390ce
+msgid "Show pending Ubuntu Pro packages (LP: #1990450)"
+msgstr ""
+
+#: ../../22.04/4.md 9c25760edc3f443886470856ed6cb832
+msgid "[2045918](https://bugs.launchpad.net/bugs/2045918)"
+msgstr ""
+
+#: ../../22.04/4.md 9214f66c60a34ff3b4cbbba836b1aedc
+msgid ""
+"Add back removed widgets to UI file to fix crash when updating Upgrade "
+"Manager from inside itself (LP: #2045918)."
+msgstr ""
+
+#: ../../22.04/4.md bdb9618497394eafb2ee82e4d016db41
+msgid "ubuntu-release-upgrader"
+msgstr ""
+
+#: ../../22.04/4.md a3fa76d10be14de2b4e4d208d3b52ff9
+msgid "[2034986](https://bugs.launchpad.net/bugs/2034986)"
+msgstr ""
+
+#: ../../22.04/4.md a0b733dc92a14529b163f863c0d19eaa
+msgid "do-release-upgrade: pass XDG_CURRENT_DESKTOP env var (LP: #2034986)"
+msgstr ""
+
+#: ../../22.04/4.md:57 9c382500b29b46d4b1f6450050c1deea
+msgid "Desktop fixes"
+msgstr ""
+
+#: ../../22.04/4.md:59 5c86948614034513bff4aa807a11f264
+msgid ""
+"These changes mainly affect desktop installations of Ubuntu, Kubuntu, "
+"Ubuntu MATE and other Ubuntu-based systems."
+msgstr ""
+
+#: ../../22.04/4.md 4dd1283d981045e09ceadc365aecf9ff
+#: 7beeda92df144729aef49dfe81e77b3f 8b8816ca0cf445d1851cb754f649b645
+#: 9045996ec53d475a9f50d41edca4023f bfc8add711704142862eb1f9a850b342
+msgid "gjs"
+msgstr ""
+
+#: ../../22.04/4.md 2f1696e1406a4a1197ff3dfe88925eb3
+#: 8606e6c79c644cd4bb8bf49f2822d082
+msgid "[2023572](https://bugs.launchpad.net/bugs/2023572)"
+msgstr ""
+
+#: ../../22.04/4.md ed886880882b4c84bf9e4c826600a30f
+msgid "New upstream stable release (LP: #2023572)"
+msgstr ""
+
+#: ../../22.04/4.md a3c9b9682d884689956aedcfec311e2f
+msgid "New upstream release (LP: #2023572):"
+msgstr ""
+
+#: ../../22.04/4.md 017cd79b6b054b7aa87a14e8905e4d22
+#: 1d5b9117e7ce44158f6d53ee388df733
+msgid "[1974293](https://bugs.launchpad.net/bugs/1974293)"
+msgstr ""
+
+#: ../../22.04/4.md d8de120e33a0434f844b48e3f6f5454a
+msgid ""
+"debian/patches: Refresh teardown patch, replacing it with the one landed "
+"upstream (LP: #1974293)"
+msgstr ""
+
+#: ../../22.04/4.md d987c0010ca443d5ac2f688f5ab78589
+msgid "[2012978](https://bugs.launchpad.net/bugs/2012978)"
+msgstr ""
+
+#: ../../22.04/4.md 2a9316a85ea9493e9fa5d429d8a6a0c3
+msgid ""
+"debian/patches: Cherry-pick upstream fixes to address various memory "
+"leaks (LP: #2012978)"
+msgstr ""
+
+#: ../../22.04/4.md 114e1949fe86467b85352f7917c572b1
+#: affd6deb16534aa2b22a2327920a2daf d4aafaf590824bb3a16fff29b64dfc9a
+#: faf48a6601f542468aa7bc069cfe7eeb
+msgid "gnome-remote-desktop"
+msgstr ""
+
+#: ../../22.04/4.md 71994c13a3ff4b218db0ec45bf098161
+#: c1ad3df638bb4b7683b2588c98f8e9bb
+msgid "[2024248](https://bugs.launchpad.net/bugs/2024248)"
+msgstr ""
+
+#: ../../22.04/4.md afaac1e69e6b4056b11223b2d3e35acb
+#: d998da901a8d43809b91927d47030692
+msgid "New upstream release (LP: #2024248):"
+msgstr ""
+
+#: ../../22.04/4.md 5b3f6260cbaf42dfadc3890dc32da237
+msgid "[2024238](https://bugs.launchpad.net/bugs/2024238)"
+msgstr ""
+
+#: ../../22.04/4.md 2a598e4e6aab4a67a61a7f69be1842ea
+msgid ""
+"vnc: Ensure PipeWire buffers to be queued before destroying them (LP: "
+"#2024238)"
+msgstr ""
+
+#: ../../22.04/4.md d4971b235bfa4a1b81cf92eafc6082ab
+msgid "[2024240](https://bugs.launchpad.net/bugs/2024240)"
+msgstr ""
+
+#: ../../22.04/4.md 64dda259a074409bb996588811824698
+msgid ""
+"rdp: Ensure PipeWire buffers to be queued before destroying them (LP: "
+"#2024240)"
+msgstr ""
+
+#: ../../22.04/4.md bb31ef0c0a2143a999b876ba0931480d
+msgid "xserver-xorg-video-amdgpu"
+msgstr ""
+
+#: ../../22.04/4.md 4f120f460f0143e19b94e6ad7080eda7
+msgid "[2034105](https://bugs.launchpad.net/bugs/2034105)"
+msgstr ""
+
+#: ../../22.04/4.md f041545ea59949f5b8ab5582684b9444
+msgid "Use DRM_CAP_CURSOR_WIDTH/HEIGHT if possible (LP: #2034105)"
+msgstr ""
+
+#: ../../22.04/4.md a59a52d73d644ff1b0a96506bb9f2d5d
+msgid "mutter"
+msgstr ""
+
+#: ../../22.04/4.md 1a355bffb6e04dcca5f72a245c47a0c3
+msgid "[2030959](https://bugs.launchpad.net/bugs/2030959)"
+msgstr ""
+
+#: ../../22.04/4.md 4ae7a98829824933b9c6b5310bc6a083
+msgid ""
+"Drop clutter-frame-clock-Avoid-rapidly-toggling-dynamic-max-re.patch. It "
+"was never really required in mutter 42 but has caused some new stutter "
+"elsewhere (LP: #2030959)"
+msgstr ""
+
+#: ../../22.04/4.md 097b0ca09b544867b8f0a30010214974
+#: 2ce1f9f479e0493199d49588d56394bc e40261b4fa094deca9ed470d2f4b8449
+msgid "libfprint"
+msgstr ""
+
+#: ../../22.04/4.md afb70f50a7ff4210a75f7515d03bdd28
+msgid "[2034121](https://bugs.launchpad.net/bugs/2034121)"
+msgstr ""
+
+#: ../../22.04/4.md e59e108410a0486a84157bb68dff82c6
+msgid "d/p/goodixmoc-Add-PID-0x633C.patch (LP: #2034121)"
+msgstr ""
+
+#: ../../22.04/4.md c809d9ffdc344ee6bb3dcf04b34d5273
+msgid "[2034481](https://bugs.launchpad.net/bugs/2034481)"
+msgstr ""
+
+#: ../../22.04/4.md 5781fe52cb4b41508cc71194353c1ce6
+msgid ""
+"d/p/synaptics-fix-enroll_identify-problem-after-user-reset-da.patch (LP: "
+"#2034481)"
+msgstr ""
+
+#: ../../22.04/4.md 5ce1f743d1834d579488a59538a84dc9
+msgid "[2031872](https://bugs.launchpad.net/bugs/2031872)"
+msgstr ""
+
+#: ../../22.04/4.md 3010a2c4b3304814aa9cd86d94a55858
+msgid "Add support for PID 0c99 elan fingerprint device (LP: #2031872)"
+msgstr ""
+
+#: ../../22.04/4.md 7cc1e2cb542d4daa89050c47b5054deb
+#: ed9834bc092d465fa74f5adf0058ad63
+msgid "software-properties"
+msgstr ""
+
+#: ../../22.04/4.md bd7bdbe524d64886ae6b91bf1f3a01ff
+msgid "[1993370](https://bugs.launchpad.net/bugs/1993370)"
+msgstr ""
+
+#: ../../22.04/4.md a5d93ca59c424f61abb5d90b70529de5
+msgid ""
+"softwareproperties/qt/SoftwarePropertiesQt.py: Don't crash if the driver "
+"package does not have a matching modules package (LP: #1993370)"
+msgstr ""
+
+#: ../../22.04/4.md 751b1837634d4cbda898265361c7eff9
+msgid "evince"
+msgstr ""
+
+#: ../../22.04/4.md b4de6d4e46fe481aa2b3b607961df87c
+#: c4f651034b424fbcaeb128ccc859eabf
+msgid "[1794064](https://bugs.launchpad.net/bugs/1794064)"
+msgstr ""
+
+#: ../../22.04/4.md 60e199324cf8445e9d6aae6930fde224
+msgid "Allow evince to spawn browsers distributed as snaps (LP: #1794064)"
+msgstr ""
+
+#: ../../22.04/4.md dae5e77c98eb40efbb8db6718b6d3768
+msgid "apparmor"
+msgstr ""
+
+#: ../../22.04/4.md 132147d0a5f942988499b69d37f6ab3b
+msgid ""
+"Add support for applications like evince opening browsers distributed as "
+"snaps (LP: #1794064)"
+msgstr ""
+
+#: ../../22.04/4.md 1a2a3a8d299b47e99ece090a62884dd3
+msgid "fonts-noto-color-emoji"
+msgstr ""
+
+#: ../../22.04/4.md 2078848fc42e449d99307b9e06472439
+msgid "[2045043](https://bugs.launchpad.net/bugs/2045043)"
+msgstr ""
+
+#: ../../22.04/4.md f99c4b16f20543a9978ca443720a6f38
+msgid "New upstream release (LP: #2045043)"
+msgstr ""
+
+#: ../../22.04/4.md d4ceba5c9cbf4f7ca3ba862e4894f1b6
+msgid "[2040273](https://bugs.launchpad.net/bugs/2040273)"
+msgstr ""
+
+#: ../../22.04/4.md 587415eaa3014cd6ad5dadddfa52737a
+msgid ""
+"cloudarchive: Enable support for the Caracal Ubuntu Cloud Archive on "
+"22.04 (LP: #2040273)."
+msgstr ""
+
+#: ../../22.04/4.md 0b34fdf3d4344bedbf33b61df530089e
+msgid "transmission"
+msgstr ""
+
+#: ../../22.04/4.md 0224e8e601f54d559895959a4e24f9b8
+msgid "[1973084](https://bugs.launchpad.net/bugs/1973084)"
+msgstr ""
+
+#: ../../22.04/4.md 75c79a4c9c864b2eaa69e9886706e8ea
+msgid "Replace openssl 3 compatibility patch to fix memory leak (LP: #1973084):"
+msgstr ""
+
+#: ../../22.04/4.md 47d9203ef1f64b9ab88deaa48e54d91b
+msgid "gdm3"
+msgstr ""
+
+#: ../../22.04/4.md bdf8c39a0c544a51a6122f3aa856725f
+msgid "[2039757](https://bugs.launchpad.net/bugs/2039757)"
+msgstr ""
+
+#: ../../22.04/4.md 6bc8b2f13cb04b1989097ba70223f3ec
+msgid ""
+"Add local-display-factory-skip-simpledrm-when-checking-.patch to fix a "
+"race condition that occurs with simpledrm (LP: #2039757)"
+msgstr ""
+
+#: ../../22.04/4.md 3a8c99d574054960be394205d17511c4
+#: 3c0d4eaad404456ea83e4ff8905c9e21
+msgid "mesa"
+msgstr ""
+
+#: ../../22.04/4.md 74e9f3c025be4d8f8be81c197e4bcb13
+msgid "[2051068](https://bugs.launchpad.net/bugs/2051068)"
+msgstr ""
+
+#: ../../22.04/4.md 58c2fb1d5716472bad2862d3c10c12e9
+msgid ""
+"patches: Revert a patch that caused GUI fail with OEM-6.1 kernel on Intel"
+" DG2. (LP: #2051068)"
+msgstr ""
+
+#: ../../22.04/4.md cf305dcb64d6435386910ad48d756f80
+msgid "[2037604](https://bugs.launchpad.net/bugs/2037604)"
+msgstr ""
+
+#: ../../22.04/4.md 6de145f8b6974d95ae89012419399fe7
+msgid "Backport to 22.04. (LP: #2037604)"
+msgstr ""
+
+#: ../../22.04/4.md 816cca07fa074e6d9cee640bfdb6733d
+msgid "Add context-Clear-all-vectors-of-JS-Heap-on-dispose.patch (LP: #1974293)"
+msgstr ""
+
+#: ../../22.04/4.md:90 97d51ace176f4fb9bf46e1df928a0aea
+msgid "Server and Cloud related fixes"
+msgstr ""
+
+#: ../../22.04/4.md:92 d1eaa2e89be849b5a248aa5dc8453688
+msgid ""
+"These changes mainly affect installations of Ubuntu on server systems and"
+" clouds."
+msgstr ""
+
+#: ../../22.04/4.md 1a8eaa29acff44c0adaf42665affcba1
+#: 7198e0382cd74cab814a99df3d8aee90 ef2994966c8c44bebed47548e5435892
+msgid "sosreport"
+msgstr ""
+
+#: ../../22.04/4.md ef953a3642894bb993c1234256625925
+msgid "[2028327](https://bugs.launchpad.net/bugs/2028327)"
+msgstr ""
+
+#: ../../22.04/4.md e168850b3aff40ef909f940ab574a06a
+msgid "New 4.5.6 upstream. (LP: #2028327)"
+msgstr ""
+
+#: ../../22.04/4.md 64c681e980db4141bd034d0b7a3d0b25
+#: fb3bd992f9c046bab0c3eab90e59931f
+msgid "octavia-dashboard"
+msgstr ""
+
+#: ../../22.04/4.md e20878f417ba4844a731a6632af7c3f2
+msgid "[2007720](https://bugs.launchpad.net/bugs/2007720)"
+msgstr ""
+
+#: ../../22.04/4.md 1f76344e71f84fd7afd24ef57c58e65a
+msgid ""
+"d/p/fix-updating-non-https-health-monitor.patch: Fix updating a non-"
+"HTTP(S) Health Monitor (LP: #2007720)."
+msgstr ""
+
+#: ../../22.04/4.md 5f3311c775ac45a888bdb7618452538d
+msgid "openjdk-lts"
+msgstr ""
+
+#: ../../22.04/4.md 22ec1f75c5ed490da68210458e8b4f57
+msgid "[2032865](https://bugs.launchpad.net/bugs/2032865)"
+msgstr ""
+
+#: ../../22.04/4.md 5cf722534f3d42acb0ab4c0a61efd1ea
+msgid ""
+"REGRESSION UPDATE: 8313765: Invalid CEN header (invalid zip64 extra data "
+"field size) (LP: #2032865)."
+msgstr ""
+
+#: ../../22.04/4.md 3c413ef7da33489eb793ddef89a2b46a
+msgid "apr-util"
+msgstr ""
+
+#: ../../22.04/4.md 3d5eae8af3714c2b8e736a0e2b54a4b7
+msgid "[2031548](https://bugs.launchpad.net/bugs/2031548)"
+msgstr ""
+
+#: ../../22.04/4.md 373e7fe28660467bbfdf235018d162b7
+msgid "Fix compatibility with MySQL 8.0.34 (LP: #2031548)"
+msgstr ""
+
+#: ../../22.04/4.md 6ba571cb52ee4e80abfafb699a9ad74d
+#: 6c80d5711acd4c838bd669ac1432ef27 d30ee2d885734b03b76764b642c862d0
+msgid "samba"
+msgstr ""
+
+#: ../../22.04/4.md ffeb8a48a24a495798dc3c3e351a152c
+msgid "[2002949](https://bugs.launchpad.net/bugs/2002949)"
+msgstr ""
+
+#: ../../22.04/4.md 6b2a4a4080a540e8868c3e74cb455c7d
+msgid ""
+"d/p/issue-when-updating-old-passwd-containing-regex-metachars.patch: Add "
+"changes to fix uncaught exception when updating old password containing "
+"regex metacharacters by simplifying samba-tool password redaction (LP: "
+"#2002949)."
+msgstr ""
+
+#: ../../22.04/4.md 49264018fc804c8085432f1e6d02d008
+msgid "openssh"
+msgstr ""
+
+#: ../../22.04/4.md 3c9b5bc6e1874f0d8ea33e2b7fa12967
+msgid "[2031942](https://bugs.launchpad.net/bugs/2031942)"
+msgstr ""
+
+#: ../../22.04/4.md 6b63e27547d546e99b0c7501aafd1b1a
+msgid ""
+"d/p/fix-authorized-principals-command.patch: Fix the situation where sshd"
+" ignores AuthorizedPrincipalsCommand if AuthorizedKeysCommand is also set"
+" by checking if the value pointed to by the pointer 'charptr' is NULL. "
+"(LP: #2031942)"
+msgstr ""
+
+#: ../../22.04/4.md 9b302b6760724fccbd634cee2521797e
+msgid "dpdk"
+msgstr ""
+
+#: ../../22.04/4.md 090d13db35b14908ba775962dc7fcdce
+msgid "[2026351](https://bugs.launchpad.net/bugs/2026351)"
+msgstr ""
+
+#: ../../22.04/4.md 6c56a8feaf524771a953d95c022adc71
+msgid "Merge LTS stable release 21.11.4 (LP: #2026351)"
+msgstr ""
+
+#: ../../22.04/4.md 95e5e4af09474926a53a5b19989c3972
+#: ad5a1813255240eb9115c2d1be6245a5
+msgid "designate"
+msgstr ""
+
+#: ../../22.04/4.md 4a55165e7d404bc2b75a828cdcb21e54
+#: 873066e9386f4de1a69f10e6bc0beeab fab31ecec1024414be70400f8de6277f
+msgid "[2030526](https://bugs.launchpad.net/bugs/2030526)"
+msgstr ""
+
+#: ../../22.04/4.md 67eaecc6ae3b40d59e8b4c95c7ad0b6d
+#: 7a8d358a0059433083061af465fb7f04 ec61e926d03c454497e098f64ed32d26
+msgid "New stable point release for OpenStack Yoga (LP: #2030526)."
+msgstr ""
+
+#: ../../22.04/4.md 381e2b8482374795a0451ed09fb46892
+#: 9a86eb19d84546d99f4ebb2eb6f55bf6
+msgid "neutron"
+msgstr ""
+
+#: ../../22.04/4.md 616f19e4cbff40d98185285ae43a65ca
+msgid "ec2-hibinit-agent"
+msgstr ""
+
+#: ../../22.04/4.md d539ff2e27bd4bc9bf0e41973898d1dc
+msgid "[2031345](https://bugs.launchpad.net/bugs/2031345)"
+msgstr ""
+
+#: ../../22.04/4.md 350b1f50abc6473293f3ce9bf3e4fa47
+msgid ""
+"d/p/lp2031345-recreate-swap-file.patch: Reduce SWAP size if current SWAP "
+"is larger than needed (LP: #2031345)"
+msgstr ""
+
+#: ../../22.04/4.md 13f8c8aaa34e476fa519c23d8c901521
+msgid "[2024188](https://bugs.launchpad.net/bugs/2024188)"
+msgstr ""
+
+#: ../../22.04/4.md 1462fd8e73eb4ed2bf53a529deac280f
+msgid ""
+"d/p/fix-popover-attributes.patch: Fix popover attributes in member add "
+"dialog. Using popovers in the member table is broken in chrome 114, "
+"because of their new \"popover\" feature (LP: #2024188)."
+msgstr ""
+
+#: ../../22.04/4.md 01baf9e249024736911a2c9d1902bb26
+#: 1382c1ea4d844770ba8b480fb4958070 c56e54d8c7b5413697199dae55767570
+msgid "qemu"
+msgstr ""
+
+#: ../../22.04/4.md 3e50245132214ff2baa7723f884a0b39
+msgid "[2033957](https://bugs.launchpad.net/bugs/2033957)"
+msgstr ""
+
+#: ../../22.04/4.md d9ce49bf32a44f33a4f800e083805877
+msgid ""
+"d/u/lp-2033957-virtiofsd-Fix-breakage-due-to-fuse_init_in.patch: Fix "
+"virtiofsd breakage due to fuse_init_in size change, which happened "
+"because of the Linux kernel 5.17 headers that were imported in a previous"
+" patch. (LP: #2033957)"
+msgstr ""
+
+#: ../../22.04/4.md b0c507a9958b4b2293ca9fb23ab7d622
+msgid "horizon"
+msgstr ""
+
+#: ../../22.04/4.md 37db0f02933f408ca66da533d8a8460a
+msgid "python-keystonemiddleware"
+msgstr ""
+
+#: ../../22.04/4.md eaa5819001c7435d94a5484d93204fd9
+msgid "[1987355](https://bugs.launchpad.net/bugs/1987355)"
+msgstr ""
+
+#: ../../22.04/4.md 386abdc172954a3886ee57ff5abeb841
+msgid ""
+"d/p/remove-cache-invalidation.patch: Remove cache invalidation when using"
+" expired token (LP: #1987355)."
+msgstr ""
+
+#: ../../22.04/4.md 1786090f71d84a65ab12b62bdd8ebdfc
+#: 5caa5f455a3f420cb50203ba1e88ca29 89c2f9aab6a64638b6c02151cccfae21
+#: ccc4b3e6ab38476fb1a44d217cc30f77 d631f3e64941466392bd7f83425bd592
+msgid "cloud-init"
+msgstr ""
+
+#: ../../22.04/4.md c054ace07516412baecd12737f43bc6b
+msgid "[2027861](https://bugs.launchpad.net/bugs/2027861)"
+msgstr ""
+
+#: ../../22.04/4.md 7585af915fea4961bb5a940b5b6328f9
+msgid ""
+"d/cloud-init.maintscript: Remove the unused hook-network-manager "
+"conffile. (LP: #2027861)"
+msgstr ""
+
+#: ../../22.04/4.md ee16324b76ff4655a79ef868a05895ec
+msgid "[2033310](https://bugs.launchpad.net/bugs/2033310)"
+msgstr ""
+
+#: ../../22.04/4.md 8f67ec12fe80488c9341dff7d81d2d8a
+msgid ""
+"Upstream snapshot based on 23.3.1. (LP: #2033310). List of changes from "
+"upstream can be found at https://raw.githubusercontent.com/canonical"
+"/cloud-init/23.3.1/ChangeLog"
+msgstr ""
+
+#: ../../22.04/4.md f2e6855f014b484f8e7d819cddf4d1fc
+msgid "gce-compute-image-packages"
+msgstr ""
+
+#: ../../22.04/4.md d1685a632eee4558b02454fd3ddb9707
+msgid "[2033061](https://bugs.launchpad.net/bugs/2033061)"
+msgstr ""
+
+#: ../../22.04/4.md 53d05d7b29a542e48aacbf45192f4712
+msgid "New upstream version 20230808.00. (LP: #2033061)"
+msgstr ""
+
+#: ../../22.04/4.md 43511762398546d2b11a256aff07e8ef
+msgid "[2028124](https://bugs.launchpad.net/bugs/2028124)"
+msgstr ""
+
+#: ../../22.04/4.md 0b6aedefe94d4649918dbce12c2a84fc
+msgid "d/rules: remove --no-start for qemu-guest-agent (LP: #2028124)"
+msgstr ""
+
+#: ../../22.04/4.md 8331785080b34c968d2517345fc1f8c9
+msgid "[2037873](https://bugs.launchpad.net/bugs/2037873)"
+msgstr ""
+
+#: ../../22.04/4.md fedca82fd0cf4b6c8f289d581ccb1011
+msgid "Correct typo in test_mask to print ip address (LP: #2037873)"
+msgstr ""
+
+#: ../../22.04/4.md 6bcd84df3b0e404b97451148a4384f4a
+msgid "[2037872](https://bugs.launchpad.net/bugs/2037872)"
+msgstr ""
+
+#: ../../22.04/4.md fcb31b07d0434accb6b317677268f515
+msgid "Obfuscate SSID password in netplan/XX.yaml files (LP: #2037872)"
+msgstr ""
+
+#: ../../22.04/4.md ec5163bb14984715b688ed68f3a55a37
+msgid "keystone"
+msgstr ""
+
+#: ../../22.04/4.md 77c3016dae034fd9bab31fc70be6c45d
+msgid "[2039176](https://bugs.launchpad.net/bugs/2039176)"
+msgstr ""
+
+#: ../../22.04/4.md 29a25a84236e4b89b38d36ee36c6390c
+msgid "New stable point release for OpenStack Yoga (LP: #2039176)."
+msgstr ""
+
+#: ../../22.04/4.md dd89fbe3aaef4ae68a9f1c8bd77c40bd
+msgid "hibagent"
+msgstr ""
+
+#: ../../22.04/4.md c064fcebb13f484eb94cd8643d4ee5a0
+msgid "[2043739](https://bugs.launchpad.net/bugs/2043739)"
+msgstr ""
+
+#: ../../22.04/4.md 4d18d8437fc34474a08f2a92b32e6287
+msgid "Use imdsv2 and do nothing if ODH is configured (LP: #2043739)."
+msgstr ""
+
+#: ../../22.04/4.md 6182f8fa584740c7be371d8beda4c2c9
+msgid "aodh"
+msgstr ""
+
+#: ../../22.04/4.md 1a63839c720b41248005ae7de816b9ad
+#: 484fae701ca24b419b6f59dca42a001a 5f8d8ab54c8f4cf6abb3552640e7640e
+#: 9c1a2c4e44d64ee086b281dee70ec329 e3eed30a0cff4b429a08e689d90957da
+msgid "[2037332](https://bugs.launchpad.net/bugs/2037332)"
+msgstr ""
+
+#: ../../22.04/4.md 2dbbda4842734f629318cae58aac0e02
+#: 5ca9c23e4a2e49b99287e78d0e545079 b363222def904456a48ddf73a128f774
+#: bc0c5aad57f54cfeb2c1d947a9fd9d05 f3d7e928d956405299ce6011fd8e5829
+msgid "New stable point release for OpenStack Yoga (LP: #2037332)."
+msgstr ""
+
+#: ../../22.04/4.md aaa2ae332d4943419a502d2d21ff7a5a
+msgid "cinder"
+msgstr ""
+
+#: ../../22.04/4.md 33d67caccdbb429bad27bc34f44e9fe0
+msgid "glance"
+msgstr ""
+
+#: ../../22.04/4.md f351d66fc54a488f8152c4930cfb35ef
+msgid "heat-dashboard"
+msgstr ""
+
+#: ../../22.04/4.md 4cf8c71ade614425ba0685652c708392
+msgid "nova"
+msgstr ""
+
+#: ../../22.04/4.md d4cac7df665a42e5b8fe1841687d1aef
+msgid "ceph"
+msgstr ""
+
+#: ../../22.04/4.md 26e686ddde5d4ba690e00944a31ed0a6
+msgid "[2003704](https://bugs.launchpad.net/bugs/2003704)"
+msgstr ""
+
+#: ../../22.04/4.md ab92a29fed7c4c699a16a94be2b7f5b7
+msgid "Create package for the cephfs-mirror tool (LP: #2003704)."
+msgstr ""
+
+#: ../../22.04/4.md 5805313f668d467580d3eb4aaf1c49f9
+msgid "openvswitch"
+msgstr ""
+
+#: ../../22.04/4.md de7b795f31f7451a8a69e956d8c3e3fc
+msgid "[2039908](https://bugs.launchpad.net/bugs/2039908)"
+msgstr ""
+
+#: ../../22.04/4.md 83bcd7baec5b46f5b8d19be1a63e8094
+msgid "New upstream point release (LP: #2039908)."
+msgstr ""
+
+#: ../../22.04/4.md d57bc30c3d874cc99bf9f14514b5641c
+msgid "[2040291](https://bugs.launchpad.net/bugs/2040291)"
+msgstr ""
+
+#: ../../22.04/4.md 0b395dcc988346eab996153e151e85bc
+msgid ""
+"Upstream snapshot based on 23.3.3. (LP: #2040291). List of changes from "
+"upstream can be found at https://raw.githubusercontent.com/canonical"
+"/cloud-init/23.3.3/ChangeLog"
+msgstr ""
+
+#: ../../22.04/4.md 19dd7cce2ced43f2b6079b57bc3bcee6
+msgid "[2039505](https://bugs.launchpad.net/bugs/2039505)"
+msgstr ""
+
+#: ../../22.04/4.md f7ff4ad4420e42e8aef10e95a8de3588
+msgid "Revert behavior, allow user login after cloud-init stage (LP: #2039505)"
+msgstr ""
+
+#: ../../22.04/4.md 9d2341b31e644d228562b417cd955413
+msgid "[2039453](https://bugs.launchpad.net/bugs/2039453)"
+msgstr ""
+
+#: ../../22.04/4.md d0e6b7f9311c47979b64ed9785346ac0
+msgid ""
+"Upstream snapshot based on 23.3.2. (LP: #2039453). List of changes from "
+"upstream can be found at https://raw.githubusercontent.com/canonical"
+"/cloud-init/23.3.2/ChangeLog"
+msgstr ""
+
+#: ../../22.04/4.md 607a5a52d6eb42f19fda3d26af3a165c
+#: a7c0cf51094b437a98176c18ceb49e1d
+msgid "google-guest-agent"
+msgstr ""
+
+#: ../../22.04/4.md 3501b0494c3049579d1404831a5bddc1
+msgid "[2040945](https://bugs.launchpad.net/bugs/2040945)"
+msgstr ""
+
+#: ../../22.04/4.md 4f8bcb5b4a7d4fd7b5f08a1c931fd80b
+msgid "New upstream version 20231004.02. (LP: #2040945)"
+msgstr ""
+
+#: ../../22.04/4.md ba531a4c62164cd6930ee25212dc1213
+msgid "google-compute-engine-oslogin"
+msgstr ""
+
+#: ../../22.04/4.md 712c872784654de5b78cb5c7049880b1
+msgid "[2043001](https://bugs.launchpad.net/bugs/2043001)"
+msgstr ""
+
+#: ../../22.04/4.md 38bb07c5d168485ba74f046e2f290a78
+msgid "New upstream version 20231004.00. (LP: #2043001)"
+msgstr ""
+
+#: ../../22.04/4.md 920bb8ce08f74868902fc2dbb489f468
+msgid "libvirt"
+msgstr ""
+
+#: ../../22.04/4.md 91d0e7df5c4a494ea41e2cb2b69446e5
+msgid "[2028057](https://bugs.launchpad.net/bugs/2028057)"
+msgstr ""
+
+#: ../../22.04/4.md 4cb154c67d244f06b58b875635c892c3
+msgid ""
+"d/p/u/lp-2028057-*, d/libvirt0.install: Add named types and definitions, "
+"along with QEMU alias syncing for Intel SapphireRapids (LP: #2028057)"
+msgstr ""
+
+#: ../../22.04/4.md 8bab1307d63c45c3b5714afcd6a49f6a
+#: 986bdf27801244d4a710bf07a9fb8bbe 99cbcbca0a1c4a6582e32624bb76848a
+msgid "dnsmasq"
+msgstr ""
+
+#: ../../22.04/4.md 7f2bce23ab3b4f278f0ad6fa469e3d0d
+msgid "[2015562](https://bugs.launchpad.net/bugs/2015562)"
+msgstr ""
+
+#: ../../22.04/4.md 775fc398c9af48c4b1a81bcc843cc22d
+msgid ""
+"src/dnsmasq.h, src/domain-match.c: Fix confusion when using resolvconf "
+"servers (combining server"
+msgstr ""
+
+#: ../../22.04/4.md 3e19975e568d4d27b4c6411ada74270b
+msgid "drbd-utils"
+msgstr ""
+
+#: ../../22.04/4.md 50827f0d0b3b45a781bb79a1065b5e3b
+msgid "[2043817](https://bugs.launchpad.net/bugs/2043817)"
+msgstr ""
+
+#: ../../22.04/4.md a8125197d47e43d183e09b405eecd3ff
+msgid ""
+"d/p/lp2043817-fix-timeout-pacemaker-jammy-*.patch: Fix timeout issue with"
+" Pacemaker. (LP: #2043817)"
+msgstr ""
+
+#: ../../22.04/4.md 6c6c6def81144f409d1705164c30c513
+#: f75dc5dcdfd34979b67c434a3b286b00
+msgid "[2046376](https://bugs.launchpad.net/bugs/2046376)"
+msgstr ""
+
+#: ../../22.04/4.md 917f702cb22747ef92adc28bb38c86e0
+#: d2de4bcd85ae4d0d964d4fc9408b4063
+msgid "New stable point release for OpenStack Yoga (LP: #2046376)."
+msgstr ""
+
+#: ../../22.04/4.md 63b9a616bb4b4c83b9a03395fa05a8ae
+#: 650427c5da9544a0a777335ff82aa35b 7275dfdb28ac4f87a4e9306ee77f8318
+msgid "openssl"
+msgstr ""
+
+#: ../../22.04/4.md 59c8b155ece9419fb676bffe6a2a50a0
+msgid "[2023545](https://bugs.launchpad.net/bugs/2023545)"
+msgstr ""
+
+#: ../../22.04/4.md b416f54246d54231a318e98f979b0f98
+msgid ""
+"Fix (upstream): crash when using an engine for ciphers used by DRBG (LP: "
+"#2023545)"
+msgstr ""
+
+#: ../../22.04/4.md 130f0d3c417d42248dad40173cdcfa00
+msgid "[1994165](https://bugs.launchpad.net/bugs/1994165)"
+msgstr ""
+
+#: ../../22.04/4.md 51ba1db277fb4d47a90043b348ba3e41
+msgid ""
+"Fix (upstream): do not ignore return values for S/MIME signature (LP: "
+"#1994165)"
+msgstr ""
+
+#: ../../22.04/4.md 7507c32c551a4314b95bc4e108b4c407
+msgid "[2033422](https://bugs.launchpad.net/bugs/2033422)"
+msgstr ""
+
+#: ../../22.04/4.md 26448c2d2fc5440d91d686b657188516
+msgid ""
+"Perf (upstream): don't empty method stores and provider synchronization "
+"records when flushing the query cache (LP: #2033422)"
+msgstr ""
+
+#: ../../22.04/4.md 210e1c8e7a3d4b0bb4433938b6beaa99
+msgid "mysql-8.0"
+msgstr ""
+
+#: ../../22.04/4.md 3bfea5d2354c49b384c0e560b89c1790
+msgid "[2024276](https://bugs.launchpad.net/bugs/2024276)"
+msgstr ""
+
+#: ../../22.04/4.md e96087317dd44c89ab9e89bd0f95a208
+msgid "Enable test suite on armhf (LP: #2024276)"
+msgstr ""
+
+#: ../../22.04/4.md 1959073e7d89421e809ef545e02744b2
+msgid "[2050956](https://bugs.launchpad.net/bugs/2050956)"
+msgstr ""
+
+#: ../../22.04/4.md 178da55e2b814d7284242985e3f206bf
+msgid ""
+"d/control: Add a dependency on `google-compute-engine-oslogin` (LP: "
+"#2050956)"
+msgstr ""
+
+#: ../../22.04/4.md c3b687a981b34defb8499ac34baa6620
+msgid "[2045570](https://bugs.launchpad.net/bugs/2045570)"
+msgstr ""
+
+#: ../../22.04/4.md 47feae2d4bde475d938672c4272fc89f
+msgid ""
+"src/dnsmasq.c: Fix a crash that can happen when an empty resolv.conf is "
+"reloaded (LP: #2045570)"
+msgstr ""
+
+#: ../../22.04/4.md c4cd6987e2364d9c806355c18f19341a
+msgid "[2042587](https://bugs.launchpad.net/bugs/2042587)"
+msgstr ""
+
+#: ../../22.04/4.md 5385b9d21c744b38b03b2f120728f856
+msgid ""
+"src/helper.c: Fix wrong client address for dhcp-script when DHCPv4 relay "
+"in use (LP: #2042587)"
+msgstr ""
+
+#: ../../22.04/4.md 0a2172ce1ad74baaa04bdf297a2d0fff
+msgid "freeradius"
+msgstr ""
+
+#: ../../22.04/4.md 209e86fd1fb14d1fbb622df01c712e48
+msgid "[2042824](https://bugs.launchpad.net/bugs/2042824)"
+msgstr ""
+
+#: ../../22.04/4.md 32e3d92fcbf541e3b8977d24711d1a21
+msgid ""
+"d/p/avoid-smbencrypt-segfault-with-openssl3-fixes.patch: load the OpenSSL"
+" legacy providers and use OpenSSL3 init for MD4/MD5 (LP: #2042824)."
+msgstr ""
+
+#: ../../22.04/4.md 06e50829b96442c7b531ce6252dc07eb
+msgid "[2051153](https://bugs.launchpad.net/bugs/2051153)"
+msgstr ""
+
+#: ../../22.04/4.md 2e1b870c71324d04be3e5309c1cb5bcb
+msgid ""
+"d/rules: modify qemu-block-extra postinst to avoid restarting run-"
+"qemu.mount (LP: #2051153)"
+msgstr ""
+
+#: ../../22.04/4.md:148 ed18f0da03154116a704053ade4bad94
+msgid "Base platform fixes"
+msgstr ""
+
+#: ../../22.04/4.md:150 1e68068992af47ccaa56d92693276502
+msgid ""
+"These changes affect the core fundamental components of all the Ubuntu "
+"flavors."
+msgstr ""
+
+#: ../../22.04/4.md 3280d33c1af14a349f568b60415df583
+#: 32bebfd35df64853a581054d8a89a585 8ca7806107d84d5198f271aa677cb48f
+msgid "apt"
+msgstr ""
+
+#: ../../22.04/4.md 4bc20cf1c2db4372a6622360c78c2e01
+msgid "[2025462](https://bugs.launchpad.net/bugs/2025462)"
+msgstr ""
+
+#: ../../22.04/4.md 6600cff83bdd4b52891d4bb771dadff3
+msgid "dist-upgrade: Revert phased updates using keeps only (LP: #2025462)"
+msgstr ""
+
+#: ../../22.04/4.md d5277718ef884a889361092ec8c498a7
+msgid "[2029268](https://bugs.launchpad.net/bugs/2029268)"
+msgstr ""
+
+#: ../../22.04/4.md 610e2787331d479bb5890aa0e939b279
+msgid ""
+"Compare SHA256 to check if versions are really the same (Closes: #931175)"
+" (LP: #2029268)"
+msgstr ""
+
+#: ../../22.04/4.md 3a2257c9e360458897d481b2192e67b1
+#: 46d349b51cc64470a85f6003d4ed98f0 738a4c59dd8e4ec99f7b1559aeb2c2c3
+#: e35c1007a40043e882c3f3f77174b70b
+msgid "glibc"
+msgstr ""
+
+#: ../../22.04/4.md a96a63a06403459bbf81f1d0af37eb0e
+msgid "[1989082](https://bugs.launchpad.net/bugs/1989082)"
+msgstr ""
+
+#: ../../22.04/4.md bc03ad6fc8cf4d8d8e477c4b7ad536da
+msgid "d/rules.d/debhelper.mk: fix permissions of libc.so (LP: #1989082)"
+msgstr ""
+
+#: ../../22.04/4.md 9b3ce995cd844d11a0b055650d3c580b
+msgid "[1995362](https://bugs.launchpad.net/bugs/1995362)"
+msgstr ""
+
+#: ../../22.04/4.md 922559c63f9248238fba1dbf695d339a
+msgid "d/p/lp1995362*.patch: Fix ldd segfault with missing libs (LP: #1995362)"
+msgstr ""
+
+#: ../../22.04/4.md 0a607d68aec04b81a0765421c0ce398c
+msgid "[2007796](https://bugs.launchpad.net/bugs/2007796)"
+msgstr ""
+
+#: ../../22.04/4.md aaf327501a36489eb74edf1cf1d72d9b
+msgid "d/p/lp2007796*: Fix missing cancellation point in pthread (LP: #2007796)"
+msgstr ""
+
+#: ../../22.04/4.md ea979a7f300c42f9afdaa2db5a6bc315
+msgid "[1992159](https://bugs.launchpad.net/bugs/1992159)"
+msgstr ""
+
+#: ../../22.04/4.md 06530f29f0634eb4b34ecfe555bf9d8d
+msgid "d/p/lp1992159*: Fix socket.h headers for non-GNU compilers (LP: #1992159)"
+msgstr ""
+
+#: ../../22.04/4.md 01d7bbe2eeed47dd9c745331d9dc3bea
+#: 033fc8b6f7134bfb87e5ad62976b8a30 0907e26df49d406091f07b365f745dba
+#: 1c924b106ba74688a32075d09e28b578 2e1e03f1d8534031860f56d35656cb45
+#: 38ecb22d39014e9086663dc6525f5bc8 484a0b72367742508367fe63ea5d9d6a
+#: 502f792d4e35439e8a1b4bc55db335d3 513ddd6d19384dd2abc9f185b6381af8
+#: 57d9022ba170499ab33e2b57bc545638 76e28aa1060a4cd1ae208a09f2b5fdc4
+#: 7ab4e351ff2e4142a8ee6fea1d9296d0 841c11a637dc418bad48f6f3bc764380
+#: 8b0bb580ad224afcb2859cce05bc9f8f b0c90bcce2144430a2b19c60795bf892
+#: b62e65bab4ed4722abb1e153d50b8688 c0dc48c4a905473ca2bf3f2bdd1505f5
+#: c483dee3cf074443adf4a0de640bd528 c49b266ccc2d40038adf744cf4c6c503
+#: c73ab2d81c2b4a50945d3486699d1afb d287f95fd6794c14a5d920b7c4d7a463
+#: d3c577809ac142889d5c77a709363e57 d655596149894d949555b00b7f59c0bb
+#: e1d7b2878bc142c1a5edb473c57e4269 f309ff9424124eddafe609d4cb8a2bd0
+#: f39a6771c1c84d6ca9a634a197a66d63 f4674afd3d6440cb86ede0e8bfd656ca
+#: f89b09438cc74e8a8961bc410c788a87
+msgid "systemd"
+msgstr ""
+
+#: ../../22.04/4.md 1f477750b96d48acbaab33161e23dd46
+#: 59922d080baa429b86bd9610b6213c47
+msgid "[2023229](https://bugs.launchpad.net/bugs/2023229)"
+msgstr ""
+
+#: ../../22.04/4.md 4ef64c63e6ea452a8ec26758a2c3ae24
+#: e44407ca2a9d49d09c01bf1ddebf888a
+msgid ""
+"debian/tests/`tests-in-lxd`: use --reuse flag in lxc publish (LP: "
+"#2023229) File: debian/tests/`tests-in-lxd` https://git.launchpad.net"
+"/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=85b2ceddff1a6cc1ddbca8a1b7e5381d146e6313"
+msgstr ""
+
+#: ../../22.04/4.md 431e22e3c3484cbcbe341bd95f890a96
+#: dcf399bda0e6482990dfdae1afc9f333
+msgid "[2023462](https://bugs.launchpad.net/bugs/2023462)"
+msgstr ""
+
+#: ../../22.04/4.md 070e9f278d134d0097fd0ac8b287f659
+#: a247b380eb314ea18d33d73825e98fa8
+msgid ""
+"pstore: only try to load efi_pstore module (LP: #2023462) File: "
+"debian/patches/lp1978079-efi-pstore-not-cleared-on-boot.patch "
+"https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=7600bbfb1e8a399e5aeb1010a20deda3e5a06c89"
+msgstr ""
+
+#: ../../22.04/4.md 44f7a9d579204613a8393616d56bde17
+#: d31e49605b58446e8c0efe036757a3be
+msgid "[2025563](https://bugs.launchpad.net/bugs/2025563)"
+msgstr ""
+
+#: ../../22.04/4.md 22353dc71f264c56adba13a60c83731b
+#: a6177e857b3640949ba3deae2e6ee7fe
+msgid ""
+"shutdown: get only active md arrays. (LP: #2025563) File: "
+"debian/patches/lp2025563-shutdown-get-only-active-md-arrays.patch "
+"https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=416a9245c8f0efbedcc4395cada23cb09c685ec3"
+msgstr ""
+
+#: ../../22.04/4.md c53c6cc7044248e18ebcfc0d878feff2
+#: d9e7a6d2a32f4505989b7c2a98a02478
+msgid "[2028180](https://bugs.launchpad.net/bugs/2028180)"
+msgstr ""
+
+#: ../../22.04/4.md 807025bc662a463b9b4aeb929ef9e33e
+#: e111c8a4330b4422be3161629da2aa24
+msgid ""
+"udev-rules: fix nvme symlink creation on namespace changes (LP: #2028180)"
+" File: debian/patches/lp2028180-udev-rules-fix-nvme-symlink-creation-on-"
+"namespace-changes.patch https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=26e85b944da9098e66fc0c39f64ee40254c0c278"
+msgstr ""
+
+#: ../../22.04/4.md 161db43e32324cd1981cdde027d29527
+#: 1df443cbec3e45aaaef2032c76f395f3 2533f3bfb7e149b795d85e35196ecfe7
+#: 3cf2357c0b274b9c87c63daef44120d3
+msgid "[2013543](https://bugs.launchpad.net/bugs/2013543)"
+msgstr ""
+
+#: ../../22.04/4.md 5e72bec57ab14985a040e746a94cc2e0
+#: 866b388adc1541868da3822061788c45
+msgid ""
+"core: reorder systemd arguments on reexec (LP: #2013543) File: "
+"debian/patches/lp2013543-core-reorder-systemd-arguments-on-reexec.patch "
+"https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=19ba0f20d311642596dc65fa5d6eb96a2d4be280"
+msgstr ""
+
+#: ../../22.04/4.md b976e49cb32543c4bbe9eee9cacafd67
+#: c6474ccd68524bf986eaf3a9ef511a4d
+msgid "[2009743](https://bugs.launchpad.net/bugs/2009743)"
+msgstr ""
+
+#: ../../22.04/4.md 369a5b38eecd44358bd5fe4d0f2b134c
+#: 58363d32ddbb4f6aa376ef7af6aa23e1
+msgid ""
+"network/dhcp4: do not ignore the gateway even if the destination is in "
+"same network (LP: #2009743) Files:"
+msgstr ""
+
+#: ../../22.04/4.md 49920458fe5a4618b60c61fb60a39377
+#: 703d969578514106b833dc18aacfc3c0
+msgid "[1982218](https://bugs.launchpad.net/bugs/1982218)"
+msgstr ""
+
+#: ../../22.04/4.md 37fbf93790ab415a820001a5d42c711c
+#: b0386755fd714939afed0bef54b5969a
+msgid ""
+"Drop debian/UBUNTU-wait-online-exit-if-no-links-are-managed.patch (LP: "
+"#1982218) File: debian/patches/debian/UBUNTU-wait-online-exit-if-no-"
+"links-are-managed.patch https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=cf82f08feea456e1c65895b34bffa8c33d421588"
+msgstr ""
+
+#: ../../22.04/4.md 8c52f69764004b18a5cf7f2894517ec7
+#: 9c47b9eb1faa47378e4560f5e8ebf4fe
+msgid ""
+"debian/systemd.postint: do not daemon re-exec if we could hit LP: "
+"#2013543 File: debian/systemd.postinst https://git.launchpad.net/~ubuntu-"
+"core-"
+"dev/ubuntu/+source/systemd/commit/?id=be484dab06d590b1792a8f016f4292373d0174b7"
+msgstr ""
+
+#: ../../22.04/4.md 573a9a61fd8f417a9ab535dc466a8b43
+#: c7482b14f30d4bca978234524a1f0ff4
+msgid "[1977630](https://bugs.launchpad.net/bugs/1977630)"
+msgstr ""
+
+#: ../../22.04/4.md 3e63f9a667ad4d3e987a07517b23d904
+#: 4245898a6e8246d78904d95edd5e2d8a
+msgid ""
+"Fix machinectl pull-tar and import-tar (LP: #1977630) Author: Dan "
+"Streetman File: debian/patches/lp1977630-fix_machinectl_pull_tar.patch "
+"https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=1e7d3febe1600c6eb03bd71a17be6a6af52988c7"
+msgstr ""
+
+#: ../../22.04/4.md a9c92e00b50a4c2993d43a8358eb3da6
+#: ea355816537b48e1b5bb60c5ec07aaff
+msgid "[1991829](https://bugs.launchpad.net/bugs/1991829)"
+msgstr ""
+
+#: ../../22.04/4.md 2aaac66bd4eb4c04a7dcbdd863d8cb1b
+#: 4330acd7e6f04e07a3a0a9e83cb6c47d
+msgid ""
+"make machinectl read-only work (LP: #1991829) Author: Dan Streetman File:"
+" debian/patches/lp1991829-add-CAP_LINUX_IMMUTABLE-to-systemd-machined-so-"
+"it-ca.patch https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=7a7c47569e0a2d175915eb0b79c60f2611848731"
+msgstr ""
+
+#: ../../22.04/4.md 676e0d1b6b1640459ab4e953b7af38d0
+#: 735d4ae6e060450986881572a2af082a
+msgid "[2002445](https://bugs.launchpad.net/bugs/2002445)"
+msgstr ""
+
+#: ../../22.04/4.md 17e9728039d8452a9bef8492fb52250b
+msgid "udev: gracefully handle rename failures (LP: #2002445) Files:"
+msgstr ""
+
+#: ../../22.04/4.md 603e0712e9ef4f7285fb6f897b2704d7
+msgid "[2004478](https://bugs.launchpad.net/bugs/2004478)"
+msgstr ""
+
+#: ../../22.04/4.md aadf5005bd2d44dd8ccf91a2ee1e7c6a
+msgid ""
+"network/dhcp4: accept local subnet routes from DHCP (LP: #2004478) File: "
+"debian/patches/lp2004478-network-dhcp4-accept-local-subnet-routes-from-"
+"DHCP.patch https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=96928d5f45ebbfe682b47e842d63506fa0ac9583"
+msgstr ""
+
+#: ../../22.04/4.md f5fc6bb8b98a43d1a4e26beccc7a79f0
+msgid "udev: avoid NIC renaming race with kernel (LP: #2002445) Files:"
+msgstr ""
+
+#: ../../22.04/4.md 50891666cec34386a51492af76abf372
+msgid "[2000880](https://bugs.launchpad.net/bugs/2000880)"
+msgstr ""
+
+#: ../../22.04/4.md 257ece6ecbd94354924ef3d00e8c24f9
+msgid ""
+"network: create stacked netdevs after the underlying link is (LP: "
+"#2000880) File: debian/patches/lp2000880-network-create-stacked-netdevs-"
+"after-the-underlying-link-.patch https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=ab620e709f3f62eda86af26fd66c00d6e5165a25"
+msgstr ""
+
+#: ../../22.04/4.md e6d207cdf8244185ba9346c7236ad226
+msgid "[2009502](https://bugs.launchpad.net/bugs/2009502)"
+msgstr ""
+
+#: ../../22.04/4.md 8176182006264fefa5aea009d93ab10a
+msgid ""
+"Enable /dev/sgx_vepc access for the group 'sgx' (LP: #2009502) File: "
+"debian/patches/lp2009502-Enable-dev-sgx_vepc-access-for-the-group-"
+"sgx.patch https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=434480ae4059a16ccbde9613be0c26ff1983cc3a"
+msgstr ""
+
+#: ../../22.04/4.md 4c33c20e203f4734b01b9fadca2286e1
+#: 603dd8aeb2d547bbbc23eae65c92a413 7b654758af6944efa63b9b912fc095e5
+#: 879cd405ee054139804b107d3a2ca8c8 8871ffb24f4c40f8b9a4c0e3b78a03c9
+#: 95fcb893de2943fe8ff5dde02d015c6d 99340ae53c4e4904bc7f2b0b7071fc21
+#: a1ad714054874002b520425f084f4b74 fa0235cd9867432f89d826066d80d6f7
+msgid "ubuntu-advantage-tools"
+msgstr ""
+
+#: ../../22.04/4.md 7e2dd3216f104dd1a54b56e65eac3a74
+#: c6ea7334fb7548ec92e564944286bbc1
+msgid "[2029144](https://bugs.launchpad.net/bugs/2029144)"
+msgstr ""
+
+#: ../../22.04/4.md 7d248736aee64b0a8c24dedd57c2c662
+msgid "Backport new upstream release: (LP: #2029144) to jammy"
+msgstr ""
+
+#: ../../22.04/4.md 8ce9edbebf124a6d88cf706fe9bfbbd6
+msgid "New upstream release 29 (LP: #2029144)"
+msgstr ""
+
+#: ../../22.04/4.md e87017ba9d874a149c7e183fe34d94a5
+msgid "[1999909](https://bugs.launchpad.net/bugs/1999909)"
+msgstr ""
+
+#: ../../22.04/4.md 3029067625dc4ef9ae7c5ef1269ccb04
+msgid "proxy: add support for TLS-in-TLS proxy (LP: #1999909)"
+msgstr ""
+
+#: ../../22.04/4.md a1a536df147442ae9a1c226ca5f724a3
+msgid "[2025731](https://bugs.launchpad.net/bugs/2025731)"
+msgstr ""
+
+#: ../../22.04/4.md b9232d0ba6e54caa94deb11ef0be1c1e
+msgid "system: try/except logic to remove files and folders (LP: #2025731)"
+msgstr ""
+
+#: ../../22.04/4.md b5fdacaf39374c35a4a4a4f8199c7171
+msgid "grub2-unsigned"
+msgstr ""
+
+#: ../../22.04/4.md 7bba6242e4c446de859140ba7116c00f
+#: 7c2e01fd0f744ebd8460437020d5fd71
+msgid "[2004643](https://bugs.launchpad.net/bugs/2004643)"
+msgstr ""
+
+#: ../../22.04/4.md bf3220fcfd7741b19eb090912c90033e
+msgid "Cherry-pick more upstream memory patches (LP: #2004643)"
+msgstr ""
+
+#: ../../22.04/4.md c3820648882448968518b37e93f04403
+msgid "grub2-signed"
+msgstr ""
+
+#: ../../22.04/4.md 814afa2588f641e0a2d16faee4dc8c0a
+msgid "Rebuild against grub2 2.06-2ubuntu14.2 (LP: #2004643)"
+msgstr ""
+
+#: ../../22.04/4.md 32cbd6c3bf5545e7b0ea1426248e8fbc
+msgid "netplan.io"
+msgstr ""
+
+#: ../../22.04/4.md 8a2dc41177184052b25960f3843e3d0a
+msgid "[2025519](https://bugs.launchpad.net/bugs/2025519)"
+msgstr ""
+
+#: ../../22.04/4.md e2733659f9c9433fad5d826ee4489804
+msgid "Backport netplan.io 0.106.1-7 to 22.04 (LP: #2025519)"
+msgstr ""
+
+#: ../../22.04/4.md b5447fe0c941416fbcc3e0bc38c5ebd3
+#: f7049ebc455c4316a8e16c968f8c90d1
+msgid "distro-info-data"
+msgstr ""
+
+#: ../../22.04/4.md 5efe8111f150488ba6ea66012dff87b7
+msgid "[2040193](https://bugs.launchpad.net/bugs/2040193)"
+msgstr ""
+
+#: ../../22.04/4.md f0e334c534184568b93da18c44102c93
+msgid "Add Ubuntu 24.04 LTS Noble N. (LP: #2040193)"
+msgstr ""
+
+#: ../../22.04/4.md 889aa9cc16504f559f6eb6fd45ec4732
+msgid "[2036358](https://bugs.launchpad.net/bugs/2036358)"
+msgstr ""
+
+#: ../../22.04/4.md 0b99b5df4e54492e9254c6da7f5891fe
+msgid ""
+"wait-online: exit early if all links are ignored (LP: #2036358) File: "
+"debian/patches/lp2036358-wait-online-exit-early-if-all-links-are-"
+"ignored.patch https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=fcf9af1efaa904b9e587a3bfa76814d2601d05f3"
+msgstr ""
+
+#: ../../22.04/4.md 73ac47a714764df388e5d95c21216ed7
+#: e6162648e2d34ff38562114fa13f4c0c
+msgid "multipath-tools"
+msgstr ""
+
+#: ../../22.04/4.md 529e34afb908481e8e91caef22cf3059
+msgid "[2035098](https://bugs.launchpad.net/bugs/2035098)"
+msgstr ""
+
+#: ../../22.04/4.md 666a85615ae64fb8a9876da8db00e4b7
+msgid ""
+"debian/multipath-tools.postinst: restart multipathd when upgrading from "
+"lt 0.8.8-1ubuntu1.22.04.3 (LP: #2035098)"
+msgstr ""
+
+#: ../../22.04/4.md 6c460b7c65754572b920bae15a43b680
+msgid "[2038453](https://bugs.launchpad.net/bugs/2038453)"
+msgstr ""
+
+#: ../../22.04/4.md 281d9338fa934bf592b822a809dfa3f6
+msgid "Backport archive snapshot integration as of 2.7.3 (LP: #2038453)"
+msgstr ""
+
+#: ../../22.04/4.md 52b1566c8d274c2ab7783d359589a73b
+msgid "pkgbinarymangler"
+msgstr ""
+
+#: ../../22.04/4.md 6c7f3829902744dcaeead25bc21a5454
+msgid "[2037584](https://bugs.launchpad.net/bugs/2037584)"
+msgstr ""
+
+#: ../../22.04/4.md 3627b8c755c7403eb2cbf77788419e01
+msgid "`striptranslations.blacklist`: Add ubuntu-pro-client-l10n. (LP: #2037584)"
+msgstr ""
+
+#: ../../22.04/4.md 6e0503b0e9bb413392f0a6d7e74f49ce
+#: 914b773947484e8ca61fe174a3fce136
+msgid "[2038461](https://bugs.launchpad.net/bugs/2038461)"
+msgstr ""
+
+#: ../../22.04/4.md 2828099389aa417c86c80dddfe15ddc2
+msgid "Backport new upstream release to jammy (LP: #2038461)"
+msgstr ""
+
+#: ../../22.04/4.md 52b6675d8dfa4d4594b8cd9062560065
+msgid "New upstream release 30 (LP: #2038461)"
+msgstr ""
+
+#: ../../22.04/4.md 9cbe6beeac4b4a9fb6c022b2ba6d3f06
+msgid "[2024204](https://bugs.launchpad.net/bugs/2024204)"
+msgstr ""
+
+#: ../../22.04/4.md 32b0d781daad4a2da8247a080ae39419
+msgid "files: Reduce race window when creating new files (LP: #2024204)"
+msgstr ""
+
+#: ../../22.04/4.md 39a127e816ee41b3a67c7bbb20b74d2b
+msgid "[2038417](https://bugs.launchpad.net/bugs/2038417)"
+msgstr ""
+
+#: ../../22.04/4.md 0d7dea07c773489bb311cf5fcd7e5512
+msgid ""
+"systemd: change ubuntu-advantage.service type from 'notify' to 'simple', "
+"dropping the dependency on python3-systemd (LP: #2038417) (GH: #2692)"
+msgstr ""
+
+#: ../../22.04/4.md b9b4a621542d4edfa318b229ecd51e9c
+msgid "[1938208](https://bugs.launchpad.net/bugs/1938208)"
+msgstr ""
+
+#: ../../22.04/4.md 2b96354488f24bc3bfbade45f596f5f0
+msgid "add scenarios where cloud-init is present but disabled (LP: #1938208)"
+msgstr ""
+
+#: ../../22.04/4.md 2c6c8eeefb854d4b9e2310c038777f22
+#: 3a0ba8973d5e45c4b2720fe3ddd77eb0 be0f091ae2054da691630d7003002bd7
+#: c062c356d0e34fe2a986b1282bdb5094 ef5aab6866db43d0aa0e54266a71abc4
+msgid "rustc"
+msgstr ""
+
+#: ../../22.04/4.md aa0266bc8fed41469e0389d75337e2bc
+#: b98f47789271486e8f5f1d8a4e2f03b2
+msgid "[2027639](https://bugs.launchpad.net/bugs/2027639)"
+msgstr ""
+
+#: ../../22.04/4.md 13d853215d42442fbb216cbb18982e93
+#: 263583a47a0b43b4b05155387273abd4
+msgid "Backport to Jammy (LP: #2027639)"
+msgstr ""
+
+#: ../../22.04/4.md f1f03fb701a046fcadcf10819b7fd166
+msgid "lintian"
+msgstr ""
+
+#: ../../22.04/4.md e63469e3dcdb40c0902e7b15808620f9
+msgid "[2040012](https://bugs.launchpad.net/bugs/2040012)"
+msgstr ""
+
+#: ../../22.04/4.md 8eab4de5188a40eea7f46758c14f09ba
+msgid "Add \"noble\" as a known Ubuntu distribution (LP: #2040012)."
+msgstr ""
+
+#: ../../22.04/4.md 585344e3d95248ee8b4b94a99d2839b7
+msgid "cryptsetup"
+msgstr ""
+
+#: ../../22.04/4.md 62e5c2f8fcd3432cb06332ac0bb335d5
+msgid "[2032659](https://bugs.launchpad.net/bugs/2032659)"
+msgstr ""
+
+#: ../../22.04/4.md f97642e7dffc45dfb0b652762135dcaf
+msgid "Cherry-pick modern support for FIPS enabled backends. LP: #2032659"
+msgstr ""
+
+#: ../../22.04/4.md 81bad08c984b4585953c6b8ab6224ef3
+msgid "distro-info"
+msgstr ""
+
+#: ../../22.04/4.md ad267d2848b34a2fa70717d8c7aa6191
+#: e5eb3aed842749f7858717ef297a37ff
+msgid "[2041662](https://bugs.launchpad.net/bugs/2041662)"
+msgstr ""
+
+#: ../../22.04/4.md 93db1d46f09248388a6cc8e86360b225
+msgid ""
+"Update tests for distro-info-data 0.52ubuntu0.6, which adjusted Debian "
+"7's EoL (LP: #2041662)"
+msgstr ""
+
+#: ../../22.04/4.md 8f1632da5d5f43179f052d44d75f66f5
+msgid "Add animal name to Ubuntu 24.04 LTS Noble Numbat (LP: #2041662)"
+msgstr ""
+
+#: ../../22.04/4.md bb505fec0bf94083b0d7229137239f5e
+msgid "tzdata"
+msgstr ""
+
+#: ../../22.04/4.md 78eca075170448dfa66027fb0d4005b5
+msgid "[2047314](https://bugs.launchpad.net/bugs/2047314)"
+msgstr ""
+
+#: ../../22.04/4.md e561a6547b794139b78ae8e257d82741
+msgid "New upstream version (LP: #2047314):"
+msgstr ""
+
+#: ../../22.04/4.md a15e524690bf45749381ed8cdf2854aa
+msgid "modemmanager"
+msgstr ""
+
+#: ../../22.04/4.md afd138c73bf34f2c8f730b65c208824e
+msgid "[2047008](https://bugs.launchpad.net/bugs/2047008)"
+msgstr ""
+
+#: ../../22.04/4.md 2b37936d43034772b727bb528fe5f7d2
+msgid ""
+"Backport the newer modemmanager commits from 1.20.6 to the LTS as part of"
+" new hardware enablement including Telit FN990 modem (lp: #2047008)"
+msgstr ""
+
+#: ../../22.04/4.md 3bc8f97eb07448baa9db80627d875e43
+msgid "base-files"
+msgstr ""
+
+#: ../../22.04/4.md 39863dec3b15476f8c339eac292b8913
+msgid "[2046356](https://bugs.launchpad.net/bugs/2046356)"
+msgstr ""
+
+#: ../../22.04/4.md c95699787f4b498ab1decedc6471867c
+msgid ""
+"motd/10-help-text: Update support url for new Ubuntu Pro webpage (LP: "
+"#2046356)"
+msgstr ""
+
+#: ../../22.04/4.md 1bdcbfcbab3240798ade6df9ca54b19a
+msgid "[2037281](https://bugs.launchpad.net/bugs/2037281)"
+msgstr ""
+
+#: ../../22.04/4.md ae09521eedb44cfea3caf887f891e938
+msgid ""
+"core/device: ignore DEVICE_FOUND_UDEV bit on switching root (LP: "
+"#2037281) File: debian/patches/lp2037281-core-device-ignore-"
+"DEVICE_FOUND_UDEV-bit-on-switching-roo.patch https://git.launchpad.net"
+"/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=00f86f0b20f794f30aabe7181912d2ec2207e292"
+msgstr ""
+
+#: ../../22.04/4.md b7bd1a5d3ea74c94960cfb0eb795bcd6
+msgid "[2035122](https://bugs.launchpad.net/bugs/2035122)"
+msgstr ""
+
+#: ../../22.04/4.md f0ed9237f9e34a6ba061883b11b5b861
+msgid ""
+"use read-only /etc hack in more places (LP: #2035122) File: "
+"debian/patches/debian/UBUNTU-Support-system-image-read-only-etc.patch "
+"https://git.launchpad.net/~ubuntu-core-"
+"dev/ubuntu/+source/systemd/commit/?id=c57406e850396a5d446aefe5e70a3aeaad080d72"
+msgstr ""
+
+#: ../../22.04/4.md 341b618d356b40ed91d15addeb6ae23d
+msgid "[2041325](https://bugs.launchpad.net/bugs/2041325)"
+msgstr ""
+
+#: ../../22.04/4.md 407a3a53b62a4cde97425a73db1cec9a
+msgid "Backport to Jammy (LP: #2041325)"
+msgstr ""
+
+#: ../../22.04/4.md e35286896b1a471c86d3f6c6fa08c2ae
+msgid "[2040339](https://bugs.launchpad.net/bugs/2040339)"
+msgstr ""
+
+#: ../../22.04/4.md f7be2137f9b843a2a2527f3cf53cf8f9
+msgid "Backport to Jammy (LP: #2040339)"
+msgstr ""
+
+#: ../../22.04/4.md 28395a07b81a401caed5e3cbebf90894
+msgid "kdump-tools"
+msgstr ""
+
+#: ../../22.04/4.md 4026fce41467440daaa5ababa65c41f5
+msgid "[2043059](https://bugs.launchpad.net/bugs/2043059)"
+msgstr ""
+
+#: ../../22.04/4.md 4441d2d9c73d41a192f3fc24c86ef346
+msgid ""
+"Disable the initramfs generation in our kernel-postinst hook when we "
+"detect we are running in a chroot. LP: #2043059."
+msgstr ""
+
+#: ../../22.04/4.md 781477f3b75a421cade4f6b9c6c66de7
+msgid "iptables"
+msgstr ""
+
+#: ../../22.04/4.md 7e2159897684493cba89784acbb5c3b2
+msgid "[2049318](https://bugs.launchpad.net/bugs/2049318)"
+msgstr ""
+
+#: ../../22.04/4.md 170e022482574e0b973856a0ff7f39bc
+msgid ""
+"Apply upstream patch to fix a double free of unrecognized base-chains. "
+"(LP: #2049318)"
+msgstr ""
+
+#: ../../22.04/4.md 2e5bfcf44a5a4b7590262e9822e06c60
+msgid "coreutils"
+msgstr ""
+
+#: ../../22.04/4.md 32958e2ebb854e41bc1c912b92a145e7
+msgid "[2047450](https://bugs.launchpad.net/bugs/2047450)"
+msgstr ""
+
+#: ../../22.04/4.md b9bfae9f333248edb7fd5f7683025235
+msgid ""
+"d/p/assure-new-macro-affirm.patch, d/p/tail-fix-tailing-sysfs-files-"
+"where-PAGE_SIZE-BUFSIZ.patch: Fix tailing of sysfs files on systems using"
+" a 64K page size. (LP: #2047450)"
+msgstr ""
+
+#: ../../22.04/4.md 98f0e8bae67d400194d1fff79db5be51
+msgid "[2040340](https://bugs.launchpad.net/bugs/2040340)"
+msgstr ""
+
+#: ../../22.04/4.md b9f3af73f9544fb7959aeb10d11ee856
+msgid "Backport to Jammy (LP: #2040340)"
+msgstr ""
+
+#: ../../22.04/4.md c39d8567d69b4ced86c04fc988411b91
+msgid "unzip"
+msgstr ""
+
+#: ../../22.04/4.md 60b1da989c2d40b4b48fc7638e7eaac9
+msgid "[2051952](https://bugs.launchpad.net/bugs/2051952)"
+msgstr ""
+
+#: ../../22.04/4.md a97b6737d7de4ac590df72827128a343
+msgid "Properly handle Microsoft ZIP64 file (LP: #2051952)"
+msgstr ""
+
+#: ../../22.04/4.md:221 ../../22.04/4.md:756 2f5a8eb0f5514d138064c7a3cc6ddc91
+#: 84f2fdbed1f74e539e70466972d36488
+msgid "Kernel and Hardware support updates"
+msgstr ""
+
+#: ../../22.04/4.md:223 ../../22.04/4.md:758 d114ff61765946019801d49f638f99d6
+#: f28b83951a204fdd9ed1ff7623db5a2e
+msgid ""
+"Considerable work has been done on improving support for many specific "
+"items of hardware."
+msgstr ""
+
+#: ../../22.04/4.md 01917236c8ae42be9c2827e1d61c41bd
+#: 064c19cb18444c279c731555dddf0af6 09244e3988014315abacd907fbb92c08
+#: 2bc44a7edd0c45b18d50376c959c4966 5d1ac7efaa6244be9f12b50d7d4ca1c6
+#: 7f8e2d064b1347478f209596f34f1ce0 81eb41681a4d44aa98b0530d33053cc4
+#: cf62253462ef4440bb959b1093cdc872 d10a49f0bef643de9212e34fc6e80032
+#: d4d583c40f3249d7b59d4989a0fc43af d97a3c8e2e4b40b1928a4b0e8663cec7
+#: da1b68a16bf14665a7a9d1e1bb6a0a2d de77681af94f4440b4663097beeee6e4
+#: ee43f6557d114a7b870b9b5165c0d746
+msgid "linux"
+msgstr ""
+
+#: ../../22.04/4.md 0eb4e34dc606406ea56012910a9168cf
+#: 1fbb76aea6864037b05b108f97bf7e0d 525cd6f059f345339adb9b68aa38c743
+#: 6b626bdeefcb43978d03ab948bb348b3 88d2f79d041a4cf099aa5f2f464cd64e
+#: 8dc4a6b9f45140f0905ac935f91b7f59 98cd691c29ce491e9dabe8b3c8e17d29
+#: 9af922f4f3bd4fad9a26ae5f7762b2c2 b52f0159efa744198e686f02955fdda0
+#: b8a24c69c702426b912d6b866906e142 cb701087cc4948cf91f0029d8887560e
+#: e0aa0076e6a34e179b24a4505ce438bb e89756da187a42ce8f81abe75072b2ec
+#: f29bfd921b574821b741799513604d7f f563de389800404f86ee0a84a90f18fd
+msgid "[2023905](https://bugs.launchpad.net/bugs/2023905)"
+msgstr ""
+
+#: ../../22.04/4.md 01a0032fcb804c8e9211d86690428b5b
+#: 24c02eaab3d2409e944fdd47c5ec1911 409c69e5fcec46e5bae735abde555526
+#: 42ad14a512a548d6a47c954c55f97591 4787ad702a0b4a7e9acc895bf086a512
+#: 65d9ba2172d84f03a64d36531ec61b1a 6d78c2d633c94247adff75c423afdb4d
+#: 826b501a4755424f883f916aad8a05db 857666a7045246149728239120fba99b
+#: 9e72a6a4188f405d837507b225d7b6ce a5dc18c1fdd440c6960793a105862b17
+#: b5f4fe4d5c1b4f7988186dbcee69918e d8dd904241d8489792abc4bdb8fbbe01
+#: e5ced5f774734ce2b85f0ec575e74783 eba6549fb525456cb4e56cf4184b0765
+msgid "jammy/linux: 5.15.0-76.83 -proposed tracker (LP: #2023905)"
+msgstr ""
+
+#: ../../22.04/4.md 016ec2a29ff24a5b84a741f7bf7edf2d
+#: 01bc2a43fcd74c38abb5cdefab97efe2 0256bec9272d4bd292d1a151410971f5
+#: 04b442bb4d4b4461b0bf506e8d53055a 0528ae81c94d43b2951fa38f12ba4abb
+#: 0594df54101b4fe1989ff662153b4822 0fad201d304c492b8abbfffd3465af24
+#: 14b95c95622f433284521ce769b70a60 1b5d0e44d2b648748efd6acad40d03a4
+#: 23eccae540f5431a8f145bc5abecf0d5 2610c4ad6d1c4a41a012667be770c650
+#: 266ab4699b38400d95e9b62049da6fa3 2969fd611acb41c6a86a9dd617b5b5d9
+#: 2e929ad76174407e87f31b56128c0569 2ee3d54b50134d72a0bac35eb9289e9d
+#: 2f1285443d3f4a8f97c2fd9944dec5c9 3866769aabb047f39c4ee9f74c6d211a
+#: 3c2651d194754f45a0dccc83ed70a383 3c618672854044edab4ba9a23a5da935
+#: 3ee43b099b07407e9e0487374331b686 408eae270ab7422c8148bbdedecc92f9
+#: 43d06572321548799e58bd30ac4823d0 43eefcab2c4e4b548af7a4b46eaf9cc5
+#: 44403f4c90ed41e2b13bf0dfd9df4a74 47b98263e9f64d84b3758cdc3ff31671
+#: 4d547b12f2354966aaee7aaccae44136 4fcd6d881fe349daab9af8312826e479
+#: 5017ee9eb18945e88d2759ecf2b86e00 62116938b7bc4d9abaff13a0269973e0
+#: 63a55fd4f9c94ced9daaadffb3b7c840 682dccf5b89e43978894e05e87b2fe7f
+#: 68588ddd112d47258f2bb6df8990797a 6b5384d8fe714626add76bcee5c36a0c
+#: 6e18ae4d8e4149a4b022129db4381064 712a1073d5c84db9803822d62d5ead53
+#: 72b1dcb62e48434da186aec1ff5ffb2b 7780ebd08e844c749792792e9180ec9e
+#: 782814a125bc48f78950ee89f73b31a6 78d67540429046d2882dcec3a34d1716
+#: 79479d2c6a334e1b941f43460a680abf 7d829d697de3411f8d21da63c7601548
+#: 7de22f37947249828d73a17639d2c1ef 7f84fc0660cb4ae483a6519580df7d89
+#: 82c7f69d68094a82b90ffa670769cd6a 86feb191033c47acb6c47d86b74acfc0
+#: 9133c927bd834fde8bc715e7aea77d9a 92603d961b834b71bead7afa20cd788b
+#: 946539d05b794e1f9bfe19afd30dd8e7 9ea7434da1ba4b888d37c34dabd62f99
+#: a2d1af70e81d43448626d55c73dd4b10 a4f47c96b9e5472a93c8843562aca711
+#: a897005c7a5e4c3faf978b6de1c8a75f afd3695817de4d0ea613bd761e34a96a
+#: b1086038212b47bcae097b921bcbe79c b19e85508b83482eb047057a59759b1f
+#: b4b214824cf0461aabc9b82f8a945fc3 b8bccc3c653b49228dc50ef279ac7a14
+#: b9ddcbe8705440868ed95eb72babe5f5 bc11489d8d184eefa3f87186e37e63d2
+#: bdab0ae8a02f4e9193ec15029a03ac99 bfbbca79319c42509f77cc50607b1496
+#: c47fc053e6e64ac2bcebc7e84983c6e6 c49b4b4ecc1446f4a4147a15413490d8
+#: c71f234642914b71bc082875ae762e1a cc3b5d91fb6b434693c2306aa2638800
+#: d049127055fe402fb3e2c0a01e03e366 d0c8a21cb2b547cca42c2e785afb39ea
+#: d4d50ece9fe6422ca80d91efd0b5a0ca d6cb638ea10d4fc28b41f8963e1c23c5
+#: dd7789e2f76c4bd196172c1e205f3ae7 e1d532ded1f84d60bf5888ac576928d9
+#: f442b6551c1340529b8fc2994e271ce3 f5bef842675242bb9c734a3837cf1ba5
+#: f7f766cd3b854eb8826a2dad511951c4 fdc24a07fec84a7f9a00a2d380fdc175
+#: fed2177897a54b2caabcde72c6ec919c ff0baa5414174dd69c160c91862a74e8
+msgid "linux-azure"
+msgstr ""
+
+#: ../../22.04/4.md 056ab94bf74c43f4b5b5b490c81ff6d5
+#: 0e290e0f524f4393897009e9c314ff2c 5d45b4e93b8a487693388eeeda9021b4
+#: 61d763b25eb148a49a25b6b6f6888854 7ce7e42527af412484377113935d28d0
+#: 91fa984a0af945e4939af95813d383e0 a5ac165bcab1413c928dd1e564a02ace
+#: e0570ca460b54b258f01a16f00615a34
+msgid "[2016898](https://bugs.launchpad.net/bugs/2016898)"
+msgstr ""
+
+#: ../../22.04/4.md 560cdba33ed547bca49c0a0a027e3b83
+#: 5ad4320f59ff4d9a8cf74f80f8a26353 6d50b0b14a204235a54af64f52243a83
+#: 7f3b0af83c7640f2912238f102fc1fbe a517bf8b8c6148dc9504b922694d7bc2
+#: b0ed5c9a80c54b2e8ced0873670ca50e c0873d63caa045b28ea60b11f0000069
+#: df8f7cf3cb704ddaaaa64e1bfaa592a5
+msgid "Azure: Enable MANA Jumbo Frame Support (LP: #2016898)"
+msgstr ""
+
+#: ../../22.04/4.md 17a663d010104210a7773793971865f2
+#: 18deccad03d7414fabd3d80d9dddae44 2587f0a5d82845ddbfcf4ae8a510a827
+#: 3692c95f6053496783d2a599d393f973 7f9eb69fef9644bfaabef277d6a11f65
+#: 87509df3ecea4901b5cd20987b9a5852 89a0481124384a3da41e3175be5d373a
+#: d115e48d247e4907b5268ada0cb1332b
+msgid "[1996806](https://bugs.launchpad.net/bugs/1996806)"
+msgstr ""
+
+#: ../../22.04/4.md 05ed551672dc4615b550103ed232f8d5
+#: 2a40f809916a47e5912b6fb68d70871a 4105cfd9984e41a096e9e4e31086e874
+#: 952c22c188004c29bebe4406469c0e17 9dcf1656bc284ce4b66c99ef8cf589f1
+#: b1b53a7be037481eaadc55b605522c11 c2ae8bca381f4056b910347c6dec3f2f
+#: e5b8ae41ca9f475097c7a6b1c5e3b0e6
+msgid "Azure: Jammy fio test causes panic (LP: #1996806)"
+msgstr ""
+
+#: ../../22.04/4.md 0be8bb53912e4dcd975e7f3035a58b80
+#: 16cb66bdf376401cacb6aaa0e3675490 1c639dc14e5c4910b9e07170168a9e4d
+#: 29bbd5e72aba4a9ab1ed9aa99a5bb1c1 4295a205af81449abb544359aadc4c45
+#: 48cba2031c1949f29a4dad031df946b1 5ecc289cb64b4e98acf85b2d88d127e3
+#: 61e03cc6a5a54c8381b87539994b3621 82d858cca99a49ada4da532d353ba9ba
+#: 833d12a4ee274c498160cdf31b20aa03 8bffe982bc1542e7af6ff69de685cd3c
+#: a77492c44bd944d59582fcbe29927e7f b5baed30e7f14f0483267ba7c70ce121
+#: bf1029294aa64ea6927cf201baa68b48 cbca21eeb423401d819c31c3e99ea7bb
+#: d6493bfef1c84439ad120b6c97ed879a
+msgid "linux-signed-azure"
+msgstr ""
+
+#: ../../22.04/4.md 0228732ceeee40cda8e9f4aa0c9e1e3a
+#: 022c07de7d7e43e8a4dc271748e2b3d2 12fe8df414274f60bd326f947331534e
+#: 1b5d511da6ff4459b5935475253ce25e 32a7bf4c641c42b2a54550878a17f5ba
+#: 383ef7a6acd14f95a1965a5963b44cc7 3ad96d594b494bd9908042872e8cc4ad
+#: 3d2712e0dc754f0d8fe20bcd02a1625f 459d0f8a69904fea9ee082493e1dddf0
+#: 611caa34febf424cb9e606f1fd6b002e 640864b64d254c0a80cb8fecc8bbc674
+#: 6ec87b1683db49cca66d712b84e2ad48 734b63bc137945a28d3f84d798f7e2a1
+#: 7d4d27a071514d6e8bc8248c05b32029 7ee3ab928e8b40d59e3986c8264bf9e3
+#: 8fe91d2b510648f486c64be6546b5ec2 a07877dd56104f228b03740a2e9538e5
+#: a25022d7342d4248907580404eeaa0de a74ddec176b740cbacbe289cd1d4a3ce
+#: aee6c99b512b4a328c645cba284b6565 b4b92634317c479da081dd934ef6fcab
+#: d0b2662c3e5240f98c8cd1ad8d896011 d161b7e63b184855af66ae03393234a3
+#: e1c86f2b728243ed87c1de18aaefc2c7 e6989cc052f94045a6395c5e5842d9a6
+#: f493117169b74cda91851291f45bd234
+msgid "[1989705](https://bugs.launchpad.net/bugs/1989705)"
+msgstr ""
+
+#: ../../22.04/4.md 009f135cfdfa442e927d4ab58cd3fa70
+#: 0481e52a0e8e4dd58488ae711ec1cb53 0c589ae6ad2044088385e5007a917a7e
+#: 11d6a1f5f7a54bb68652c91a654c755d 239feb6690be48158ea0b81d3ad046a8
+#: 266923d9c12545c586e6e2b42a05cc47 29ebc09cced9491a98dae0dd1867ae44
+#: 3134d9c17edb4e1ea702ac95eb2f766f 3c2f9a7d6d6d4fa0b833fd4f0565c5b2
+#: 3c90a671d325435682af81542f7647a6 3cfc686fac7b4c518163e8b31f04d4d6
+#: 4fae35a3e601428fb0d5cb6a5576e689 6d19c2e539b046e2a65a95f58811ae55
+#: 71064fa6473448fa8dd1ed3ac05a9014 77fd31f69db046a2b2afbf41cadfa4e9
+#: 7d58b75ed6e14704b99672739ee055a8 95a7b6d1b07b4f4ca4ec790949cef833
+#: a1115505bc4540fba956f27b9763a224 ae1b2cf7b2cc42f5be1e11470282e41d
+#: c61aeb180d2b4962b91d4be1bbc6dcf8 cba99010a43943e29fdbd132e2b137c9
+#: cff17c50bfab47219bcb0e495db39686 dc7139e9e591402faf5bc2860388767d
+#: defbaf0881a848ab86dade396a63a1ef e2ac33b4b40246b4a2d350f6ed5ee864
+#: fc404102da2244c09227675809014a23
+msgid "SIGNEDv3: add a linux-generate ancillary package (LP: #1989705)"
+msgstr ""
+
+#: ../../22.04/4.md 187aac15c18745838e143d4f0e536c6e
+#: 211f6ec7265743a4a2abc0afb4dbf88e 269b73430cdc4b9d9c4635269501159e
+#: 2940679d465f40faa8bed4cedb23ddf1 62f4bf4990374e079b6563bf77f984ab
+#: 65271698b9ad4cd2bb1a3597735eaebf 6ffbf745da28416b8ad866636856e6e1
+#: 7b2fb4b900df4ba79a02663fa8cddf25 7fabba89f0604280805c3e7ead38f197
+#: 80cbba0b8d97495c87339ce33074dd5c 80ed925492354d6cbff069abcb9e56a7
+#: 826e176ec0da4d9c849ae039495b48d1 8be46a20633141f5a5fec4f65ddcf147
+#: 9810cad9a196446287fe10bfb98bfe2b a668f4a149764a038a81fcf9753090b6
+#: c005ba67289f4080aa902044c9e087f5 ca27057533494f1681f900dd7eca5297
+#: cdad22b216c142c4b216e4f3beea3d9b d4c39e4056964c2e8c0f56b00f97fa79
+#: e12773582d25460e8696dff83e378daf eb84ba24d07a48df980bb83a844814b5
+#: f33f826b41b14b38ada5ff64de00caff
+msgid "linux-restricted-modules-azure"
+msgstr ""
+
+#: ../../22.04/4.md 0566c31045a945c4af4c565b13787b1d
+#: 164d9e9a8c844f65aa9d241db06aeb35 1ae3bae83bae44a9885dbc27afa923ce
+#: 1cfee65ace034672955f3adce6642fc7 1e2799eb3fb040edac4523bab5a89b84
+#: 22b61f8e7c6b41238418ba95f6250bdb 238f006b90df4463a45c7d2f8b2d1980
+#: 280b30ae83c44118b779d893434f7836 2aed1c1ca25549f8941db4aa77e0b207
+#: 3992e67e5fbe4ac7858b25ee69a927d2 3a12f87dd9544d35b57c131aa44c05ba
+#: 3bd29ce669c84c86912e9a074b3f5ec1 3ce05c6ccf7246df83d5baffd93a0d39
+#: 3ff8ae10e6de42cab6c52e54bd3e535a 43a5d4d2b8954fcdb9316301bb567916
+#: 49e1c346f5b44976b92b9526276731c9 4c06885ba43e4074ad21b31a45822b4f
+#: 4cf2e96e07c84a45b641309f61ed9819 504cb5e1db9e48a4ab9700c2dc021de0
+#: 52741bb3b1d94903bd360c29f9ee53ba 588ea648563442d39824096d16cd2f52
+#: 58d7637b3689448eba6def971454bc35 5fddbc8de4c44544ae286fd5bc7053bf
+#: 63f7e14ec2e94b6eb7ebb757401fce5b 677410ff0a744f5988eb729ee260ed05
+#: 69c0f613a6604b959038cd3ab5cc9239 69d8406c251d422481a217d1c8156a23
+#: 6f841019381a4240a54f53d0fce63917 710f9cf11dec4aed829c181e8e7118ab
+#: 7349c830fb104bb0bf356840dbb6e422 76719a46e966415bb68f492cfbfa93f6
+#: 7715771f88b047edb4906633e94429cf 79bbdd3758ef4207a3ad522789286391
+#: 7c7a24c185434b56aa3c6d205818824a 7d4a8788704b4df4bd3616e7fad3c75c
+#: 82820201302248818d75abca2db83cc9 85186c34ab9f4c0280fed18788063530
+#: 85a35a98b5434307818e78eb54a8ad5d 93972ccd223d4c3299c89e27fb1b3821
+#: 947924e734094cd0b15cd9e155fb7f6b 9992854f1b95470aa306e0de8925b588
+#: a0a64cbd072b42829db412ba8bff44a4 aa5da14570e948adb4562deddd150509
+#: ab88c5c57e7a48649864a2ed8b332e7b acafb976bd174ee89cf6ffd846c2fe10
+#: ad91c58681ea4f088f914875742e73d2 af7f311005f44de1bfa15a6e928cb6fa
+#: b158ebdae6234cefb0f7eb4c06522d39 b756d0845433460bab8ce6a4dc52ab5b
+#: b8a18272344c40acba4355e99a15c3e1 c4eaad1f80674cc8a2994e8657f3ab09
+#: cab11b165cd94987956dd9b7d6017ed4 cca470e63ea6430bafc980f2820056ca
+#: d11766ccba204454a1a97985046e7315 d13ae06c91e54ed2b4ce061d283129ca
+#: d317c98a80be49649178c6494ae6d1f8 d97a4f16871442c2a8a9a096d43b9475
+#: da6ec8933438466889210ed904b152e0 dce94256633443809ecdd8a6283fb8b5
+#: e1efda96eba84b0a8ed7ac79883f7b40 e6f58e6ac5c6441197d5941c86481fd0
+#: ec1f447f727445a9a6adeaeb2db6ebfd f39919d11c2847eba2a53878669c65de
+#: fa08eeb4971f4c2da1d7f9c571d256c8
+msgid "[2019299](https://bugs.launchpad.net/bugs/2019299)"
+msgstr ""
+
+#: ../../22.04/4.md 0759bbc5837a4acba5c828a1e72731bc
+#: 1099b94d565040bbbf6de9053d47d144 113989cae57d44af85e39a0b6f22d15b
+#: 139220aecfdf4f58a53fbb68ced8762c 1785068fbe974cfb8349ea5682c281fa
+#: 1f985998cf6e4a35812254c4ba7c173f 22c674e04d404cb39ce1f3a468981963
+#: 24bacbbb9294450d9db924429fe7a4b5 29e0dc1c9bd1402a8e3f406f15314a05
+#: 2dcaabb67bc548a7af63bd8ee94fb6cf 2e842b825d3c4a2682d7d6b4d17e51a0
+#: 2e9bee63ae0f4aee9449524cb6daf8a5 30c4d477abf546968a408bd2ee412754
+#: 32687880cd89404f8bd78dee76f91513 359a97bdcd8c496cb45fc2d1e62468c5
+#: 3abbc649d4284609bc6c7f5a75095892 3fff9872f40646af8f9851e7c9b41b9d
+#: 422e812b5e7241549e5b23a285b16b10 4da5112d28a449d1906a1e62fbd78583
+#: 5456d58fd70643e8bf4e2ab464dc13a0 54f3e9c9c72c4b679e98dcb3da4415b4
+#: 5b0f271e4ad548dd8fe5f7713967b9b3 63116dff3b0045b8b657294820c668c6
+#: 634f728f1a6a4876b2fd935b2a3dffd6 636c4786902f46239b5183cbfd767b9d
+#: 67c3eb3e000e40169f464653ee842df3 688f95da00fe41c3b641733d60998b0c
+#: 6b935e636e104f6f9a1a13971c6271bd 7199fe0ef82c47a6833d5cbf1d9aba17
+#: 78d8f2bd07b44de09089bcb468c24e8b 81dbf57cae9448aa838395738f9a8324
+#: 8b6f16a7cebf411b860ecec920b3d538 8b7613f9b365416d903f4d9a1a583650
+#: 8eb69a4c26cd4591932cd12f87f2e6c9 907c0a9513fd4e5e8c2f914a917f923f
+#: 96e7cfad33b0454585d8352153ea779f 994efe71e348424c9d57f4b3a7f9bf1a
+#: 9d699f670e854188b6b2279711b6c3c0 9eddaa5f0a204fc19d81af02ec86a05e
+#: a45f4290559c409194dcd6a874c0cf9a a5ed5938555c4793b12f87453a29be09
+#: a64222a135284c089d21f67cdc05fee3 b74a8a80d2c14129a93486e52b0d5c28
+#: b7e3a0781de74879a79059807a1e14e8 b8f08c3cd04f47c89e85a4e0d856a0cf
+#: c337f8825edd4002b3bd094919e225ef c3e90bca5bd2484e8012e477cf5b8caf
+#: c4350c8952584fc09176c1aa98f99e6b c95dec5eceee45f88736ee6702363f92
+#: c97defdd4c8347e794e125db9c4af429 c9d2e30fd33f416fbcc82c409de296b6
+#: ca879b32ad0e43e883a9a43d8c09da2b d740afe01fbb432cadc0158a922dbd46
+#: d7cb8be59aae4bb282bb4670ea2f2ba6 d80664d148f7452cadfca793d61fc461
+#: dd3f55f75c274b6382d347c400535ebc de9259411c314364904ca10a6ddbb336
+#: e95975623d0e4d6d94ae9bc1dfab667f eb5e4871ebb749b4adf53f553a8bc41d
+#: ec55b681cfcd4978aac991f6e8b0c6c2 ece942a5884344bba1e90c23dcecd397
+#: ed0efe1c19824c6c9681e7bb5788064c f354d470fb354723990feb862f34265a
+#: f802655bd53042b0ad27c70b7ee8dc0f
+msgid "standardise ancillary naming to simplify backporting (LP: #2019299)"
+msgstr ""
+
+#: ../../22.04/4.md 0a1f2666c73342598c94a6410b357d7f
+#: 14fcdf3c3d134b6fa7105e03f5ccffa4 21f29eb3b940464ba32a38178f7106c2
+#: 24a5cc9271d8434fb2becab39e3a8dc3 35e008c4f2434ee0a68ed8a321973698
+#: 5d09e677ca75470e892832a67387f883 618de434cf4b425a8024ab42215790c1
+#: 65ca610c61ed426fa1a55d05bc9c8248 8e2f36b9e15f4ae9aacba07e29ebaa54
+#: e52d8585199a462082358d2a8d20e712 e62ba4f07921481696be168339b256ba
+msgid "[1988836](https://bugs.launchpad.net/bugs/1988836)"
+msgstr ""
+
+#: ../../22.04/4.md 0c766a2c77f14bb8ad8a4943da3bdf2c
+#: 280a3d7859ae4bb3b6c4d7767c3de736 5bc37fc532034fe388dc32c8daf7c343
+#: 5cf71e9b4dec45f08419bb632b3fa459 6ec830c31cbf4934be090e5780cf31a9
+#: 94464fc5d528420ba60abea57d5f90bc acccc838165d4110afdd57b8107d702e
+#: ba43168c1e064ec980b3e6095e2f4b71 c27df27b54834481bfb45873fa7e6a3e
+#: c30255f99415496ea4d2432e4747747b c6685a9f2bd041d38ae6f441a95e2b94
+msgid "LRMv7: Enable the open NVIDIA kernel modules (LP: #1988836)"
+msgstr ""
+
+#: ../../22.04/4.md 399ce9fe675748e29d3bb8f43d187262
+#: 3b87044caf984e1d8de2187758a8949a
+msgid "linux-restricted-signatures-azure"
+msgstr ""
+
+#: ../../22.04/4.md 1dd6628ae98842a288afc7b428e7f5fe
+#: b6fc8b8ed92546f38c47158b0cf3b5fa f4893f379af44554b4ebbe09273d765d
+msgid "linux-restricted-modules"
+msgstr ""
+
+#: ../../22.04/4.md 88dda75ba27745928add0a24a4fa164c
+#: dbc3aae7fc3642babc4edbbe0be63f7c
+msgid "linux-restricted-signatures"
+msgstr ""
+
+#: ../../22.04/4.md 02cfdd3248c44428aa25dcb905f7c943
+#: 047b8b2792a74d5881c97e5b8047d78d 049bb83b5c22476c899a5452751be17c
+#: 05a4fc6bbb14419b85608c477331c288 0b4f9c6d48924b9099109d155813022c
+#: 1b274431d6dd455386d28ea58881ad99 1d7022297f2b4a658bd74963ecd1f49b
+#: 1e1d7f75082d4d56b29b846fcfe0e30a 21b08bfd44984290b585bed14a50dced
+#: 27adb31342d042d5ba1cc4d14ce1c4d6 2a96b0e01b7e46d99d088557bb0adf79
+#: 313c4127f9a746bcbe2835c6b0b8a983 33b8293b50614540857363c6e33e6f2b
+#: 351f75a06eed4750990dbaa576b5bf35 3584ff5888b34ae3a4007968cebdcf4c
+#: 41402369cedb4e0194a274b1a23605b1 4224dce7c7914b8c8cff2720adf5ce46
+#: 45d4f97fcafc49b2974a92b31534c088 480c14d636984fd08f6bcab3cff0cedd
+#: 498a53512f1a42eba9102755113d388f 49ce315ccec5479486d81049a2c310eb
+#: 528504e60f6d42d1bd974d31a437e1e7 55d842c1471a4ea996e104ee722f01fc
+#: 5cf8950396f64f8cab1f4d8b7185c352 5fe7fae78a8b464e86c33f034723fe7f
+#: 6421c5a2478043cea8e7896386dffaf3 67fe72a752024136a05c34a0ededbc00
+#: 68486a9eab904315b105b981d08f3ace 6c4f731952fa452dbb14f1e1d99b9cb2
+#: 6df4d5bb941441019b8da55a1fba573c 701c05ab27234f7c9f16abecc21b0dac
+#: 784d609cb2604107aa0ec966016dbb4d 7b7a895be4984360ae40b5ae8bb53d06
+#: 81b6ec91ec7e420397c8be80b6cdbae6 85bb68de5b00415093500579994eb084
+#: 8773e3123d6a4cb4a698bd527586bcfa 8cb73d7d267c407598eaf6eb3d9d7b98
+#: 9129eab2776c49cd98715a97f6d62705 93eec92a88b64bc08ea05c81e66ec1af
+#: 99d4b6f7a73a4008baee754457063337 9c729621734d4c26b7e6468769079e43
+#: 9f537f8be1d14c9c9b648cc305cc518c a769c7eccce04aa58df16f867f93ac28
+#: a8185f6abb0a4d538bc5c8f4c1d40790 a8c68c3227a54d0b97f842f49c107a75
+#: a9513ab6b9274881a73132d02f250a22 aac5026b46304809bf9d1e8b6c02a851
+#: ac1f796343934adeb62e7da52f9fe6d7 bd0f33d386e5411781f7a5024aeb10c9
+#: bf28d121af5c477ab5a29e550ed32fe2 c205c982548b49d69b6c263766ee8642
+#: c2a73392d7ff44eea93455d4b37607b5 c324d86bc1fb40de9e1f61dfbf284971
+#: cd3dce5819b24f4a9eea5129ff07ab10 d0045d45a95646659bbdbca3e66380f0
+#: d0c8356721d94e41a3ddc3f015ba6f55 d40cf7972ab449638e63e9562609e250
+#: d6738168b8374c898f5b70f36cbbb5fd d83992b1c6c6459b8d8790cda6c2e259
+#: dc428d429555447d85b61a2ae231b45b ddb96fbebbab4d7fb9edbb3c22f96477
+#: de079697d21b4bae9b081fda08c07b9d de810090a71f40d98824defb234dff01
+#: de861fbcf934421d9c75c7057572c960 dfc30a97f3d643abb1cde7bdef20b275
+#: e2c106dc152740819d42dc29ad2e46ff e41a4a02c8b54836983e5b2bafa11fba
+#: ecd59805ce584a2aab4bd802e2b64b71 ed3e9e42d50d4780893467151a6b3be6
+#: edb296fbf2074e7caeef44cf58554d02 eebc1a0df3214c9f9794b00bfa33021a
+#: f5a676b91c904938a531f59c252482d0 f771e8dae239427a9f341339f5b8f57d
+#: f96d64939a8049f59f49accc748475a6 fa421b7d2f2c41e5a0c63cc4430a9c9e
+#: faba80e512244c3eac40ff371823cd9c
+msgid "linux-azure-6.2"
+msgstr ""
+
+#: ../../22.04/4.md 3fa5383badca4c5b9b5dd2df80e85f3d
+#: 4f90ef8ab4ff451ea15fe828db77b862 70fe48f6f19e41d7a46f22af7e2caa03
+#: a7c5361b05e94afabd880a9f80b4dd72 bb0caeb380d945d8adc70f441f0c3a02
+msgid "[2024049](https://bugs.launchpad.net/bugs/2024049)"
+msgstr ""
+
+#: ../../22.04/4.md 0055f8e208ce460cb050ba3fa4aabbc9
+#: 3997fc3bcd864a5299fcecc803760134 3e599a0c002e47f8b441d8b68d3b2efd
+#: 65f07c7a89704a418a05d71fb04e7052 86642539a3194c8b8582fbc0c5f25142
+msgid ""
+"jammy/linux-azure-6.2: 6.2.0-1006.6~22.04.1 -proposed tracker (LP: "
+"#2024049)"
+msgstr ""
+
+#: ../../22.04/4.md 6c83dbfd88be45bbb5b94b78482d5d9e
+#: 7635f19b967c45adbd62541e1dfaed98 b42a4be8507345baa273da98e9099c67
+#: d6fc338c2ee646e1aaf753efe958f4ca e0429e8db70240d0a54c24b3b3952ecd
+msgid "[2024058](https://bugs.launchpad.net/bugs/2024058)"
+msgstr ""
+
+#: ../../22.04/4.md 3c1c638768604ae7912b0236678ca51c
+#: 61d2e249bd854e3b97beaef3a514ed38 8053d4603f034e7aabbdbcb356133470
+#: b7b75794ac174e5dadb17373d4d8cdd7 cc885530d288478cb1f610c504d79199
+msgid "lunar/linux: 6.2.0-24.24 -proposed tracker (LP: #2024058)"
+msgstr ""
+
+#: ../../22.04/4.md 4a29cf0e5a42424581ff1b7d9b457743
+#: 53288217d92e4d3db10a8d5c24fcfc29 ae9ae3677616475583646c30634a3f72
+#: f92bbf9b7d564bafb1e9c2a8eab2d7cb
+msgid "linux-restricted-modules-azure-6.2"
+msgstr ""
+
+#: ../../22.04/4.md 332b2f9dbc0e4c1ca894feadf71ed344
+msgid "linux-restricted-signatures-azure-6.2"
+msgstr ""
+
+#: ../../22.04/4.md 05d5b1b4284549a2b41731a78095d939
+#: 0742e9542aed4078b2f2a75bb8690d94 2446a1133af948cd901a74fd75b4b2b7
+#: 2fb1086547f14b75ac9baa050dd7aadf 43cdc65e0cd14fa4a5c93587525c123d
+#: 4692c42a5ea24093912a83c888608b83 523ada2e135d46cd9a4066b2d852f573
+#: 52acd251727643aab7d1452bd4542cff 53aee84d8b954ad7bbad61b0ea3bb3a7
+#: 6abe84f5bfcf4bfbb35fb984b8f6fad2 97b3d636668f4f8e8ab5f2fc8ee79031
+#: 98b250a3110c4b57ab97721e113f58fa 9b8c6aeca03445c5ae7c118d27e43ad1
+#: a9ca31360dbf4c9fb4e791880e3bdb6a ba93e71fda434aba8fde047e241009d0
+#: d57a11c109864e30bd7c92e35d9e9c9d df3fde85d1db4214b3960e85b3b0feb5
+#: e425a1551fa449d88e90e96ef06989c6 f3c383f35fcb48e2b5fcb799c1212d9b
+#: fb72562d6755456f979c9c6f912d2c22
+msgid "linux-aws"
+msgstr ""
+
+#: ../../22.04/4.md 2b478257828c45fab3dce697d9f2de5b
+#: 5142e8a1ec7a4c919d4aaa80ade82cb3 538e9b01d0d54948be31c2da6a5cbf6d
+#: 6a22a4f9d4364403b9bc6ace9dea4fd3 6f7106db75454346b8dacb94a1274058
+#: 6fcfc16a5e0841189ca062366c5ea6d3 aa227c55727042859beb0b449e12a6f2
+#: af3d26adfc764fa2a6e262617fc20982 c3faddbc099a49a4ae43f4c1b0bd0b0d
+#: f2a7af858419499bb0911887f739ec52
+msgid "linux-signed-aws"
+msgstr ""
+
+#: ../../22.04/4.md 0b1ac62086d44b7ebab68430c43bc37e
+#: 10a92568689f4ea1bd924ab2a4a7f336 13c58662bc60484b9073ea800a44d14d
+#: 154129fbce88450281bfcb75d361b9d2 237b364da0c24750a55e98551c15adb2
+#: 3150c14814914ef78d6876aa3f8017d2 3665d902e8704000a9fdcab2ffc14151
+#: 4c90a8f212b44f8c8fada238663fe82a 65f3c6220f09488bab35a32e0d3b20b3
+#: 771fbd3c9bdc4819beb44118fbacb776 79ae70aa94bb4e839951a30f2e4ae0a2
+#: 8388fa9a781b48c3af83824f5d456524 95829a0518c0415aabe77ccaf9bb0df4
+#: 985c9e24c55e4061b5f25c2cf1e191be a8f0be8293f7430aa10926a1502bb667
+#: b107a8df998b474789691d2dd4c06af8 d2f2fec0f91c408cb1b9edfaaf585fc8
+#: dfa5a9e47f064344b85066e57cb1a124 e752be6afcbf4212807c7a8f23aa5f3c
+msgid "linux-restricted-modules-aws"
+msgstr ""
+
+#: ../../22.04/4.md 0286588bcb204a97b42e8b36e95438f9
+#: 149dbe86b62e410aa36dbeffdcd7a2bb 38229869352345069edc29999ba6a61a
+#: 40a25b984c354594b369f67287e95ab7 a685e41d1f714fc4a13f33999ed0e872
+#: a943631e814b46bf93d320eeec7847f6 bb20ebf278834dac8722115915505e5e
+#: bc1a467b0f744205ac4131a2e470d392 de2f53a860644672bbd413f9ca48597f
+#: f94ea2a65f2d47519d7689c60120ffb5
+msgid "[2023695](https://bugs.launchpad.net/bugs/2023695)"
+msgstr ""
+
+#: ../../22.04/4.md 0a3a1b94391f4b22a679a6cfc6f23a60
+#: 1553f71a18eb407c984ff875f4434a71 2365eb0fcc564d7d9853eb857b80c3b6
+#: 3f33801551a440fa8acae54b1a86508c 6fbfcbc0110847b9b11ff0b495471db4
+#: 82e7f3b2d5bb4cf48844776c4e8d8cf1 99c2050305fe43d78fc28d1e7b8b1a44
+#: 9ba18f3626be4dc3a65ebcec057a9fc9 9d735078808e4fbf803d46c1ff8e91de
+#: e4805dee9e534d399f67659743d1d611
+msgid "Azure][MANA][VLANTagging] Support for VLAN Tagging for MANA (LP: #2023695)"
+msgstr ""
+
+#: ../../22.04/4.md 0ed49cf51b504726bc733b1c3c6912ae
+#: 23b243e881ae4680b7e9a85cfb7fed7d 3cdaa031cab341948c0dd111262a18ed
+#: 4671a86332c74b27a7b9287208595cd1 4e1eafc1d16f455bb0b4b0b7158cd5c8
+#: 5fb7dec220774fc4b944f13f19a410d2 80566b0ed096457ba679696e6d66d4c5
+#: 8ac22f06567c421483380559287c0c13 8fb6901ff4d04f78bb58c551eec2753b
+#: 942c58da70fb40bb8aad6f84ae55fbc0 969c468d515643109e576b040c727f4e
+#: addb5fe693dc4942bcd7dfd4ac18e1d9 b0a29b081a704c2e828e9c12de474954
+#: e216715631684e38898104b8990c5799 f64966ba5d96418c9ad65f3b38add2a9
+msgid "linux-ibm"
+msgstr ""
+
+#: ../../22.04/4.md 07d71b966dab46fc801d2ee6e0db1673
+#: 1151c8663f41469e9e89cd3ae9eac753 14df707429a44bc29680213ea5f81d91
+#: 1bd17224cf914017aeae5f14307a0384 239def58bce04f3780d76bf67f94c14c
+#: 2587a55f536d4b08bd38ce453318618a 3110aac24b9342c483518ea5d2ba3499
+#: 342d454cc00945bcac51dca975570102 3dc3d5f1dda44767bf53042c21b1cadf
+#: 4124757a4b4a455f98a65141122190a3 4b1c900080e04360b35a03b5e7cfd371
+#: 4e88126f316e4082ba18a10adb273277 51697fcef0a7432797ff8c24a0d7a1ac
+#: 5db8f77c8ffe42a08f9d8671b0feda9d 5f5ae8b2a5f547dfb1e97256fd2c282a
+#: 72787dc6cc364b0bb454914aacc2cee2 7813ee40685a4577a0d9d049a598b69f
+#: 8ea07e0426374784888bad1916823739 b0fcdedc0c8d4e65b87ba3f85332ae4c
+#: d56f13b28600444bbc4277351fabf845 d91be46ffbb64d57aff23899ad299ae0
+#: e687f57881e44b8784883b53f978c3a0 f46b301748c14571844dc7c2479b7f05
+msgid "linux-azure-fde"
+msgstr ""
+
+#: ../../22.04/4.md 1af4e140a902409e8bd92719c3b87f88
+msgid "[2029290](https://bugs.launchpad.net/bugs/2029290)"
+msgstr ""
+
+#: ../../22.04/4.md 030ca637cadb4f38a1095fddc9d20571
+msgid "jammy/linux-azure-fde: 5.15.0-1044.51.1 -proposed tracker (LP: #2029290)"
+msgstr ""
+
+#: ../../22.04/4.md 00ccdf7356074448862ecacd4dbef279
+#: 1ad57677005341b0a5b9bfa728f654ed 3b140d51faba4662a873de888c6af374
+#: 432750fc4d42477ea357b9b8c10eeccc 469b4199f66e4de58df30cdf4c53ba74
+#: 4cd2077778b2467b85204c97fb0b8dd3 6c6c27a4de0e43a3b22175fc703df994
+#: 794540f10c1643f19bb265b39d007e03 933ccf01270a45f4b0888a575b2baebb
+#: b968e21fc4e04cffbe995ab2ca3ae448 bb98dd7ea6db48729f83f93ec84d4497
+#: bc307aa0f01c4d62ab768ef31e7d14cc c2664b0075e34968a2597e2d18780498
+#: c864cc618ce246af835e1823d87c2921 d20334f9b6c94656b0623a306eb26da4
+#: d2cb005d01a240149022530fd7bd14e9 d81e615eed744508aff3bb7dc90a65d6
+#: ddca3324f4cf47ff84305ecaeffd31d8 e6a948d4895d46adb29221cb7dfc6bdf
+#: f857ea03b5df4bf2a91a5c3b9b00251d fc8b498e5a8d47479a2a50b313fb1ea1
+msgid "linux-gcp-6.2"
+msgstr ""
+
+#: ../../22.04/4.md 72ce96535d5140ae82cd450707c75655
+msgid "[2026477](https://bugs.launchpad.net/bugs/2026477)"
+msgstr ""
+
+#: ../../22.04/4.md c709c1912af2447bbbd5a28eb9b39ac4
+msgid ""
+"jammy/linux-gcp-6.2: 6.2.0-1011.11~22.04.1 -proposed tracker (LP: "
+"#2026477)"
+msgstr ""
+
+#: ../../22.04/4.md 30df7fbc82b64bd6b5bac9231dda0ea1
+#: 48db13a6a7f2451bb3435a1f07ab511c 5ee08297cc084ecd99a719e9b2e4d219
+msgid "initramfs-tools"
+msgstr ""
+
+#: ../../22.04/4.md 0666a72a31774fb3afeb3476959a1c0f
+#: 5cb8ea9d42d14eb5b7118ec84cdd0c09
+msgid "[2027636](https://bugs.launchpad.net/bugs/2027636)"
+msgstr ""
+
+#: ../../22.04/4.md 1cf260cb8b67488c8b2e5790c1c569d1
+msgid "hook-functions: add stusb160x kernel module for Tegra IGX (LP: #2027636)"
+msgstr ""
+
+#: ../../22.04/4.md 008a57d5514f4c68bf481293bfaf1623
+msgid ""
+"Include kernel/drivers/usb/typec/ucsi with MODULES=most along with other "
+"USB storage drivers; LP: #2027636."
+msgstr ""
+
+#: ../../22.04/4.md 7fc83ef0067a43bb9353357fdc92872d
+msgid "[2027575](https://bugs.launchpad.net/bugs/2027575)"
+msgstr ""
+
+#: ../../22.04/4.md 17b0da64f4ea47c580140dd11ec9009d
+msgid ""
+"Port the net autopkgtest to the common test framework. This drops "
+"depending on downloading a cloud image from the Internet and reduces the "
+"execution time from 3:19 min down to 0:57 min. (LP: #2027575)"
+msgstr ""
+
+#: ../../22.04/4.md 037c66d9b2ff47399335805830ad9545
+#: 090478afa9d04212bcd319270066ac36 0a04a1b22a7d48c6a3f80b05e4e545b4
+#: 0e47e8a30c204fdc9eed6ed657aea494 1c3363c12504446d9c46e9bf76a9bfd9
+#: 233f80df34214bc9b4289b25571d97a8 343a13c92c4f447681d2e66d41fe72f6
+#: 38334cc3e97842e5a3218849ec74475f 416ed82829c14111ba4ca80e570790e6
+#: 46ef7a3452324fa0b34f8409f791ece2 48923bee88124858804f3c265a0733d6
+#: 5ac2e649cc2943bcaf3ae0ddf93b5e9a 6678b6e1d7f243c78608b5cb99cdc120
+#: 676b767e671d4380827013e60629931c 69b9db663f9e401e8f04d21128683439
+#: 6acac91b3b1f4b60948c0b6ac34de4f0 78da40fdc82f4e88b27b7764f5d8665d
+#: a35bfdae6a0743639a86b5db75169647 aab7f251a1014a338b2944b5360a9819
+#: ab160a5b01ed427893aa2f4d62868744 b87d75a6b6734f2c9f5d0fef50d159e8
+#: d920ee5134b04fc2ad1439b8e01f308d e139e9175641461f9fa7b6f97940106e
+#: e2cacb027f714c859c305e5539ce6d37 f27cf99533ae447aad5ec2125dbe730e
+#: fcf5b2ec46fa438c8a3cfd8fbe7a040c
+msgid "linux-firmware"
+msgstr ""
+
+#: ../../22.04/4.md 51e933eb15204dd097fc31ed39182d2e
+msgid "[2029384](https://bugs.launchpad.net/bugs/2029384)"
+msgstr ""
+
+#: ../../22.04/4.md 912cbf292f754839a2edfc9ed82524b7
+msgid ""
+"External thunderbolt3 & built-in monitor black out on AMD Ryzen 9 PRO "
+"7940HS w/ Radeon 780M Graphics (LP: #2029384)"
+msgstr ""
+
+#: ../../22.04/4.md f0bb155ffc2540e9886bc1ac80b72f1e
+msgid "[2027959](https://bugs.launchpad.net/bugs/2027959)"
+msgstr ""
+
+#: ../../22.04/4.md c5ef572e643744e5805d6488efdf5110
+msgid "Update PHX GPU F/W (LP: #2027959)"
+msgstr ""
+
+#: ../../22.04/4.md 28018112915a4c5a95cd880aa9b6a3e2
+msgid "[2029377](https://bugs.launchpad.net/bugs/2029377)"
+msgstr ""
+
+#: ../../22.04/4.md c9d299cd71e84310a447ea6af1dcbd5f
+msgid "Include the RTL8851BE support (LP: #2029377)"
+msgstr ""
+
+#: ../../22.04/4.md bd0e4199b2c944eb880e8a896d7a6b4f
+msgid "[2029345](https://bugs.launchpad.net/bugs/2029345)"
+msgstr ""
+
+#: ../../22.04/4.md 74d1205d83274953a27687464a9b276c
+msgid "Missing DG2 HUC firmware (i915) (LP: #2029345)"
+msgstr ""
+
+#: ../../22.04/4.md 8a34ed1e8f974b44a203d9aae500741c
+msgid "kexec-tools"
+msgstr ""
+
+#: ../../22.04/4.md 38ef7becc6fa4eb6a9f987ab3d3891e9
+msgid "[2030476](https://bugs.launchpad.net/bugs/2030476)"
+msgstr ""
+
+#: ../../22.04/4.md 14bc4d6da80f46619257fe1c142fd203
+msgid ""
+"Add d/p/lp2030476-s390-handle-R_390_PLT32DBL-reloc-entries-in-"
+"machine.patch to fix kdump kernel load failure on s390x. (LP: #2030476)"
+msgstr ""
+
+#: ../../22.04/4.md 070b8bfa76e647f4a7432a9258f382a1
+#: 0ff02b935ad945cc95132dc7ea4d3837 1537b1f252f942c8bbd62757f19a1bf0
+#: 163fd51bc3e745269108ab8d99707ca5 22b4e86544f643d0a3b45d1c4cc2cc57
+#: 2b925973765c4f9d8e4a8d46c65b6e88 2cf75128c91442949740114c4eedde64
+#: 2f0d43dd831a48c49889938855ef0d51 30b0f54fb770413bbb0c1e74671d0ae3
+#: 34707e6e61aa470a835543d63f91e9ad 3fc94e196ead4804b8ceb85aed7e5ec0
+#: 4325a23320554c44a03d22d1a04d6eda 460b496b63f44c32bb53994287c6324e
+#: 4e91f1f67470401dbcaf0c9a34c64b55 55bbba8be90649afbec9999e111a5017
+#: 587a0db90e5b4a6482b6c62a6e37d608 5e81206694514e958995e59e7df76429
+#: 6101b3386f1f441d8d0e8b549c822b1f 6796a667fc1b425bbb2a872761cab420
+#: 6f5d6628fae64c50886f358a1edf44d9 7023756208d649ffb36f5828739f0953
+#: 823ded23d78a460f81870ce9e1ab70ad 879b96960ec7468abd5c9de1f0d86355
+#: 8acb8a1dc7694cfdba10a5c0baba22d3 8b2b966e382f4308991c4352c76b7cc7
+#: 8f99bbb2181540fc9e3f6def29c10a03 a27ecefe846940b798b5ba86c283da3d
+#: a445bb3599cb4d76aaff258d2cef1114 b1433626d87041659022f63318b77d40
+#: b68d5b8f5f48452a905a1d3f1d7a1ff1 ce334b29ac6345fab81768bc634a10c5
+#: d21dc3efed754c68922b98826df7c388 d3a1864eb76a4e3080c3e81b82e62abe
+#: d9bb24b7f0e5472cae0474ca762a8967 da1e7e1395a34ddf86b4a922be98c209
+#: dc6f88743cf84b14afe27a9ee6a542e1 ded12e454f2a48868525f8ae0803257a
+#: e2c8602968854e6fa4750e4dcff25bac e962ed446b984096b8843f93b516da53
+#: f036366a96af4a739c08c14c271c83db fb640c12de364abca9a7d4156730380f
+#: fbe57f2399c14d12912ce8991270b269 fe11510a4b794523af63803a19a8bd65
+msgid "linux-azure-fde-6.2"
+msgstr ""
+
+#: ../../22.04/4.md 205b8992a68043e38993a9aaf52d23ba
+#: 3de23c59024f480a9ff6ec7a346bdc41 4581dc61bf744f1d85ea3c5686b9a1c7
+#: 9a143e751e344b30a576d58dd3177728 c11a5d6052d549cb94a81ddc511a283d
+msgid "[2029293](https://bugs.launchpad.net/bugs/2029293)"
+msgstr ""
+
+#: ../../22.04/4.md 562e7ae1e5f140c78918e04939ff1158
+#: 88a7b67fad8f4639bd26470d05857f4f 97d59186280e4e5ab3542622b3741ee3
+#: d9cdeaf8eecf4f8f94ecc859788952ee f3882d6372dd42c4b073e573c2ac6046
+msgid ""
+"jammy/linux-azure-fde-6.2: 6.2.0-1009.9~22.04.3.1 -proposed tracker (LP: "
+"#2029293)"
+msgstr ""
+
+#: ../../22.04/4.md 1ddcd99320ff46d8b541a5b2dbc27b98
+msgid "[2031901](https://bugs.launchpad.net/bugs/2031901)"
+msgstr ""
+
+#: ../../22.04/4.md 7386b3b6011648fba62832bbb107c640
+msgid ""
+"jammy/linux-gcp-6.2: 6.2.0-1011.11~22.04.3 -proposed tracker (LP: "
+"#2031901)"
+msgstr ""
+
+#: ../../22.04/4.md 0898dcb31a8a4a0ca2a58f1faa4684af
+msgid "linux-restricted-modules-gcp-6.2"
+msgstr ""
+
+#: ../../22.04/4.md ec111b396a034d3c827758e1e83e1969
+msgid "linux-restricted-signatures-gcp-6.2"
+msgstr ""
+
+#: ../../22.04/4.md 0df675ed892a41e2ad6dab5596fcdd7e
+#: 143236e4903f4c0b944f88d5cf4d5b8b 25c743ece7ae48baa10f8b112fd60c2e
+#: 370f804e94c342a08b196e3c660deab8 4e9febdd883b4148b87b731eb1c211ca
+#: 550e97bcb70f4dbea42d9c82e594ef15 6039f7e651ed49d793a181782fe5de3a
+#: 690b1ca949f84ef9a355475b1d3e4202 6ab787f96f1142a797bcb4ccd0a04f21
+#: 729fae0f0bd44981b08ca40541270bca 830805d5b91a45809d07fb21bd483863
+#: 990750998233444099b71e1f1c70b29e a5b24e4a70484d44be99469ead0ad645
+#: acf58a9d4b35472c9a97058a2a8ebc2b b0ab5887fcf849b2930143b00907da8e
+#: ca1605eed8d34f22abad903c376d98e2 fb6791707bc648768559cfd93cbbda15
+#: fe710ae0c93e4e0c90188729dff7bb72
+msgid "[2031147](https://bugs.launchpad.net/bugs/2031147)"
+msgstr ""
+
+#: ../../22.04/4.md 1dc359b01a044e3a9b5aba785849c46c
+#: 1eb4210173c348a293e48667b37dc30a 22918a242770460580b098a76d15c2b1
+#: 4f6c02db53c448979f85f3fd3a911242 664458561baa464fa64c57ac475b674d
+#: 79322f686f7f4c68964c85b3ffda5bab 7c2645ba503a4b91a6ee4540c5ad21fd
+#: 7f3fd426da624418abca0f65abcf2a09 8880377644e34838b1ed8e44b9c55941
+#: ab3331b243274778ad7a2ce570f3fc9a added4c12b4147d3997e026bc2efcff5
+#: b656a473782347b6813a609cb2c09090 d66d8aaa5d73491eb81def132ac247be
+#: d7a1f7c66e664f8284db4277675f6f9c e8dae06459f240399a2450f14ae4b710
+#: ee121b187e784379928065bc82f7c855 f877bd093c0243988865b0c4e66d84ab
+#: fa66a7fdb2d44d2cae4da34ba94d3a88
+msgid "jammy/linux: 5.15.0-82.91 -proposed tracker (LP: #2031147)"
+msgstr ""
+
+#: ../../22.04/4.md 031e3da596e8451396d57ca563a3bb88
+#: 05a1ef2cc7ea43c8beeefa3784bf7d20 064ed2e513ac4f0d942af6cb38a178d3
+#: 0b21fefa7fe34944820f7dc8ad029d7f 0c4561a6efd2498f90b45a2a9a451573
+#: 116b6a49134a46db862e15c28e8abb43 137b976c3620406b8636ebb39bf5a588
+#: 19709cdce7c942a79f49dcc4f066ff79 19b4f10f774a47e587e1c8fcd2172931
+#: 1d5d9f70d667428d8547ee31d06c90db 1ff493ca824443d186662eec24c6ebdf
+#: 258ab06147934b039cdb639d7f4b7e19 26e3ad24ba544ac788b11d3bebb9db71
+#: 2ede544be10b4aefb4018418068e2afb 35ee422f197a4231b22d5c826f9a9fce
+#: 3a16e2ad10884fdc8ab74e1336adf607 3bb8e7e6a9a8422ea624678e0302aedf
+#: 4773defcdf854c56be219ffe751f19b8 4a61dd5a555945e8beed68ccec15e728
+#: 547cbbd2304b4cc18fd880454d7c741c 59fac58f3218423cbc5bd0009bd19f49
+#: 621319923ca34a2085c2d9f2af7a7498 65f4813f8ed3487a961309a46de2b67a
+#: 6f8e903258a2429e952db61fbd18bd65 7482233a2a9c4206914b1bf2e78d1cb1
+#: 752be44e126449ab82bc99f10ccb1a80 762b8cd24a8f4a41a887c5c1ad04bf98
+#: 79aa9a92b247485bacfd1137a71fdc85 7b516ae473b14fd698bb9f16d673b2bc
+#: 7dcb50012b2a4ec9b2432f7eee188258 8442c50bc3974d429c56063307254fcb
+#: 87cbc2947b0b469594746149c76ece2a 87d2a07983bf4269b2f98d4e6de3c1d1
+#: 8e7c2c2012304ece80cc32cac823ad7a 97af68f89b294bf587e97b9a133d43d6
+#: 9813a32ec6634c7dbd46ec4ba23a49e2 9bb7f4d3860742f1a3bef3a431eee2b2
+#: 9be681c6f36049678817fc3a77ca386a 9e8952cc7de648e581cf6ac05204b217
+#: ad7e821c12584768ac039b329d376d72 afeb7ec929594a3ab2d4bf38a9cc8ba1
+#: b2e58b04163d488cb582730f2e7f7cdd bf73ea67d5b141e49629d7329bad53b0
+#: c1134f653e24432ab8a24d6d6fe9b22b c1b212fc31544548888797259b8d11b8
+#: c218523483b24055acf8ec96e80de478 c711b860913b41d490e59ff7cdded095
+#: ca8845d152e149399d99caf0febee3aa cccfaddf4137403fbf5c1706406f7fda
+#: cd47a5c2254341bb8d7cc24dc705f296 cef1acb1e6b54f80a0e077fa273915e3
+#: d32a691c6a1d448c8188e4ae2c0d6e6b e1eb1251539646e490c98021677270f6
+#: e49f41c43943494eac72bd29275c3a37 e9867cb32c1e4a2c966aba334296e194
+#: f64058e5920d4a6986c680f738157763 f8f34e123d364f398a05340719e11c30
+#: fc13dfd31a064692a41345a062bb15a7 fc9a9dcf4c5c401395115a10d687903c
+msgid "[2031093](https://bugs.launchpad.net/bugs/2031093)"
+msgstr ""
+
+#: ../../22.04/4.md 0394a60eff1c472696c3a037d01c4187
+#: 0658034c69ae415580cbd81cc4092850 09c7bf209a164c2db1a87e27a753cc9b
+#: 18e30fc8e6414426b3bb6c346af3d5c0 1a25e6a3fd2645638f665aef8d1d0d43
+#: 1d62bedeba6246889cfb80661417130c 222ad1ed30144199a4cbe0c112fce6e6
+#: 223c8d10224d4a06b1b670f584ab59bc 22b12734cb2f42709955c36f8b3978dc
+#: 25e31180b0c74fa8a50c51c5a56f343b 2d47e2f3e2e0424cbd5b15a83401bd3e
+#: 2de35f7b512f4848bf336c5139800baf 2e3880996ac04cf58aaf76d81ab66863
+#: 327f8e046ab3481fb05b97ece3576c18 3ba9f1067dc64c109e8010cdd6cf6cdb
+#: 45cb1c5c25284d77afe8b80e5ea87b5c 4f89f427df3245cbbccaaa6201003af5
+#: 59c0a7b060cb44c280b8e394b343db3b 5a461bea1bd3452799f86edf6c93275a
+#: 5e35f43a494c4e02bf9ca446d13af535 6043dc88ba9f4ce6a34d6818c04252f7
+#: 67d7d0d392b5410eaec892d5720ae3fe 6b912ef58e5a4500a3f8869915d23fac
+#: 6bb7f05a040d46d6af5c65986d0c3402 6e12a3d2bbe94a7cba5866652c3be0cc
+#: 7d5da4740e8645b0a5150b679626474b 7fa1ff677f3049c1aa5a81233f5bfc36
+#: 88cf606d749643c49a04f4ed90331eb6 8cbdad85c3af4e51a53fba5b0de7f79f
+#: 8cfdca4ac7d34846aafd3c227259a61f 91c6201f226f40a2a0daa10695023aba
+#: 9bb2413d1cc64f2fad0a2fe5886595a2 9f80a0fb4ea74ed6a0c03cbe498e1aed
+#: a433730c73f84d3d87dbf07d33ea8180 a68050421c4640fd88bbbff1463afcbc
+#: a98999e1f7f64a6f97cd3e9859cdbac5 aab55d50a8214cf69fe0ab0cd323b148
+#: ad0e1010cfa8467fac909717da76abc0 b01568c8095b4ae1b0669c71bddb78fe
+#: b08a4bd70ee040149ebd1073f4d73698 b1b546e68555492f9f9ad32bc996011d
+#: b1d080d674774106b6392be18a141dc9 b882d8b07c8744ef9b94946c9851d13b
+#: bde0fffec4bc45dc9309d33dcc0ff6fe c08c66be29fe4273a244d0e1a32eb0a8
+#: c1f155d6c7664d2dbdff0621f9654dc6 cfda5980c8fd495d83e1b2370fba807a
+#: d48c8c8ee83b41fd850afa8cdf6ab25e d6ef3fc8497f4413adb2f8286a875df6
+#: df17e1735dec497d9a1a901e846f91a7 df2b359eb6404ebb85d82fa439fa4549
+#: df35f2f0239f4edd9bd685ccba197786 e981915fdcc94122b56606ac101ea69a
+#: eec3dd0f318443c795143c4a87d1532f f0b4e96fe39046a8b7f5f75f42df2692
+#: f7040569584e45dc9dbaf3b683734464 f724d5d7d44d46e5a569f88b7c941cc9
+#: f9883703cdf34cfdb1a845438ddd75ae fa8e7e6653c14489ba88b0bd2dcb9a1d
+msgid ""
+"libgnutls report \"trap invalid opcode\" when trying to install packages "
+"over https (LP: #2031093)"
+msgstr ""
+
+#: ../../22.04/4.md 019ad69222e145d6a08eff37e78f4916
+#: 1bd2ec6de28446969dd2a3388d044c13 20228a97921e4f3183955640121dae10
+#: 26042071487d4bcab9cfbb60c6aecabb 2aab44cfc6d7404f828c6955b46f1ad1
+#: 2d95222905d444cd961bbd6eaf68ee0d 2fc2a3272dd749e0afd60774f114163d
+#: 308984d9ccf94ed6898e6d36383fd12f 57fb8dc10e844d82a925124d4e6507b8
+#: 687d293f652a4445a37037ac544b8cdf 744f9a1c9f2d470bbf5db081ff49951b
+#: 761cf652048d4892bcede3e00adcec08 7dd6d506a2b34a7189bb52cdfcf4f31b
+#: 9a55d3feafe84bb8867c5b4a79fb8d64 a184160027b24d14ac21ddc33fcd9a14
+#: a894e0a63016450f89201f44ca4d8bcf d73d1a70df1643b395b459018f84f3e5
+msgid "[2030588](https://bugs.launchpad.net/bugs/2030588)"
+msgstr ""
+
+#: ../../22.04/4.md 156477ad11c3448ca8035cc3165697ab
+#: 1c89c41516ee404f8a3f37b4ff0778ab 2cf2853407714ad1bca6cc675615b6a8
+#: 30227aa9e4904659a853ac7dd96d4737 37d6397ee5074b19897fbffd28826e94
+#: 5b382b405b834e5eadd229023307eb89 63f562244b8c485e99d3ed3791d1483b
+#: 6b318544615444f7a93cb8d6b2cc7aa5 6d3d50b448cb42e088d1c496575db4e0
+#: 7bda4f61276c4f45a661db9f319addcb 82f58d1dffe24ddb8e2f2a9b630e4580
+#: 9fadc9273de042c097d40a51acc0f381 ae1ededcdc774ac79da605927702d26d
+#: c6ed75bc5df44ea5b85841e0110fc52c cce8a5eccf0543eca94f20ba91e4660b
+#: de425dc17c68408789f9590e39667d16 fb655902c1034196be3e53987f8ddf89
+msgid "jammy/linux: 5.15.0-80.87 -proposed tracker (LP: #2030588)"
+msgstr ""
+
+#: ../../22.04/4.md dc1905f54aa545f2b8d675020a366cec
+msgid "linux-restricted-signatures-aws"
+msgstr ""
+
+#: ../../22.04/4.md 041d2047629c4cf885927f6dfbcacf12
+#: 187473f6ee04427e9bfbc37b5fc73961 18d4b291fd9b43ecb7273a118773813b
+#: 1c31d293815149de914ba6e11c14ed7d 1e63ea1723544b8881844f599b90f43d
+#: 1fa100d2db2543ff9410313499d4c39e 208907e688a3442888f5b5d003614c39
+#: 2386961191484d4c984ce4552b17772f 340bed6bdf0e47ee96e8557c9d628020
+#: 3c35234a5dff467ab4e2a8851e00d5bd 435829ee056d469aadea1ab0d1e5c18e
+#: 44d34f35b3404a78a78d709679ee0a7b 458841396ed646dcb942ed0b3e6db0a9
+#: 45db9e8f677b41c3b72b7bd1184f8fee 478af88f5b014c809b5c5e1592d3d825
+#: 4a0474bab86d44909bb1b29b94590574 4d172b988bf143259d6cf9c3ea6b3a6f
+#: 4eec771cfe9a459e9c8b8fad845e6c2f 50aaec36adea4e5f931e2e24cd1bfcf4
+#: 5958409db7944c6f86b0558c7817f725 59ae9a3cd4d742f4b11bb7f4362f586c
+#: 5a0ccad6bb054bcda5d5b29acd58ce26 5a7a17b9df8d4ebe8143129599862189
+#: 5e208d5e2a4a43048ae2ce01fc8eba7c 5f2c470545994099a715b0e4910c98fc
+#: 60b232cad7b94da8afb7c86b23f9d092 6443134913454bd49cdbf12b65d2a02f
+#: 6749ca52e70f493584b806429e57a557 68b20573d28940ba96b9b4a6ecc0c917
+#: 6ce7b6f0f1fa4e78b50306414f43a0eb 6e1d49d7442b4fb984c548d4fb40c88d
+#: 72b6dd3c9fcf4f62a0c535e7203a4d59 734de0ef277a4501ae0f0433c4b1a14d
+#: 76c35cdb15764c44850b06416cc1ee36 83b1ba2283cf4330b1de8b7cd01ed97f
+#: 86bf348a8fc24c32949440aa73f8e00b 88bce6f93d034f06954b4386d305948e
+#: 88d84bdc015e43bda317b9d479e96ac2 8c718e5594e240ab9a349cbe06455ff0
+#: 9171bcfed44c411983a295fda736a2b6 949292d8885b490fa35d0970d4623bd6
+#: 979bfff27c3e4722b6cd2b431dc15576 9d38f264ae414ba7b1307dd77039b6e9
+#: a6ab8350f5174ac58f7e1adc14c3ffe4 aa8ef5cdf47844868f66506e630e4168
+#: ae0684e990144db5a696da019360eea8 b52f2bc2153449fdac37d2e8102874af
+#: b695734037c64ac3871df874fd18af1a bd631de7ba1c486491677655d9ab84e7
+#: bf60521d4a5d41c6bcd43824dbc9c551 c2ce20b038ff49bb80c0a8b659f2124a
+#: d097d08ad1034969a4159e96e060eb21 d1de70315a1c432dab82781221bf6bd7
+#: d530c0be65d447f296e1d5d2853212fa d711db7a30a840f791ad39b52c841b94
+#: da43a3d1aafe49f193d37151a8d1df01 de4a51ca95754a1b927b94187118b0d8
+#: e0d6410887d74743a8e05a422980a990 e651c3841f4546de8e2b84b3a0cf09aa
+#: ebdde38b560f4198be22aa9bce6fb643 fb79d9fc011a401a87aeda9952aa90a1
+msgid "linux-aws-6.2"
+msgstr ""
+
+#: ../../22.04/4.md 0497239eef964047b12805787bd9b896
+#: 0e55b5ddd3234e1aa7cf24948c514f6b 1bc7b1cdb8774e44a553197b584c8137
+#: 4f017e9844c7435daba09ad4773cab62 68745497521642af9bb97baad558695b
+#: 70eb853be91d450795350ce5cddcfeb0 73be89e19e4a4912aa75dc88d0d7de1e
+#: 75436aa34dfa426da03bc72b803cbb69 8a726dea8cc24d91b86ea6ad6e110c66
+#: a1ff45e23b434f7f9731b3e3d7bb4c32 c2903f4b503f41aabaac7126849f8c2f
+#: f3acb035c8f1433fa9e56106f542c848
+msgid "[2031146](https://bugs.launchpad.net/bugs/2031146)"
+msgstr ""
+
+#: ../../22.04/4.md 2320769908614c55ac8402260d7fb41c
+#: 279d73b58c744b51ae258cd53ea5acd6 27f304c14aaf44dd94d1620aadcf9cd1
+#: 2b06a763da1b448086679f57f0a981af 2fb39e7a05754bb297ffe1d8090e7ff2
+#: 414641f9383943b8a9f2fd33d37b1e3b 516366767fb94b91bee2ce6c86b659fd
+#: 5e74000840a64b2da52524f9de5db6b7 83ca25f42ef84706a4e7dcc75b3fc5c9
+#: 8b985aea283647afbbeb3a89eb76d132 95eadae7991c447fbce69792e412b14b
+#: 9f0f57f5e2404556834659f1faabc51e
+msgid "lunar/linux: 6.2.0-31.31 -proposed tracker (LP: #2031146)"
+msgstr ""
+
+#: ../../22.04/4.md 029e51bc343e42f093cc746ffa3329cb
+#: 14009dbbf4ea45fdb77bfa00b39aa163 19495da137534795bc4711b97aeaaf11
+#: 44287c5dbb5a4b75929354a7db76e7cc 5381eec9971647398d9c07ca55e7c813
+#: 61658874fc1c4ddda2f2835e3f3d0d59 662495689d07439da873a098f8934593
+#: 7d0558015a094097a40c8bcb97f1dd19 8b364047e50e42da9b52858b2ae71734
+#: a4b361889444492da9d012138320b21c cdf6f8291f2e414ba9c5d43ca4ef6139
+#: dbf495f3d0d94fc2afb03b745d8d402e
+msgid "[2030547](https://bugs.launchpad.net/bugs/2030547)"
+msgstr ""
+
+#: ../../22.04/4.md 2877405086754745bb857abe78ace4d2
+#: 33c254d9744142fcaa6c519a74357368 3a7825e361db448286156abb6c82be3e
+#: 40f9cc0a75554cbbaa6898d51822ff3d 602f0d21131c426680f05a14f2f87cb3
+#: 7322175df8d542c9846df4b04820c487 9263ee9d479541219774514bf560bb5a
+#: b629421962a24e66b62977fd308edd88 d07d3ab10c9645b6898417e54274f6ef
+#: d0a141e9ca3a4950b90d858289c9aef2 e640291a4efd4a5ab1fc8706a8e47a53
+#: eac29f250d78401ea12d28d709ea3b21
+msgid "lunar/linux: 6.2.0-28.29 -proposed tracker (LP: #2030547)"
+msgstr ""
+
+#: ../../22.04/4.md 25b475937da243fca6c3dfe577d5149d
+#: 6a1a96ce8ff148d587fdd224356a3ebe 8b9ac8b7382c4c339b5d6ae2b363c70e
+#: 98f8d1843c41448faf11f864d376e30d
+msgid "linux-restricted-modules-aws-6.2"
+msgstr ""
+
+#: ../../22.04/4.md 3d12e61a5af54fb8abb4b3dbb92579f2
+msgid "linux-restricted-signatures-aws-6.2"
+msgstr ""
+
+#: ../../22.04/4.md 06b47f402ee84477a239b023b162aaef
+#: 12c32bb844e04b94b358bc8410ab697b 12fd900894f84d5eb01a033abd455812
+#: 23743a05b4c445cfba3ae3f1e376315b 248fbc69d95a4498adacd6c1f4ae24bc
+#: 2dd4cd7650904b9da9bee6e6a17b62b5 33119ccb8bc84917b8359f074d1f7e97
+#: 38781c10174b49d78507ef1139ac8b8e 3bc894e6bf1242859c75257a60c48ebc
+#: a8014f8a360a4dea9a07444e9a16ec40 bbd3f2b2a0464458a021b7d6b3d538ca
+#: c566bd4bc6a946b3a93c984e0ad06365 cd23955e0760433a85d1184b67053eea
+#: d5e4258209c645a2837148dbba2d68e3 e8f978ceb28f4f5f932d4a6576f127e8
+#: fc5f6356ae4040f288d07a2cf13911d2
+msgid "linux-gcp"
+msgstr ""
+
+#: ../../22.04/4.md 362b6986b47e4bd19834a7fee7dab966
+msgid "linux-restricted-modules-gcp"
+msgstr ""
+
+#: ../../22.04/4.md 5bf4b9eeeb20438ea131e375e1b995c8
+msgid "linux-restricted-signatures-gcp"
+msgstr ""
+
+#: ../../22.04/4.md 126f6d68d9894a4883af14ac928ceb4b
+#: 561d1bcc708c4ff897063b7a30e84a72 628f70ef205a4707b008b2f46cbcfda1
+#: 634a49476bc24ccdb2dc63c03cef6ef7 75dfe0cc61b545289fe0e51147e6d2eb
+#: 8188d581e2b54983b1b066f54668c70b 93d2212a48dc4da6b1685da293224e0c
+#: 9c588f0846574eec9342a7c71f239e5e 9f086d6bbee84cc8a56f9baf69fcecdc
+#: a51610fd6cc04ecda14dbf8db2275f71 a7305783cad248c089760047c464aa32
+#: a78789ef89084fc198f067659a959f2b a79feb447d6b42c49d97d5e4c7f79d02
+#: ca613a8d46c54ceb96c5267d8d651b39 d276b4a1e7354d27b851f9b7c1520732
+#: ef7142475e5f4153b5b6d73a10b8f565 f2991b505146422682378cc8c34bdf4d
+msgid "linux-gke"
+msgstr ""
+
+#: ../../22.04/4.md 028ef0e32e6d48c182b6cb91b960ade0
+#: 0c4b44c5353c46ef995013af25852a21 0e32228137be49b6bfc07ab9cf04e6ae
+#: 281d3790887c482caa9c639dcf4923a6 6591070aa6a04266aaa354ea19b6589c
+#: 938c8a38d5e14328b79a2655f85d52b8 a3b917c9612f431aa2a56145f1c0d73a
+#: a86e5b69a501437da83067d73322b019 a946faba02ce447992199c5db5bf9144
+#: c6d958dabc314fc980c252298ff4c57c cd5e244aa14f44f796c76b1092d39061
+#: d5659e7724644f7b9dd69542e4889052 e862c7d6484a45a695eb547febba5b84
+#: ed6a0e6525d94fa5b84a5d2b1135a49c
+msgid "linux-hwe-6.2"
+msgstr ""
+
+#: ../../22.04/4.md 05996c39338d4a8fb328d1ab5bff6727
+#: 3b80ddbd3e2e4ee8b0f50b9ed6a97964 3f95bdf520a54d9ba166212ca556041a
+#: 478fe8239969418d81ac29b3069c2b09 5f6a69e76a03437788f0b99e50bc6d40
+#: 60993b67765f4bcb8bea091b51c40791 6682f80ac1e545a6a313fa43a4060df6
+#: 69e0ddf0e431406db30f4f5662d71d49 85f031158f0a430ab52ea0f022a4f466
+#: 9769f768714b48f4bc3f8e8957ced0db 9fd9e42a684545d2aacdb91895a6413e
+#: b9102e83935e4d7e861217ee97c3b07c cf23645aa90d4c969cb5a8e0f85b40a8
+#: d037d20f0c25434db1a44ee17403cd43 e57c6ffe27984501af120df602f6de8e
+msgid "linux-kvm"
+msgstr ""
+
+#: ../../22.04/4.md 0ba155ef061e4b7abf2e4b10a0649907
+#: 1a3a82c66c4242fb8076876b3aa84762 26201b1de90d40aebb16a47da349f19e
+#: 329fb7b515c4402ebddbb417bc66fc82 42a77e806945485ba402b5f0e2a52e15
+#: 6b9e9ef7cec64f7583bce32a1601612b 79f69ec5c6734c95a82cc87cd360d237
+#: 7ad7e9a427884407962f20cbe992ee97 9c58aa65e2bd4009b2776a422f1f7587
+#: 9f32e61c2c4d4e079f580c8101bdb4a0 dea108b0690a42fab91a0a1b512b1bd5
+#: e463b976e8b74dd1b582f13078bfc979 ff007ba2a3724232bd0ff861f5ad1149
+#: ffb529a08174482b8703b6fd7e00b6b7
+msgid "linux-lowlatency"
+msgstr ""
+
+#: ../../22.04/4.md 537f4e87f4294abc98565dd52af5eda9
+msgid "linux-restricted-modules-lowlatency"
+msgstr ""
+
+#: ../../22.04/4.md 523139c785834be2b7b6510c4cefa631
+msgid "linux-restricted-signatures-lowlatency"
+msgstr ""
+
+#: ../../22.04/4.md 02e29f1f3c414bae8cfbed6ed02f7ff8
+#: 127fc14cbeb747e7b8e88fa447fdc2c3 16fa4468419844b0b5adc3e148936bb5
+#: 304b50325be04fd2b3ab4a31468e5c23 490726a43bfb481494fafb0fcc6f0d90
+#: 62b9a19090314e6a9db591aa6a6288a4 937be9e03ca142bd910b5b14d4463b57
+#: a9207fae787c440a9e6260ea9df89291 ad49bb0044704e929852a6a1e0e509fc
+#: cc6eec8309854750a64f72a1f435e5bf d349e72ece8e494a9d8097c7404a311a
+#: da7a7671cf954f4b802fc9dbbc640704 e4ba11438d774e5e850207f2df756455
+#: ef29448386754eb1bf75df05095f0250
+msgid "linux-lowlatency-hwe-6.2"
+msgstr ""
+
+#: ../../22.04/4.md 0cf069b9b0d748979c5ec6152d214b44
+#: 209092e918674c2dac3ced66d9d89f55 2fe859c8565147a99b2628941737b50d
+#: 4025c1b5ea984e02bfe9fd99e1362e15 47bbf669069d4971bb755f229176aaa3
+#: 607d77ffd2ca429b9570e3d5cbb964ae 8f82f8a7e7424e0685f2a491a14857ea
+#: 8fd4b49052a1495b8645980e71dc5dbc b1d9029f762f446b873911a8405a021e
+#: b9a99ed6a1314185ada64b8da783599b ce9009441f41453fad8d9dcb24912249
+#: e983fa30221243619361322f99924067 f87edb656b7641e0ad943c73781bdae5
+#: fb66d01907c343ce9822377c5a6a1702
+msgid "linux-nvidia"
+msgstr ""
+
+#: ../../22.04/4.md 355f84c047f54f7686b9a6d193f726e5
+msgid "linux-restricted-modules-nvidia"
+msgstr ""
+
+#: ../../22.04/4.md 5c16ec88b6a04beba641f658425bc55d
+msgid "linux-restricted-signatures-nvidia"
+msgstr ""
+
+#: ../../22.04/4.md e1216e818b8344c2ac463c74b5ac5377
+msgid "linux-restricted-modules-oem-6.1"
+msgstr ""
+
+#: ../../22.04/4.md 65c99d27c14344fcb57426a8526b0163
+msgid "linux-restricted-signatures-oem-6.1"
+msgstr ""
+
+#: ../../22.04/4.md 04225f626c7d49dea3adc2c144733799
+#: 0f911d2d16ab4a99ac5f8c3b9daf4e8f 28ad922cfc42461c8edacc756a2cd708
+#: 3377f9d4e70e404e93de1aa6ecfb21cd 4800d56f14cc4f35956e56e9f4318f1a
+#: 4eeab7abcaa3466e93aae555051dd18a 5dd6b15f6d2a4e68a2fae0142f5f28fb
+#: 75fd516d44704415a987e34b0c47d3ef 7790bfede9e348ca8a48fae2919dd7ff
+#: c04c11a8da964e3d9fa42d984916cd26 c1e5ca6121d042d69a80206bfcaeb1c6
+#: d1f7b57c524842469cac9f920fd2700b dfd33136bfea46aebc9390dcd3446a0a
+#: f35b9f889d9e498bb4120de025178707
+msgid "linux-oracle"
+msgstr ""
+
+#: ../../22.04/4.md 06ab46b622694e1f843d1e312b188ba0
+msgid "linux-restricted-modules-oracle"
+msgstr ""
+
+#: ../../22.04/4.md 4ab47a80d2df463aad11fbcf0d6bf9e2
+msgid "linux-restricted-signatures-oracle"
+msgstr ""
+
+#: ../../22.04/4.md c367ce73af40470faf8689a98052a320
+msgid "[2024639](https://bugs.launchpad.net/bugs/2024639)"
+msgstr ""
+
+#: ../../22.04/4.md 61944918cd6c498f9ba6f5e501cd9512
+msgid ""
+"fix: bind correct apparmor feature for validating snap seed. (LP: "
+"#2024639)"
+msgstr ""
+
+#: ../../22.04/4.md 0f1e57da6fcc4bb4b3d59c3216401371
+msgid "[2031943](https://bugs.launchpad.net/bugs/2031943)"
+msgstr ""
+
+#: ../../22.04/4.md 789f012bdb0c4021b10eb0eb4c582150
+msgid "fix: 6.2 kernel missing feature. (LP: #2031943)"
+msgstr ""
+
+#: ../../22.04/4.md 25fca90de7b041cf8a8b3a08af635fc7
+msgid "[2015644](https://bugs.launchpad.net/bugs/2015644)"
+msgstr ""
+
+#: ../../22.04/4.md 1e6abbe1ac7142e69aed643ad333ecde
+msgid "Initial support for NVIDIA Tegra (LP: #2015644)."
+msgstr ""
+
+#: ../../22.04/4.md a5875defb19b4b2fa0417aa2ba48be7c
+msgid "[2015596](https://bugs.launchpad.net/bugs/2015596)"
+msgstr ""
+
+#: ../../22.04/4.md 70195416bb404ac5ad53f45291a83f3f
+msgid ""
+"add multiple kernel apparmor feature sets for snap preseeding (LP: "
+"#2015596)."
+msgstr ""
+
+#: ../../22.04/4.md 107935a7e4ed4a569a31cff635c975e9
+#: 14cd73e906fb48b38d3894a0a6310474 1875db8c835846a68fa6ed3189459f32
+#: 1e0427f1f25e433eb6a4a0546a62b1a8 2b8d0016a28a4616819bd3e89ca08994
+#: 436a791c37344eb7b9fe00f57cf2ec7e 5514bfb1e69b431b97f48903418dd835
+#: 8b54d30b5c7748839228ef4107e24602 af3ff51d30734d4badf904214fd51d63
+#: b038b0e2524b44d0b809952e0e9773cb b4d1aa4979d94082b0b83b919acebcf4
+#: b9883443a89b4f29961cbfb799c2ea29 c76687f013f64020823a6823caafeee7
+#: d5f4de1cd2d042d39027c37d03510312 df1a4b0941154f6d8ab27757d00db175
+#: fdbfec6f5e2846b2939a4c9d323e8265
+msgid "linux-nvidia-6.2"
+msgstr ""
+
+#: ../../22.04/4.md f3df8d47ea0c4f4fa094fa65ac1112b5
+msgid "[2031342](https://bugs.launchpad.net/bugs/2031342)"
+msgstr ""
+
+#: ../../22.04/4.md f6f728b3cf7c48e8802d82c3de184e55
+msgid "jammy/linux-nvidia-6.2: 6.2.0-1009.9 -proposed tracker (LP: #2031342)"
+msgstr ""
+
+#: ../../22.04/4.md 13cae28250df4a2e9353438fe1f3e33b
+#: d22f3bc383f2454ea1588bccabc6e490
+msgid "[2031320](https://bugs.launchpad.net/bugs/2031320)"
+msgstr ""
+
+#: ../../22.04/4.md ebda077a34034e97b0b402fd985fe648
+#: fe85bfc5b98940bb9529059069dea006
+msgid "Pull-request to address ARM SMMU issue (LP: #2031320)"
+msgstr ""
+
+#: ../../22.04/4.md 0db4b27295fa4f74b38fa8439e93a087
+#: 2b6ad9822c024352bd1e41660740d40b 52d4a1ef4e284aebac5e379d714614c1
+#: 53c5684a85aa4d9b8cc53182b345cb5a 549c34e7f6a44667ab5c593f1243d0bf
+#: 6159c91784ee4c058b56e406e2a281cd 821810d0323a4010a1b2333f0411718b
+#: 86db4631d0f249e3beb699e3513b2749 881ac609f1304a2192daeb0210a6bbf8
+#: 88ff7f75dbc1425d918d6eda6058f947 a348d88f0ea74106a7dcfe1e72f514c9
+#: a86751685af14b128037174203254678 c99d6e715c30438a98c5bcaa7900e8ae
+#: da77e8c7f0904610ade8ef63c14b862b f748c20e07bc41e7a47fd34952296012
+msgid "linux-intel-iotg"
+msgstr ""
+
+#: ../../22.04/4.md 480bae2ea40b43f08cfeb4317790dba9
+msgid "linux-restricted-modules-intel-iotg"
+msgstr ""
+
+#: ../../22.04/4.md cee89cac5bed4255a535bc82d2a4744e
+msgid "linux-restricted-signatures-intel-iotg"
+msgstr ""
+
+#: ../../22.04/4.md 9fc83e4a84e541f98b39a6c87ad50933
+#: bb0313013360479abdcdba161ec21d27 c638b3db033b46cf8f34e5949e78b0bc
+#: c9ab51b49ae44ba886a097e87b6febe0
+msgid "[2030550](https://bugs.launchpad.net/bugs/2030550)"
+msgstr ""
+
+#: ../../22.04/4.md 10d483d878ff427491245de34d0b9b5a
+#: 58e38b10173749e6bf71143e54d1b211 c405e78a66224db1a3f08382b8a24508
+#: e18805d5c2c84d09b20d064acff784af
+msgid "jammy/linux-azure-fde: 5.15.0-1045.52.1 -proposed tracker (LP: #2030550)"
+msgstr ""
+
+#: ../../22.04/4.md 0a305624be154ee397f883addf541ac0
+#: 1e710197e922414d85c5d2e02fc0aa09 2795b9f38a9a4d419a48d2357b6890db
+#: 2a2bd0a3f4d9467eb22d98f687d1140c 571b6ea30217400e83d43dd9b0b621d9
+#: 5bba3b4185534fb9b70e7a9d1a65d690 5f221984176146d09c8d68ec973ee6f7
+#: 86f63caa685c4d7aa4f76b71d0850918 af905bfbaecc40f09ba8ffe1b4e7b338
+#: b0a00330a25240b6b3d64caf58bbadc2 b381eabcb3944f9cbc0c6a8a97846101
+#: b6b378a7cba840c09c2ff7e3a831d4d7 e10e0849c7b145ec9d54751b35b583ff
+msgid "[2030422](https://bugs.launchpad.net/bugs/2030422)"
+msgstr ""
+
+#: ../../22.04/4.md 19ae315125d44e318aa2c1867156dd8e
+#: 2486a62c37fe419099a87b8afa106b6e 31a841b8e75e4c4bbefa2fc574a8d462
+#: 3bd1e4c3da854b17a56c94146f539025 51a473ede27846df8d3d08b331ba4a85
+#: 52b251a332af4958b753e028c8bc8b1f 96c37bfa966044cf8670db91e319f4c4
+#: acb3f80950c6423aa3d2a3fa4ae2b3f1 d0c874d0ac33494c905ded14424485be
+#: f0183a0a39b14bd6839426893b7fba1a f6f8e9ac47e14985849cb84ec19225a5
+#: fae70e2d614c4dabb13579c1b3017d7d fc82bf2589a142f29a07493bed76d24b
+msgid "jammy/linux: 5.15.0-81.90 -proposed tracker (LP: #2030422)"
+msgstr ""
+
+#: ../../22.04/4.md 0b9a32cb30d148d2a165214531ff3357
+#: 17f9886f26bb4e5fa5a29a421fde2b6c 367cbe14a4d8474d854fb6ebe4a68c1b
+#: 49dad462d6e8492fafaab4bc26986a73 4e5f6d8a08954ac2bc96fe4275cb97d7
+#: 5c1cf9bc7c114aa2a38c269f1f7f2bab 62df452fd7e841a999629c8795232062
+#: 6a6dac8bd29d4bf2ad8369a43ac4d441 6a83921f94d84de68e18162b06cf9fc0
+#: 72121917f1b14b0cbc660183cd68343b 72ec81c77f754c7c891d9b944bc5fc44
+#: 75d3e3ba26fa4d5685b3fbe308b75432 85d0473546c8433fb3ff4367bd94209e
+#: 943efb6f5900488d885b88e8b3ec55f5 aefb61110a104e16bd67ded0492b2d30
+#: b23c885120bf4c188f31abc24c172dfc c494e9d0a60243b3b1ce9e68555f8b1e
+#: c809ee46f43a479bab101e94fa27fc22 c834159d279b41a99f58066396385334
+#: d66eeb0757464a7f9d309cb0808e1440 d99679851bbe46dbb0bf05651107836d
+#: de1d1b42edd74ef38cc9e5397beb5cb7 e668a4fc4c314c9891424f8a6f309cbd
+#: f978d6398bbd45909520bd7fee9c4367 fa168b7c14af4a2e9297a504de8086fd
+#: ff4d845ef6d840c2af2f4329699c5f9c
+msgid "[2015400](https://bugs.launchpad.net/bugs/2015400)"
+msgstr ""
+
+#: ../../22.04/4.md 06ffc77755104577824ebb4f49e0b87e
+#: 0733dacf35fa4ec59ec2cb2daaa83e80 0aeb76f424e34df1a8d6cf1f568e0f08
+#: 2299902ee35747c39555957f60d07877 2651ba0cae5142b8a5b187d9c3f865c3
+#: 298cc4a07c044f8dac7bf6159fb167bb 2e38f3d06fcc474faf780abe779babff
+#: 3bd65bae586848d1bede6d6c2b512da5 4f8a955f6eba4eab9d781a609441b152
+#: 55027edc2a9c457f927ead570d191932 55ca21b5887a449f8fc79ed9cbc6a7a2
+#: 55e8ea22839f47ca99a38c66cdeab797 64688dfdb8924aefa324af5785dd085f
+#: 7a881fbc8071479a91d662558ce6d544 88beede565cd4dcbb001e51926acd43d
+#: 8b08ab66c2a94560832443acf34b8dd1 8ff1cce890d54b2cbc564c71abe0815a
+#: aab70ff241b24c5da383d610dbbcf713 d56f8a8bf0ad489fbaa7cd993797b6b5
+#: daf7611e2fa94653a65d9ca9457dd925 e895f3a1d84c4c1093b445683c5fbc94
+#: ea7bdb4be928407d901d1db6a0bbb42e ec7cfd0334434e3db007749323a1a7b8
+#: ed524941bfd940249c8519d16dd2c690 f133209842e5448f93c2b0a74eaf4e7a
+#: f99c6631b55042d4b70cf7d01aef90aa
+msgid ""
+"losetup with mknod fails on jammy with kernel 5.15.0-69-generic (LP: "
+"#2015400)"
+msgstr ""
+
+#: ../../22.04/4.md 081fd335f5004484ae5fe893be172515
+#: 1945e418e661483bbc0a4c513a9d1335 3ddf32f0910149b8946a8b05a80728ef
+#: 4652180df10b4f76975b690972fe575d 4a50f681eff2486b86886280e6f38639
+#: 58b9b04a2755436a91df3416848d38b1 82e6af0525074d09855dc0b039544a0b
+#: 82f1723ef41743379bf891f2eb8c4fc5 898805e382ce4c938733cdfb0b2ba746
+#: be25f20e38534229b6087b2d906bf308 ce3aa92a7b654b1baee80e3ba82870cf
+#: d466655ee4104135a470850e7fe87c9b f7ef381c886c4b87a93bc530aafad420
+#: fa8cd83a913547e09d5fb6307737e523
+msgid "[2029401](https://bugs.launchpad.net/bugs/2029401)"
+msgstr ""
+
+#: ../../22.04/4.md 238e3fe47b6a4c55901eacbcccceaa2d
+#: 2ad4eef19d654207942eebf3816fdf11 31bb20841bb74d3e880212071f88a67f
+#: 326342319c2949fd9c4413fac4ce6eac 3905cf5a47ae4f31990a1fefc30b4ecc
+#: 52bbc3379a4447abbda88c11953433ac d5fc371b35b045bab2b8c73fd004caf7
+#: ea8f78c8f74c4051bda4a561ea5fdce4 edfdfd3780644ea39465d3c8abf8a591
+#: f0408edca1b94821801c595c09ca9bcd f37cf4f84eac44a89e6bf9035199af00
+#: f65f6cd163a744c497c1e56ede0ba6ab f88473dbeaee42d9aef0cccfd2e0ecbb
+msgid "Jammy update: v5.15.116 upstream stable release (LP: #2029401)"
+msgstr ""
+
+#: ../../22.04/4.md 07d5778916634868bfa4e9f7a2747ede
+#: 1465380ca85e4e8fa8e76e61ab47ac05 18e4c67e80eb4f1c995796737bfcf57e
+#: 27668e5b26ef4741b44c6073e3039afc 587d8fdf6d004c338e3c64bf739658ee
+#: 5f857bf6de424b4f9e47c9aa9c42c1fe 64b6d007c2654cc6a9491ca7cc9e2ea1
+#: 687ca619aaa44dd09e8637d6793873e6 69f2ac9a633543e59b9f831ba55b12e1
+#: 77c790f0cb9f4694a4e080f2ef28aad8 af5d69c7e21646329415f9fa36f33de2
+#: d3abf4c70ea14a3c95b8e9505e7c7e36 fd47a50569364c8ea949c9c0fbec38e7
+msgid "[2028550](https://bugs.launchpad.net/bugs/2028550)"
+msgstr ""
+
+#: ../../22.04/4.md 07b861e0547d4d5b87d0b5008dafb9a9
+#: 1c5bdf97fcf54c3984627334cb702456 3cda8bc9c68e4fe2b6dd63b9c68d89e6
+#: 407d3d8ddad6458b9b1769940ba4152f 478555f701b443a4ad022004fc1a55a2
+#: 49b5e8b3cd3d4ff783b9086d801bae8a a8f35032456a46aaa0ca34d82cddf967
+#: b1dbeb5748144095a8faa020a160640e b287303e734d4a7cbd824080fd5d3399
+#: ccb7d1405d4b46d2a8ac9489fe0a396a e3286351cdd74a00903d36b828856883
+#: ed30625895fb4411be79c7c1c290c0f7 fc9ea0614cec4573a18d7f183b6c81d5
+msgid "Backport support to tolerate ZSTD compressed firmware files (LP: #2028550)"
+msgstr ""
+
+#: ../../22.04/4.md 102bb80990c24fecbc018ff13d55fbfe
+#: 1ffce8de73904d50a8217756b17a09f9 22631cfb0ed34830a8fe63a695c856be
+#: 239a29052484408abda9a1014f3d8fec 289cacc5c8ff44828c66b39386bdf11c
+#: 3042a1b535b24c8aab7c2beb1f2d636c 30c12bf274bf4ce2bd05509d9a705236
+#: 4b847f71ae264676b63ab2a946cdc3b4 54316376ac0240c2bb334af871d1fa59
+#: 576638503b9f47e0957ef49c338dbefc 62d330535ab64cf4a5ec567a32a452a3
+#: 648842b5910f49d581180e25065038a7 662e0be5e6834b419d75ab21c7111ba4
+#: 88fc807901ee4decbd3321934831ee39 8b60a6273e4f4b968a81d4781a801b4c
+#: 90eaf41c4bf444d88b339fc82c8d6571 9d7380d52ed5495294a12d22186ca349
+#: 9e1b7eab09194e79afb8c24696c32a19 a3fc6f8d4a90443e98f52d7ff5ff4746
+#: c07df5827b7e463f9253ca156debf572 d3c3251421c9435ab4681ee8b6450bf9
+#: e3f8288fd6bb4025b33a23f614e96750 e62309bf828649a591ade7157c4250d5
+#: ed7cdc3d715d4f41aa40482464fc2c58 eded25463aec4133ba4bb4c392708aea
+#: f7808313f69a4f00945e594e569aaf2f fcacc01cc702404d808b050f7bfbd80c
+msgid "[2016398](https://bugs.launchpad.net/bugs/2016398)"
+msgstr ""
+
+#: ../../22.04/4.md 10b1d58aa9184f1c890df93b229c5d71
+#: 153547a4c6764659988f1572a12010b2 1ee1ba7b0ad243a49b91d44f39f7514c
+#: 29d580a04f8042e0bcfe1a8f1dd2bee1 329279eb28c1408eaac7cec7db332872
+#: 345c623f048b4a798196a550551e520e 34766bd975444ca485af71d1b4d765e8
+#: 362bb4dd764d4d9c820214dd774b34bb 4c664a4824984fd6847ae8e465aad797
+#: 59d91d202c2746ecbb74453ad543f971 65e90659e9d94f3492a750531284f583
+#: 694fc8e88e1b43caa30c20a8960774dc 6ed9dcf87cba409fbc72ba03af9351b6
+#: 714f23d24c06496d83bab770cf65892c 794026427a5340d2ab417ce62e3796cb
+#: 801e7e5cf40944229b374e86b1d5083d 861d26004fbe482498b521198ad58161
+#: 8c2d389396644dc1bec14e0aab137d2f a35d983fd26b48fca1958cae940bd653
+#: b228a744360b4145ae81c6059d3f7bdc b50546ac48f344f29ffcb9e1f0bc7c39
+#: b86abee606894c8fa6fbde856687feeb bf8cdbdac3524499808c4aec56f12f48
+#: f006e52022904fb38a9658079105c2fa f332580b6d824208b1fbce73fde455aa
+#: fb7cfa93233245afafc3937e83234840 fcfe7a08756a461784d6e0daab3ffe3e
+msgid ""
+"stacked overlay file system mounts that have chroot() called against them"
+" appear to be getting locked (by the kernel most likely?) (LP: #2016398)"
+msgstr ""
+
+#: ../../22.04/4.md 04005aa85ef8401aa5e77db4962df9a4
+#: 224648620081455e990d4be1e8affca0 2fe5943fa42e49a0b9f08934e2ac77aa
+#: 33ad0de8ab3945a489521a64421b4ddd 509c024333fd421b8834aa1120693890
+#: 607757df761c4984826b5862ddab8186 63526fa836db4c8d8f7d051c2f167546
+#: 7289d02c610f4c25982072793199030a 84aef794c455424c8ce1bed01230386a
+#: a31ad71475984741a31a9b0400835b8b badd1a10bdb042a493b4b34145a5df3d
+#: c90baa01a22e46a48f6b76b60f7d5168 fc3f9f3797c74eac9d93f84518ac4241
+msgid "[2026028](https://bugs.launchpad.net/bugs/2026028)"
+msgstr ""
+
+#: ../../22.04/4.md 2c9fbe9b9f3a411bb9d05d4f673cf083
+#: 3319b96d466b4dae858f5c8ed73b8ec3 86f6f982fcfc46aab1e14340840e37c0
+#: 8d5017b1eb594fca91eb2e527ee2c21d 9610c886a0944c218220e1f489bc2d16
+#: 98e27c6658e641ddb6b96b36e7218a52 b207840a67604b8e9370b356970fa14d
+#: b4e823e9754d4a56aaf38e0c8efb121e c35b6ac53e1342a48d5dbb6ff1578d09
+#: c5f9687f525b49949761ee2aa8b4bc4b ce3867c9e9aa4fa190ac6db3f82019ef
+#: f0d365fd8dc54d06b2b792e8100f3987 f3fed497579c43c5beee15d761458564
+msgid "usbrtl sometimes doesn't reload firmware (LP: #2026028)"
+msgstr ""
+
+#: ../../22.04/4.md 1c0a434a69994b938883ff61f6b0b16d
+#: 1f37e968933245d688ba04a34256703c 23257ccb85524db3a347bf36758396c0
+#: 324bc6c28d004c30a89839987f0489dd 343b8249da294bcbb921eaaf517cf66f
+#: 3835449c89cc41478130b90cdd1a3cab 4dd38c50df1c4ae3a6f0d311fa2da093
+#: 540f3d12a7b841b39596c098d87ff470 60786469252145bd96d2402b73ec71ea
+#: 9466719bd7014c4bb1bd42130579a0b1 b748e5600ec44276b1fb8aa98a1558a8
+#: edf0c34186dc4d6e84bbfb4b9fc59d8b f63901b7de65494b8c13584815040392
+msgid "[2028799](https://bugs.launchpad.net/bugs/2028799)"
+msgstr ""
+
+#: ../../22.04/4.md 03b2e48e97d1487f847a5dd6d651caef
+#: 136baf26ac55439ea628d9e9a51e288b 3f70f5e1f13f4f329d6f8b8779e746ad
+#: 505258083dc84e08b0180ae599893249 6d66065172664480bda310c8ce79200e
+#: 6f7bae79a1064c04bef70412245984f3 8a05d38f6fa941d79469e8f9ae9816b5
+#: 9c5302f4dffd4b3e92c7a8478d21b7ea bdd9ba004e194220958616ffe19b480f
+#: c850bc9d269e41d5af60efed6cdd3b48 d362068c9ccf4d5ea64bf52c461e4ada
+#: ea773987139d498d8ef9c38a2b967634 f96b0e060e4d45a6b970234e1fb6a4dc
+msgid "Jammy update: v5.15.115 upstream stable release (LP: #2028799)"
+msgstr ""
+
+#: ../../22.04/4.md 17f5935ff8a84a3984690948c2f49bc8
+#: 23b5b41d386a4117959dc2ea130e2492 3dea08c1066346dd9b576eb61cb68678
+#: 43439306fbb246558890e91c4907671b 449be6a4b84e4e2eb6385929db799651
+#: 4b52bfed2b92403396b5ec0b640bc055 6d1881429a2e41cb8ca1a820b8b5f51b
+#: 7d2b5e99233a4c528cdfc37929c90c42 8752ad7804da48199df15b68327bd669
+#: 8bb790aa5fa14efdb1353bd902a7d657 906bf022c9d54a13a0c517a91a790eec
+#: ca84b7b07a364c73a96591f7d2e2145a d0ffeb82dea44fc7a2d8f0eb2be07026
+msgid "[2028701](https://bugs.launchpad.net/bugs/2028701)"
+msgstr ""
+
+#: ../../22.04/4.md 1d91c2881de648f5991704c639710634
+#: 1f4ea4f9386e4df4880b37ace87dfb75 242aca403a954541a5e2ee77d88eedc7
+#: 45a2d62ade9448bf8c0cad79f3c669ee 47e849a4199d4ef08a72f9579ba2e290
+#: 494145073a374de496a7f52ebe752f1e 54e40b4a5a7e4b70a4eaeddc0b4b9d1a
+#: a9e34e54b61446f3af36e0b3fcf5cf3a bd8ce44931124d278c2b9883a668ded4
+#: c106af0861b443b38fb97021bd187cf4 c21282e4cd8f42a7969114c0dada779a
+#: cd5237ee59f74530b1ec4e21e4498e18 eb2a974954334866abc8e1433783d57b
+msgid "Jammy update: v5.15.114 upstream stable release (LP: #2028701)"
+msgstr ""
+
+#: ../../22.04/4.md 072ae9238ef94a4c8f5b1acf5811ccd6
+#: 084649043264443b8d10f5fcff22db72 12119a2afdec4d879fb345571b902b02
+#: 28b984dadb4648a49f5da58fb0779008 509aab1a616b4dc28bda5b48434c95bd
+#: 5dfe940696bb4abbb735e0f44505b693 800f67c7a050403fbf0434177923df2f
+#: 8cf96e9ed7bd482eb1cab531d44a0a4b c987bf0a7e714e24bb17d7cc57ab94c6
+#: d0c8d1317ca74b199aed46e3c5376b68 e1889287004847d3a54e46fe9c552b76
+#: eca76e0c21784daa97412265642d4fff f12315750e2c458a8de9a09b682d0279
+#: f39aaa2a69ed4f18bbd7da35511d1b0a
+msgid "[2028408](https://bugs.launchpad.net/bugs/2028408)"
+msgstr ""
+
+#: ../../22.04/4.md 24c59e59df914dc1977ce12f144ef353
+#: 454e456413314fb289266a0bd20c0ef7 5a4dd928331f4735be37168c499a2a2f
+#: 7e81f89896f348a5ac82e82997028566 8621e822a23c4173b5457b0d3bfea12a
+#: 8e9d29491d394afdbff0c601931ff33a 9f821044adb14d7f96c330fcc59998d6
+#: bbd83020b21842ecac8b375f340deff6 c3cb1184c2e34a87a551163a291de977
+#: dde4a89490a741e78d939450beeb59df e1f7b8e34f4a46589c51a9994aac0439
+#: ededeb1bd0094045915ada6c3f78f58a f5eb5964433243cd9c5d2ccb402a8681
+msgid "Jammy update: v5.15.113 upstream stable release (LP: #2028408)"
+msgstr ""
+
+#: ../../22.04/4.md 0aec18ffe7e64ac2b1855df7790d89ba
+#: 0d7b9af2b97f43df9a53d214f061c8d4 25d4766926814d30bed26264e397b6a7
+#: 3937441007904f29a22e895e1184e7be 3b4fecefe896445e84f3d12042dd5655
+#: 5d12b3faaa704bcc969377be0f5f30d6 6e63bd4f595f44d387839dcdb00515a0
+#: 920d9df67fd44243b9304d604badbf57 9764407479c24e2f9fb0e2b1d5398153
+#: 97927eb9794942039656c452ad1d6f3f 9b8c8d99dd6241c6ad3df674c685db2e
+#: f34d68e52ad04d3eb1516e1c2ae4ff07 fed60bcfa2284184ada0bb1c9703a712
+msgid "[2026607](https://bugs.launchpad.net/bugs/2026607)"
+msgstr ""
+
+#: ../../22.04/4.md 00eab44e541045d2972ebdf4b57ed093
+#: 03c14533fc3d443782725f06c9faa75d 24ff3d6b9745484f92453c564423bea3
+#: 3000540d77034b118155e9d643ab0cd1 31e48fe26ea040de8ed720c99dcae798
+#: 39dde19d0b8249e78dcf2295a9adaf06 49dd0ccf3e144bb0ac6abdf69f00fea3
+#: 7242db4ca9f8499ca6a63e32ae175150 74cc922b26274840bd36c287bb0ffa9c
+#: 8f8365782e2e49318c02f0c5e8691535 9e4360b24d8c41db903ea77128594a9e
+#: c70e1441e3f64ffd93abeefa9f6eb573 e7977aac89ed4531ad726fa0a0de959d
+msgid "Jammy update: v5.15.112 upstream stable release (LP: #2026607)"
+msgstr ""
+
+#: ../../22.04/4.md 21bbcc62548b485c9f7e338d8db518ea
+#: 42fc46b9c91640699439f9a54fa790f1 4b35bd520bf341feac257715d1467454
+#: 8b804eddd0cc4307a172656b489d5e1f 9dbfd2e5032c405c8ae574942e850a70
+#: a11ed88fb5424485a583c9326ef1369e b4b36ecd910f4f70a23d1c82ac999313
+#: c0af5d979c114dae81f226e60ecb0724 c337fb6b8f4049e3a3e75dca20fb8e2d
+#: cabf72d2dac840b7ad4af01745a8b2e8 e4ade47033484120a19ad99b25862dbd
+#: e60e5d110a3c4c5cb03bc89ac2753c81 e7434b0fd7644a1fa3c729723862da07
+msgid "[2030381](https://bugs.launchpad.net/bugs/2030381)"
+msgstr ""
+
+#: ../../22.04/4.md 026d1c3749df491c8ebc79b1dafefe43
+#: 182bbeba9f1449f6bb242adc98e48b4b 3d7b556d0ec74e27bb9d893741c019c2
+#: 51b08df24b594e29b11bdd7c3c213365 56dd6ef3c42c48f1a24a1697a0f0b16c
+#: 60cb3a16d25a4da7b2c0b17fc356d6e2 743721645b994c2cac27a96b720817c0
+#: 7f9182c4b4b94640b9d7ec9339afb328 972c405688704f09a8f5d01f5e8b11f0
+#: b87357135e374fc287554c2e993f4ae8 bebff130bd6a4df192e49be7279880de
+#: f16cd732335e45fc8fd2987e3a68ad84 fbc6f473b2be41b582a8b4646e2bd322
+msgid "lunar/linux: 6.2.0-30.30 -proposed tracker (LP: #2030381)"
+msgstr ""
+
+#: ../../22.04/4.md 0dbe8141e2a042b3b133c111a1c08772
+#: 21660cfc38704fc6b3255441ba974687 3450ff01276c41b3920498cef2bcb4e8
+#: 35f46c3efcc84a3e92d70588d45cfd9b 446cf00b3f8a4cc085123811518955c6
+#: 6a1a868dd0604a8a86224770c9a99bf3 801430f494894d9e86d7c0449e40a741
+#: 867e4ce1df0742bcb6ae6826711a6d77 9beaebfda7964535a15adb5cc25a3841
+#: b2441c626c314c2191ed38ad1bd19e35 c1790dd4bad84cc5829302cf35225ee4
+#: f041bfeb815a4598beb131446c4e8a02 f5867b97c1a94b138230e8b7ca1dd0f4
+msgid "[2027957](https://bugs.launchpad.net/bugs/2027957)"
+msgstr ""
+
+#: ../../22.04/4.md 063bea0d543f423f9eacfcf7c5325229
+#: 12d8b8139701488ab7364d3a5e8708e8 1cce667745194d66bb9033f97cd994df
+#: 295a13ceb8034d2fb17e1f22aa0747fa 44185083de6c4af2ac588b6eb75eb707
+#: 4dcefde7a128480ba33cd81c80724251 51f55e53643642c9b4d37109741a9d39
+#: 532b434c4941416ea1bbdc365ee89d5e 553ef7befa3041ecba294dd87b45e8c1
+#: 7e400d7cb7504559a7d43d5e24e19e8d 852d0ac8ac704f92bd6071f6cae1ae5e
+#: 97e1acde0c4741079f862f0922fe6fa1 d75d1cc7c1be46929a7ae6518fbfaf4a
+msgid "Fix AMDGPU: the screen freeze with W7500 (LP: #2027957)"
+msgstr ""
+
+#: ../../22.04/4.md 3604cf3a2dd64e8886a572927df72abe
+#: 71cd4ea3a63041f7a74d05a330b9b625 7380c09555ef4ea08b01349b03d023eb
+#: 760045ea271440ca97352eb389aaaede a6744945669249be9253180871926e25
+#: af104432a71c48ac94ca189c1a0b5425 af873e40c9bb4349adc23cd3e542a05e
+#: c842a8767f9649b29d9b1709627c7b10 cf0a03eada38477a8ef9d378b7bb8c48
+#: d42ba35213d54529831f03c52478b210 eca63abc63b243a2a2a0cb3a6772c427
+#: f3b8b33b094144589c351914915dc3e7 f671c0df47a8413cbe4350c809f53449
+msgid "[2027773](https://bugs.launchpad.net/bugs/2027773)"
+msgstr ""
+
+#: ../../22.04/4.md 06d99f14f24d4820903286727cbbf6f2
+#: 0a21cddddcb44cf6a36fb5d14e0980ac 0ebc802644524c71937fd35a85be0a45
+#: 0f8db047d8c64d3099a5337583380f76 2c9a44e3bd9241878d5f6f4e8f3e4186
+#: 488b6978481d4973b2c5a4e1acfa9fb1 502f35b0c92841a2a4806bd37b20b06d
+#: 5c921d69ceb447e8b241c961461cb9a1 66f6e4faf7fc4fbfa3f0916b653cdbd9
+#: 7765c387bbbd4d7d87aa110287169855 a9c3af4984724f5fa663a72816a49788
+#: b0bb92d06d3349fbb5173acacd590435 de987b179d82455082871f13e847a5c7
+msgid "UBSAN: shift-out-of-bounds in amd_sfh (LP: #2027773)"
+msgstr ""
+
+#: ../../22.04/4.md 0457212cdeb34760a5989d06c1a30063
+#: 1a76af4f4b614f819be8d8c86139f298 20affd518731453e93f226dca484d2e7
+#: 37ff4679448547cea08d4a60259b4ab4 39da40126822424dbe0d711fe15e7e75
+#: 4ca284ae4b574e7f83ea921c5da44066 4d16df57ea9441fcb72b0fff33ca7b1d
+#: 5031131633ad4fe3b4d1f13e4a78df99 50770cde8e824bdeb68a15a0a613d076
+#: 64e232166aad497c8aefeae4c35eccdc 6ed7d095ca3e43b6b8dd3d9599b7d4bf
+#: 6f2b76da0e3f45efab9b58f4992eb99d 77e2d7046d8445bba3ed5950eaafdec0
+#: 780b8b250caa4033ade001f8e3beccad 7ffa3cffe2fb464a887444f6558bb5a2
+#: 883509b69c944d98834bb1625437b4bd 8a0018dd091b448283f8ef57c453050c
+#: 93a8585ea0484a1b817d01f04b113585 960cf2ea9ff74fda9eacaf6bcf87ea32
+#: 9807f200eed847229e596964b3e9197f 9a41dfbb66c246ab8c1e5bc7e3ec3e73
+#: a1c3fa3ed88241d7b0f1ce674221aa87 b5976bab306e4106a9557d83804d7907
+#: be525387f8ec4c9c8d90100aa443a9ed d34f4e2a38584cd496e782c59a47d513
+#: e78e661795224d2eac2b0b1223dc785a
+msgid "[2028979](https://bugs.launchpad.net/bugs/2028979)"
+msgstr ""
+
+#: ../../22.04/4.md 0034800605164814ab9cef9a20fceec6
+#: 2563db289432418db931cf7cbcb109ad 2ef1343fcadb443cb5d14aa888787f56
+#: 421d7cfcf7b649b5912153363789611f 4b06ae2303fe4f55b3c021d4cf0f1fd8
+#: 796c5bcc592e409ca12b198cb3006c9d 79cb4e52cbda475aa5161ef38adaf9eb
+#: 7dccf078a2d54fcaafad17a61d849c64 8fe8ee0d3b6d4adca03a64303ffd0740
+#: acd0b3be92d44592b787fc3092d4cade ceca3bfdc22e4d9a8e435e7989c1539b
+#: d3c05b700c7d4c94a534f651613eef87 f7b4be4525374bbfa5f8e47ced41ca57
+msgid "Lunar update: upstream stable patchset 2023-07-28 (LP: #2028979)"
+msgstr ""
+
+#: ../../22.04/4.md 0e4b4660c9f546be818ea592ba001a73
+#: 47893cde7e4d4804a0c899771d39e482 4b75f780772144f18036f3a7d7a52b87
+#: 685dbd85608f4964a283b07e7beed308 82aa20eabfc6487a9baf2472a8732dde
+#: a1f5325d7ca844839e770f93324bcae3 b65b0a0e50c84120ba1779afa922e126
+#: b79ba54fb817491eb5fd5f2a300424e7 ba92937b3f0f45a1bddb8ecd9d006664
+#: cda5e7224ba746be9b7145e5b58b52ff d37afb4c390c4a84851dd25232e9752a
+#: d3a513f178784f67ab5b2c2e15390002 eeb16a39a7884fb08a0e8e9c29b27d5e
+msgid "[2022354](https://bugs.launchpad.net/bugs/2022354)"
+msgstr ""
+
+#: ../../22.04/4.md 01d83038c9184197b6348cf83c4cee1c
+#: 0e7c8736a81c411f8dc84eedb90aee08 341e1d01125b4846a2135bdc33e97f3c
+#: 4089c8f9ee1c441894864682396624e4 44403d7abef94f07a31b8bc2d6d470df
+#: 4548ab35bd754cda97c1deff4aa169a3 45b448c559824ec4a3f1b7823bdfd61c
+#: 4bc4a3fe6285420289e2261dfbb4753c 4dd58ffff7864ac0b12de594b0439242
+#: 60764bb63e7a4e6e94ad8dca4c342461 7b95c5a6a30f4231bd9f9e9d74152dd2
+#: 863799be4c044177a3a00204d21e34bd a0be70a4b09846d3b36f051360ad69e6
+#: a87ddc51c549441889823c02e16480ee a97681abafa94d1d981c32a8bbcd7fc8
+#: ab0ab579bf2b424c976016954a85659f adf7d2ad586842cfafea24dfb6255af9
+#: c010f7b2c05a477d99b086a327e2c73b d48637b2ace44291945156c123a3e335
+#: d49d6e0b857a41aeaf6324acb7c49d24 dd26f218279f4847b005ce565c36a02b
+#: dd4d76f97f594b15b22f0cc80646fa57 f616414599644eeeb62043fe602edc08
+#: f7ba1f52d9a744559354a9a416daaf48 fb2823650f5c41f29ba549177b4ac1a9
+#: fc366d39419f409d9e721506d6b93369
+msgid ""
+"sysfs msi_irqs directory empty with kernel-5.19 when being a xen guest "
+"(LP: #2022354) // Lunar update: upstream stable patchset 2023-07-28 (LP: "
+"#2028979)"
+msgstr ""
+
+#: ../../22.04/4.md 14d6c6f2136f45feb97fe03ea3ebf0b6
+#: 2c71565c827a43269cce0d4af03ac556 3018e720f36b45cfa7a661aec05c8e29
+#: 3b8683900ca24eadaf70767365a3b71b 46230d32e52a426f8432f9cbfab554ec
+#: 4a2a204b62ab4241ab6463f9a4fed0d7 709d9771a87647b1b500ae92d69b25c5
+#: 72033bea3a25404a9934f08b6753bec8 93a8ca98578841cfba22a3cc8fee8d8e
+#: bb7abe0d9f124bf8b1a3c384e93a426e ca391f2638e44862a43ca961e22685f3
+#: eeb66149142649d7841940c4ebd56cc6 f9ab9ce0eb6648f68129b90a5bd6e80a
+msgid "[2028808](https://bugs.launchpad.net/bugs/2028808)"
+msgstr ""
+
+#: ../../22.04/4.md 02cbe35f5ef145c7a1137bb993058c78
+#: 0969194bdd804cc9a87d4f74d310bd22 162cb05cd9164fd2a5a7f1e9d5d9d938
+#: 1eebef1d53244132a046749ef69e5c97 3ad15e3d45494881a571a385850e01b2
+#: 49f136625f37402aa1ac8fe9fa73d574 5243f5f042c2471194860633fdc78445
+#: 70edb3564aec47e199afd8a48a70739e 906d586b7f2b4c08bdcfb03a2549c686
+#: 964976838f7c4593916f7f5712c5d1ff b84052a03a3a4f299a76997c9838a9f8
+#: f007ee0a2ed14b0eb06cc3f8c948a74e f5af230119914385b4d904e6bce0ee41
+msgid "Lunar update: upstream stable patchset 2023-07-26 (LP: #2028808)"
+msgstr ""
+
+#: ../../22.04/4.md 33ba0ef45fa74a61920c415cf4f56842
+#: 42d20a43aaa140b489d3652c109944ba 55639c7c0e40473aada803db76ff33ff
+#: 64f48a54c83d406ab36c1463768c0888 6579f0ac139e4361954dfd57d0be1958
+#: 68de4ef67ef04b24bb73ac5b162b8470 896365f79f3a4f6f8cf6bbaafb78f330
+#: a86bc75e9bf74e3da51fa57bac731321 b9d5f43e25024b6fab4972c811c96d68
+#: cc70876472e0416c9200a29c02d85d84 d0b0f7860dbb48e3b9806f627a40f29a
+#: d7fdc78c249c4b0e99c67fdcfc729079 eeb21ce1e419476980b9564ecaae458b
+msgid "[2028580](https://bugs.launchpad.net/bugs/2028580)"
+msgstr ""
+
+#: ../../22.04/4.md 004f0afc438a4b5c84378456218c1c23
+#: 00557b055507481a8d497f5292eb5403 0654281275b5451bba2c9f3eeadec9f8
+#: 2e894fee0af840e18322812d6b2441a5 516d2472349445ebab73d22b98c155a0
+#: 996f07195d5e483b8f5008f3d4b02092 b48447bb749548059aa3aeaeca7f0df5
+#: b805b521b8e7435f89638e7a803c272f be52cbc1f4784a68bf3b7c6f9f290dce
+#: c1b319e2681f4724aa82951f0d6e8547 c998fb31732f4363bc64aa9e227aaee5
+#: cb750a9425f2448e97f31e45a113035c d199a60f50714a15bcd0f6784fdcabff
+msgid "Lunar update: v6.2.16 upstream stable release (LP: #2028580)"
+msgstr ""
+
+#: ../../22.04/4.md 0961b2d4890b40379ff4e09c723c7f62
+#: 32171d9445844babb05cbf69d185953c 3b419acac402440ab1a79dd27b794117
+#: 3cc62208645547c7a3887374f2d56ad5 4366f43f3ebb4ed1b10f854e4c39b969
+#: 4dc11500b00348ef8d91ed6a12e237b4 61bd9d81ab6d42a18bb47d10ee7702ec
+#: 7efe5ff95f564027ad46165e0c1aa637 8f77b115e7564afeb4e9f235243a440d
+#: 9e94aaef537b4162a2ef8501dc3f9e72 b0139c233830418591b06c778bd525a4
+#: b44eced99d4c434b80c45df7deb6dc9c b46aceac9a1048d59404391030f411e4
+#: e6225c129b9b45f4afb7f8eff5c8b5e8
+msgid "linux-raspi"
+msgstr ""
+
+#: ../../22.04/4.md 02df1bab33d241cf920622d40f16738b
+#: 12495252f1cb454aba2d32a1aac19c2c 13f8b7c2a5d9487f8d0d595ad57409aa
+#: 18b9ee20fc4a4bc2ac4c5568edfd1e80 18c406bb97f6454ab4afe511cbd5c5ee
+#: 18d79f2a42de42aa800b51969fae42f8 1b73651d84b0479e867d91d5ba9f1c52
+#: 1c417faa31d14150aaf5f1d4a6214b48 1f44075e782c4735aa0a9cbe63cdd472
+#: 26c58b8373f24f00ab6917ad261445fe 2dfa39ca85ab4b04a3d7be617c258f47
+#: 2e7376cf7b06471ea7510b44d6ce3f95 33f013034866476aa038a4e3299b287f
+#: 34c2031957954876b58a7bb2d01e22e8 36d63a9bc2304a588860339eed0f82ff
+#: 399429de037b4fa8ab23651f8030ecec 3bc2875526e444dfb5b8cead7a650662
+#: 479fe45e141d4f72bcd9def8bf5e3d8d 4cda8562904f478aa662a9767fe5c845
+#: 4d218814fbd04146891376fd5e12e65a 526a627f1a354e7fa0e313d651721c0b
+#: 592eb084a0c0470ebcd5dab653391381 5c063298a2b847259fd39096c19b7abc
+#: 5faca4451ab848f4b5aa74ab7ca7645e 608cae02c169458b9ec7ea581dec76d5
+#: 61f91eef675845cea3d6b15ea1241011 652955bc16c5480485dcdf44dbf35b18
+#: 68ed39a2520e491f978f5a03820add62 6e49d90d73a44b819c520b2fcadb17ff
+#: 76c83197c88c4d41ab4e1ed6dbd6454b 7723f037c33246789d4865ea23fd1c3e
+#: 7bfd79685c7b436faa199329e4b3d05d 82427dba24f944d4a013cb9c0333b6c0
+#: 89823667d32c4a69b1c9294a41d80a94 8dd367c816c84190910b0aa45b7240e5
+#: 9067d242665a4c75836fbbac7cd969e5 90d7dab3152446be9ac6582ec8726c0e
+#: 98405239493c48e999082379f2fcbf3d 9c95ea24d6d94798825922fc4daad61e
+#: a1444aafc30544dab4515c3939f44626 a2966c911ebc435e9ce0b5b1a99c917a
+#: a32d51ee831c426aaf8a307c0cf47761 a4698961d3954151bd2a6a7915c7925b
+#: aa84bb9938a64f1bb493bd6eef68a815 ab92bc4129b747dfb63c19a6ee0de916
+#: ac7158fb4d914c289f9fc5eab7419002 ba59edbd31b0426b801ccc4b97835271
+#: bd0c08284b774a6e99c9e060385d668b c4a27169862d4a5fa16d36023648af19
+#: c578857484ad4d66ac4258fc190ad07f c8365ac97afd443aa614beb1b91d1997
+#: cd1927ce287143bda74820321f0ffca1 d56ced4a08694e558dc9406f0746e2b1
+#: d57064c6026e44ff92ac48db81ac33eb d80c0f0c7c914cdd98364a3b45353511
+#: d87c5281de5a434496515e4b526b7eff e0a85b75f275482da623f531daeabf62
+#: e0d70a4033594189b8369d0f8c06bf77 e3af57d95d494e0caad158af28eb5481
+#: e7420c1463a44f0aaeef5b2bc86cab3c ed521e24d7824b5184bafa2ac750b022
+#: ee6e51d35aa442f0baf1bad3db81d11a f01b9da6da5b4d399285d2c1e2e73fc8
+#: f324687f36c74d048b3e67002367abb9 f999b9ebcdac423ca90ad62ee0f12082
+#: fb56cfb66e004ef9a8e447074dc5ccf0 fb63a95f523047c493b47661d4c149f1
+#: fb6d752fd99a4d05a0822f17ddd173bf ff56f9e078364506a2edf1305e694169
+#: ff6bc1f1845c4159b62d587ffffaf3fa
+msgid "linux-oem-6.5"
+msgstr ""
+
+#: ../../22.04/4.md fb02fb8fbe634c5e917a640ac70efe3c
+msgid "[2033279](https://bugs.launchpad.net/bugs/2033279)"
+msgstr ""
+
+#: ../../22.04/4.md 78aaf139ca6645c19de5d4e267fc8fd4
+msgid "jammy/linux-oem-6.5: 6.5.0-1003.3 -proposed tracker (LP: #2033279)"
+msgstr ""
+
+#: ../../22.04/4.md 4f6d6a7229e449c693f8a5a615d540e4
+#: babe7063cd6f49a58dc3c66838300bc3
+msgid "[2024199](https://bugs.launchpad.net/bugs/2024199)"
+msgstr ""
+
+#: ../../22.04/4.md 1a6311f70b304cb6a813056012b15bd6
+#: 9390a214883445cb8e386fdbcef3d16c
+msgid "Resync CI Runner Configuration (LP: #2024199)"
+msgstr ""
+
+#: ../../22.04/4.md abda4f273f9c43b591991f1fa3c8b269
+msgid "[2032781](https://bugs.launchpad.net/bugs/2032781)"
+msgstr ""
+
+#: ../../22.04/4.md bd016c38de4748fba89319846a0246a1
+msgid "i915: Backport some fixes for Meteor Lake, vol2 (LP: #2032781)"
+msgstr ""
+
+#: ../../22.04/4.md 26bb977346014bfebae51a1dbb89ce00
+msgid "[2028932](https://bugs.launchpad.net/bugs/2028932)"
+msgstr ""
+
+#: ../../22.04/4.md 8f0936b7e0c54ffdbf26f0c9059add86
+msgid "ubuntu_bpf failed to build with j-oem-6.1.0-1018.18 (LP: #2028932)"
+msgstr ""
+
+#: ../../22.04/4.md 85242f8aec2943f9ac4c1a8e63a6083e
+msgid "[2033240](https://bugs.launchpad.net/bugs/2033240)"
+msgstr ""
+
+#: ../../22.04/4.md 6c9149d435424486b648b6a90ad382cb
+msgid "mantic/linux: 6.5.0-2.2 -proposed tracker (LP: #2033240)"
+msgstr ""
+
+#: ../../22.04/4.md 42fdb10bb4aa41ac90f7c3eca915ae6e
+#: 8bce5dec7f5344a5babc8acf39e069ac
+msgid "[2029281](https://bugs.launchpad.net/bugs/2029281)"
+msgstr ""
+
+#: ../../22.04/4.md 593ec208dc1e48b9b381430cd9d4fffd
+msgid "Soundwire support for Dell SKU0C87 devices (LP: #2029281)"
+msgstr ""
+
+#: ../../22.04/4.md 454fe7b4a32c4d2e9d169ce92f83be91
+#: 9b369db9e0284941a4c81408134ee2ff
+msgid "[2025672](https://bugs.launchpad.net/bugs/2025672)"
+msgstr ""
+
+#: ../../22.04/4.md 898399f476a54f8c979656392c64453c
+#: cb1086edf5a74ea589b37259f6ffb048
+msgid "Support Realtek RTL8852CE WiFi 6E/BT Combo (LP: #2025672)"
+msgstr ""
+
+#: ../../22.04/4.md 05ef01d01f97483b8d6e5f0c70d72609
+msgid "[2032750](https://bugs.launchpad.net/bugs/2032750)"
+msgstr ""
+
+#: ../../22.04/4.md 547dfb0c9c444f43bcd20d01b08a0013
+msgid "mantic/linux: 6.5.0-1.1 -proposed tracker (LP: #2032750)"
+msgstr ""
+
+#: ../../22.04/4.md 7f4f7963ce2246b8a80d27f915770e06
+msgid "[2032959](https://bugs.launchpad.net/bugs/2032959)"
+msgstr ""
+
+#: ../../22.04/4.md 0c38f1bbbcda41f086b78bb2865d995d
+msgid "ceph: support idmapped mounts (LP: #2032959)"
+msgstr ""
+
+#: ../../22.04/4.md d37f6319b994425f85b5d845566f6304
+msgid "[2032174](https://bugs.launchpad.net/bugs/2032174)"
+msgstr ""
+
+#: ../../22.04/4.md 79950df133f04b1b8732b657e47ef0ca
+msgid "Got soft lockup CPU if dell_uart_backlight is probed (LP: #2032174)"
+msgstr ""
+
+#: ../../22.04/4.md 0d10a15468124b2482f95309135385e1
+#: 5e9cca6c9fa34ecc9e0fc9bf3f41d1ce 675aa49ecafd4d388e7d3df868aeff03
+#: d18bc36d267d4dc09eef17aef814f668
+msgid "[2017980](https://bugs.launchpad.net/bugs/2017980)"
+msgstr ""
+
+#: ../../22.04/4.md 55ec473eabf043ef9c85aacf73ca1772
+#: 7b9db443dff94050812a848a40f665a1 89c0747dede2469ab251ce4155be3e32
+#: e0c92e332c924dc380be41c9241b381c
+msgid ""
+"FATAL:credentials.cc(127)] Check failed: . : Permission denied (13) (LP: "
+"#2017980)"
+msgstr ""
+
+#: ../../22.04/4.md 9c07355d3f6f4de882cd3c0cb59c93e5
+msgid "[2030745](https://bugs.launchpad.net/bugs/2030745)"
+msgstr ""
+
+#: ../../22.04/4.md 7c8869d6c03d42d792477315ff2f92c9
+msgid ""
+"Support initrdless boot on default qemu virt models and openstack (LP: "
+"#2030745)"
+msgstr ""
+
+#: ../../22.04/4.md 0695e0853abf4b86b707ee6f3a6886f8
+#: 0fb5479e787846f7bbf412cc8a3f148e 4bc32642e1c14eb2bbafbca657553b67
+#: 7cbe11ebcb9a44c1ae0537b2d237f4fa 8408511b32b94f88818c9faace317d8d
+#: 8d0ac62865bd45bdb670773a05476522 a1ebceed12434922908b6abba5be9121
+#: a61c62310862425e9bb1bf4fd7ab062e b34cc31e7c674bdfab8b21c8339c4b1e
+#: e8c87d3b09034e8dbda1e375f43801f1 f771aaf0ad9044c7a39078ede5f01541
+msgid "linux-oem-6.1"
+msgstr ""
+
+#: ../../22.04/4.md 5fbe497e3f5a47058464d353eda4ce06
+msgid "[2030859](https://bugs.launchpad.net/bugs/2030859)"
+msgstr ""
+
+#: ../../22.04/4.md acddbaed303343799ed58e15edebe1c8
+msgid "Jammy update: v6.1.42 upstream stable release (LP: #2030859)"
+msgstr ""
+
+#: ../../22.04/4.md 4dfcbd76069e4d069863d2d3b68da782
+msgid "[2030858](https://bugs.launchpad.net/bugs/2030858)"
+msgstr ""
+
+#: ../../22.04/4.md 9f2bd8c70afa475db3b6c8b37f7284ec
+msgid "Jammy update: v6.1.41 upstream stable release (LP: #2030858)"
+msgstr ""
+
+#: ../../22.04/4.md 6bc4487aea8e42939d60ca9e30c7018e
+#: bd87802587134e1f98e9a907f34a22a3
+msgid ""
+"Jammy update: v5.15.113 upstream stable release (LP: #2028408) // Jammy "
+"update: v5.15.116 upstream stable release (LP: #2029401)"
+msgstr ""
+
+#: ../../22.04/4.md 7f6a8dd946e04e7a83e07e3b8cbeaa81
+#: b1135dc95d6e41e0bfc149de390f7de4 c8a7f23bb34643aba713b7660bfdfd5d
+#: d1bc17d8cf9d454883a19b4f71ec5ca7
+msgid "[2026736](https://bugs.launchpad.net/bugs/2026736)"
+msgstr ""
+
+#: ../../22.04/4.md 179d60c791184bccbbd72bfff7be2440
+#: 4f7cfdc9104942d4a7727f46f326c5a2 5fdc73d28cb04f3f96d5222400ec5991
+#: ef9a29dce3e04c6aa50af6807227c093
+msgid "Azure: Fix lockup in swiotlb when used as a CVM (LP: #2026736)"
+msgstr ""
+
+#: ../../22.04/4.md 34c96b12e051439fb069e70d3394395b
+#: ca0d6f53c3fd4b1bb482387ff1f30f13 ea7beb79ecc24cb9882e0af21ce59198
+#: ef2508893e46430fa6398036d23e897f
+msgid "[2030366](https://bugs.launchpad.net/bugs/2030366)"
+msgstr ""
+
+#: ../../22.04/4.md 05a7aa2599ae448c981b3380a2ca5567
+#: 739d291fc39446f69487d122f9a30709 9b0296dce4fe422cbd56a63a0d6584ba
+#: f76c9b2c980440a49efbf2fe03d70ff2
+msgid ""
+"jammy/linux-azure-fde-6.2: 6.2.0-1011.11~22.04.1.1 -proposed tracker (LP:"
+" #2030366)"
+msgstr ""
+
+#: ../../22.04/4.md 1c45255262ea49d69cd92ca23f3d1f02
+#: 708fb9256f274e96b5182c15ec930939 829db40d018e4e3b85c098cd14069178
+#: b1a644caf71844c8929850705f5a56e8
+msgid "[2030532](https://bugs.launchpad.net/bugs/2030532)"
+msgstr ""
+
+#: ../../22.04/4.md 482b11bc27434020ac56e61eec88baf0
+#: 8cbb9b90219e4c99843b5d554785e4f5 dd852ad5fb544258b40a2f7156480e16
+#: f78f7c2017dc4044a952e89e5f651115
+msgid ""
+"jammy/linux-azure-fde-6.2: 6.2.0-1010.10~22.04.1.1 -proposed tracker (LP:"
+" #2030532)"
+msgstr ""
+
+#: ../../22.04/4.md 23bad77dd65c43cf8e7d044f9ec583e6
+#: 4563844d8b4e4a19a2243f251c840d28 4d2244e7360f4fea8ca26f86b8bb3429
+#: 7a3530b9b7a04c9da756209a1ae2e833 9b5e4b44239e458cb58e1d2fdf4d1a07
+#: c5d124ad9eb74f7bb8e0ab2aa450fa86 c8bf9c9f221d4eb7a184c04557d4b37a
+#: f61e2f719e2f45989c9a9590079d8735
+msgid "[2026474](https://bugs.launchpad.net/bugs/2026474)"
+msgstr ""
+
+#: ../../22.04/4.md 25d9a2ad7b194fb8a4356b0bdd61fcca
+#: cf14e174b70e48ab80f438be9033a66e d7e9bb441c4a4969ba4c76c6295ead46
+#: f387c4e448b442e99d1cc567ddb8fc52
+msgid ""
+"jammy/linux-azure-fde-6.2: 6.2.0-1009.9~22.04.2.1 -proposed tracker (LP: "
+"#2026474)"
+msgstr ""
+
+#: ../../22.04/4.md 0965da5f1d324d328c4fee543cfdb9a3
+#: 0cf3ee2c058242949201bad535cee961 d13ca7467b5f4f8fb4234be7367b71cb
+#: f181073a3ca44823ae52385e6d452aa7
+msgid ""
+"jammy/linux-azure-fde-6.2: 6.2.0-1009.9~22.04.1.1 -proposed tracker (LP: "
+"#2026474)"
+msgstr ""
+
+#: ../../22.04/4.md 58a3f2b677ab4982a8532124919a2735
+#: 643930e862b5412181fb93db97d0b50d 8cac556e964a4ac28bdc3c5817e01a2d
+#: bf16a351e7d84b35bee1fd932e133c9f
+msgid "[2026739](https://bugs.launchpad.net/bugs/2026739)"
+msgstr ""
+
+#: ../../22.04/4.md 27dee7d012ca455ab8ad6913fea1af0c
+#: 298e08d5c3a64d6294e559a38c4e340e 42737d9699034310b96e30d537b81b94
+#: 897ffb80b5134f2db9c682468f92b486
+msgid ""
+"jammy/linux-azure-fde-6.2: 6.2.0-1008.8~22.04.1.1 -proposed tracker (LP: "
+"#2026739)"
+msgstr ""
+
+#: ../../22.04/4.md 1b593ed1d4044b4aa04735d3049561d7
+#: 1e3ac62bba1343fd8e805c56186f0846 86e517ae7344419997cadd4b11d6db48
+#: bcfc6b72f2d3442eb2868dccb40c38e6
+msgid "[2024532](https://bugs.launchpad.net/bugs/2024532)"
+msgstr ""
+
+#: ../../22.04/4.md 729005ed8f45465291cd826c40f47224
+#: 80c73d4871744c57b2267635687b76b7 b2110db55ddd4b54bd06afeb216f2f54
+#: bd47eb7142ba4709bd7279fe05bd705d
+msgid ""
+"jammy/linux-azure-fde-6.2: 6.2.0-1007.7~22.04.1.1 -proposed tracker (LP: "
+"#2024532)"
+msgstr ""
+
+#: ../../22.04/4.md 1562c9778379446bbfc6f594ea30589f
+#: 170d15e0cb434b5b9cedec31da53e6f1 80acbcb8ccaf4575ae64b47f2a5ed8c9
+msgid "[2030384](https://bugs.launchpad.net/bugs/2030384)"
+msgstr ""
+
+#: ../../22.04/4.md 36a8da5f2520459aab23cb7fd5fe9370
+#: 5010221dc4f24a00b2c47fc5c00823b6 728a4ed2f20a4fcda46fb9f9c7d4d184
+msgid "jammy/linux-azure-fde: 5.15.0-1046.53.1 -proposed tracker (LP: #2030384)"
+msgstr ""
+
+#: ../../22.04/4.md 9a7b96ae378c4224ba0425af66a3a29d
+msgid "thermald"
+msgstr ""
+
+#: ../../22.04/4.md 526569986cae4e999b82a3c507fee802
+msgid "[2028217](https://bugs.launchpad.net/bugs/2028217)"
+msgstr ""
+
+#: ../../22.04/4.md 4519b2f510d9456c8107d42642e91fe9
+msgid "Add support for Meteor Lake (LP: #2028217)"
+msgstr ""
+
+#: ../../22.04/4.md 6d0538b4ab1341a8976e8e9e72942d98
+#: 98e901c302f14471a2a4bf380f699544
+msgid "[2034163](https://bugs.launchpad.net/bugs/2034163)"
+msgstr ""
+
+#: ../../22.04/4.md 3efb272561f040d3a738c9b19bd38527
+#: b0904c555ed54d6db30aeb8fe09f5e47
+msgid "jammy/linux-azure-fde: 5.15.0-1047.54.1 -proposed tracker (LP: #2034163)"
+msgstr ""
+
+#: ../../22.04/4.md 8354050f7a2c45caa27d659839cfaecc
+#: a40db3eb28e740848dfed5f012f0ba00 d6e0fb17f9fa4849ba016089cdb7b316
+msgid "[2034142](https://bugs.launchpad.net/bugs/2034142)"
+msgstr ""
+
+#: ../../22.04/4.md 9890fb0a803e4e2ab17c9104067f3a0c
+#: cff85edf7f754095bed131f4e8ec19bf dbbf73a64b6341f2987bc77b669112fc
+msgid ""
+"jammy/linux-azure-fde-6.2: 6.2.0-1012.12~22.04.1.1 -proposed tracker (LP:"
+" #2034142)"
+msgstr ""
+
+#: ../../22.04/4.md bbac5e20950e475c8f3053fbf1acb5cc
+msgid "linux-restricted-modules-oem-6.0"
+msgstr ""
+
+#: ../../22.04/4.md d45091e4245e43549fe00ddba02e9623
+msgid "linux-restricted-signatures-oem-6.0"
+msgstr ""
+
+#: ../../22.04/4.md 0d0de6e78aaa4bbab4d6d98d4449ecc3
+#: 40586f964db54f9ab125a57432a4f158 469886d214244a70b22b7145f878133e
+#: 6f078f8e21284f46a33729e1fb2fe0d4 ab0354cc7e3a41d38a2ad223b82f4014
+#: d89bc158d169452c85eecfe365c6f89e
+msgid "nvidia-graphics-drivers-535-server"
+msgstr ""
+
+#: ../../22.04/4.md 126ff1893a5d45a78ab32793aee44293
+msgid "[2025243](https://bugs.launchpad.net/bugs/2025243)"
+msgstr ""
+
+#: ../../22.04/4.md 37da80feea3e446299d3f8145e08a885
+msgid "New upstream release (LP: #2025243)."
+msgstr ""
+
+#: ../../22.04/4.md 8a317faa18bc4e4787fb56a79f5a0c87
+#: a1a9e01ed4a2448ba8f9cdbb92ad8a5e
+msgid "[2026622](https://bugs.launchpad.net/bugs/2026622)"
+msgstr ""
+
+#: ../../22.04/4.md 4bf1ecea13f24137b45106e4902bc918
+msgid ""
+"Add breaks&replaces on identical firmware files from other flavor. When "
+"535 & 535-server driver versions happen to be at an identical upstream "
+"version, they both ship identical firmware files on disk at the same "
+"path. When a user attempts to install two drivers at the same time, this "
+"results in dpkg file conflict. Allow replacing one firmware with another "
+"(LP: #2026622)."
+msgstr ""
+
+#: ../../22.04/4.md 05d145cc0b8f442185f2ddf4e49b6c0e
+#: 289ba5b7859042ca90a29e19d07d1f71 2f0bcd25141a48228a39651f9d19a15b
+#: 4a23641931b44cf2a7804ef6181c103c 4d47a05c47f34a86aa77f95bd2832e8f
+#: 6b5c757092114a23ba7256d924acbb99 aba336d2b10d436b8a6f0b92574e1746
+#: f7294e47255f4ceaa772eaefdb95325f
+msgid "nvidia-graphics-drivers-535"
+msgstr ""
+
+#: ../../22.04/4.md 2a188fb77f5546f08bcb6edd187c3a24
+msgid ""
+"Add breaks&replaces on identical firmware files from other flavor (LP: "
+"#2026622)"
+msgstr ""
+
+#: ../../22.04/4.md 713232ef671349d5805e46c8612a477b
+msgid "[2032672](https://bugs.launchpad.net/bugs/2032672)"
+msgstr ""
+
+#: ../../22.04/4.md 5336e7603c1648a09f261cd94ab34a41
+msgid "New upstream release (LP: #2032672):"
+msgstr ""
+
+#: ../../22.04/4.md 840234261e9143ce8bbaf38508e586ac
+msgid "[2025538](https://bugs.launchpad.net/bugs/2025538)"
+msgstr ""
+
+#: ../../22.04/4.md 85643b185c654ba4871c3f846ba2c6e0
+msgid "Introduce the new -core and -lrm meta-packages (LP: #2025538)."
+msgstr ""
+
+#: ../../22.04/4.md 4713d66163554c4088cf993402ca4406
+#: 8c9cb12c27934950b34c5ef5f2777ede
+msgid "[2037266](https://bugs.launchpad.net/bugs/2037266)"
+msgstr ""
+
+#: ../../22.04/4.md 840dca05dc5a4ac097db2d174aaf1aca
+#: ea980f5215c04200807b3f0afa05cecb
+msgid "New upstream release (LP: #2037266):"
+msgstr ""
+
+#: ../../22.04/4.md 96fa129e71fd411eb78a57e35df67616
+msgid "[2031882](https://bugs.launchpad.net/bugs/2031882)"
+msgstr ""
+
+#: ../../22.04/4.md 8339abf2a42f4d01a8fb6584e965fb58
+msgid ""
+"Missing firmware for Intel VPU on Intel Meteor Lake platforms (LP: "
+"#2031882)"
+msgstr ""
+
+#: ../../22.04/4.md a9ad5f7a2e5f4333bdb2c924c0f9344f
+msgid "[2024427](https://bugs.launchpad.net/bugs/2024427)"
+msgstr ""
+
+#: ../../22.04/4.md 08ead408b8134faea93b15182f00d2d6
+msgid "S3 stress issue for amdgpu Navi 31/Navi33 (LP: #2024427)"
+msgstr ""
+
+#: ../../22.04/4.md 20f223a1b7da440698c3255d8083964f
+#: 82733147b4fd4be8ae65cc17ea1d08cb c48fd5a6c315490783b0f4a41680ce17
+msgid "alsa-ucm-conf"
+msgstr ""
+
+#: ../../22.04/4.md 4bcc5f4a0d8c49de8e79fae753e1e66c
+msgid "[2000228](https://bugs.launchpad.net/bugs/2000228)"
+msgstr ""
+
+#: ../../22.04/4.md 1ec240c4577f4fc2b97cbcee90906d4a
+msgid ""
+"Backport patch to add initial support for MediaTek Genio boards boards: "
+"mt8395-evk, mt8390-evk, and mt8365-evk (LP: #2000228)"
+msgstr ""
+
+#: ../../22.04/4.md a3c079b47e794c4baae31f2fcc218281
+msgid "[2036238](https://bugs.launchpad.net/bugs/2036238)"
+msgstr ""
+
+#: ../../22.04/4.md 494ad20a89734006971d422fa01dfe8f
+msgid "jammy/linux-oem-6.5: 6.5.0-1004.4 -proposed tracker (LP: #2036238)"
+msgstr ""
+
+#: ../../22.04/4.md 01e4ba49bda34407ac5d2a5e647eafa3
+msgid "[2035299](https://bugs.launchpad.net/bugs/2035299)"
+msgstr ""
+
+#: ../../22.04/4.md 3cbd8abd0b2e435e9103c529d6ad3830
+msgid ""
+"dell-uart-backlight fails to communicate with the scalar IC sometimes. "
+"(LP: #2035299)"
+msgstr ""
+
+#: ../../22.04/4.md 2af08a5fde01461d91307677484428e7
+#: 3419a7c38b9148fab133fd40fb276fb8 82690f47979c4c2d8878cb355874dba9
+msgid "[2035595](https://bugs.launchpad.net/bugs/2035595)"
+msgstr ""
+
+#: ../../22.04/4.md 0452d82915e146df85dab67cda693cd7
+#: 2baecb547f5d48db92479bdb6d2f9e52 98dd942eae024e159b2bc7091d30bb21
+msgid "mantic/linux: 6.5.0-6.6 -proposed tracker (LP: #2035595)"
+msgstr ""
+
+#: ../../22.04/4.md 4ed07620bbf44a259cbb4b94d7125963
+#: c466bd5563e042299ef16b80944481f5 c6e03205f6e1403b9e53fd9f5164ed77
+msgid "[2035588](https://bugs.launchpad.net/bugs/2035588)"
+msgstr ""
+
+#: ../../22.04/4.md 1235b50ce19a47dca9dd4e551080db56
+#: 86be818cc95e412c8230bc934a6ea4ec d97d49e354c14399b6e0cfa6adc2f009
+msgid "Mantic update: v6.5.3 upstream stable release (LP: #2035588)"
+msgstr ""
+
+#: ../../22.04/4.md 0b9f6cc2053940e7b7a0f0759362ba57
+#: 17ebf663f1e642bca9c00aa5ab17562c f9922ba578c948eb8d3985d1a69e4619
+msgid "[2035583](https://bugs.launchpad.net/bugs/2035583)"
+msgstr ""
+
+#: ../../22.04/4.md 1a051bb47e05416fb3e241f62bf4f5fa
+#: 66291a45b9264edb97fd46252dfc8097 7b09d25669a9434f9f6e53bc1ec99ce3
+msgid "Mantic update: v6.5.2 upstream stable release (LP: #2035583)"
+msgstr ""
+
+#: ../../22.04/4.md bc324321b85a4ed2b9fd13bd7cd11566
+#: c3ad1639d47d41d691dcf7a536ed7772 ed81fe74feb547669d645ae60e46204b
+msgid "[2035581](https://bugs.launchpad.net/bugs/2035581)"
+msgstr ""
+
+#: ../../22.04/4.md 1dd03943509445c9a8b6104a68d9085e
+#: 37b7a510d9d442b7a1ef14048cf54100 f3e6eb6cdd0b4eba977407dc4f12964c
+msgid "Mantic update: v6.5.1 upstream stable release (LP: #2035581)"
+msgstr ""
+
+#: ../../22.04/4.md 701ab36b95ab4d078e5e03f70b1f4a84
+#: 7f8010c6aa434aaab0fe9b6da3fc5e68 d97ee4fada124db5a9aff173c4ebefb5
+msgid "[2029390](https://bugs.launchpad.net/bugs/2029390)"
+msgstr ""
+
+#: ../../22.04/4.md 560a5cb68c454459b32b0deeb8ab4a40
+#: 8c60f69b050146db8a671b3add28ee61 bd68fce22c194e0ba82ec4945458d7bf
+msgid ""
+"23.10 FEAT] [SEC2352] pkey: support EP11 API ordinal 6 for secure guests "
+"(LP: #2029390)"
+msgstr ""
+
+#: ../../22.04/4.md 84bdcef838f745f8860706cf9c2420d6
+#: 884a29d3d2534d569126c9a3b72841a6 f8688ee89c3d41c38b99dc93d19b7cec
+msgid "[2028937](https://bugs.launchpad.net/bugs/2028937)"
+msgstr ""
+
+#: ../../22.04/4.md 6c0d8588dd6145758ecdfccb368494c4
+#: be94dc72ba8642fe89088ee0a2c96b1d dc74f13535c843afad71a87892998721
+msgid ""
+"23.10 FEAT] [SEC2341] pkey: support generation of keys of type "
+"PKEY_TYPE_EP11_AES (LP: #2028937)"
+msgstr ""
+
+#: ../../22.04/4.md 2b04750786c94a75872350f2a5ee456c
+#: 56225bc00ef9414bad2594415c613b67 a9aa7815abb64504ba22fa19c4431bf3
+msgid "[2003674](https://bugs.launchpad.net/bugs/2003674)"
+msgstr ""
+
+#: ../../22.04/4.md 347d6623782243e2892a79fb33edc033
+#: 3519a71fab62455491c176e9e2423ed7 78f4752a9cb14c8195cc76919cf5499b
+msgid ""
+"23.10 FEAT] KVM: Enable Secure Execution Crypto Passthrough - kernel part"
+" (LP: #2003674)"
+msgstr ""
+
+#: ../../22.04/4.md 18c003bb09ee4fe5b0aa6b9cf819c1ae
+#: 3fa7891513d34edeaa66ccf68b8c5664 5b6283d061ba47fda14d4ab12699265b
+msgid "[2008882](https://bugs.launchpad.net/bugs/2008882)"
+msgstr ""
+
+#: ../../22.04/4.md 7bb0e49bc6614687b9a9766339fa8bcf
+#: b7e1f7ab34d94011add788b9cb21c749 bb8d4a75748c443dad9d2a741e5453a8
+msgid "Make backlight module auto detect dell_uart_backlight (LP: #2008882)"
+msgstr ""
+
+#: ../../22.04/4.md 22abb74ca6c44e0b9e00649b5903f3e8
+#: 5181c9935efe4f2eb4195a475c401162 8e1ca59ad06c4d11abf3e718d146e665
+msgid "[2035306](https://bugs.launchpad.net/bugs/2035306)"
+msgstr ""
+
+#: ../../22.04/4.md 003d45059acd48c8bc6da48a2c3defd3
+#: 3591a79a566942ad8bccb24bf9a7f319 51953ad2923f4e8aa6428854f558e79c
+msgid "Include QCA WWAN 5G Qualcomm SDX62/DW5932e support (LP: #2035306)"
+msgstr ""
+
+#: ../../22.04/4.md 5f2d4983f7d94b659bb4c89c52b60abf
+#: 8208069f6df845cb9fb238ae2b38c11e fd812722f30c45bbaad32d3ea378d01a
+msgid "[2021364](https://bugs.launchpad.net/bugs/2021364)"
+msgstr ""
+
+#: ../../22.04/4.md 80f043ece4d344dea46a5f40f526090a
+#: ba90ed2234514152b4a08008d7dc5b39 d0ac5df0ba2e4581913f2cc1bc85bb8e
+msgid "Linux 6.2 fails to reboot with current u-boot-nezha (LP: #2021364)"
+msgstr ""
+
+#: ../../22.04/4.md 42183499f8954ab4a225c944457f2ce0
+#: 54ce146e76124aff9f168fac0a590127 64c2e6241015470fb95d2b43fa978283
+#: be4469cd61cf419ca45aa40f272756ec ce1080ee779644bb93a87d0a7b4124f7
+#: ce94fc38c1cd4a169f48c3a76377a422
+msgid "[1975592](https://bugs.launchpad.net/bugs/1975592)"
+msgstr ""
+
+#: ../../22.04/4.md 22031765ac5a446fb2c1c54a138e90fb
+#: 35e88cb6f8cb4533bee6c1c20631ea9e 70ae64d1d20046cbb64570d9f77e8263
+msgid "Enable Nezha board (LP: #1975592)"
+msgstr ""
+
+#: ../../22.04/4.md 4ae30954692d4237813dbb1cb2c4f870
+#: 5727b11a3f574104b98d08e2a4de3e39 7403a79008b149eca0559cdfa91079cd
+#: 8f2c28ac021740199801a4925a6ddd18 9c4ed2dd5ab0458f86c29be528bad64c
+#: a7add22eb8a04657b984ffe93896d9e9
+msgid ""
+"Enable Nezha board (LP: #1975592) // Enable StarFive VisionFive 2 board "
+"(LP: #2013232)"
+msgstr ""
+
+#: ../../22.04/4.md 1767f242485b426c9c5decf1988871f6
+#: 38400f519ffb4aeeb137f95ca1d27add 7bd73183b93445e8b812573ea8b373fa
+#: 89692f4df31344d59fd0b25940d60f6d 8c5bcc87b7cc4600874fd7313f8cce4d
+#: 99b9d7fd09284421b5ea7f1a2ad8f7e8
+msgid "[2013232](https://bugs.launchpad.net/bugs/2013232)"
+msgstr ""
+
+#: ../../22.04/4.md 08819750ab1a4f73a9d858384896aa28
+#: 71eff7e20fdb4e0c87c381cc258c8006 ba17908fbecd412fb0f1df82e502d8a7
+msgid "Enable StarFive VisionFive 2 board (LP: #2013232)"
+msgstr ""
+
+#: ../../22.04/4.md 1ce821798bc043ddad5a11facda5b921
+#: 40a5fd9dbbf24d31afa58fad1a0fd520 addeb54c228a4b25b467f3357d4cebde
+msgid "[1967130](https://bugs.launchpad.net/bugs/1967130)"
+msgstr ""
+
+#: ../../22.04/4.md 6db7b25d3dd64f90935d18f3fd107906
+#: 817f8ace4ed74225b607aff03f1dab44 bd2aa73993f04e8c893a45bd251833fd
+msgid "rcu_sched detected stalls on CPUs/tasks (LP: #1967130)"
+msgstr ""
+
+#: ../../22.04/4.md 69ad0e110f7a43968e223c3a9ae7ed81
+#: 72ea19140c83437b9eda6c214b51d3e5 9a42b2b5ca7d478e9482f77b1eebb456
+msgid "[1981437](https://bugs.launchpad.net/bugs/1981437)"
+msgstr ""
+
+#: ../../22.04/4.md 0bc98ad00a7c4900b8a9ba8b36c822fd
+#: 8d7269deb78f40b79adf285623a1ace8 960c00266340479498b85916fddd5e04
+msgid "RISC-V kernel config is out of sync with other archs (LP: #1981437)"
+msgstr ""
+
+#: ../../22.04/4.md 3a55a29fc7b24a71a8424d43537b7dc3
+#: b9fa807c87a04950b7e2ec6ab9c34727 c8036ab2573e49e78af52b715de067bb
+#: f6947c1832284bc58845585d76a62ee5
+msgid "[2028065](https://bugs.launchpad.net/bugs/2028065)"
+msgstr ""
+
+#: ../../22.04/4.md 8870f7221b094833a1689d06eeb7f024
+#: ae6047f974034a3fa918a868fcbf3c3b b70d7b5942634decbf80552b8eab47ae
+#: d6df599fcb694822bc402f1bf5e8aa3f
+msgid "Support for Intel Discrete Gale Peak2/BE200 (LP: #2028065)"
+msgstr ""
+
+#: ../../22.04/4.md 397dc37f4c1e43b8ad5febbcd636f98d
+#: e278101106e8472ba23ab809b595bb39 febab521ce454fc497bd753eaea19d3b
+msgid "[2033455](https://bugs.launchpad.net/bugs/2033455)"
+msgstr ""
+
+#: ../../22.04/4.md 3a2c984dac9e47039ef6eef945b7854f
+#: d6d045ea403d4689a0aae2aef5f9f8a2 daa6cb9313a9455da9bba8bb9fb42ba5
+msgid ""
+"Missing BT IDs for support for Intel Discrete Misty Peak2/BE202 (LP: "
+"#2033455)"
+msgstr ""
+
+#: ../../22.04/4.md 219c0f9a1ed44949834f407b20bd6f4d
+#: 5d2e866905834be4901094c0c96f1e3c c8442b03bdb741d9ba9c683002095362
+msgid "[2034506](https://bugs.launchpad.net/bugs/2034506)"
+msgstr ""
+
+#: ../../22.04/4.md 9ddb270ee4c64406a676d04a34a9c0ca
+#: a9498c10d6de4ef1a83f959ffe453a57 ef7e283927b348d58c09b2c0158719f5
+msgid ""
+"Audio device fails to function randomly on Intel MTL platform: No CPC "
+"match in the firmware file's manifest (LP: #2034506)"
+msgstr ""
+
+#: ../../22.04/4.md 4c45ae6ccbda413fabb66df295542ddf
+#: 6bf9e29d5f834a2b8e9eb90ab610faaf ac2ee0f86737458a931393a65667ce65
+msgid "[2030525](https://bugs.launchpad.net/bugs/2030525)"
+msgstr ""
+
+#: ../../22.04/4.md 2edac331c5c44fef8892bc7425664f44
+#: ccfc5035a7f34c08a19d4317af706441 f2985788d8494ddb9cc2dd80fc1eebde
+msgid "Installation support for SMARC RZ/G2L platform (LP: #2030525)"
+msgstr ""
+
+#: ../../22.04/4.md 0dfedf4b6a014067b5d257c2762ec9fd
+#: 2ca489f0821c446ea85b66e42e5d665a 6c8160b88b544108b10ed2b4ed67a800
+msgid "[2002226](https://bugs.launchpad.net/bugs/2002226)"
+msgstr ""
+
+#: ../../22.04/4.md 0e47a9c753454de0a74e153661a9a681
+#: 1f0fcdf49bd3443a96ff4b29cfea3330 71f870841ed248f88b3dfa7b751c300a
+msgid "Add support for kernels compiled with CONFIG_EFI_ZBOOT (LP: #2002226)"
+msgstr ""
+
+#: ../../22.04/4.md 1fa107f7d4734e95801f1db888c52f56
+#: 375d014971f9482a917292c18892a338 e047055449704cfb8184c69433a00305
+msgid "[2034061](https://bugs.launchpad.net/bugs/2034061)"
+msgstr ""
+
+#: ../../22.04/4.md 5e2bac8a510849ce8757aa25eeb154a7
+#: 804ef232dea34776805fa85872cda1f8 940be10cc21b4dcf9c1c637a2544f932
+msgid "Default module signing algo should be accelerated (LP: #2034061)"
+msgstr ""
+
+#: ../../22.04/4.md 1bb9ff1126904dd1bf4539d7786aa597
+#: 44b6cc17457f42aab2f40a181d14aced c379df1d56ae46808484d50a8c1a256d
+msgid "[1993183](https://bugs.launchpad.net/bugs/1993183)"
+msgstr ""
+
+#: ../../22.04/4.md 8db3ac35e75f4be4ad24de13dd0f51fd
+#: a24ae8d005cd428b80d291d99a903282 e223c1682e9a4fc1b1f0d3cb9a697a86
+msgid "NEW SRU rustc linux kernel requirements (LP: #1993183)"
+msgstr ""
+
+#: ../../22.04/4.md 03eec42ec3284465916c0c8975a87c9d
+#: 097100aa0f9e45f78ece4d57a575db41 09913aee0dd444eab4d1a6fa7374c4f1
+#: 104e540a60114d55b0113e3cfa204c14 16c5e5fee431406f9c8bfec0fc1dfc58
+#: 19cbacc379634d3ba8d13d3d54d76715 19e44ecb662047ce8fd2340537ab1a8b
+#: 1b3471a2281041febb9fe8d2348aa7cb 1c932b113f224678ada2e57dfa20957e
+#: 1e940554abf64bceaddfbd216c5883aa 25c9bc9b24bc4a08988dca1605e7c55f
+#: 27d35697ff2541eebb9a2ba95334e6b1 2a7adf23520f4186b2c16cca56d090b2
+#: 363134cb80a3432eb272455329922f87 39b747db42a147a4873eaceecf0f0417
+#: 3c4115de97584951a89e329c719c25fc 3d4cf31854254ced856c035e1b5a30f0
+#: 3ff2622b287d41c9a14709974b3fe8eb 527bd806c4d94dbd966c7870926f460e
+#: 56732b7801c64b84ad03ae521ffd92ce 58f7c7686681402996df001d7e0679e0
+#: 655f4cf24b09425ba43336fce1774235 6a6aac2e00d842f58600be530c449374
+#: 7989319315644d13a3067d663430ac7a 7c5817fe8bd9425489184bb134f990b8
+#: 9ac4bf7dd0184572b38e76ed00535f53 a89a17f5b43449af9dae5b72e730aaf2
+#: addfb34394ab46f89c7ae186dab3eeff aed956d257ca414e908c9b071c024ae7
+#: af51d9490b7747a983ece3994013bd8e b3f0021ab73a4e08ae45af584f7ca46b
+#: c2013923dcc841fca4b34bdf8eb4b1de c2e67ee1c97547ccbf165ccf4fe5f870
+#: c7b240c2e7574722a0433e8168a2d61e c9c200dc053343c782b6a35ba2a20f9c
+#: d13f2cf64d034b97943c00f13e3e7918 d45d81de637b4bf2ba4a2be3538a0888
+#: de0b284d2bcf40b094bf6bbdc56f8ff1 e77c5d398b6a4d29a7d55d5e61790ea1
+#: ea563618d89b4bc0a616f12348e4b0cf f0ac476593f544cc963df58e0a470d2c
+#: f51741ae2ff94209902943454c734ec1 f6bfb9c3611c47deacedbaea48969ed5
+#: fd16e63af86a47cc91c671132a424706 fea11c7ea6c144a9a1f67892d36bde2e
+msgid "[2028253](https://bugs.launchpad.net/bugs/2028253)"
+msgstr ""
+
+#: ../../22.04/4.md 14da7d8eebef43fc94d6204bb4946a01
+#: 21a14bb8557542608f58f03c47f0e574 2544957e744f438dbc714a55e2ebf1fc
+#: 33a70ce79d1c43bca08b419606a201d0 43ee708477d24212b510722f30b52b3a
+#: 637df038ec6c48448424caaab2f7c424 87cfadc62e5b4d9fbf23f31bd6f989ee
+#: 96eec1a7f88c421fac5da284a5f75594 9b5d887961cc49b1a5845f77ef1e6e1c
+#: 9c36cba1b41f4bd890466379cf298caf b465817fad284d7a85ef5b3c4743fd18
+#: c2150161817e48dcaecfff35eaecbb3a c5d247f4a67c497696d6df39b274ddc5
+#: e51d742720bf44dd98b2490e01a17dd9 ff18a60469424f9ca9a7b912e85fad72
+msgid "update apparmor and LSM stacking patch set (LP: #2028253)"
+msgstr ""
+
+#: ../../22.04/4.md 117f71d573b546b8bad92ac4f329979a
+#: 3285aa70d5ae4bdf882161951bb64ade 5c7bccceba86446996c78e6da2da670e
+#: 75ce3984fc4b43eb8162ed653ca7e688 b1476d24ec09447ba6b84307d3459973
+#: e5a5fdfa687145e3accace6d893b0f17
+msgid ""
+"update apparmor and LSM stacking patch set (LP: #2028253) // [FFe] "
+"apparmor-4.0.0-alpha2 for unprivileged user namespace restrictions in "
+"mantic (LP: #2032602)"
+msgstr ""
+
+#: ../../22.04/4.md 2074d0e5386040cfb1efb60a358eaf9f
+#: 4618f7340da44c9e98dc418fe3d2e703 8b19da9d406f47ceb32412470efb5cbf
+msgid "[2032602](https://bugs.launchpad.net/bugs/2032602)"
+msgstr ""
+
+#: ../../22.04/4.md 00077aed8bb540a099156335f78d459d
+#: 02c4faf8d02c4026a8463648a3abc991 03a8f0f3ac824a7bb0f342b0cd27127e
+#: 19c385e28f3f4ace9c74a160a9f70004 1a1d78a6c0434965b5862bf4de4ff19c
+#: 399c8cce75f5483b896c695fce88dbf3 5250ee4367c3491ca580171f24a3a91f
+#: 8edeb8a74a1147deaf669000fda1772c d61a1ebc61f84290a62eeb89c8917ebd
+#: e83ba7e338fa40889f4926911c984b49
+msgid ""
+"LSM stacking and AppArmor for 6.2: additional fixes (LP: #2017903) // "
+"update apparmor and LSM stacking patch set (LP: #2028253)"
+msgstr ""
+
+#: ../../22.04/4.md 2411ab4b8445456f98fc4ff1925432f0
+#: 2e010705ad2743a2a609945f65f10066 34756eafb0e445d09987cecf465b4441
+#: 45b3de7bb2df40ba9649b0e23628f937 467f37cc2e3845d28773aac2714a8ed8
+#: 57007bc0caa0497cb272dc8c72a11142 96d01dd54ea84b66b97fa4b184620f99
+#: 970e4418902d4849b87209abd4f77282 dfe96cfee066459183b5fe406643483e
+#: ee2a9299aaa24151b5b6941b51eba0ab
+msgid ""
+"udev fails to make prctl() syscall with apparmor=0 (as used by MAAS by "
+"default) (LP: #2016908) // update apparmor and LSM stacking patch set "
+"(LP: #2028253)"
+msgstr ""
+
+#: ../../22.04/4.md 184310c78cf448b09d4b9d0dc66d15a1
+#: 330ab14bdc72492faecc9cecbe296b64 5e64fc1cbaf7475eab53b30a6b3ab01c
+msgid "[2034546](https://bugs.launchpad.net/bugs/2034546)"
+msgstr ""
+
+#: ../../22.04/4.md 4ec1d06c4d294cbe95db8a0ed6376663
+#: d4c719a63cef45bbb16f413ceff9878e e339b6de829144a2af97d21499aee11c
+msgid "mantic/linux: 6.5.0-5.5 -proposed tracker (LP: #2034546)"
+msgstr ""
+
+#: ../../22.04/4.md 016fadfb5a6e490aacf7420a6b23a900
+msgid "[2034042](https://bugs.launchpad.net/bugs/2034042)"
+msgstr ""
+
+#: ../../22.04/4.md 0a87fd744ffd4be09ddd95198bd604c8
+msgid "mantic/linux: 6.5.0-4.4 -proposed tracker (LP: #2034042)"
+msgstr ""
+
+#: ../../22.04/4.md 5893e75728554a47a7411da4164c8051
+msgid "[2033904](https://bugs.launchpad.net/bugs/2033904)"
+msgstr ""
+
+#: ../../22.04/4.md c967f58085b641e996bab612ed5e0dcc
+msgid "mantic/linux: 6.5.0-3.3 -proposed tracker (LP: #2033904)"
+msgstr ""
+
+#: ../../22.04/4.md 2c23a8b76d5d49f3a75d5ece64e8c31f
+msgid "[2026833](https://bugs.launchpad.net/bugs/2026833)"
+msgstr ""
+
+#: ../../22.04/4.md 4cb2bed446b8452b8e43e7f7a31e5ca1
+msgid ""
+"23.10] Please test secure-boot and lockdown on the early 6.5 kernel "
+"(s390x) (LP: #2026833)"
+msgstr ""
+
+#: ../../22.04/4.md 7c66d8df435240cbba6b75266e5b41b7
+msgid "linux-signed-oem-6.5"
+msgstr ""
+
+#: ../../22.04/4.md 1d35bc8a9ec24b1f84299c3165b90057
+#: 719223c38c844c0e8c0b2e1e3711f1c8 7549f2ed9b0c4492846c11edc2710423
+msgid "[2027818](https://bugs.launchpad.net/bugs/2027818)"
+msgstr ""
+
+#: ../../22.04/4.md 0040db85b3904d178acfdc52fe7d62ac
+#: ab9f14aa727e4a38bfc2ccd14079bad8 bef393f53a884121a6cf271b2a50b78f
+msgid ""
+"SIGNEDv5: add ubuntu-core-initrd support to the linux-generate ancillary "
+"package (LP: #2027818)"
+msgstr ""
+
+#: ../../22.04/4.md 35c7ffcdf4b24139a0dcbbe705899aa6
+#: 52d6b1ce44cd4a81b53699943089e8a4 9e41b2f64ce746ea9a2f48a4e8605a0b
+msgid "[2032164](https://bugs.launchpad.net/bugs/2032164)"
+msgstr ""
+
+#: ../../22.04/4.md 809cc1051cc74830912ae64166bbe710
+#: a9e76b103b3b4c0ab687a3da820ea3e3 b39fb8ac6619426ca689e70000b54a14
+msgid ""
+"A general-proteciton exception during guest migration to unsupported PKRU"
+" machine (LP: #2032164, reverted)"
+msgstr ""
+
+#: ../../22.04/4.md 289703522293486fad71d27396ccc3b9
+#: ff9cc74088eb4685adcb5e7261df6cf5
+msgid "[2035364](https://bugs.launchpad.net/bugs/2035364)"
+msgstr ""
+
+#: ../../22.04/4.md 5ba6b3cb184e4d4d9ab4b67af44441aa
+#: 81ede68e0b2b4cdbb45d3858afaabd68
+msgid ""
+"jammy/linux-azure-fde-6.2: 6.2.0-1014.14~22.04.1.1 -proposed tracker (LP:"
+" #2035364)"
+msgstr ""
+
+#: ../../22.04/4.md a833e14a0dfb435589b068f6f6c1ecc8
+#: e7e262c84b924913a4e86a1c5b2969d3
+msgid "[2033764](https://bugs.launchpad.net/bugs/2033764)"
+msgstr ""
+
+#: ../../22.04/4.md 097ce9b199924d19828aae667e1f5cfb
+#: 9fbae4ade99345bf8d6548492d8d4b77
+msgid ""
+"jammy/linux-azure-fde-6.2: 6.2.0-1013.13~22.04.1.1 -proposed tracker (LP:"
+" #2033764)"
+msgstr ""
+
+#: ../../22.04/4.md 631a5616c97b4388b2ead9c176165681
+#: 85841b4fcef04ea6bb77986eef10f488
+msgid "[2036534](https://bugs.launchpad.net/bugs/2036534)"
+msgstr ""
+
+#: ../../22.04/4.md a7e2b0ee33e54c0d8cfed94cf8b74952
+#: aed1265051eb4113b4cc80405f51c311
+msgid "jammy/linux-azure-fde: 5.15.0-1049.56.1 -proposed tracker (LP: #2036534)"
+msgstr ""
+
+#: ../../22.04/4.md 519c85d1dfad4b3fa43234c1b2b473ee
+#: 6f82b5bfa2d849a19d84ceebe804d211
+msgid "[2033783](https://bugs.launchpad.net/bugs/2033783)"
+msgstr ""
+
+#: ../../22.04/4.md ad92786898074fe2a7979a3bee1a7296
+#: ec37aada87e54cb8a926291d18db1ec9
+msgid "jammy/linux-azure-fde: 5.15.0-1048.55.1 -proposed tracker (LP: #2033783)"
+msgstr ""
+
+#: ../../22.04/4.md 78c7e672b70e4975865afd0648b3aba3
+msgid "[2036542](https://bugs.launchpad.net/bugs/2036542)"
+msgstr ""
+
+#: ../../22.04/4.md 85c7e488e40a42febb50af982eacc019
+msgid "jammy/linux-gke: 5.15.0-1044.49 -proposed tracker (LP: #2036542)"
+msgstr ""
+
+#: ../../22.04/4.md e98eb09df96f44f2a0cab2890edc13c8
+msgid "[2036541](https://bugs.launchpad.net/bugs/2036541)"
+msgstr ""
+
+#: ../../22.04/4.md c80016b5884341efa4c43f81c69b01f6
+msgid "jammy/linux-gcp: 5.15.0-1044.52 -proposed tracker (LP: #2036541)"
+msgstr ""
+
+#: ../../22.04/4.md 336c967c568f4128b137b5b45e502b66
+#: e31775a8c5a54c33aab7444017f3759d
+msgid "[2034894](https://bugs.launchpad.net/bugs/2034894)"
+msgstr ""
+
+#: ../../22.04/4.md 2cb2e41341bb480d83c5954103bb73dd
+#: 849104376eb04f40915d603b9cc8e713
+msgid "Fix requested for SEV live-migration (LP: #2034894)"
+msgstr ""
+
+#: ../../22.04/4.md 8d79b42ec46348bcacab7ff60f4a7ad7
+msgid "[2036581](https://bugs.launchpad.net/bugs/2036581)"
+msgstr ""
+
+#: ../../22.04/4.md 1368f4974fec4534b3a4b951bed632f9
+msgid ""
+"jammy/linux-gcp-6.2: 6.2.0-1016.18~22.04.1 -proposed tracker (LP: "
+"#2036581)"
+msgstr ""
+
+#: ../../22.04/4.md 116bfe2cda6146f4af2d858e4d45ce9c
+msgid "[2036582](https://bugs.launchpad.net/bugs/2036582)"
+msgstr ""
+
+#: ../../22.04/4.md 8deefe78afbc4e5d86fb82fe97f55300
+msgid "lunar/linux-gcp: 6.2.0-1016.18 -proposed tracker (LP: #2036582)"
+msgstr ""
+
+#: ../../22.04/4.md 33d22788f926480c97bc454887d583a8
+#: 4104416804194c7aa1b62c5d84b7fdb8
+msgid "linux-meta-oem-6.1"
+msgstr ""
+
+#: ../../22.04/4.md e834c117adf94f0e807659d586719aef
+msgid "[2019024](https://bugs.launchpad.net/bugs/2019024)"
+msgstr ""
+
+#: ../../22.04/4.md f65468e33da1408fbdc0bd1b00351f40
+msgid "Migrate oem-5.17 and oem-6.0 to oem-6.1 (LP: #2019024)"
+msgstr ""
+
+#: ../../22.04/4.md 2e0bab7b077e4addb80089851db6cd11
+#: 35b2926bffbe4a47b2a81015012243ea 505cacd7f70e4166ae6182c68af17e08
+#: 5be73717160f4b77a3cbf048eed035bc 5fe9c1bf6bd3411480488fa70b0d8db3
+#: 60c2e7fd1fcf472aab67c86793803122 6643d2997ff84e9b8dd6e2d25af86251
+#: 863878aaa76140f3a09de62097b7e493 a3f59940ceb04df9b3aca8c55d40274c
+#: b30750d922994050ad0e43591887e862 e6d2f7df909b451f96b0ee526ac142df
+#: e98f07be831c443da85a22bb3591aa74
+msgid "linux-oracle-6.2"
+msgstr ""
+
+#: ../../22.04/4.md 2dea052a3bd74fed910b8eae2b87a897
+msgid "[2033773](https://bugs.launchpad.net/bugs/2033773)"
+msgstr ""
+
+#: ../../22.04/4.md eb7cea76b50041efb7779d03730719d0
+msgid ""
+"jammy/linux-oracle-6.2: 6.2.0-1013.13~22.04.1 -proposed tracker (LP: "
+"#2033773)"
+msgstr ""
+
+#: ../../22.04/4.md f14a50ab45934a73b1b535c4de618756
+msgid "[2033441](https://bugs.launchpad.net/bugs/2033441)"
+msgstr ""
+
+#: ../../22.04/4.md f92588b33cfe4247aab7bc97488f4495
+msgid "linux-firmware is outdated (LP: #2033441)"
+msgstr ""
+
+#: ../../22.04/4.md 6ec17cc731074eb5a0f5f9bf2ae92c31
+msgid "[2038745](https://bugs.launchpad.net/bugs/2038745)"
+msgstr ""
+
+#: ../../22.04/4.md abf59086cca84ae6a6231d7332c36e42
+msgid ""
+"NV31 XTX cannot boot into Ubuntu 22.04.3 Desktop with upstream(inbox) "
+"driver installed (LP: #2038745)"
+msgstr ""
+
+#: ../../22.04/4.md 254794c02d89407484773b9017341fe7
+msgid "[2037224](https://bugs.launchpad.net/bugs/2037224)"
+msgstr ""
+
+#: ../../22.04/4.md 9ef6078b28c84c608334867b7e11e74e
+msgid "Multiple RTL8851BE BT stability issues (LP: #2037224)"
+msgstr ""
+
+#: ../../22.04/4.md 273001685e9f4335a67550df66eb360a
+#: ceeca4207a6041c297f7dce261880f2d
+msgid "linux-starfive-6.2"
+msgstr ""
+
+#: ../../22.04/4.md af155e479ba743fba63bcdaae1e5bd53
+msgid "[2034560](https://bugs.launchpad.net/bugs/2034560)"
+msgstr ""
+
+#: ../../22.04/4.md d7af1f5957cc487a98ff56cd98e2d939
+msgid ""
+"jammy/linux-starfive-6.2: 6.2.0-1006.7~22.04.1 -proposed tracker (LP: "
+"#2034560)"
+msgstr ""
+
+#: ../../22.04/4.md 320d9cd895d74f8db6fabddbfd75314a
+#: 98b7e9a611b44a998b139aebef5153d8
+msgid "irqbalance"
+msgstr ""
+
+#: ../../22.04/4.md 5dcae866ef104fdba3eb31241dbed57a
+msgid "[2038573](https://bugs.launchpad.net/bugs/2038573)"
+msgstr ""
+
+#: ../../22.04/4.md 76907d6273444b6b9328addb3851045b
+msgid ""
+"d/p/lp2038573-fix-unsigned-integer-subtraction-sign-overflow.patch: Do "
+"not stop balancing IRQs due to unsigned int issue. (LP: #2038573)"
+msgstr ""
+
+#: ../../22.04/4.md 397390bed05d4a08b63bf473eb8665b9
+#: d9a7f57fdf2247bbb1795998f47c5f53
+msgid "[2038170](https://bugs.launchpad.net/bugs/2038170)"
+msgstr ""
+
+#: ../../22.04/4.md 61c6f12c53dd46588dfa49f0025cadfb
+#: 7aa3f9a18a3740209f3a43bd85e918cc
+msgid "jammy/linux-azure-fde: 5.15.0-1050.57.1 -proposed tracker (LP: #2038170)"
+msgstr ""
+
+#: ../../22.04/4.md 8001b5cedee744c5bfaa039c772e44be
+#: ab743f14a17744a6968a8a7d851837cc
+msgid "[2038213](https://bugs.launchpad.net/bugs/2038213)"
+msgstr ""
+
+#: ../../22.04/4.md a52c3a93c5b449bd8555cb780e401f33
+#: c9bcc9caab9b427c857d9eed680de9d9
+msgid ""
+"jammy/linux-azure-fde-6.2: 6.2.0-1015.15~22.04.1.1 -proposed tracker (LP:"
+" #2038213)"
+msgstr ""
+
+#: ../../22.04/4.md 57f4113d220c4fe2ae11076516669792
+#: dc7d415979a6492dbbacadb575521f5a
+msgid "[2025640](https://bugs.launchpad.net/bugs/2025640)"
+msgstr ""
+
+#: ../../22.04/4.md d4fae314821f4d5aa4ebf9be4131a146
+msgid ""
+"Pass in --no-stop-on-upgrade to dh_installsystemd. Prevent "
+"dh_installsystemd from stopping services (LP: #2025640)."
+msgstr ""
+
+#: ../../22.04/4.md c0863333e50741e5b708bec35988e813
+msgid ""
+"Pass in --no-stop-on-upgrade --no-restart-after-upgrade to "
+"dh_installsystemd (LP: #2025640)."
+msgstr ""
+
+#: ../../22.04/4.md a0c97690b1644c0f87297d2939ba23d2
+msgid "[2038225](https://bugs.launchpad.net/bugs/2038225)"
+msgstr ""
+
+#: ../../22.04/4.md a4b8b0a857d5457c91f0510acb870206
+msgid ""
+"jammy/linux-starfive-6.2: 6.2.0-1007.8~22.04.1 -proposed tracker (LP: "
+"#2038225)"
+msgstr ""
+
+#: ../../22.04/4.md 1013233a9b4a4408af4b33d69219baed
+msgid "[2039056](https://bugs.launchpad.net/bugs/2039056)"
+msgstr ""
+
+#: ../../22.04/4.md 9d929d4312394bea8e4062e68115fb83
+msgid "jammy/linux-oem-6.5: 6.5.0-1006.6 -proposed tracker (LP: #2039056)"
+msgstr ""
+
+#: ../../22.04/4.md b9ca7fd96c5e4d408bf0e7150e554d6c
+msgid "[2038641](https://bugs.launchpad.net/bugs/2038641)"
+msgstr ""
+
+#: ../../22.04/4.md fc364e4faf954dc2be93681778b87b81
+msgid "drm/i915/gsc: define gsc fw (LP: #2038641)"
+msgstr ""
+
+#: ../../22.04/4.md 1e8496e272e44153b197e83960840383
+#: 5280317d974a469d8179fbc6a5be109f 7369d3c8c604419d8aacc96829f5dea3
+#: 775d2cb92ca64fd4b8782aaf4c4ecb26 95d68fdcfb2d4de89f1e262f3ca3cc8a
+msgid "[2037273](https://bugs.launchpad.net/bugs/2037273)"
+msgstr ""
+
+#: ../../22.04/4.md 31127200acdd4afaa3a37ad57a332402
+#: 363736d586a6486c89cd7534fddb7aed 3b1fb3b5946644c2bbdca970080164c8
+#: 67808cce79e048a6896671d0dae18fdc 9e67a7d2458f4983b0b6eb5eb3c80338
+msgid "Realtek 8852CE WiFi 6E country code updates (LP: #2037273)"
+msgstr ""
+
+#: ../../22.04/4.md 09d77a263aa94293b9e4e2fc869e4ab6
+#: 1bdd70b0275b43b7aa099eddf2d76602 5fbd52cf8b9a4af6b8ba7bf416d9a200
+#: 807aba053ea8405c8f867f2c07102bfc bb64e2ecadfb469dbbbc2d8e8ebdb506
+msgid "[2038687](https://bugs.launchpad.net/bugs/2038687)"
+msgstr ""
+
+#: ../../22.04/4.md 37170e83922041199b2e47b15b451e4e
+#: 5b11eac02ebd43fb8083bf75776b7fe9 5b58630df7d24b1c97da249edb137057
+#: 6d56b607641f4a6a9853a8196b8bbbde 865b5e5a3e5e47209a75c02f765a2b54
+msgid "mantic/linux: 6.5.0-9.9 -proposed tracker (LP: #2038687)"
+msgstr ""
+
+#: ../../22.04/4.md 1b5be4befd674f29a88b8c0460c706a2
+#: 23ae5ea1fe8645768cb6df30de623b1f 60621097bd01483cb35935a1b7163763
+#: 66fe5fc1fa9140cb82def60a6940ffc0 c053213400ec41ceb794ee3c8df5c024
+msgid "[2038567](https://bugs.launchpad.net/bugs/2038567)"
+msgstr ""
+
+#: ../../22.04/4.md 126d206fab8c410aac03ad84f8708aa6
+#: 2e6c6d3a9a124cce83a658963968e9c0 686493cabb8740e883a965463efc4f97
+#: ae637a15c0c648d9bb0152939a484bb0 bc467dcc84fd49faa8f8188cd60ac291
+msgid ""
+"Disable restricting unprivileged change_profile by default, due to LXD "
+"latest/stable not yet compatible with this new apparmor feature (LP: "
+"#2038567)"
+msgstr ""
+
+#: ../../22.04/4.md 24e6a590a7b346a292586ee8a60bb4e3
+#: 4d69e44638e0495b9c5da2e1fad67ebd 8212906c7b0c4815afaea3517f392bee
+#: b2d01da64dde40b69e490b17387f88e0 fe4280b890ab432a810f70aab6e1fe00
+msgid "[2038577](https://bugs.launchpad.net/bugs/2038577)"
+msgstr ""
+
+#: ../../22.04/4.md 08e3c6cc11824e6883d6771d2e8d9264
+#: 0a52b534b81745b7bb8c10ae3a9fcf8c 7a0c2e1be4cd480db3a5fb2fc4650d9d
+#: 7dfc2f8273d64490a14b6af146a3fc71 eca3833622eb484eb61ac08e314e5946
+msgid "mantic/linux: 6.5.0-8.8 -proposed tracker (LP: #2038577)"
+msgstr ""
+
+#: ../../22.04/4.md 1c8ef6e1ee11450a8f97a731ff2af488
+#: 1df8e136488a47ba8dc66a028db57ce9 299cd54d30724487929699683286ce6c
+#: 3fa02bdca6f048d090cf6772b9347c3a 63107fb5e88b407384d051a97d78b8d1
+#: a7b23142e01447f38b2891ada3c93574 ac9058ac0b074c069745d3f05d525960
+msgid ""
+"kinetic: apply new apparmor and LSM stacking patch set (LP: #1989983) // "
+"update apparmor and LSM stacking patch set (LP: #2028253)"
+msgstr ""
+
+#: ../../22.04/4.md 637c2bc67f3f461aa9a1d55a4fb3712a
+#: 8de7fdb11e7342dbb418fcf35e563d54 9a7f8d382e634cb2b93fcd1e57f435f4
+msgid "[2037611](https://bugs.launchpad.net/bugs/2037611)"
+msgstr ""
+
+#: ../../22.04/4.md 04b656edbdf240b58ac8a9364cd005fa
+#: 3b38531bc2ea4bd592156076be4eaff9 7b50d1fdbca5439b83162e4ee302d655
+msgid "mantic/linux: 6.5.0-7.7 -proposed tracker (LP: #2037611)"
+msgstr ""
+
+#: ../../22.04/4.md 5a354667ba824801b10657e5cb4397bf
+#: 918cb6f56b994aa6a73b7ebba5481fdc 962887dd27d04431a96455137e75bcd7
+msgid "[2037398](https://bugs.launchpad.net/bugs/2037398)"
+msgstr ""
+
+#: ../../22.04/4.md 74d620f279ff4a3b9e92b792c89299c2
+#: 7b09aca714454d54b4e9d20fec311b73 d066eece71734465b55845eed602dbac
+msgid "kexec enable to load/kdump zstd compressed zimg (LP: #2037398)"
+msgstr ""
+
+#: ../../22.04/4.md 2b08004d3c1f4c6bbf32b3143d405d3d
+#: c341c8b80d2d4d52adaeaf24cd07d661 d38d5a30698c426ea42ee9b9ac10b299
+msgid "[2036968](https://bugs.launchpad.net/bugs/2036968)"
+msgstr ""
+
+#: ../../22.04/4.md 18eae347b7a4442eb51d7e4a1371efd0
+#: 21fbb3b171a2442a8098ebba497e0b22 3cc4b38029574f3c97c4478fa078cad1
+msgid ""
+"Mantic minimized/minimal cloud images do not receive IP address during "
+"provisioning (LP: #2036968)"
+msgstr ""
+
+#: ../../22.04/4.md 000fb9af0c3a4d1a8fc4a387848da3e3
+#: 0873564b80de438e907eb13526de96c5 0dec7f21221349709d0e7ca67fa20674
+#: 126a7722591e41458c0f6db3a22c0dca 1560910b6f674de79f0fc88454b02af9
+#: 1b9b0849d1904532a34d9b4ab1d92bf5 1c02097dcbcc48e2aa1a5efe1471db00
+#: 1c047cca13e64781a44b59f54b069ace 1d7e4df837834fc3aad9650a3102fc84
+#: 2077cd62a77d438bb5cd8317929e863b 2272b862efbb466789b377e23ce3f54d
+#: 23ff2a3c04fe4ab28fb6b9af72c9e637 27e33442b4c5414986f865f3ed3751a7
+#: 28a3fd31d7fe40ea8ee8811e011ab822 33708ab623af425d94610d29943da145
+#: 38238cc8b645439e90d316db6da8e39b 3b2d803cd6ad418a8d3b9220dfb688e6
+#: 3c3396f147724b89ae36403a2f2b88f9 47e9f484995543b5b0f818b956c8a99b
+#: 494d756f54814cc4a4a363444f9962fa 4a6a849c344d419d91d34ef137b858fa
+#: 4ad92df736674b74a124a1b0e91d815e 4bd77730c9954b2c8e70347c0afe1089
+#: 4e652446e4194441a11320d3fcaee909 4f112d717b504f83967447bfece13f5a
+#: 500c2773622b41d894e7d29657b16023 57dc44a8b2ae4129b16c1eac712d6190
+#: 5b66cdd4f0ce4dcbbb80db93e797fe19 5bec0e556da547df9f8cbb3ac96b6ab8
+#: 5d213cfa53e24d8b837250b14a01611a 5e9b2a83dc2a4b20ba8565395fd1b63f
+#: 640eef80a6cb43deb03b9f3186134829 68ff8f9776c646f88cf8b352ca86cc12
+#: 6aff01e0c15c45b2b33d712123404998 6eaa5ee0a3bf44168f602c9dacebe48f
+#: 6ec84ebbbe824990b3104b1defdd8e36 7066ad9271e24849bc203b32d5275ac5
+#: 715c0113327a4a439d1cbdf9e5e770d1 717a3b6a74d547a9a22e4c4cf995794f
+#: 71cec1b63f6d49968a79820a2543b92a 82dc57857bf8455da72a304204e4c3ef
+#: 83d3cf86a2314b6ab8f7947a6f7299de 85620f7148244c8cb1d9b245dd5852fd
+#: 865e657be402457ab5f596154b256f11 8827e13361af4157bd30ced6bb74140d
+#: 8a436a43efc748f0aa17400155c886f5 8cf9dc0212204b73a35a732aaeb7b026
+#: 940a960c113c497cbd9ae9c2268420eb 95b1084dbda444db84f3a67229c241a0
+#: 95c1b54dae364da08b1a04f5cc8f0d01 968e711801b94adcbc9444a185dedcfd
+#: 9b98bb08d08c447ab610bad90dc97657 9e546f7aa5134dc0b8cf898305cf71c0
+#: 9eb2750273e947429021600d5dc0b8fb a28e7f31afe54f9689dd586752b74123
+#: aac32386e8024a8784b3ff0fd68b76f0 b0b2470c985744cfb69cd328e208784c
+#: b640ecbb915745eea97f8e6a3cfc991c ba4675e5fe324caa85cf6b9d65f10c55
+#: ba4bda1aca2b4f04bbd308bf3f83a908 bac7d44c4177456eb48099b6780a92bb
+#: bf7ea8b8abdc4d8abcf856568170d823 c08768262fa04915a4b04251eca72dba
+#: c43e378fd72d4db88817f516e19ba154 caec1ff7879f45b89b4fffb61dbc8fde
+#: cccdc617ff914e8bb75159f64a9cf6ab ce2be4ee4e1c42b183535b15b41eb953
+#: ce7bfe2d0e1444efae96ee8708d38c89 d773e8bec7b742938d3d4f216344f88f
+#: dd375946d9d94e39a170851ecdfa2ff6 df8a968ef9bf45b8b42d40666a60ef05
+#: ebce3194e30646e4b3d7327350218700 f339f820d8fe4e419b314245e2b47b25
+#: f449132ab2444890acc91f761fca1ace f514b003c9354da0a647ff37c2e3ce7a
+#: f7b817c5fa8d45a1a93c8765d145c9fd
+msgid "linux-aws-6.5"
+msgstr ""
+
+#: ../../22.04/4.md 6b87d6d3d1ca461d8cdede8e384bd29a
+msgid "[2038955](https://bugs.launchpad.net/bugs/2038955)"
+msgstr ""
+
+#: ../../22.04/4.md 4f9f1ab3c0944c4580240d1ee4bca2f5
+msgid "jammy/linux-aws-6.5: 6.5.0-1008.8~22.04.1 -proposed tracker (LP: #2038955)"
+msgstr ""
+
+#: ../../22.04/4.md 5e4ec322d3d249bbb22e03004dc1387d
+msgid "[2038689](https://bugs.launchpad.net/bugs/2038689)"
+msgstr ""
+
+#: ../../22.04/4.md 43d72e12a3864637a278a60fc598b7ee
+msgid "mantic/linux-aws: 6.5.0-1008.8 -proposed tracker (LP: #2038689)"
+msgstr ""
+
+#: ../../22.04/4.md d4ca92b80bc74fe8adc1c705b5b7f0c7
+msgid "[2037624](https://bugs.launchpad.net/bugs/2037624)"
+msgstr ""
+
+#: ../../22.04/4.md 5534f0d9c2d64e7f9298be39a3c4f02b
+msgid "mantic/linux-aws: 6.5.0-1007.7 -proposed tracker (LP: #2037624)"
+msgstr ""
+
+#: ../../22.04/4.md 80040d2da6124aa4990c46684c2c0c40
+msgid "[2035596](https://bugs.launchpad.net/bugs/2035596)"
+msgstr ""
+
+#: ../../22.04/4.md c2651bd2917444d08a44d8fdfbeecc3e
+msgid "mantic/linux-aws: 6.5.0-1006.6 -proposed tracker (LP: #2035596)"
+msgstr ""
+
+#: ../../22.04/4.md 2e32f3c0a9084ffcbce87316625b5e8e
+msgid "[2034547](https://bugs.launchpad.net/bugs/2034547)"
+msgstr ""
+
+#: ../../22.04/4.md 234d98b87bb2487abbb4723513d62c00
+msgid "mantic/linux-aws: 6.5.0-1005.5 -proposed tracker (LP: #2034547)"
+msgstr ""
+
+#: ../../22.04/4.md 30356daf026543a4be10cfe453167901
+msgid "[2034043](https://bugs.launchpad.net/bugs/2034043)"
+msgstr ""
+
+#: ../../22.04/4.md 8d16ad4e6cb343f490fa1c11aa16bb69
+msgid "mantic/linux-aws: 6.5.0-1004.4 -proposed tracker (LP: #2034043)"
+msgstr ""
+
+#: ../../22.04/4.md 06146394daf848ec9ecf87389f423e9d
+msgid "[2033021](https://bugs.launchpad.net/bugs/2033021)"
+msgstr ""
+
+#: ../../22.04/4.md 714c899ebc1d4c34b858988a0136f82a
+msgid "mantic/linux-aws: 6.5.0-1003.3 -proposed tracker (LP: #2033021)"
+msgstr ""
+
+#: ../../22.04/4.md b0f49b3ef19d496c9e24d4c77ad13485
+msgid "[2029364](https://bugs.launchpad.net/bugs/2029364)"
+msgstr ""
+
+#: ../../22.04/4.md 04e95ac884f64626a34f771a21bcd0eb
+msgid "mantic/linux-aws: 6.5.0-1002.2 -proposed tracker (LP: #2029364)"
+msgstr ""
+
+#: ../../22.04/4.md 6c1ea9b976664041b1a717595b1a497f
+msgid "[2029220](https://bugs.launchpad.net/bugs/2029220)"
+msgstr ""
+
+#: ../../22.04/4.md 7fa43fa1deab469ebcafef06617a89d3
+msgid "mantic/linux-aws: 6.5.0-1001.1 -proposed tracker (LP: #2029220)"
+msgstr ""
+
+#: ../../22.04/4.md 1bab6174f49c4f64b6621b828cd0c3d6
+#: 25b992ff9f9f47a289feb59c29a74917 656bb6d9af7742e7a16557cbafccd7e6
+#: a26bcb907a4041a0bfb5f3efb76424b2
+msgid "[2028568](https://bugs.launchpad.net/bugs/2028568)"
+msgstr ""
+
+#: ../../22.04/4.md 16ab6b6c3b3145e0a5609deb330a7db3
+#: 6575775979a846ac956a8ca4df4d6aa5 80314eb2a3ef4565a36300297f58fc42
+#: c11909559f38488fa086b42b4b89dc38
+msgid "Ship kernel modules Zstd compressed (LP: #2028568)"
+msgstr ""
+
+#: ../../22.04/4.md c7c0bd63e108429ebe9892a862f71770
+#: e94bc1f53bb4461ab9b6c7b12eef865f
+msgid "[2029086](https://bugs.launchpad.net/bugs/2029086)"
+msgstr ""
+
+#: ../../22.04/4.md 2b424d254a654e66a3d219f75344c92a
+#: 3188a8c8581e46189f5b164d9bb3ac56
+msgid "mantic/linux-unstable: 6.5.0-4.4 -proposed tracker (LP: #2029086)"
+msgstr ""
+
+#: ../../22.04/4.md 246b3054f18247899dab0f7eb695e7d4
+#: 45192b52eb674fb7b6d1c1cfb8bffabf
+msgid "[2028779](https://bugs.launchpad.net/bugs/2028779)"
+msgstr ""
+
+#: ../../22.04/4.md 078ba0744c734d1faf1bddae1952204a
+#: f4655164b27240c09de4d14341cff45c
+msgid "mantic/linux-unstable: 6.5.0-3.3 -proposed tracker (LP: #2028779)"
+msgstr ""
+
+#: ../../22.04/4.md 2949ae066d8d47cfa9bf4ea3c2092ab0
+#: 5dea93e600994329aefdf55fe3933d63 a101328fbd2943e19618323767b72446
+#: f9ccddea5fa9405e889740bca5e0b95a
+msgid "[2007654](https://bugs.launchpad.net/bugs/2007654)"
+msgstr ""
+
+#: ../../22.04/4.md 2bdd078a794e4422a409b3d4a9f71ca2
+#: 31c76b69fd9c4aed9d847755f76b873f 34595d3fc3f0471ea7200f0a0b432133
+#: 5f8cdc51693d4a118025383887b51f8f
+msgid "enable Rust support in the kernel (LP: #2007654)"
+msgstr ""
+
+#: ../../22.04/4.md 171780eb401c432fb8432af5f1cd6371
+#: 4981cbc848a449318f255df4af7c552d
+msgid "[2027953](https://bugs.launchpad.net/bugs/2027953)"
+msgstr ""
+
+#: ../../22.04/4.md 4f45940d9b6d4328b7551664dce8a9bb
+#: 9d33208d4e894d6aa87153ec9aea4567
+msgid "mantic/linux-unstable: 6.5.0-2.2 -proposed tracker (LP: #2027953)"
+msgstr ""
+
+#: ../../22.04/4.md 2206bbf8105e483c8ea8a88b216b4688
+#: 7067f917e97d4ea0b9432e991cb8cdb1
+msgid "[2025265](https://bugs.launchpad.net/bugs/2025265)"
+msgstr ""
+
+#: ../../22.04/4.md 1edd912293814d6eafd6de94906e518e
+#: 4281ab2664e8499eb70a97579af091f6
+msgid "Remove non-LPAE kernel flavor (LP: #2025265)"
+msgstr ""
+
+#: ../../22.04/4.md 1f22e4bef3724452aa8567e9cbc68465
+#: 3ae56ee3c24648d3bf72d2b5b0b1cf42
+msgid "[2026689](https://bugs.launchpad.net/bugs/2026689)"
+msgstr ""
+
+#: ../../22.04/4.md ac7f21e238bb4b7baf54dc4881b61885
+#: c9955d0d136b492388db27250c799f63
+msgid "mantic/linux-unstable: 6.5.0-1.1 -proposed tracker (LP: #2026689)"
+msgstr ""
+
+#: ../../22.04/4.md 75df53c0b39340f3b295ca2967f5eb85
+#: fcf501db5c674edfa170cb14ee692746
+msgid "[2025018](https://bugs.launchpad.net/bugs/2025018)"
+msgstr ""
+
+#: ../../22.04/4.md 81bb94110c8f460d8f4340c6368f4c7b
+#: 8d7581e4ea4b4a64b87aa2d53590a854
+msgid "mantic/linux-unstable: 6.4.0-8.8 -proposed tracker (LP: #2025018)"
+msgstr ""
+
+#: ../../22.04/4.md ae21b8915ea047ee898616018ded3486
+#: c7d17e4931df4ed5938d45f21aa18b93
+msgid "[2024338](https://bugs.launchpad.net/bugs/2024338)"
+msgstr ""
+
+#: ../../22.04/4.md 55586054365348be9af9738c02564d1d
+#: b91047d0bbd4465cbf64bfdf9e9370b7
+msgid "mantic/linux-unstable: 6.4.0-7.7 -proposed tracker (LP: #2024338)"
+msgstr ""
+
+#: ../../22.04/4.md 21e62bed7476459aaa17fb70fd594ae7
+#: aeaf617ad7c74a0a834a6b4663da40df
+msgid "[2023966](https://bugs.launchpad.net/bugs/2023966)"
+msgstr ""
+
+#: ../../22.04/4.md 0709b0f704264982a66915e21b976566
+#: ba8e32219421405188cdce22a2650be4
+msgid "mantic/linux-unstable: 6.4.0-6.6 -proposed tracker (LP: #2023966)"
+msgstr ""
+
+#: ../../22.04/4.md 0acfb6709d2f468d8ebdaccd977e88be
+#: 8f06e638a8d84e5ea9cab92280524dea
+msgid "[2023629](https://bugs.launchpad.net/bugs/2023629)"
+msgstr ""
+
+#: ../../22.04/4.md c91d90be16b04dc0b293307a1850e2d2
+#: f95e1fd18567441cab5ec7415552a853
+msgid "enable multi-gen LRU by default (LP: #2023629)"
+msgstr ""
+
+#: ../../22.04/4.md 851a23caca354ccfbc2410870da0c437
+#: c4061fc670ba4d47988ca985a514dab5
+msgid "[2012776](https://bugs.launchpad.net/bugs/2012776)"
+msgstr ""
+
+#: ../../22.04/4.md 9ad4339c24e04ae88d1acd6fc3075543
+#: e575c735a07e45c4ad6ab1b73123623c
+msgid "Neuter signing tarballs (LP: #2012776)"
+msgstr ""
+
+#: ../../22.04/4.md 8b22f8d70abc43bf912bd2ed2da664be
+#: 9bd5633e59284b73b6cbf9714907e358
+msgid "[2022886](https://bugs.launchpad.net/bugs/2022886)"
+msgstr ""
+
+#: ../../22.04/4.md 2194a691d5e242f68afc36d3f51aef08
+#: 8c9ca2c8dbb24cdca2df64ce9ed2a5d9
+msgid "mantic/linux-unstable: 6.4.0-5.5 -proposed tracker (LP: #2022886)"
+msgstr ""
+
+#: ../../22.04/4.md 0c2928d7fcb545e2a1311698d20fcb23
+#: a1984cd475bc461281585add738611b7
+msgid "[2021597](https://bugs.launchpad.net/bugs/2021597)"
+msgstr ""
+
+#: ../../22.04/4.md 85db0da663f4499e8af32cfd588041f6
+#: b836030d8ff74b1c8887daa1996996a5
+msgid "mantic/linux-unstable: 6.4.0-4.4 -proposed tracker (LP: #2021597)"
+msgstr ""
+
+#: ../../22.04/4.md 92abfd4e6f294101ab19d707ddecc67d
+#: cdf8a0e7e2784342b054811cca5792c4
+msgid "[2021497](https://bugs.launchpad.net/bugs/2021497)"
+msgstr ""
+
+#: ../../22.04/4.md cfd141226a04448b882d382dcc4476e4
+#: f540a78bd9164592a7612a6193695871
+msgid "mantic/linux-unstable: 6.4.0-3.3 -proposed tracker (LP: #2021497)"
+msgstr ""
+
+#: ../../22.04/4.md 7b872ff5f6cf4eef9a57c4cd2b980409
+#: b66e16830d0744ce9fb747bb9f847068
+msgid "[2020330](https://bugs.launchpad.net/bugs/2020330)"
+msgstr ""
+
+#: ../../22.04/4.md d0cc77106f6f485fb296a9a1855aaa86
+#: ecbae51c116745558d30d0473ebc9821
+msgid "mantic/linux-unstable: 6.4.0-2.2 -proposed tracker (LP: #2020330)"
+msgstr ""
+
+#: ../../22.04/4.md 5723a92c7ed4441e991ad6856bd07d17
+#: 6e9cdafa2331476c8d6b08ad01b2ba67
+msgid "[2011768](https://bugs.launchpad.net/bugs/2011768)"
+msgstr ""
+
+#: ../../22.04/4.md aee72ac3e9954e5f862dee0ea65b622b
+#: baeb71422f3a493eaaac1b30d525830b
+msgid ""
+"Fix NVME storage with RAID ON disappeared under Dell factory WINPE "
+"environment (LP: #2011768)"
+msgstr ""
+
+#: ../../22.04/4.md b0d8842a5b0445f59415f7dadc104340
+#: f9bc4e0eb3254194acc62c39797869a1
+msgid "[2019965](https://bugs.launchpad.net/bugs/2019965)"
+msgstr ""
+
+#: ../../22.04/4.md bc644a1d58cd497aaa1cbf923929ba84
+#: d2938a76b0e54d54af49c2c0e092f0bd
+msgid "mantic/linux-unstable: 6.4.0-1.1 -proposed tracker (LP: #2019965)"
+msgstr ""
+
+#: ../../22.04/4.md b3e404ba6a6d445d8098138f784f628d
+#: cc34aaa67acc44ada576a018f6c4243b
+msgid "[2017788](https://bugs.launchpad.net/bugs/2017788)"
+msgstr ""
+
+#: ../../22.04/4.md 2cf0c61a306a4c5da5de6357ff72464a
+#: f1648520c5eb4740ad7f79609963f4cf
+msgid "lunar/linux-unstable: 6.3.0-2.2 -proposed tracker (LP: #2017788)"
+msgstr ""
+
+#: ../../22.04/4.md 6f6a0647341046908cb3e229ed797b2c
+#: c3d321b7d5734a97ab3ae77712fb1d1f
+msgid "[2017776](https://bugs.launchpad.net/bugs/2017776)"
+msgstr ""
+
+#: ../../22.04/4.md 339c45f76192491b913fa248c0c82f88
+#: 7ded35b6bb8d45f698e43da646c28dee
+msgid "lunar/linux-unstable: 6.3.0-1.1 -proposed tracker (LP: #2017776)"
+msgstr ""
+
+#: ../../22.04/4.md 1e9d2e5ac99d427dbbf1adf4364339f5
+msgid "[2038015](https://bugs.launchpad.net/bugs/2038015)"
+msgstr ""
+
+#: ../../22.04/4.md 51e0fe60be3f46ea9586421aa1aeaee1
+msgid "jammy/linux-azure-fde: 5.15.0-1051.59.1 -proposed tracker (LP: #2038015)"
+msgstr ""
+
+#: ../../22.04/4.md 0164b46c42ee44088b7566931bcff16c
+#: 08548ce19ca84cb586547886abe55588 0aa08bcaa007488d953edd0c3b494b09
+#: 0e4aa2afe0a5463894d22d3d8ead0422 0f24a4b43a7a40968f5bf32bbc2837c1
+#: 0f9f086322014692b7a20f130b802cc4 1695c7343d2749068d63ea18c68087f5
+#: 17ec11b625bf4770a0caacb106d3e1c1 1a54724281994f4aaf587c568542ca78
+#: 1c6661515372468fa8dc18a4dd3bd547 1d5688e2b4cc47b691de7f904d46eb0e
+#: 1f190e25506d4925bc26682e32ebd63a 1f3e9b039a0346e1a7c404d0e75dce25
+#: 21b49337dd5e4b129ebfef76f324b6c1 27601c079f8846148527f6c0b785f873
+#: 29ff1e9e3c41469082af6d17c3577784 2d5c75f8d7a44a58adba82debaa00b0d
+#: 302889a3cf2146f1840857a2f8e4b3c7 3047de32d0b548eea06a1d410d8b3769
+#: 31f68c40079943f5a16fcb5bde16f2a0 32004e7dbb9844508ebd78051d40e926
+#: 346aabad84b34f2d937204b04eb57f0d 3c6caecd515a42e4bc99e4a30fa26057
+#: 3d48fba878ee4890b005bdd8f05bd1c9 3d6a8e9cd1db4c3089bedecccc428974
+#: 3e9e494e64aa4b388edbe6c68a21adde 40d44338d275440e8d7cc4bfe76b65a1
+#: 5117111aafcb4e1482c96bfd58ade501 52897b8ab58e430da100944e790f2e13
+#: 535946e95e0e4ad8be079adca13fef30 55e41b6a9e41448095fd86785e64cc22
+#: 575e6f0fc17a42d695c23b0d556b0027 580621cbdc9c4b0c9b058e29d8f5c72b
+#: 587bf9e008654ea9ac5270bc31bfa253 59064182b9884911aeb367c3dbbd491b
+#: 5bf842460f6641f699a6ee12551aee84 60f5b9c059c141a68a34fac018350dc2
+#: 65627e16c8324250993410526dabf7be 65a3c28b9a8b480280cd85c743ca6104
+#: 65fde5bf7ef74b9bac1d651ef0abbd04 6a80690f7e59405e82aaa14f7163b9c2
+#: 72377c59ceb44d3fae812f4317683467 751c2cfb254c446b9d4aeb48a049ca92
+#: 7b357063a2dd46b88fa46d1e83abafb9 7b9cd1c0aa2d475aab9cbd0381181f77
+#: 7bbc3b54daa34b9bbd9a715f14c47266 7bbee27d309445b0a7602ed39317ae38
+#: 828a855792ff42f3b0a85e082621260f 82a6180899164324bde97d69b640bdf7
+#: 833a2ee7c1e847409cff8f1486d78070 86b5a231888b462e80d046c9d21d74d1
+#: 8868abc17d4849ba9aa54cfe4955597b 88f80c486e7f4946876a983eaefd3807
+#: 91337cc1662344f29e0c5a339c0e40b6 922bd2c573b94ce9a0cf154e723537ae
+#: 98ac709fbc4e4332ad4cae64b478de31 9a98e712d76a44e7a9ca9885e7f29d6f
+#: a202b7183ebd43d180662a65444e1c1d a4f7e0efdaa54f048e8c2bcdb6ec7b86
+#: aacd47272d5c43c2a869ce54253eb8a7 adf44a884e224aeea30c30b199668f63
+#: aecb3535cce74791bf4c318d13e4b1ef af5d63c00ec64eb0828af59f5c84fbc8
+#: b2ec7b536662458bb3516cf015540aa8 bd805a930e084914bdc461c4c5463ee9
+#: bdaab2a087cf418ea697a76740cf2505 bdac2858eae046dd80932cda47189403
+#: c3379dfe93fa41eaab71dd32df25a121 c7f5d70899314e3c92e0ab62c5d0b36b
+#: cc09d8260b89473c9082378ba1a09049 cd17e587273849899c8ee8b8560beffe
+#: d0ae23b4d14b4182a522b9943210698e d5c5f4e87854426c9d39b8f1ad7f9975
+#: d6767386385f4017a8092d6a70e0b66f d8f1b064660b4c84986279f98a6e2d9f
+#: d92bc7a5b9e0499e97e419b12490585d dc870aabd5c44e4c9e6c864015b378e2
+#: e81aecae2c264683b301b327c2cbaff2 e85a2cf7497f4adc9a4de494c19cf60a
+#: e88e81d2b6d04f988f6c0a48e57c0c7a ec4f727f489f4139bc1c6ad54a306afe
+#: ec76862178624b34ae2c655d4350665e f0a10a5b320c4d58b187e53aae0dc23b
+#: f9ab34cdfca442e090232d81fca27ee6
+msgid "linux-azure-6.5"
+msgstr ""
+
+#: ../../22.04/4.md 1adf38a8578d4edfaf9dea8288788cdd
+msgid "[2038954](https://bugs.launchpad.net/bugs/2038954)"
+msgstr ""
+
+#: ../../22.04/4.md 1195a1a695c041ec98470204566e8ee9
+msgid ""
+"jammy/linux-azure-6.5: 6.5.0-1007.7~22.04.1 -proposed tracker (LP: "
+"#2038954)"
+msgstr ""
+
+#: ../../22.04/4.md 903e3e8c489447afb306822eef3cc1be
+msgid "[2038690](https://bugs.launchpad.net/bugs/2038690)"
+msgstr ""
+
+#: ../../22.04/4.md c29357bfc66a4565bee06e06335de3e0
+msgid "mantic/linux-azure: 6.5.0-1007.7 -proposed tracker (LP: #2038690)"
+msgstr ""
+
+#: ../../22.04/4.md c0da664f5ac340f3a59bcbb48f791199
+msgid "[2037625](https://bugs.launchpad.net/bugs/2037625)"
+msgstr ""
+
+#: ../../22.04/4.md ff520a32ae3048ab853276cf4515c243
+msgid "mantic/linux-azure: 6.5.0-1006.6 -proposed tracker (LP: #2037625)"
+msgstr ""
+
+#: ../../22.04/4.md 3abb534794b745a382d9d57ac71229a5
+msgid "[2035597](https://bugs.launchpad.net/bugs/2035597)"
+msgstr ""
+
+#: ../../22.04/4.md 02b0f42083b6438682e8b3790c44d098
+msgid "mantic/linux-azure: 6.5.0-1005.5 -proposed tracker (LP: #2035597)"
+msgstr ""
+
+#: ../../22.04/4.md 68f69c6226d14fc089010f0bd989d299
+msgid "[2034548](https://bugs.launchpad.net/bugs/2034548)"
+msgstr ""
+
+#: ../../22.04/4.md 6747f2c4e1144a5aa782dc4aaf1de587
+msgid "mantic/linux-azure: 6.5.0-1004.4 -proposed tracker (LP: #2034548)"
+msgstr ""
+
+#: ../../22.04/4.md ec543b7166a04be4a5817723718e9768
+msgid "[2034044](https://bugs.launchpad.net/bugs/2034044)"
+msgstr ""
+
+#: ../../22.04/4.md c8c0fb1665aa4f288e7c8ada99c8bc04
+msgid "mantic/linux-azure: 6.5.0-1003.3 -proposed tracker (LP: #2034044)"
+msgstr ""
+
+#: ../../22.04/4.md 3ea963b0e9b34f0e9f03f2967d932224
+msgid "[2033022](https://bugs.launchpad.net/bugs/2033022)"
+msgstr ""
+
+#: ../../22.04/4.md 6fd8948e01004f3488a7ce73b10c04c6
+msgid "mantic/linux-azure: 6.5.0-1002.2 -proposed tracker (LP: #2033022)"
+msgstr ""
+
+#: ../../22.04/4.md 892285f0407641cfb27b18a6a09db037
+msgid "[2029222](https://bugs.launchpad.net/bugs/2029222)"
+msgstr ""
+
+#: ../../22.04/4.md aefed91e565c41288c76d743a3977224
+msgid "mantic/linux-azure: 6.5.0-1001.1 -proposed tracker (LP: #2029222)"
+msgstr ""
+
+#: ../../22.04/4.md 43b7eacdb3d64aee8ec35d51c9d58344
+msgid "[2038060](https://bugs.launchpad.net/bugs/2038060)"
+msgstr ""
+
+#: ../../22.04/4.md 57ca79f13e904e7d8852a6e36a60b9c7
+msgid ""
+"jammy/linux-azure-fde-6.2: 6.2.0-1016.16~22.04.1.1 -proposed tracker (LP:"
+" #2038060)"
+msgstr ""
+
+#: ../../22.04/4.md 6ddc37481f8e403290ed6c0b92a3925a
+msgid "nvidia-graphics-drivers-470"
+msgstr ""
+
+#: ../../22.04/4.md 2c368fc4239045788bc60bcbe0124bbc
+#: 6bf5d7c22780438a979c60fb768e5313 7fb27ba6aed7403d94ce08f88e693622
+#: b12592c85a82478b94199b7a17b09f6b c4becc445672471a8a2bf1733dca7e27
+#: f02638106b1d460a995acabae6773fa0
+msgid "[2038514](https://bugs.launchpad.net/bugs/2038514)"
+msgstr ""
+
+#: ../../22.04/4.md 221f1e142c3245de85d3a71f282bf011
+#: 465079b255474ddc8d3c28dc660261b4 51e10764880640a4b9ebe676ea4758da
+#: b4ce01dc4634421f9ad33609f85d8672 ce7b929992a247abb2ddff3178fa925c
+#: f33003a07f5a4903b94d87c8206cbe0d
+msgid "New upstream release (LP: #2038514)."
+msgstr ""
+
+#: ../../22.04/4.md c10cdbb7cabe4a0cb905eb10ac5ca0d1
+msgid "nvidia-graphics-drivers-525"
+msgstr ""
+
+#: ../../22.04/4.md 233a61b974bb468799417b2967f83312
+msgid "nvidia-graphics-drivers-470-server"
+msgstr ""
+
+#: ../../22.04/4.md e28a2db2251b42bd9b3256fd570276f5
+msgid "nvidia-graphics-drivers-525-server"
+msgstr ""
+
+#: ../../22.04/4.md 076fd3c376054775899787635703a457
+#: 1dff6d06bf804343b752692a2eb27764 208dd48af897412a847d232f95fa3be3
+#: 27dd0d2e1a4a4bde9876f1900284246c 297abfc39c824cf18b2005306d169e16
+#: 4c2a546ef1b84186881e8a0521ae037c 58e51befd0b7445e84c18b528ab42332
+#: 728c0d8ff8654375a7a998f6d18382a6 8d237814395347c99071f411faf3d5bf
+#: 9452991878604494893a0649a9d2cb80 a7761a9e5a6c4ef09c901be72fcdd918
+#: ad08657c6aa34cd093d33f2b5b0c9aa9 b26d141e856a4ae8b1a0093b654ddb8a
+#: b65fccd0e4cc4c6c80717197dcf7022b b7c0388561b84013a51a02a212072a52
+#: bdccff80e1624a808073dbd22aebc945 d1751f473c6843a9bd8e5536849aedee
+#: db4c874638db42488d8204cbc66e0084 f4a6c087bd424bfe893ed37647e26ae7
+msgid "linux-nvidia-6.5"
+msgstr ""
+
+#: ../../22.04/4.md 3a98b967578d411dba3ec1f38734b03f
+msgid "[2038972](https://bugs.launchpad.net/bugs/2038972)"
+msgstr ""
+
+#: ../../22.04/4.md d20a62f2099248cebbd4a855ac9ea7e3
+msgid "jammy/linux-nvidia-6.5: 6.5.0-1004.4 -proposed tracker (LP: #2038972)"
+msgstr ""
+
+#: ../../22.04/4.md 9d8b568e51e54eac80b82f940ab2cf65
+msgid "[2029899](https://bugs.launchpad.net/bugs/2029899)"
+msgstr ""
+
+#: ../../22.04/4.md 0a0291159eb947918677d40ff982e258
+msgid "Update firmware for hwe-6.2/oem-6.5 kernel migrations (LP: #2029899)"
+msgstr ""
+
+#: ../../22.04/4.md f16929af330342e8be8132365cbb8d10
+msgid "makedumpfile"
+msgstr ""
+
+#: ../../22.04/4.md c2e900842793452da94a95c78b3b7de0
+msgid "[2038248](https://bugs.launchpad.net/bugs/2038248)"
+msgstr ""
+
+#: ../../22.04/4.md edcf022aa77249b59f53de679299aee6
+msgid ""
+"d/p/lp2038248-fix-wrong-exclusion-of-slab-pages-on-Linux-6.2.patch: When "
+"using the \"makedumpfile -d 8\" command, exclude user data rather than "
+"other slab pages (LP: #2038248)"
+msgstr ""
+
+#: ../../22.04/4.md 00b3f6adcbb84dda93c913b672be7230
+msgid "linux-meta-kvm"
+msgstr ""
+
+#: ../../22.04/4.md 02353c41294941d4a67ede48caf6dabd
+#: 2ec132b6cff4449982891f8729458379 319bb78cd631448ca08d7193e56b8ccb
+#: 323e05098b4c4983945b9ba498939a52 3395251e1dde425b955d065eda7ec72b
+#: 3e31359e5eed42b68bc497700ce35919 509eae63f5bb4ad79774eac464250631
+#: 6f880653e7224389b5a3f59d4238a695 71ccc9659bd3489382060362302fae53
+#: 7f7ce3265e054432a6003d128ee00808 8e0a91b45ee24cb7bfc519689fe05a71
+#: a0ca49dabe584323852c5485cd60fe5e b1f8dffa398f4a78b5c5ef44497b7207
+msgid "[2039437](https://bugs.launchpad.net/bugs/2039437)"
+msgstr ""
+
+#: ../../22.04/4.md 376ade1311ea4c91ab5a23d9d3197f6b
+#: 41d3ba071b4e41a79a1f644cd4a22b01 5266792d6bd84a27bc4cd77910c2d59b
+#: 68f52e7b6e7440dba3820691a920f32f 922bb389645d4ce993e72a196b4ccc48
+#: 9d3d95a9fdb545b884109645caf96aa4 9f1d3fe317314bf5a7987d7af0149858
+#: a8451a5c71634dc7a6bc941ec26d5ca8 cd02856579bf41bcac0684e1e4aa214e
+#: ce89792ef7514ce988156466ec8f14b5 dbdc85a7027e495384adff8a200b92d2
+#: e4368abb8a7f4e488fb832542200e549 f41066ea31f344a281c3c28d71501dbc
+msgid "`linux-tools-<flavor>` should provide linux-tools (LP: #2039437)"
+msgstr ""
+
+#: ../../22.04/4.md dd024c794b324e52852ab51ea99a53e9
+msgid "linux-meta-raspi"
+msgstr ""
+
+#: ../../22.04/4.md 029490b93a0743dba12ad2848b7cfbdb
+msgid "[2042534](https://bugs.launchpad.net/bugs/2042534)"
+msgstr ""
+
+#: ../../22.04/4.md 6f799b6dbae14bc6b97937a6eb286443
+msgid ""
+"System freeze at suspend stress test with WCN6856 WiFi 6E - Qualcomm - "
+"2R8DY (LP: #2042534)"
+msgstr ""
+
+#: ../../22.04/4.md 70fbfa84d21b41c8a545c04cbf3f4bcd
+msgid "[2042999](https://bugs.launchpad.net/bugs/2042999)"
+msgstr ""
+
+#: ../../22.04/4.md 30d14a5434304c6eb439b2bf22628837
+msgid "BT/WiFi coex stability issue on RTL8851BE/RTL8852BE (LP: #2042999)"
+msgstr ""
+
+#: ../../22.04/4.md c9c301c62a7e4fed950bfd0c9df20d05
+msgid "[2042074](https://bugs.launchpad.net/bugs/2042074)"
+msgstr ""
+
+#: ../../22.04/4.md 93287b5e3f674e7d931305bb09da655f
+msgid "missing mei_vsc firmware for HM2172 and OV02E sensor (LP: #2042074)"
+msgstr ""
+
+#: ../../22.04/4.md f8d1c6a74c1c4572b0b5fbbc4c6d32fc
+msgid "[2036697](https://bugs.launchpad.net/bugs/2036697)"
+msgstr ""
+
+#: ../../22.04/4.md 78986e90498c44d7ac2da12ea08ffe5a
+msgid "i915: Update DMC, GuC, HuC fw for Meteor Lake (LP: #2036697)"
+msgstr ""
+
+#: ../../22.04/4.md 9f2b2d8acc10433e98d4f5ae31f29311
+msgid "[2043580](https://bugs.launchpad.net/bugs/2043580)"
+msgstr ""
+
+#: ../../22.04/4.md 217ef6341f8f4429914b28eb6937e4a0
+msgid "New Intel MIPI IPU6 firmware available for MTL-P platform (LP: #2043580)"
+msgstr ""
+
+#: ../../22.04/4.md 37a2a13b500c432ab98bbc040e4c984a
+msgid "[2042716](https://bugs.launchpad.net/bugs/2042716)"
+msgstr ""
+
+#: ../../22.04/4.md 49857c9631094c84947c0d6dc3810343
+msgid ""
+"Intel AX201] Direct firmware load for iwlwifi-so-a0-hr-b0-83.ucode failed"
+" with error -2 (LP: #2042716)"
+msgstr ""
+
+#: ../../22.04/4.md 9424263ad1ea47ab8e77cb432b9eb05e
+msgid "firmware-sof"
+msgstr ""
+
+#: ../../22.04/4.md 1b4d3d99a0d84cdc88f3a8e66cf9e992
+msgid "Soundwire support for Dell SKU0C87 devices. LP: #2029281"
+msgstr ""
+
+#: ../../22.04/4.md 716bfe94fff842e98759e89993e17985
+#: e57e10e3f8a94c4fb99872d64d1c9674
+msgid "linux-meta-azure"
+msgstr ""
+
+#: ../../22.04/4.md 3d7c6a21514a4302b4c4dca3721eb08e
+#: 77d6ab94166d4b43a3772efcfbdca673
+msgid "linux-meta-azure-6.2"
+msgstr ""
+
+#: ../../22.04/4.md 252a7e6945624b73aa85588ffff9a636
+#: 269015050b324e8e97a4425cc984d599
+msgid "[2041908](https://bugs.launchpad.net/bugs/2041908)"
+msgstr ""
+
+#: ../../22.04/4.md 5936e2c1a8494865bfe15136cac797c1
+#: e7bea32502644f83b02641e9583e06ae
+msgid "jammy/linux-azure-fde: 5.15.0-1052.60.1 -proposed tracker (LP: #2041908)"
+msgstr ""
+
+#: ../../22.04/4.md 45db316f9d9a4d88a632b1f240e856d2
+#: b8cc5d090b40415fa6df74c4303155bc
+msgid "linux-meta-azure-fde"
+msgstr ""
+
+#: ../../22.04/4.md 272f903641454598b7b3f3f590f780e4
+#: fe197510eb14473eac1a0d5ff6591589
+msgid "[2041882](https://bugs.launchpad.net/bugs/2041882)"
+msgstr ""
+
+#: ../../22.04/4.md 033ea7805d2b42e0b7a03e284ecebe82
+#: 4934b39ff74149a9b40cbc2503d12f1f
+msgid ""
+"jammy/linux-azure-fde-6.2: 6.2.0-1017.17~22.04.1.1 -proposed tracker (LP:"
+" #2041882)"
+msgstr ""
+
+#: ../../22.04/4.md 88ffce7b03dc4dd18e8a172e63607685
+#: e718b45abf964723941dd9b68e64f6a4
+msgid "linux-meta-azure-fde-6.2"
+msgstr ""
+
+#: ../../22.04/4.md fcd7f1f4bbb341af85260573a40dd5bc
+msgid "[2038300](https://bugs.launchpad.net/bugs/2038300)"
+msgstr ""
+
+#: ../../22.04/4.md 410093b56f0a400f9f0a0ba61a1fdfb7
+msgid ""
+"d/p/lp2038300-parse_proc_interrupts-fix-parsing-interrupt-counts.patch "
+"Fix parsing of GPIO irqchip on Tegra platform (Backport) (LP: #2038300)"
+msgstr ""
+
+#: ../../22.04/4.md 5c56d0717f4f4a6c8681be671f25b614
+msgid "[2041540](https://bugs.launchpad.net/bugs/2041540)"
+msgstr ""
+
+#: ../../22.04/4.md f21d1aeaa6d043aaad45514ecd1581d4
+msgid ""
+"jammy/linux-azure-fde-6.2: 6.2.0-1018.18~22.04.1.1 -proposed tracker (LP:"
+" #2041540)"
+msgstr ""
+
+#: ../../22.04/4.md 12e6ffceedb54a5aaa5cf766a578e797
+msgid "[2041604](https://bugs.launchpad.net/bugs/2041604)"
+msgstr ""
+
+#: ../../22.04/4.md 5a293d542aef48b4b3c2a2efae9ae04c
+msgid "jammy/linux-oem-6.1: 6.1.0-1027.27 -proposed tracker (LP: #2041604)"
+msgstr ""
+
+#: ../../22.04/4.md d94cff48e07c41359e47b1ec432b84dd
+msgid "[2042580](https://bugs.launchpad.net/bugs/2042580)"
+msgstr ""
+
+#: ../../22.04/4.md a14f6ab74afb49589f2dc81c8ca71fff
+msgid "Jammy update: v6.1.61 upstream stable release (LP: #2042580)"
+msgstr ""
+
+#: ../../22.04/4.md 4050472204b2430cbbd8e88557b0c916
+msgid "[2042577](https://bugs.launchpad.net/bugs/2042577)"
+msgstr ""
+
+#: ../../22.04/4.md dc7409900ed14520979a508e1fdf51d4
+msgid "Jammy update: v6.1.60 upstream stable release (LP: #2042577)"
+msgstr ""
+
+#: ../../22.04/4.md 379606c1ac0e4a81a3fc29fb01f00a89
+msgid "[2042572](https://bugs.launchpad.net/bugs/2042572)"
+msgstr ""
+
+#: ../../22.04/4.md c2e664b2367248e893417b743c4f98d4
+msgid "Jammy update: v6.1.59 upstream stable release (LP: #2042572)"
+msgstr ""
+
+#: ../../22.04/4.md 8bb43f38068f458f8cc442c326b35440
+msgid "[2042569](https://bugs.launchpad.net/bugs/2042569)"
+msgstr ""
+
+#: ../../22.04/4.md 88b307ccdea84e34b661e6a606ab542d
+msgid "Jammy update: v6.1.58 upstream stable release (LP: #2042569)"
+msgstr ""
+
+#: ../../22.04/4.md 859bd5b3e085492b9ec918f28aebf441
+msgid "[2041693](https://bugs.launchpad.net/bugs/2041693)"
+msgstr ""
+
+#: ../../22.04/4.md 7bf0690c1c1043ed974153d7cde967dd
+msgid "jammy/linux-oem-6.5: 6.5.0-1009.10 -proposed tracker (LP: #2041693)"
+msgstr ""
+
+#: ../../22.04/4.md 0b248ea822ee42e68b1c8198ca1884ef
+msgid "[2039925](https://bugs.launchpad.net/bugs/2039925)"
+msgstr ""
+
+#: ../../22.04/4.md 7142dac1c0ee48beb6e28b14ad435277
+msgid "Realtek RTS5264 SD 7.0 cardreader support (LP: #2039925)"
+msgstr ""
+
+#: ../../22.04/4.md aef425e9527242afb6c7fd82e9df173d
+msgid "[2044091](https://bugs.launchpad.net/bugs/2044091)"
+msgstr ""
+
+#: ../../22.04/4.md 44924f704ae34979ad42b18af1b896f6
+msgid "Long resume on surprise dock unplug (LP: #2044091)"
+msgstr ""
+
+#: ../../22.04/4.md 3865695170be4e45aaed2d42be7d2aba
+msgid "[2043551](https://bugs.launchpad.net/bugs/2043551)"
+msgstr ""
+
+#: ../../22.04/4.md 5740254947114d32ae51bc9a047f894a
+msgid ""
+"Fix headset microphone for Dell laptops with audio codec ALC295 (LP: "
+"#2043551)"
+msgstr ""
+
+#: ../../22.04/4.md 8c0ded3193424b9caa9ce8597ebc61b2
+#: a3e2c1b47fb3491889b14be1577b7332
+msgid "linux-signed-azure-6.5"
+msgstr ""
+
+#: ../../22.04/4.md 168e8a14cb7f4c5183021e259cf6af84
+#: 723b6d14748741898c0ebf1585988a67 a7509bc5fe5546068019b22110fd81bb
+#: d1d287a76bc34f479acea4c9af248a1f
+msgid "linux-meta-azure-6.5"
+msgstr ""
+
+#: ../../22.04/4.md 70daf092068644c08c2317bd7bb9cc09
+#: e5f58f28f65b4a3d909a9800cc348bff
+msgid "[2017571](https://bugs.launchpad.net/bugs/2017571)"
+msgstr ""
+
+#: ../../22.04/4.md 6f4f733f408d4bfe9dc8d97f7131d0f2
+#: d080739577664036b4581204f2a2c0b4
+msgid ""
+"SIGNEDv4: add Azure CVM support to the linux-generate ancillary package "
+"(LP: #2017571)"
+msgstr ""
+
+#: ../../22.04/4.md 0e36aa5add054c0aa1c2eb50383afb90
+msgid "[2007827](https://bugs.launchpad.net/bugs/2007827)"
+msgstr ""
+
+#: ../../22.04/4.md 7be0507af3424b10831767426dbdeddd
+msgid ""
+"Ensure that only kernels in fully \"installed\" state are considered for "
+"flashing (LP: #2007827)"
+msgstr ""
+
+#: ../../22.04/4.md 954cf309c2f34bd8a12866d8976fe3b6
+msgid "[2041562](https://bugs.launchpad.net/bugs/2041562)"
+msgstr ""
+
+#: ../../22.04/4.md 1c413d11d6844aa98972a60e944acadf
+msgid "jammy/linux-azure-fde: 5.15.0-1053.61.1 -proposed tracker (LP: #2041562)"
+msgstr ""
+
+#: ../../22.04/4.md d3c68f8977084d9c92b279578eecf291
+msgid "[2042902](https://bugs.launchpad.net/bugs/2042902)"
+msgstr ""
+
+#: ../../22.04/4.md c2c6121afd1b4bf0a4f3355da9d4ed48
+msgid "Backport patch to add rt713 SDCA device (LP: #2042902)"
+msgstr ""
+
+#: ../../22.04/4.md c070eff9ea164f49b196b455aab617e3
+msgid "[2042697](https://bugs.launchpad.net/bugs/2042697)"
+msgstr ""
+
+#: ../../22.04/4.md 12fcd72666864887b4c4e20b215c559c
+msgid "Pull request to address thermal core issues (LP: #2042697)"
+msgstr ""
+
+#: ../../22.04/4.md 0573dd323ea04f42b9f8c1e9d63cd08b
+#: 18e7d2265d4a4a4097f4ba3afa7199ee 48813b6c60a147778e61d155c7fa8378
+#: 48b3d429597b41f3b8e34fad7af653a2 4d11a1076cdb42b596e36d29f75f64a9
+#: 5877e060e78549609a61d33894eecac1 5b306d376a51401f9fc7b8400313d2b6
+#: 7448669ff6eb4ba28c9ee40a3cdc119b 9a00999785be493d891b686bd76392d4
+#: 9bbd2bd80b6048ef9698782df164bdca 9d9d8ffa9514459885b942bf34584d0f
+#: b27f84f923b947c8b98437761a5febd9 bb1643a1023e496893f195ea2835d97c
+#: bfc93c05f92742999b07e9622bb1bb6a c6e16413fa834933b1908fa6e6c6a69b
+#: c9961109654f4937aa6b3ac7aeaf0dc7 cbadfccc664a4a3cb4b2a67756e8032a
+#: d18960861c77424e9e6035a4e4c27417 d1e029dbb115498d9534ecee8b2a2d00
+msgid "linux-hwe-6.5"
+msgstr ""
+
+#: ../../22.04/4.md e9a68dca51da4976a97bfeb1959a0a4d
+msgid "[2043483](https://bugs.launchpad.net/bugs/2043483)"
+msgstr ""
+
+#: ../../22.04/4.md 1ab7d3d2b098439fba083de373a04fb5
+msgid "jammy/linux-hwe-6.5: 6.5.0-14.14~22.04.1 -proposed tracker (LP: #2043483)"
+msgstr ""
+
+#: ../../22.04/4.md 81874ef9c19f41cc855f90b6436de1e8
+msgid "[2043102](https://bugs.launchpad.net/bugs/2043102)"
+msgstr ""
+
+#: ../../22.04/4.md 9964961ef21342e782b8b19705cba408
+msgid "jammy/linux-hwe-6.5: 6.5.0-12.12~22.04.2 -proposed tracker (LP: #2043102)"
+msgstr ""
+
+#: ../../22.04/4.md cad8bc6b5f8047979483522b0e9fca38
+msgid "[2043086](https://bugs.launchpad.net/bugs/2043086)"
+msgstr ""
+
+#: ../../22.04/4.md 7ef43cd660e64a28972240859098e27d
+msgid "jammy/linux-hwe-6.5: 6.5.0-12.12~22.04.1 -proposed tracker (LP: #2043086)"
+msgstr ""
+
+#: ../../22.04/4.md 745bdb1b4d9c4815892e35d2cb416c7d
+#: 8128d69a86434d65a845a13de32e22f0 a3275825f8214080ba0858d4a5424361
+#: b53c21b50fe747639db95670ab12df7e
+msgid "[2041536](https://bugs.launchpad.net/bugs/2041536)"
+msgstr ""
+
+#: ../../22.04/4.md 2f6d29eca3ac4d3f89fd1212653feefa
+#: 4fd993ddb8d243ec8483b07b9437ad25 7998075662974f179f80d2f39fd744b0
+#: c983df12c06949738778368165b278c2
+msgid "mantic/linux: 6.5.0-12.12 -proposed tracker (LP: #2041536)"
+msgstr ""
+
+#: ../../22.04/4.md 1e6c6b0ec91b4702a6194c12ec0ec29a
+#: 223cd0e707f54fc691fdf9a580f47d28 c531c21c7cab4616962643792a54ee09
+#: e8e24b393d374e6b8e0c786ea3c6a382
+msgid "[2040194](https://bugs.launchpad.net/bugs/2040194)"
+msgstr ""
+
+#: ../../22.04/4.md 3bdc51d748904113acd149c485bc3a5f
+#: cb8e0e5776e44bd181d099dd10c3a79b d2fed68808cc4023b104959fc199b609
+#: e1fca156e75345f584cb12db65cf7f68
+msgid ""
+"apparmor restricts read access of user namespace mediation sysctls to "
+"root (LP: #2040194)"
+msgstr ""
+
+#: ../../22.04/4.md 4de0e68d51cb4f90b63741db9bea132a
+#: 69e25171091a4e7f85a4ad39511a095e c98361bad56e469abf72f2136bb0adc8
+#: f2d03c8d7a734bfc94b7fcad1151f493
+msgid "[2040192](https://bugs.launchpad.net/bugs/2040192)"
+msgstr ""
+
+#: ../../22.04/4.md 004b93f74e0546c5b6be4f4611e53a30
+#: 2d992a7c9a574ebb9eb87d4c39f3fad5 4668cc84ceb34302b184a7b0f98b130d
+#: df52e2b550b34192b00162475b30a220
+msgid "AppArmor spams kernel log with assert when auditing (LP: #2040192)"
+msgstr ""
+
+#: ../../22.04/4.md 659f371cd4b343f5aa3da07949eeb970
+#: 7ba41390d49b47219de00d1124dac207 c29aac21da5f48f5abf08add810354b2
+#: fe828144ebb740f082a5de436e8ff64b
+msgid "[2040250](https://bugs.launchpad.net/bugs/2040250)"
+msgstr ""
+
+#: ../../22.04/4.md 0ef0d08983f44134abb76dc1f25afadf
+#: 4a5cf264497c4c39ae0dec7f3f409ef1 742692de9ea24c41ae75d8f6392b0475
+#: a610864eadd249b98625ce94ad875165
+msgid "apparmor notification files verification (LP: #2040250)"
+msgstr ""
+
+#: ../../22.04/4.md 0c70add2e0484a68badf6bec95cfdc9e
+#: 296104a3b47043778648c21b0d88d2a6 9e751f37f4e54f00914b7fa2cdbe1bfa
+#: eb1f31fe813649749835db5f9da4fb92
+msgid "[2040245](https://bugs.launchpad.net/bugs/2040245)"
+msgstr ""
+
+#: ../../22.04/4.md 007b951a8baf4004a784cce7f5ee4970
+#: 3269bc737b5449658b07e22f49962142 5031175cff334eb09b5c9f4aed824804
+#: b66ba916fa36402587f4cdbf41f4559b
+msgid "apparmor oops when racing to retrieve a notification (LP: #2040245)"
+msgstr ""
+
+#: ../../22.04/4.md 5fdada81fbc34ee7b294796fad7dc177
+#: 8ab8429fc65a4cadabed675c3f7f0a9e 8bdcab7aa8e04dffb03f25f11b12fa88
+#: f1cbdf99b07d414da029c6eb721dda67
+msgid "[2038611](https://bugs.launchpad.net/bugs/2038611)"
+msgstr ""
+
+#: ../../22.04/4.md 9c8be066d41645a3b9d8a14c0861e5cf
+#: af5e196127c84a518ca7910b8b4d5876 b9225dff49da4083b3c2a01ce152aed5
+#: fbbe98d18a0d4e24abb7e66c26e80511
+msgid "drop all references to is_rust_module.sh in kernels >= 6.5 (LP: #2038611)"
+msgstr ""
+
+#: ../../22.04/4.md 03003dd9c68c40c9a2cefb8585ed9758
+#: 4d61d839abdd44bb97f4fed93e6ed98b 757a339decdc4e65b0e120754d07206d
+#: 821baf40dad749069e8afd4efd218622 c019ce6f20aa4cf3960b03a8acf2ac2f
+#: ce2fa39426a84809862f55d2050e9422 cea7ccd59b574e8c98b1d687b036ee61
+#: e1db97476ca349f6985b2bf3aa14b4dd
+msgid "[2038522](https://bugs.launchpad.net/bugs/2038522)"
+msgstr ""
+
+#: ../../22.04/4.md 3cdd4a271fae4531952576f18fe75c7c
+#: 532771e900744108b6c6f5c39a2cf3a0 533a13da09b84b4a9ce95e0f9979b709
+#: 67a24c6aeaea42f9b30552891b5c605b 71b3a0cc45974615aaa5eacb83698bdb
+#: c3305373e9154c599beac69267656757 d587c5a7dc9648c0a82987e4cfa0f5e1
+#: eaedeb52417141f3a89524c8f72f7557
+msgid "disable shiftfs (LP: #2038522)"
+msgstr ""
+
+#: ../../22.04/4.md 66be49550af3435b8c0ad6c91ea8165f
+#: 865e9e4dd81f408c847c7a015af9852c b905636138f64943ae905d41428c0a57
+#: f2541f3e23d44be9b16e5fabda114a20 f821a6b275854d919c32ece4060b30bc
+#: f8577dd36cb34434be36723ea64d3fbe
+msgid "[2036587](https://bugs.launchpad.net/bugs/2036587)"
+msgstr ""
+
+#: ../../22.04/4.md 24eab9a70f6b487993bbedef406a6ab5
+#: 76e35c8a2eaa440d91834a364a68266e 98f59b186b7d4911957e2fc153ef9434
+#: 9cdda103f0d6417eb29b6eec767145d5 b9fee64da1b648f0b81774ebf0d8455a
+#: e76d87b06d4b478eb3d806fdd2cf2e3b
+msgid ""
+"Mediatek] mt8195-demo: enable CONFIG_MTK_IOMMU as module for multimedia "
+"and PCIE peripherals (LP: #2036587)"
+msgstr ""
+
+#: ../../22.04/4.md 89a7834b063440879ab90d3bfa9f972a
+#: 96dcd4da14d94feb913092fd26ede548 9da685fc7f4148a0b47cb12072859c76
+msgid "systemd-hwe"
+msgstr ""
+
+#: ../../22.04/4.md e7930d6a7f8e4e55b6b495ea763209be
+msgid "[2044431](https://bugs.launchpad.net/bugs/2044431)"
+msgstr ""
+
+#: ../../22.04/4.md c0ca23f474cc4ceb9b96d09f0cf929b5
+msgid "hwdb: Add Dell models that require ACCEL_LOCATION=base (LP: #2044431)"
+msgstr ""
+
+#: ../../22.04/4.md fc964f192fe84f91aaf51adb272f419f
+msgid "[2044150](https://bugs.launchpad.net/bugs/2044150)"
+msgstr ""
+
+#: ../../22.04/4.md 52c62c204c234df98bc402134a0f5ff9
+msgid "Missing CS35L41 firmware for HP G11 mWS models (LP: #2044150)"
+msgstr ""
+
+#: ../../22.04/4.md 73c03dc6b0b74b7195d8bbaa5eb5a3ab
+msgid "[2044158](https://bugs.launchpad.net/bugs/2044158)"
+msgstr ""
+
+#: ../../22.04/4.md e83a5bc7fc9f4bb4ba41973bb13a2ca6
+msgid "Missing CS35L41 firmware for Dell Oasis Models (LP: #2044158)"
+msgstr ""
+
+#: ../../22.04/4.md 4bdf85dc3af144e0a769f7faec29633f
+msgid "[2037390](https://bugs.launchpad.net/bugs/2037390)"
+msgstr ""
+
+#: ../../22.04/4.md f64bc63e8241408697526a0b62a40807
+msgid ""
+"Missing firmware for Intel CNVi AX211 on Intel Meteor Lake platform (LP: "
+"#2037390)"
+msgstr ""
+
+#: ../../22.04/4.md a87b0a80723949c89c02f2deaa3dbbc3
+msgid "[2045913](https://bugs.launchpad.net/bugs/2045913)"
+msgstr ""
+
+#: ../../22.04/4.md 52810befbffa4246aceeb3bd3158a70e
+msgid "New upstream release (LP: #2045913):"
+msgstr ""
+
+#: ../../22.04/4.md 804fd26e23bb4e9ba6aff69f20fc0a28
+#: ecfdfb4244e1496b99e67483a187ca29 f46307d94bde41768deeec50a67bbe8f
+#: fedcc995bacd43c690d0873ff30962cc
+msgid "linux-gcp-6.5"
+msgstr ""
+
+#: ../../22.04/4.md 7eca3b5e189c479599a09b1d09bbdf70
+msgid "[2043107](https://bugs.launchpad.net/bugs/2043107)"
+msgstr ""
+
+#: ../../22.04/4.md b4caf78214654af88f61b9b620ee3c71
+msgid ""
+"jammy/linux-gcp-6.5: 6.5.0-1010.10~22.04.3 -proposed tracker (LP: "
+"#2043107)"
+msgstr ""
+
+#: ../../22.04/4.md 2437b702da9a4a1abbabf5899655af75
+msgid "[2039010](https://bugs.launchpad.net/bugs/2039010)"
+msgstr ""
+
+#: ../../22.04/4.md 9907667391dd4b429bd7fc7a75cd2ab0
+msgid ""
+"revert support for arbitrary symbol length in modversion in hwe kernels "
+"(LP: #2039010)"
+msgstr ""
+
+#: ../../22.04/4.md 4b90ff578ea44e97b05eafd66e59737d
+msgid "[2039009](https://bugs.launchpad.net/bugs/2039009)"
+msgstr ""
+
+#: ../../22.04/4.md bbae37dcc32c4402af2d90b4b8fe7f9e
+msgid ""
+"do not ship ZSTD compressed modules in jammy/hwe-6.5 kernels (LP: "
+"#2039009)"
+msgstr ""
+
+#: ../../22.04/4.md 9b742d469627459cbb12bdef4dd5f403
+#: b9f731f103734689b01ebe37ae90ce3b
+msgid "linux-oracle-6.5"
+msgstr ""
+
+#: ../../22.04/4.md b634fef8604f484faca14727b7bacfa1
+msgid "[2044275](https://bugs.launchpad.net/bugs/2044275)"
+msgstr ""
+
+#: ../../22.04/4.md 18e0f2ba77d34e9c9341f75805122400
+msgid ""
+"jammy/linux-oracle-6.5: 6.5.0-1013.13~22.04.4 -proposed tracker (LP: "
+"#2044275)"
+msgstr ""
+
+#: ../../22.04/4.md 9969918596d84bd4bfb6e5b14bee4042
+msgid "[2047946](https://bugs.launchpad.net/bugs/2047946)"
+msgstr ""
+
+#: ../../22.04/4.md 73d4a35acc3442b6b2b4cfbe3e252a30
+msgid "jammy/linux-oem-6.5: 6.5.0-1011.12 -proposed tracker (LP: #2047946)"
+msgstr ""
+
+#: ../../22.04/4.md 92cfd2e776eb463b9e342c5fb4769f9e
+msgid "[2041800](https://bugs.launchpad.net/bugs/2041800)"
+msgstr ""
+
+#: ../../22.04/4.md d7275de9b2f84a74baefc502afed8eac
+msgid "needs-packaging] usbio-drivers (LP: #2041800)"
+msgstr ""
+
+#: ../../22.04/4.md 370c98d343094d559d66dd9a7241ba5d
+msgid "[2047909](https://bugs.launchpad.net/bugs/2047909)"
+msgstr ""
+
+#: ../../22.04/4.md 123be5b97c08472ea3b1d913b4e3843f
+msgid ""
+"Support standalone dkms source tree embedded in kernel source (LP: "
+"#2047909)"
+msgstr ""
+
+#: ../../22.04/4.md fd905510e15544ad88d3a6257b684e08
+msgid "[2046681](https://bugs.launchpad.net/bugs/2046681)"
+msgstr ""
+
+#: ../../22.04/4.md 3521359dd4624f6cad74d6270f08bcef
+msgid "jammy-oem-6.5: one more panel needs to disable psr2 (LP: #2046681)"
+msgstr ""
+
+#: ../../22.04/4.md 1793760c6ad944f3a4460671bcb1ca53
+msgid "linux-restricted-modules-oem-6.5"
+msgstr ""
+
+#: ../../22.04/4.md 22f434850db149acb592680c673f1f8e
+#: 7daf7454490640e281803c4db6a19b83
+msgid "[1991130](https://bugs.launchpad.net/bugs/1991130)"
+msgstr ""
+
+#: ../../22.04/4.md 170ebace7c0545fdaa8af54673d55091
+#: a1515851acaa4c368a223099fd93f3d5
+msgid "Add lrm autogenerated transitional independent of variants (LP: #1991130)"
+msgstr ""
+
+#: ../../22.04/4.md 6de00c90feaf4865b620ef6776b5868b
+msgid "linux-restricted-signatures-oem-6.5"
+msgstr ""
+
+#: ../../22.04/4.md b911c463c1664ab795e64ebd20ed6ec1
+msgid "[2045621](https://bugs.launchpad.net/bugs/2045621)"
+msgstr ""
+
+#: ../../22.04/4.md 4957578848c2438da2346de98c0e9903
+msgid "Add autosuspend rules for Framework (LP: #2045621)"
+msgstr ""
+
+#: ../../22.04/4.md 6e9c0bf2196b4cfca13dfb25bb43b1ec
+msgid "[2046687](https://bugs.launchpad.net/bugs/2046687)"
+msgstr ""
+
+#: ../../22.04/4.md b7c8fe2b22da4bbca43fa9faaab70ff5
+msgid "Add three Dell platforms to sensor accel location base (LP: #2046687)"
+msgstr ""
+
+#: ../../22.04/4.md 030ebea800c54ea0ac65ace495aa2ed5
+#: 0f7269b2c7dd429c9702714f465b8989 176ed2cc195446fdaa545b1c9d6054dc
+#: 1a70e117b70c449692b8b266c095b931 3646709bb8ed40839b2503136aa912aa
+#: 50f5fdc32eef479f9b57a12a23a5fc6d 51aa2971ffc247d48f0f5fa1673bfcba
+#: 53a4da2579df441e83cced85a969f31e 5e6af2f24ac3407f9818511481c5cc44
+#: 6e9e03c507d24c9dbee639f68093ea32 7977bbc4d3bb4818af461276c8d7094a
+#: 7af179e6f3ae477eb23525e989a06ec0 7baed8ad300c4f2faa11c6ed4c470edf
+#: 7d3a4978f0c14981b4c3fbd11d10951d 96c4ed186348476c87af58ea7c4b1f6c
+#: a700cbf6e9684cdfa8786ed8cdefc576 af765e4d92a64aa99c157925a34e0aa7
+#: bfeb178f78924baba376ba969493def6 c81803afc1ad4339b6e55d2731e141cf
+#: cd82c9dcad3b48a9a099bf3a5436142a d73cf7f949de451c8eaf70be34844a9b
+#: fd5b700dff8b4731ac6ca9e51b53daaa
+msgid "linux-lowlatency-hwe-6.5"
+msgstr ""
+
+#: ../../22.04/4.md 91b80f1aee7544289b711bdb4961959d
+msgid "[2043484](https://bugs.launchpad.net/bugs/2043484)"
+msgstr ""
+
+#: ../../22.04/4.md e675c42b3e664965a0857087a571ef2a
+msgid ""
+"jammy/linux-lowlatency-hwe-6.5: 6.5.0-14.14.1~22.04.1 -proposed tracker "
+"(LP: #2043484)"
+msgstr ""
+
+#: ../../22.04/4.md 94fe4dd3de9e4e43bb63d3733bedae0d
+msgid "[2038688](https://bugs.launchpad.net/bugs/2038688)"
+msgstr ""
+
+#: ../../22.04/4.md f3d962368dde4ea4b75b94e56901f721
+msgid "mantic/linux-lowlatency: 6.5.0-9.9.1 -proposed tracker (LP: #2038688)"
+msgstr ""
+
+#: ../../22.04/4.md 5c375b5bdfee4b258d7cef446f343730
+#: a0761de22c7346e09d10a8bd7146787e
+msgid "[2048901](https://bugs.launchpad.net/bugs/2048901)"
+msgstr ""
+
+#: ../../22.04/4.md 6c2836acb7f548d694ac972e39a56687
+#: 94b87d351d7a4a9ca8115d97f07dc511
+msgid "New upstream release (LP: #2048901)"
+msgstr ""
+
+#: ../../22.04/4.md 1542d25a86de4ef69baa1303dd2d3b85
+#: 92bb57c5d3634cdeb275861467389bf5
+msgid "nvidia-graphics-drivers-545"
+msgstr ""
+
+#: ../../22.04/4.md caeb58ce0c074bcdbb63347f6a6f1251
+#: e779d37975a64be5b96c7392d3a941d0
+msgid "[2042426](https://bugs.launchpad.net/bugs/2042426)"
+msgstr ""
+
+#: ../../22.04/4.md b0d0b8d6283b45eb88a8c120fa04c9ea
+msgid "New upstream release (LP: #2042426):"
+msgstr ""
+
+#: ../../22.04/4.md f9847381a2c8456684a8298a4ce93203
+msgid "New upstream release (LP: #2042426)."
+msgstr ""
+
+#: ../../22.04/4.md 584add8d27c541999736ae8c83195beb
+msgid "[2048551](https://bugs.launchpad.net/bugs/2048551)"
+msgstr ""
+
+#: ../../22.04/4.md 7a4e479aa69748b69a06acb87576d6a4
+msgid "lunar/linux-aws: 6.2.0-1018.18 -proposed tracker (LP: #2048551)"
+msgstr ""
+
+#: ../../22.04/4.md 32b111aa8eb64b4f859e90b65eef91e5
+#: 33cbae733b254b5e84641a6950ef240a 73c886df93894bbe8b99b97c3c93ab9f
+#: d572df7131264caaa10c7ffb7ce876e4
+msgid "[2048568](https://bugs.launchpad.net/bugs/2048568)"
+msgstr ""
+
+#: ../../22.04/4.md 3e4c8116c7f641c48e537f7c59f4bed0
+#: bbf244facb834328ad682ed9b48f7d88 da6d56523cb442d7a5156d236bd45d1e
+#: f9a477278bbd4154ac55c1554f9ce2d8
+msgid "lunar/linux: 6.2.0-40.41 -proposed tracker (LP: #2048568)"
+msgstr ""
+
+#: ../../22.04/4.md 33b59e27c8ea4252b864af0113e3d6aa
+msgid "[2048554](https://bugs.launchpad.net/bugs/2048554)"
+msgstr ""
+
+#: ../../22.04/4.md 66ad5dd3e18043dd8868d4a46a197812
+msgid "lunar/linux-azure: 6.2.0-1019.19 -proposed tracker (LP: #2048554)"
+msgstr ""
+
+#: ../../22.04/4.md 83206687bfed46a29965889b71aaf0d2
+msgid "[2048552](https://bugs.launchpad.net/bugs/2048552)"
+msgstr ""
+
+#: ../../22.04/4.md 6be48486dcb748439d27a90df63b0772
+msgid ""
+"jammy/linux-azure-fde-6.2: 6.2.0-1019.19~22.04.1.1 -proposed tracker (LP:"
+" #2048552)"
+msgstr ""
+
+#: ../../22.04/4.md 9a8bfc8ace864cb58f72bfcea67d868d
+msgid "[2048573](https://bugs.launchpad.net/bugs/2048573)"
+msgstr ""
+
+#: ../../22.04/4.md c4c16c2c9959445baf424b4eb59ae38d
+msgid "jammy/linux-azure-fde: 5.15.0-1054.62.1 -proposed tracker (LP: #2048573)"
+msgstr ""
+
+#: ../../22.04/4.md 5fccdca8ab0644df99fdf246fb068a9d
+#: ba0c1551b03b44dba1bf0a9e88a15322
+msgid "[2048977](https://bugs.launchpad.net/bugs/2048977)"
+msgstr ""
+
+#: ../../22.04/4.md d2f8b57629a74d33885d199fc3de077e
+msgid ""
+"Revert \"WCN6856 Wi-FI Unavailable and no function during suspend stress "
+"(LP: #2048977)\""
+msgstr ""
+
+#: ../../22.04/4.md 7a9b51e5e9544999a53c945137659a9d
+msgid "[2048747](https://bugs.launchpad.net/bugs/2048747)"
+msgstr ""
+
+#: ../../22.04/4.md a47f8c53fd3e45298bad6c2efc15492a
+msgid ""
+"Dell dock station WD22TB4 loses ether dev after reboot/power off (LP: "
+"#2048747)"
+msgstr ""
+
+#: ../../22.04/4.md d6a4d1b36e5849fc9bad547a111db361
+msgid "[2048853](https://bugs.launchpad.net/bugs/2048853)"
+msgstr ""
+
+#: ../../22.04/4.md b606ad36b2994a1792f8a0f341da8dd9
+msgid ""
+"occasional wifi firmware loading failures: wiwlwifi: BE200: Failed to "
+"start RT ucode: -110 (LP: #2048853)"
+msgstr ""
+
+#: ../../22.04/4.md dd9e8981efd047699997e59fecbae99a
+msgid ""
+"WCN6856 Wi-FI Unavailable and no function during suspend stress (LP: "
+"#2048977)"
+msgstr ""
+
+#: ../../22.04/4.md ee948268a3e94d9887743e03c34e8476
+msgid "[2048991](https://bugs.launchpad.net/bugs/2048991)"
+msgstr ""
+
+#: ../../22.04/4.md 6f8a610792214829a494ce929a9f0f8c
+msgid "upstream Intel VSC firmware paths moved to intel/vsc/ (LP: #2048991)"
+msgstr ""
+
+#: ../../22.04/4.md 8b413555d27042ad95f7d8600d7c64fb
+msgid "[2049327](https://bugs.launchpad.net/bugs/2049327)"
+msgstr ""
+
+#: ../../22.04/4.md c566de9216994ddab265ef224a3bba96
+msgid "fix typo to make the patch work on mt8390-evk (lp: #2049327)"
+msgstr ""
+
+#: ../../22.04/4.md 87378792dd5d490eaf6805e68b760b64
+msgid "smartmontools"
+msgstr ""
+
+#: ../../22.04/4.md 2e277837125745e19b160571f11d9d86
+msgid "[2042885](https://bugs.launchpad.net/bugs/2042885)"
+msgstr ""
+
+#: ../../22.04/4.md eb6c6a85ed334897bdc5231221001038
+msgid ""
+"Add d/p/lp2042885-fix-segfault-reading-nvme-error-log-on-be.patch to fix "
+"a smartctl on NVME segmentation fault. (LP: #2042885)"
+msgstr ""
+
+#: ../../22.04/4.md 9c3be95ab75c4f859c73dd7e46a21893
+msgid "[2037407](https://bugs.launchpad.net/bugs/2037407)"
+msgstr ""
+
+#: ../../22.04/4.md 410d34d908ff4706b32b0637bc7f006d
+msgid "Add support for Xilinx Kria KD240 (LP: #2037407)"
+msgstr ""
+
+#: ../../22.04/4.md 0739dea580c442fe83a538a80215c2bf
+#: 317688354b8549b28c65e4b9ef7bca05 339be31105c142418fe5e1dc7e30a90a
+#: a177b18c4e2a48b4bcbc334bb24faa8f a8b70319fa524c4c84d6178ff8a36885
+#: c0209423a2b84219a770e1176c81b5d6 c2e23fcd8cfa438382eb20ac97d2c2c9
+#: f19a5fd746d344b995be4021b205e953
+msgid "[2042853](https://bugs.launchpad.net/bugs/2042853)"
+msgstr ""
+
+#: ../../22.04/4.md 5b0c701679284050ba5fcb66ad248f0c
+#: 82b3ca5af9e34a04a730fedf43080679 837c748ca4074b1098eb9c7bcc3938a4
+#: 92e9c3f45d46456d81871a3cc0780705 95a903daac3048bc9cfffc6c43a151f8
+#: 9668f020480a4f8bb9729c8226efa9e3 f59417ae073b49eebd25b2fc9ec810d9
+#: f82b8e284c4043148874c7737c440548
+msgid ""
+"UBUNTU 23.04] Kernel config option missing for s390x PCI passthrough (LP:"
+" #2042853)"
+msgstr ""
+
+#: ../../22.04/4.md 389f070b45434884a6c274cf9b2c321c
+msgid "linux-riscv-6.5"
+msgstr ""
+
+#: ../../22.04/4.md df12e89ad5084365bd0b1f465bc676a1
+msgid "linux-starfive-6.5"
+msgstr ""
+
+#: ../../22.04/4.md 8ac99cf28f444f9ea743a70c6930d4ca
+msgid "[2051966](https://bugs.launchpad.net/bugs/2051966)"
+msgstr ""
+
+#: ../../22.04/4.md 3086277cfec94dca83e9b3f5a4538449
+msgid "jammy/linux-oem-6.1: 6.1.0-1033.33 -proposed tracker (LP: #2051966)"
+msgstr ""
+
+#: ../../22.04/4.md b81bc008503f4ceda396f144c4acef4b
+msgid "[2046577](https://bugs.launchpad.net/bugs/2046577)"
+msgstr ""
+
+#: ../../22.04/4.md 5bc798a5b5de44e295d8ecd450a42d91
+msgid "Jammy update: v6.1.63 upstream stable release (LP: #2046577)"
+msgstr ""
+
+#: ../../22.04/4.md d4438dd9ddf54edb8e9c4e69e994dc22
+msgid "[2048556](https://bugs.launchpad.net/bugs/2048556)"
+msgstr ""
+
+#: ../../22.04/4.md 945a53caf99747fa8f1110799837b9a1
+msgid "lunar/linux-gcp: 6.2.0-1021.23 -proposed tracker (LP: #2048556)"
+msgstr ""
+
+#: ../../22.04/4.md 3f7f36fd10d54d7ab721e7cac5aaf4a6
+msgid "[2048317](https://bugs.launchpad.net/bugs/2048317)"
+msgstr ""
+
+#: ../../22.04/4.md c49da5b1529e488384b5230e6285f702
+msgid "jammy/linux-intel-iotg: 5.15.0-1048.54 -proposed tracker (LP: #2048317)"
+msgstr ""
+
+#: ../../22.04/4.md 833fe134f27a4a98b79c3a0531afe379
+msgid "[2048567](https://bugs.launchpad.net/bugs/2048567)"
+msgstr ""
+
+#: ../../22.04/4.md 13e31e2317924fb7975ba6ce4a38aaa6
+msgid "jammy/linux-hwe-6.2: 6.2.0-40.41~22.04.1 -proposed tracker (LP: #2048567)"
+msgstr ""
+
+#: ../../22.04/4.md b0a91101715a4b1a81079deb1e25a298
+msgid "[2045233](https://bugs.launchpad.net/bugs/2045233)"
+msgstr ""
+
+#: ../../22.04/4.md 4e1dac1869834870b53b4f3316640798
+msgid "SRU][22.04.04]: mpi3mr driver update (LP: #2045233)"
+msgstr ""
+
+#: ../../22.04/4.md eff38a73bfa54262b8eef8029664a67d
+msgid "[2052542](https://bugs.launchpad.net/bugs/2052542)"
+msgstr ""
+
+#: ../../22.04/4.md f87834dd51784b1c8698f0aeb1628e58
+msgid "jammy/linux-azure-fde: 5.15.0-1056.64.1 -proposed tracker (LP: #2052542)"
+msgstr ""
+
+#: ../../22.04/4.md d0e4df348dc5463596b9b534ec6d59a0
+msgid "[2048288](https://bugs.launchpad.net/bugs/2048288)"
+msgstr ""
+
+#: ../../22.04/4.md 0f4b5229863949449a77c96b920dbe29
+msgid "jammy/linux-azure-fde: 5.15.0-1055.63.1 -proposed tracker (LP: #2048288)"
+msgstr ""
+
+#: ../../22.04/4.md:1264 789ab86240c6495abf923729a05fbc0b
+msgid "Unsorted changes"
+msgstr ""
+
+#: ../../22.04/4.md a28de7582cae491390e03b2103b42646
+msgid "[1977746](https://bugs.launchpad.net/bugs/1977746)"
+msgstr ""
+
+#: ../../22.04/4.md 3e55f64995ab4da6a801a8a9676f72a7
+#: 7b470f76ec3a4f70a5af00479537d50f
+msgid ""
+"Cherry pick samba AD DC provisioning DEP8 test from later Ubuntu releases"
+" (LP: #1977746, LP: #2011745):"
+msgstr ""
+
+#: ../../22.04/4.md f2a1f33fda0949b29ea31d0b9c882296
+msgid "[2011745](https://bugs.launchpad.net/bugs/2011745)"
+msgstr ""
+
+#: ../../22.04/4.md cd5eb0cf6afa4975b181e0e1ad846698
+msgid "python-oslo.privsep"
+msgstr ""
+
+#: ../../22.04/4.md d4df7b74f8ff460d883f12512d0e6ff6
+msgid "[2029952](https://bugs.launchpad.net/bugs/2029952)"
+msgstr ""
+
+#: ../../22.04/4.md 870bfd6fb69d4f3ba540c81f25ae3fad
+msgid "Backport max_buffer_size fix (LP: #2029952)"
+msgstr ""
+
+#: ../../22.04/4.md 1014f2be20594e1aa4e1bf1ce5120879
+msgid "oem-stella-aron-meta"
+msgstr ""
+
+#: ../../22.04/4.md e881c15863f34bd282e14ac0258d01d0
+msgid "[1997637](https://bugs.launchpad.net/bugs/1997637)"
+msgstr ""
+
+#: ../../22.04/4.md 569faae7a83c491dba7cf5f7ca2b9f3d
+msgid "Meta package for Stella Aron. (LP: #1997637)"
+msgstr ""
+
+#: ../../22.04/4.md 29e9f296ad074e7b80bb6c2d57a7e313
+msgid "oem-stella-cascoon-rpl-meta"
+msgstr ""
+
+#: ../../22.04/4.md 9b2803f638b843ebb9c6c16215126b9a
+msgid "[1997641](https://bugs.launchpad.net/bugs/1997641)"
+msgstr ""
+
+#: ../../22.04/4.md 7328cc6a79cf4b4d8f9cf4e723288cbc
+msgid "Meta package for Stella Cascoon-Rpl. (LP: #1997641)"
+msgstr ""
+
+#: ../../22.04/4.md 562cc06f4178476abb5bf45a1f94aefa
+msgid "oem-stella-asobo-meta"
+msgstr ""
+
+#: ../../22.04/4.md 6ecb899dc3ef41ea82d7a4a208fbf8df
+msgid "[2000214](https://bugs.launchpad.net/bugs/2000214)"
+msgstr ""
+
+#: ../../22.04/4.md f7d3c9e8e55e472eb0c22b81ef253380
+msgid "Meta package for Stella Asobo. (LP: #2000214)"
+msgstr ""
+
+#: ../../22.04/4.md 337b9a6eff0e4772980f6b17c4067289
+msgid "oem-stella-kuku-meta"
+msgstr ""
+
+#: ../../22.04/4.md 0379e7e4635c4c29896340a81a02bcec
+msgid "[2002654](https://bugs.launchpad.net/bugs/2002654)"
+msgstr ""
+
+#: ../../22.04/4.md 8cf4ac0f30fd4755aa8555c7c5a005e4
+msgid "Meta package for Stella Kuku. (LP: #2002654)"
+msgstr ""
+
+#: ../../22.04/4.md 605773c54a084276b9c4b777daefeff6
+msgid "oem-stella-romi-meta"
+msgstr ""
+
+#: ../../22.04/4.md 591e374800454d0db50b8d5fa6cdba22
+msgid "[2002655](https://bugs.launchpad.net/bugs/2002655)"
+msgstr ""
+
+#: ../../22.04/4.md 64bfce1e1cb0497b8dbff3e22e58c00f
+msgid "Meta package for Stella Romi. (LP: #2002655)"
+msgstr ""
+
+#: ../../22.04/4.md 1419fe4ef2a54db6b64f5e538f3322c3
+msgid "python-os-brick"
+msgstr ""
+
+#: ../../22.04/4.md 576abe64d7b04ff380be507abdd5f997
+msgid "[1888675](https://bugs.launchpad.net/bugs/1888675)"
+msgstr ""
+
+#: ../../22.04/4.md 2ce27903c23e4b658478e2b10bc7f45a
+msgid ""
+"d/p/avoid-volume-extension-errors.patch: Avoid volume extension errors "
+"caused by multipath-tools version (LP: #1888675)."
+msgstr ""
+
+#: ../../22.04/4.md 04f232a020634635a8321f9da6c88b5b
+msgid "oem-sutton-abishag-meta"
+msgstr ""
+
+#: ../../22.04/4.md 821c928f654b4dd68d4931a9ce79d1e6
+msgid "[2002216](https://bugs.launchpad.net/bugs/2002216)"
+msgstr ""
+
+#: ../../22.04/4.md bb8b43d5e3ab4de4824e1fd91529964d
+msgid "Meta package for Sutton Abishag. (LP: #2002216)"
+msgstr ""
+
+#: ../../22.04/4.md 495358cf508e4eafa9bae5fcab0d4b77
+msgid "oem-sutton-acheron-meta"
+msgstr ""
+
+#: ../../22.04/4.md 5d8962f41a914e8789a399ac0308d8a7
+msgid "[2002218](https://bugs.launchpad.net/bugs/2002218)"
+msgstr ""
+
+#: ../../22.04/4.md c864582de6bc4af7a56f26de1d032e59
+msgid "Meta package for Sutton Acheron. (LP: #2002218)"
+msgstr ""
+
+#: ../../22.04/4.md 5d9193995e064278908cacfaa3db6c82
+msgid "oem-sutton-adamina-meta"
+msgstr ""
+
+#: ../../22.04/4.md 2766db5c564e4a53a8133f7382d4a1e6
+msgid "[2002220](https://bugs.launchpad.net/bugs/2002220)"
+msgstr ""
+
+#: ../../22.04/4.md 55fa7a831d604bcbb606144dec324321
+msgid "Meta package for Sutton Adamina. (LP: #2002220)"
+msgstr ""
+
+#: ../../22.04/4.md 627bd0217b6047208aee11f9aef55d74
+msgid "oem-sutton-achaicus-meta"
+msgstr ""
+
+#: ../../22.04/4.md af04a2b23fa94dcdbaa927b57f699a9d
+msgid "[2006392](https://bugs.launchpad.net/bugs/2006392)"
+msgstr ""
+
+#: ../../22.04/4.md a01b19957f8444a5993cfdd95d95749b
+msgid "Meta package for Sutton Achaicus. (LP: #2006392)"
+msgstr ""
+
+#: ../../22.04/4.md ebcc1f277314423c847665849ceb827b
+msgid "oem-stella-bergmite-meta"
+msgstr ""
+
+#: ../../22.04/4.md 7d5b55d2683542c59ded971ef98f2098
+msgid "[2008109](https://bugs.launchpad.net/bugs/2008109)"
+msgstr ""
+
+#: ../../22.04/4.md baac17f63fb944839876b9911bf6c9f7
+msgid "Meta package for Stella Bergmite. (LP: #2008109)"
+msgstr ""
+
+#: ../../22.04/4.md 4c8f3a1865e141c5b3775e8eb34f0063
+msgid "oem-stella-chiko-meta"
+msgstr ""
+
+#: ../../22.04/4.md e84be6bcede747a2a9a00e9b0afe7988
+msgid "[2007392](https://bugs.launchpad.net/bugs/2007392)"
+msgstr ""
+
+#: ../../22.04/4.md 7c67a410c75441918f99b5348fc77a66
+msgid "Meta package for Stella Chiko. (LP: #2007392)"
+msgstr ""
+
+#: ../../22.04/4.md 6ef3152438b84720ad7eb29074f13892
+msgid "oem-stella-graveler-meta"
+msgstr ""
+
+#: ../../22.04/4.md 2a3fbac5ccd44baeac1c788991afa445
+msgid "[2008262](https://bugs.launchpad.net/bugs/2008262)"
+msgstr ""
+
+#: ../../22.04/4.md 93f99399ba664a9280f74909d7558358
+msgid "Meta package for Stella Graveler. (LP: #2008262)"
+msgstr ""
+
+#: ../../22.04/4.md f8d298cec2c6404ab7e20faa10449a2a
+msgid "oem-stella-yoshio-meta"
+msgstr ""
+
+#: ../../22.04/4.md 742fd207f5b443a4a690283338f7a576
+msgid "[2008264](https://bugs.launchpad.net/bugs/2008264)"
+msgstr ""
+
+#: ../../22.04/4.md 2b9afb6c86774fd5ade1b59e2c46a5c9
+msgid "Meta package for Stella Yoshio. (LP: #2008264)"
+msgstr ""
+
+#: ../../22.04/4.md ea24c2b28f334c1ebdf157932c6637b9
+msgid "oem-sutton-aitland-meta"
+msgstr ""
+
+#: ../../22.04/4.md fd808b3111d04b888f2929ddf1bcb942
+msgid "[2006393](https://bugs.launchpad.net/bugs/2006393)"
+msgstr ""
+
+#: ../../22.04/4.md 7a0dfe264bff4652a9846a258d773e94
+msgid "Meta package for Sutton Aitland. (LP: #2006393)"
+msgstr ""
+
+#: ../../22.04/4.md 362bd1c9b1ac4ad59dc96891c89066b0
+msgid "oem-sutton-adair-meta"
+msgstr ""
+
+#: ../../22.04/4.md d3c345fcacfe4a5180e32e6689184040
+msgid "[2007393](https://bugs.launchpad.net/bugs/2007393)"
+msgstr ""
+
+#: ../../22.04/4.md 9816a63fb3f74267a752fdce1e5da3c4
+msgid "Meta package for Sutton Adair. (LP: #2007393)"
+msgstr ""
+
+#: ../../22.04/4.md e5998d30907b438c8e3334f253524f22
+msgid "oem-sutton-barrett-meta"
+msgstr ""
+
+#: ../../22.04/4.md 61267b3fc9c84de7b918c398edcd2a6a
+msgid "[2011704](https://bugs.launchpad.net/bugs/2011704)"
+msgstr ""
+
+#: ../../22.04/4.md 7a9b4e4f5540474db09a6937a728dc01
+msgid "Meta package for Sutton Barrett. (LP: #2011704)"
+msgstr ""
+
+#: ../../22.04/4.md 9d567915aec44ddfa2f907e626cb9e93
+msgid "oem-sutton-barrington-meta"
+msgstr ""
+
+#: ../../22.04/4.md 3b337379c1d045ba9f23a28bd0a829d1
+msgid "[2011705](https://bugs.launchpad.net/bugs/2011705)"
+msgstr ""
+
+#: ../../22.04/4.md 77c75efdc2a94e82acf7cb055d465987
+msgid "Meta package for Sutton Barrington. (LP: #2011705)"
+msgstr ""
+
+#: ../../22.04/4.md 66bd9e12cb154ce986aa1342d6e6b902
+msgid "oem-sutton-caitir-meta"
+msgstr ""
+
+#: ../../22.04/4.md d6d3b2f812a643b9b9f7a1ac2bcf8984
+msgid "[2020043](https://bugs.launchpad.net/bugs/2020043)"
+msgstr ""
+
+#: ../../22.04/4.md 82e422be0bed45a9befaa2627ce79a70
+msgid "Meta package for Sutton Caitir. (LP: #2020043)"
+msgstr ""
+
+#: ../../22.04/4.md cc8c7a51922b4af0be757e75d66831a8
+msgid "oem-sutton-calaminag-meta"
+msgstr ""
+
+#: ../../22.04/4.md 249a66b77fa34a74a3a472c38131b275
+msgid "[2019525](https://bugs.launchpad.net/bugs/2019525)"
+msgstr ""
+
+#: ../../22.04/4.md cfee4e79959348aa8e1f6f71d8ddaaca
+msgid "Meta package for Sutton Calaminag. (LP: #2019525)"
+msgstr ""
+
+#: ../../22.04/4.md d823cfbc73104c8cbe7bc381cd518412
+msgid "sg3-utils"
+msgstr ""
+
+#: ../../22.04/4.md 8d2588f794ce47449f523f3115f70b33
+msgid "[1976228](https://bugs.launchpad.net/bugs/1976228)"
+msgstr ""
+
+#: ../../22.04/4.md 980d9a6a3ab041c383d1225099d11662
+msgid ""
+"d/p/0002-Fix-crash-with-rescan-scsi-bus.sh-r.patch: do not allow rescan-"
+"scsi-bus.sh to remove device (LP: #1976228)."
+msgstr ""
+
+#: ../../22.04/4.md 6600191f47e14e23abd9a7ba90bddf6b
+msgid "oem-sutton-akando-meta"
+msgstr ""
+
+#: ../../22.04/4.md 3c169d10715f447b8f1d247d99b5f441
+msgid "[2006394](https://bugs.launchpad.net/bugs/2006394)"
+msgstr ""
+
+#: ../../22.04/4.md de62538100a847f0981b025160644ce0
+msgid "Meta package for Sutton Akando. (LP: #2006394)"
+msgstr ""
+
+#: ../../22.04/4.md 0d42fc1ff5b24f2781d8c4b6470069e0
+msgid "oem-sutton-adelia-meta"
+msgstr ""
+
+#: ../../22.04/4.md 6746b11387a34551a12cc00ba1d3d53b
+msgid "[2007395](https://bugs.launchpad.net/bugs/2007395)"
+msgstr ""
+
+#: ../../22.04/4.md 672c05255b494ead868482fbe22d22d0
+msgid "Meta package for Sutton Adelia. (LP: #2007395)"
+msgstr ""
+
+#: ../../22.04/4.md de7f8d48f0dd475da1baecee26ec2a42
+msgid "oem-sutton-barossa-meta"
+msgstr ""
+
+#: ../../22.04/4.md c548734039324fa4b4accfc1516c3222
+msgid "[2011703](https://bugs.launchpad.net/bugs/2011703)"
+msgstr ""
+
+#: ../../22.04/4.md 21d8d17d1f2841f19d8e4fff884064f7
+msgid "Meta package for Sutton Barossa. (LP: #2011703)"
+msgstr ""
+
+#: ../../22.04/4.md ece29ccb04004ead8c16aca0697a96e4
+msgid "oem-sutton-caia-meta"
+msgstr ""
+
+#: ../../22.04/4.md 28f110a73be249ecb1da72ba75edc824
+msgid "[2008787](https://bugs.launchpad.net/bugs/2008787)"
+msgstr ""
+
+#: ../../22.04/4.md 8ed819ef0e6444fdb113680baa333fcc
+msgid "Meta package for Sutton Caia. (LP: #2008787)"
+msgstr ""
+
+#: ../../22.04/4.md 7221469e895e49d18f68533986a159c9
+msgid "oem-stella-sensei-meta"
+msgstr ""
+
+#: ../../22.04/4.md 001d73cec92649858d628e89ee05a917
+msgid "[2008263](https://bugs.launchpad.net/bugs/2008263)"
+msgstr ""
+
+#: ../../22.04/4.md f0e81ece9e984d158187b1b8d8a621f0
+msgid "Meta package for Stella Sensei. (LP: #2008263)"
+msgstr ""
+
+#: ../../22.04/4.md e4b8dee636c7449fb4095b8b28f12f2f
+msgid "oem-sutton-caimbrie-meta"
+msgstr ""
+
+#: ../../22.04/4.md cdbe3542b3194837ae1ab85bdeebc809
+msgid "[2015332](https://bugs.launchpad.net/bugs/2015332)"
+msgstr ""
+
+#: ../../22.04/4.md 62e44411706b4aa28f615cf2507e43fd
+msgid "Meta package for Sutton Caimbrie. (LP: #2015332)"
+msgstr ""
+
+#: ../../22.04/4.md f2d1e89d099b4090b2d970b672d188bf
+msgid "oem-stella-purrloin-rpl-meta"
+msgstr ""
+
+#: ../../22.04/4.md 3647a3c5d40f49dab828cf3eb96ee789
+msgid "[2016938](https://bugs.launchpad.net/bugs/2016938)"
+msgstr ""
+
+#: ../../22.04/4.md 80a01c348c624f109e09289704e7087f
+msgid "Meta package for Stella Purrloin-Rpl. (LP: #2016938)"
+msgstr ""
+
+#: ../../22.04/4.md 2af26efe55dc4acfa0404b1a456da40e
+msgid "live-build"
+msgstr ""
+
+#: ../../22.04/4.md 6080a1fde473441bbbc65c7c48de50b8
+msgid "[2033308](https://bugs.launchpad.net/bugs/2033308)"
+msgstr ""
+
+#: ../../22.04/4.md 190db79ef13847de8c88527f396d70cc
+msgid ""
+"To avoid removing packaged preferences.d files, in lb_chroot_archives "
+"install stage, only remove apt/preferences.d/* files after we backup any "
+"existing preferences.d/ files. Then during remove stage or "
+"lb_chroot_archives restore the backed up packaged preferences.d files. "
+"(LP: #2033308)"
+msgstr ""
+
+#: ../../22.04/4.md cdd941461f56485abc54315228ebe28c
+msgid "u-boot"
+msgstr ""
+
+#: ../../22.04/4.md a0c8ee819c9d4492b2db499ae0aa00a8
+msgid "[2036406](https://bugs.launchpad.net/bugs/2036406)"
+msgstr ""
+
+#: ../../22.04/4.md 361d06802e444b48bd5149b245cec479
+msgid "Support mkeficapsule command to generate capsule file (LP: #2036406)"
+msgstr ""
+
+#: ../../22.04/4.md fb1f7dffaf454776b9f50578c2032110
+msgid "[2042366](https://bugs.launchpad.net/bugs/2042366)"
+msgstr ""
+
+#: ../../22.04/4.md 4e0ce5ac035b4cbb8acfa919cf4b542d
+msgid ""
+"d/p/lp2042366-dm_get_map-fix-segfault-when-can-t-found-target.patch: "
+"Introduce NULL pointer check to multipath map params. (LP: #2042366)"
+msgstr ""
+
+#: ../../22.04/4.md fd36313183484a6db3b6ed38757e4b6f
+msgid "oem-sutton-barth-meta"
+msgstr ""
+
+#: ../../22.04/4.md 77171379528a4a19abef9a70c297909d
+msgid "[2023537](https://bugs.launchpad.net/bugs/2023537)"
+msgstr ""
+
+#: ../../22.04/4.md 2f6854dfbefb461bba26d22ae42bc587
+msgid "Meta package for Sutton Barth. (LP: #2023537)"
+msgstr ""
+
+#: ../../22.04/4.md 9d24526f582b4b25a6369af4337e22ca
+msgid "oem-sutton-barry-meta"
+msgstr ""
+
+#: ../../22.04/4.md dcac244189c240528a4400a044905418
+msgid "[2013053](https://bugs.launchpad.net/bugs/2013053)"
+msgstr ""
+
+#: ../../22.04/4.md e19491fe809d4e2691c23ec4ecf84eeb
+msgid "Meta package for Sutton Barry. (LP: #2013053)"
+msgstr ""
+
+#: ../../22.04/4.md 0e3b95b1bdac43e3b2a32b94b92fef8a
+msgid "oem-sutton-balesego-meta"
+msgstr ""
+
+#: ../../22.04/4.md 67899769248341b0926017edbb7f682e
+msgid "[1997636](https://bugs.launchpad.net/bugs/1997636)"
+msgstr ""
+
+#: ../../22.04/4.md b4ec3c8d0c8045c8a07c067879b26c5b
+msgid "Meta package for Sutton Balesego. (LP: #1997636)"
+msgstr ""
+
+#: ../../22.04/4.md 2d696b9dac4b434b83b319992708bde9
+msgid "oem-sutton-bartek-meta"
+msgstr ""
+
+#: ../../22.04/4.md 3eb1fd70d03444908488dc403b394a15
+msgid "[2013054](https://bugs.launchpad.net/bugs/2013054)"
+msgstr ""
+
+#: ../../22.04/4.md 4fa27e2f70534c4cb565fd501fe730fa
+msgid "Meta package for Sutton Bartek. (LP: #2013054)"
+msgstr ""
+
+#: ../../22.04/4.md eb2aabc5d3ef44659ddd352e6a65ce1d
+msgid "oem-sutton-caprice-meta"
+msgstr ""
+
+#: ../../22.04/4.md 1f6a1368105d437eae8475f326c539e1
+msgid "[2008788](https://bugs.launchpad.net/bugs/2008788)"
+msgstr ""
+
+#: ../../22.04/4.md d9fadcfc57f94d6fbb31b63ab64c506d
+msgid "Meta package for Sutton Caprice. (LP: #2008788)"
+msgstr ""
+
+#: ../../22.04/4.md 54af5a21a3214ff2bf7817dfa9d9168f
+msgid "oem-sutton-balwina-meta"
+msgstr ""
+
+#: ../../22.04/4.md 3f81e2fe97cf4caaa657dc085803d74a
+msgid "[1997639](https://bugs.launchpad.net/bugs/1997639)"
+msgstr ""
+
+#: ../../22.04/4.md d7bd55e63a4043c1aa32af9398d904b7
+msgid "Meta package for Sutton Balwina. (LP: #1997639)"
+msgstr ""
+
+#: ../../22.04/4.md 282dc8cd66d6470fa7978bafff0684b3
+msgid "oem-sutton-capricorn-meta"
+msgstr ""
+
+#: ../../22.04/4.md 4b007b03ecc544bf836b6f7c178114f9
+msgid "[2013055](https://bugs.launchpad.net/bugs/2013055)"
+msgstr ""
+
+#: ../../22.04/4.md 62cc6c64c0c447f38f02675815b40600
+msgid "Meta package for Sutton Capricorn. (LP: #2013055)"
+msgstr ""
+
+#: ../../22.04/4.md d38a07eb1be74d1897e007dba4d6ab07
+msgid "oem-sutton-capri-meta"
+msgstr ""
+
+#: ../../22.04/4.md 836e98dbcfc94c5ab5f828e55ed1bdc8
+msgid "[2007397](https://bugs.launchpad.net/bugs/2007397)"
+msgstr ""
+
+#: ../../22.04/4.md 0f5f5aeda0d8416b8f2558d2634e8d54
+msgid "Meta package for Sutton Capri. (LP: #2007397)"
+msgstr ""
+
+#: ../../22.04/4.md 957a66fb8be34395ac67d0a082830fd3
+msgid "oem-sutton-addie-meta"
+msgstr ""
+
+#: ../../22.04/4.md 413e4eeaa38e4c0ba240283b231d7396
+msgid "[2017396](https://bugs.launchpad.net/bugs/2017396)"
+msgstr ""
+
+#: ../../22.04/4.md deca85276f5c40c6afeb0d0b05ac604c
+msgid "Meta package for Sutton Addie. (LP: #2017396)"
+msgstr ""
+
+#: ../../22.04/4.md d2f498f98aff431992150b879bef7b5b
+msgid "oem-sutton-addo-meta"
+msgstr ""
+
+#: ../../22.04/4.md bf5913843c67485b877a032b9ccbf54e
+msgid "[2020042](https://bugs.launchpad.net/bugs/2020042)"
+msgstr ""
+
+#: ../../22.04/4.md 41e40eea951e46b0a03b074c3b145a40
+msgid "Meta package for Sutton Addo. (LP: #2020042)"
+msgstr ""
+
+#: ../../22.04/4.md 98c2ace0d6cc4e6e9b60eb2157d710ef
+msgid "oem-sutton-adelaide-meta"
+msgstr ""
+
+#: ../../22.04/4.md 78183a979f0f4f39a87f05260cfd6bba
+msgid "[2017397](https://bugs.launchpad.net/bugs/2017397)"
+msgstr ""
+
+#: ../../22.04/4.md 4a015ce1c69b4b0f8b72862ce6cc764d
+msgid "Meta package for Sutton Adelaide. (LP: #2017397)"
+msgstr ""
+
+#: ../../22.04/4.md dea711f846c84313aad4585462000506
+msgid "oem-sutton-africa-meta"
+msgstr ""
+
+#: ../../22.04/4.md 16f27acfeaff40eeb13b2c56153dde48
+msgid "[2017398](https://bugs.launchpad.net/bugs/2017398)"
+msgstr ""
+
+#: ../../22.04/4.md 4e7dc94006f042abba4a2236c0b50c55
+msgid "Meta package for Sutton Africa. (LP: #2017398)"
+msgstr ""
+
+#: ../../22.04/4.md fac13bf23bb54f77b2b4b5d3cec0e6db
+msgid "dns-root-data"
+msgstr ""
+
+#: ../../22.04/4.md 73840906ce9d4228a2703fa676c31742
+msgid "[2045297](https://bugs.launchpad.net/bugs/2045297)"
+msgstr ""
+
+#: ../../22.04/4.md 09acedd65eae435d92c1f5c2bc09b0b8
+msgid "update root hints to 2023112702 (LP: #2045297 Closes: #1054393)"
+msgstr ""
+
+#: ../../22.04/4.md caaf6d0265e44023ac0f479e86db88c7
+msgid "cd-boot-images-amd64"
+msgstr ""
+
+#: ../../22.04/4.md 0b1778b1cc6b40bfa3b04f98393043d6
+#: 1a171121dbd347d7b6298f450e7dc602 374dd02efb734269b056010077e5657a
+msgid "[2053072](https://bugs.launchpad.net/bugs/2053072)"
+msgstr ""
+
+#: ../../22.04/4.md 82c839892bd94e6b8c7f2b81c0925a88
+msgid ""
+"Rebuild against grub-efi-amd64-signed v1.187.6+2.06-2ubuntu14.4. (LP: "
+"#2053072)"
+msgstr ""
+
+#: ../../22.04/4.md ab18e682b3e54155a357e7a2afcfac45
+msgid "cd-boot-images-arm64"
+msgstr ""
+
+#: ../../22.04/4.md 4ea025d5feaf4b819d11a638ad767b22
+msgid ""
+"Rebuild against grub-efi-arm64-signed v1.187.6+2.06-2ubuntu14.4. (LP: "
+"#2053072)"
+msgstr ""
+
+#: ../../22.04/4.md aa5cfdc562114f99a29afaf3cb953c32
+msgid "cd-boot-images-riscv64"
+msgstr ""
+
+#: ../../22.04/4.md c5943bdf7b3e404db959543a6ce534a6
+msgid "No-change rebuild with latest u-boot-sifive. (LP: #2053072)"
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/22.04/5.po
+++ b/docs/locale/ja/LC_MESSAGES/22.04/5.po
@@ -1,0 +1,3701 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../22.04/5.md:2 2b9be87d8ae84cc882eaee30f2a5a6ae
+msgid "Changes in Ubuntu 22.04.5"
+msgstr ""
+
+#: ../../22.04/5.md:4 de53da959cdc4711b287f3fa2903c692
+msgid ""
+"This is a brief summary of bugs fixed between Ubuntu 22.04.4 and 22.04.5."
+" **This summary covers only changes to packages in *main* and "
+"*restricted*, which account for all packages in the officially-supported "
+"images; there are further changes to various packages in *universe* and "
+"*multiverse*.** Some of these fixes were by Ubuntu developers directly, "
+"while others were by upstream developers and backported to Ubuntu. For "
+"full details, see the individual package changelogs."
+msgstr ""
+
+#: ../../22.04/5.md:12 eadd97cd6c27463eb4dd21426a95f08d
+msgid ""
+"In addition to the bugs listed below, this update includes all security "
+"updates from the [Ubuntu Security Notice "
+"list](https://ubuntu.com/security/notices?order=newest&release=jammy&details=)"
+" affecting Ubuntu 22.04.4 LTS that were released up to and including "
+"September 10, 2024."
+msgstr ""
+
+#: ../../22.04/5.md:18 91ec5a84c45b464fbbe5cf667801c63d
+msgid "Installation bug fixes"
+msgstr ""
+
+#: ../../22.04/5.md:20 033a8e9dbe3b4f47a2b748f7d85a389b
+msgid ""
+"Updated CD images are provided with this release, including fixes for "
+"some installation and image building bugs. (Many installation problems "
+"are hardware-specific; for those, see “Hardware support bugs” below.)"
+msgstr ""
+
+#: ../../22.04/5.md:24 9fb3ac198be247a687a932d1a6c35b6e
+msgid ""
+"For changes in the server installer (subiquity), please see "
+"https://github.com/canonical/subiquity/releases/tag/24.04.1 ."
+msgstr ""
+
+#: ../../22.04/5.md 23c3241078d4421c895669c2e057e974
+#: 368b794967a34004a93ef9db48b2d0be 3a1c9e2e475f4222bee2bfb59c1d1196
+#: 3c1acb7a14e1452f8d639e260488c424 99d433c4ca9d4eeebc00ae14a5be5487
+#: a436fe5d417f4c409240a7f02d5e3a5a b63ac6dc60d74edcab4458497b0eb306
+msgid "Source Package"
+msgstr ""
+
+#: ../../22.04/5.md 74c74556a0734f86b509fd8d5c7a8382
+#: 81dc1f131ae7476897bbbb606d89b420 8a644b8cb2da43cd98cf7acbc68b1f17
+#: b37c1532b3eb48a1935ef8466520eca8 c45e6d63206d4b5cae75268f5a23ebbc
+#: c4df6197ade24d998981dc414e35b08f f723af0866814c359acbc5662d54d446
+msgid "Bug #"
+msgstr ""
+
+#: ../../22.04/5.md 0a1f5af3cca846a2a5127674f52e6867
+#: 10452f82eb7c403ba95c2d601ad2fcaf 10c7b9db97dd44f9829f4a9e0ba06559
+#: 97035059b9d54fa98946cbe76800e1b5 ae6f898f39844f119c94db09c4dadbdb
+#: c35cac839afb43a38951f9f8bcf617e6 e1fe6a649da14e85a68eab5b38bdf1b6
+msgid "Description"
+msgstr ""
+
+#: ../../22.04/5.md 28d1d5499b6c4eb9822b8d0486f0ed33
+#: 49b4a281e60f4693b30f7ee37b47c948 4f39c09a00564761b90664170bcf06d3
+#: 5ac0c30ed51b47128ceb3423f6dbecac 9cb9dcae738a4bfe832b2a16dc514e34
+#: d694b41d08484d3497c5fc9098b06ee4 ea68b3cdd19c4cf5bef9968f18277a65
+msgid "livecd-rootfs"
+msgstr ""
+
+#: ../../22.04/5.md 89e3c411f1f64d129264b9c990693970
+msgid "[2052789](https://bugs.launchpad.net/bugs/2052789)"
+msgstr ""
+
+#: ../../22.04/5.md a054bea9c44d49e484176d7c609551fd
+msgid "add 5.15 apparmor directory for snap preseeding with 5.15 kernel"
+msgstr ""
+
+#: ../../22.04/5.md 0ab2128d186f46d5be641f868cedf226
+msgid "[2070070](https://bugs.launchpad.net/bugs/2070070)"
+msgstr ""
+
+#: ../../22.04/5.md 2f045298c0cf48a590ba0da556ae8cc6
+msgid ""
+"Backport support for building tegra-igx Server and Core images; LP: "
+"#2070070."
+msgstr ""
+
+#: ../../22.04/5.md 8167c12247a14a2ca0bf539320e33ef7
+msgid "[2064175](https://bugs.launchpad.net/bugs/2064175)"
+msgstr ""
+
+#: ../../22.04/5.md c6ee365c9a1e451a9486ef7e4ce979e7
+msgid ""
+"buildd/02-disk-image-uefi add udev early hook to satisfy grub-probe and "
+"grub-install."
+msgstr ""
+
+#: ../../22.04/5.md 2737a844662f4237b2a647a02f8578f6
+msgid "[2062929](https://bugs.launchpad.net/bugs/2062929)"
+msgstr ""
+
+#: ../../22.04/5.md f6cc87c2b80542faaf11b7ad2232b5bc
+msgid "Add policy:unconfined_restrictions feature to 6.5 kernel"
+msgstr ""
+
+#: ../../22.04/5.md 22791435034a4a7195e1dcc45ed378e0
+msgid "[2074204](https://bugs.launchpad.net/bugs/2074204)"
+msgstr ""
+
+#: ../../22.04/5.md 692b9c4105e3413a8c974ebfcd16d2d6
+msgid "Add 6.8 kernel apparmor features' preseeds."
+msgstr ""
+
+#: ../../22.04/5.md 536823c875204a77a657350ed68be1b9
+#: 8a1c24aa35694af3a9c5279ef6f10042
+msgid "[1974483](https://bugs.launchpad.net/bugs/1974483)"
+msgstr ""
+
+#: ../../22.04/5.md 76e6078c944149478486b9117e978f13
+msgid ""
+"Remove openssh-server and ssh-import-id from the ubuntu-server minimal "
+"and full layers (LP: #1974483)."
+msgstr ""
+
+#: ../../22.04/5.md 953cdb85e17840519383debef511a542
+msgid "[2079803](https://bugs.launchpad.net/bugs/2079803)"
+msgstr ""
+
+#: ../../22.04/5.md a30f5147bb2640d0bdbd2c751a42676f
+msgid ""
+"Explicitly remove v4l2loopback packages to workaround issue with tasks "
+"and seeds. Should fix build failure (LP: #2079803)."
+msgstr ""
+
+#: ../../22.04/5.md:36 7dc9b99b6a8047449bd3a48180103fd6
+msgid "Upgrade bug fixes"
+msgstr ""
+
+#: ../../22.04/5.md:38 6983a9397306453c9ce6f3d3e0e9bb56
+msgid ""
+"These changes fix upgrade issues, smoothing the way for future upgrades "
+"to later releases of Ubuntu (and not only)."
+msgstr ""
+
+#: ../../22.04/5.md 1187437c3b62476ca99100eeae27dc26
+#: 15f3854d3cf84f8aa807f377c455a118 bb52553a2cda49fead5f58f1adc97692
+#: e8b5c8c52f404641b6841134e119666b
+msgid "update-manager"
+msgstr ""
+
+#: ../../22.04/5.md 38513190f3c0488b9442a70de3bc31b9
+msgid "[2049785](https://bugs.launchpad.net/bugs/2049785)"
+msgstr ""
+
+#: ../../22.04/5.md cc5076a7a9064c39bd5abdb805d2a60d
+msgid ""
+"d/control: Depend on ubuntu-advantage-tools >= 30~. Fixes edge case "
+"whereby the program crashes upon an incomplete response from ua security-"
+"status (LP: #2049785)."
+msgstr ""
+
+#: ../../22.04/5.md ad00e216c43f44feb7becab23a53d792
+msgid "[2051115](https://bugs.launchpad.net/bugs/2051115)"
+msgstr ""
+
+#: ../../22.04/5.md 3430100c671b4ab5b77d76b71e7dba34
+msgid ""
+"The New Release dialog should take precedence over a list of updates "
+"dialog if the latter would only show Ubuntu Pro updates in an unattached "
+"system. (LP: #2051115)."
+msgstr ""
+
+#: ../../22.04/5.md cb2831a702e54a7aa0e26b13f5934bad
+msgid "update-notifier"
+msgstr ""
+
+#: ../../22.04/5.md 526a71862e4b4630b94a894393ae8c8a
+msgid "[2015420](https://bugs.launchpad.net/bugs/2015420)"
+msgstr ""
+
+#: ../../22.04/5.md 5aee08d76aba4a4bbd5f94da19bb1085
+msgid "update-motd: use a marker file to hide ESM messages"
+msgstr ""
+
+#: ../../22.04/5.md 041b02e6a4f143e7aa7c46a8275c9944
+msgid "[2058133](https://bugs.launchpad.net/bugs/2058133)"
+msgstr ""
+
+#: ../../22.04/5.md ccfe89cfa0344d7691ea8245ff12b41f
+msgid ""
+"Replace Popen to 'ua security-status --format=json' by the Ubuntu Pro "
+"API. The former is not stable enough and would break the program once in "
+"a while when something unrelated to Update Manager (Livepatch, for "
+"instance) went awry. The updates() end point from the API, on the other "
+"hand, does not raise exceptions. LP: #2058133."
+msgstr ""
+
+#: ../../22.04/5.md 5ae4998a983f4142878a1bfbbf6a4f4a
+msgid "[2064211](https://bugs.launchpad.net/bugs/2064211)"
+msgstr ""
+
+#: ../../22.04/5.md 101135ca642942edadd6487ffe4f2041
+msgid "Don't crash if the end-points of the Pro API fail (LP: #2064211)."
+msgstr ""
+
+#: ../../22.04/5.md 2ebe4e5ccc7248c393a586596f6d0507
+msgid "nss"
+msgstr ""
+
+#: ../../22.04/5.md eb3eb8376f424108bb6435fd9d333bb7
+msgid "[2060906](https://bugs.launchpad.net/bugs/2060906)"
+msgstr ""
+
+#: ../../22.04/5.md 4a5d684bccf44d73bdc0adfd60f99c0a
+msgid "SECURITY REGRESSION: failure to open modules"
+msgstr ""
+
+#: ../../22.04/5.md:50 71812fec8942427c98eeb191bb3e4ab0
+msgid "Desktop fixes"
+msgstr ""
+
+#: ../../22.04/5.md:52 e25a79763c0040aaa8f0b107716775e4
+msgid ""
+"These changes mainly affect desktop installations of Ubuntu, Kubuntu, "
+"Ubuntu MATE and other Ubuntu-based systems."
+msgstr ""
+
+#: ../../22.04/5.md 1efad4d501144619af44e5ada6dfb831
+#: 2a961c6195d74dfea3e0987f8dce511e 597a2ddaabf24de697d1c5dc13bd2e9f
+#: 76539f533c2b4c7e87b66d075d7548b8 8e949cb664b242f29652c3c61df31233
+#: f3b9b5c4e0814c578076d2a8aca7e72b
+msgid "mutter"
+msgstr ""
+
+#: ../../22.04/5.md f495374c562e4cb2a0c37945893acda1
+msgid "[2055530](https://bugs.launchpad.net/bugs/2055530)"
+msgstr ""
+
+#: ../../22.04/5.md bc9647c6f5de4e689451d61be23f6d02
+msgid ""
+"Add build-Set-built-headers-as-libmutter_dep-sources.patch to prevent "
+"occasional build failures depending on parallelism"
+msgstr ""
+
+#: ../../22.04/5.md 888a6eeadd554053b1b762b1e093fa70
+msgid "[2055519](https://bugs.launchpad.net/bugs/2055519)"
+msgstr ""
+
+#: ../../22.04/5.md 3653e51a794340d6882af1a6828b53fe
+msgid ""
+"Add cogl-gl-framebuffer-Fix-inverted-test-in-ensure_bits_init.patch to "
+"fix test failures in mutter:cogl+cogl/conform / framebuffer-get-bits when"
+" Mesa >= 23.1.1"
+msgstr ""
+
+#: ../../22.04/5.md d21358a8d9924de49fbf7cc3db8ac112
+msgid "[2051074](https://bugs.launchpad.net/bugs/2051074)"
+msgstr ""
+
+#: ../../22.04/5.md c7d4ac53631544dba09904f2491f4cb9
+msgid "Fix mirror mode on reduced blanking panel."
+msgstr ""
+
+#: ../../22.04/5.md a792c0c823cb4af9bc0671fb01926a9a
+msgid "[2054510](https://bugs.launchpad.net/bugs/2054510)"
+msgstr ""
+
+#: ../../22.04/5.md 8c65f8ca4c784bcc8839c61772b60153
+msgid ""
+"Add compositor-x11-Sync-again-at-the-end-of-before_paint.patch to fix "
+"incomplete redraws in X11 virtual machines"
+msgstr ""
+
+#: ../../22.04/5.md 292438b2d27e45369e450d549373908e
+msgid "pulseaudio"
+msgstr ""
+
+#: ../../22.04/5.md a9896f188c3b4270aa521e32927a7d50
+msgid "[2051895](https://bugs.launchpad.net/bugs/2051895)"
+msgstr ""
+
+#: ../../22.04/5.md 77a1a27852c64ad58f03bf4aff76006c
+msgid ""
+"Lenovo Thinkplus XT99 bluetooth headset supports mSBC and could issue "
+"multi AT commands when negotiating with pulseaudio, but pulseaudio "
+"couldn't handle multi AT commands when processing one buffer, this makes "
+"the HFP/HSP mode not work, cherry pick an upstream commit to fix this "
+"issue."
+msgstr ""
+
+#: ../../22.04/5.md d1f3dd62892643b3887b771c6c816378
+msgid "poppler"
+msgstr ""
+
+#: ../../22.04/5.md 1b8a428f22a84286ab5eb05b164d74f9
+msgid "[1980836](https://bugs.launchpad.net/bugs/1980836)"
+msgstr ""
+
+#: ../../22.04/5.md ca70afddb3a7488896f1b844eadcea15
+msgid "Pick upstream fix for a regression making fields invisible"
+msgstr ""
+
+#: ../../22.04/5.md b01358ad15e54c9d8233a25bc7b22d29
+msgid "[2059847](https://bugs.launchpad.net/bugs/2059847)"
+msgstr ""
+
+#: ../../22.04/5.md e5a9633128dd4283a78373348aa3fbd7
+msgid ""
+"Add compositor-sync-ring-Allow-the-gpu_fence-to-be-moved.patch to fix lag"
+" and freezes on the Nvidia Xorg driver"
+msgstr ""
+
+#: ../../22.04/5.md 3729c716bf9244d5a1fe549ed8ada354
+msgid "[2065066](https://bugs.launchpad.net/bugs/2065066)"
+msgstr ""
+
+#: ../../22.04/5.md 76986a4a9bf64c989a55fbb059f503f3
+msgid "debian/patches: Add fix to handle crash on destruction of invalid popups"
+msgstr ""
+
+#: ../../22.04/5.md 183ed865fa02477493a2925e06fa8ceb
+#: 30bd3c0ddd8f453386edabc180564f87 44a361c456ee4e07997249279b9ccf3c
+#: 4a3f7cfc0aa442c487cc817cdc169609 4d80d0ae682c44c9bf5d3def74d31984
+#: 55ca2e294b234894a772a72bcdf8d338 7c2b7b9670d849978858c53f5da311fc
+#: bac114212264446ea158c44c31e5dedb
+msgid "libfprint"
+msgstr ""
+
+#: ../../22.04/5.md f686e87cdbf24203bb54fe172dc4c8d0
+msgid "[2058193](https://bugs.launchpad.net/bugs/2058193)"
+msgstr ""
+
+#: ../../22.04/5.md 74317d5a22b4401e9e4c400db6c18fb2
+msgid "Add support for Synaptics devices with USB pid 0x0106"
+msgstr ""
+
+#: ../../22.04/5.md f37a1fc5bc7e40e1afdcd9583d4d9f81
+msgid "gnome-remote-desktop"
+msgstr ""
+
+#: ../../22.04/5.md 25240ce79ffb4c5d86604d46ea792655
+msgid "[2024237](https://bugs.launchpad.net/bugs/2024237)"
+msgstr ""
+
+#: ../../22.04/5.md d306906232d448a49207aeaf633bc04c
+msgid "debian/patches: Add upstream fixes for a shutdown crash"
+msgstr ""
+
+#: ../../22.04/5.md ce20eb448463438fa7815078320b87cf
+msgid "gjs"
+msgstr ""
+
+#: ../../22.04/5.md 94ff2cd8ccb04b6aaf5e2bd61063e13a
+msgid "[2066315](https://bugs.launchpad.net/bugs/2066315)"
+msgstr ""
+
+#: ../../22.04/5.md eff5851b1f2642919ada657b5eb79ad1
+msgid ""
+"Revert sources to latest valid version in jammy so that people who might "
+"have had updated to the potentially unstable proposed versions are "
+"reverted to the last safe version we know (LP: #2066315):"
+msgstr ""
+
+#: ../../22.04/5.md 66e351acf3cd47e688ad31d7a3f74a62
+msgid "alsa-ucm-conf"
+msgstr ""
+
+#: ../../22.04/5.md eda42de54cad4158ac0caeb4f67a02cc
+msgid "[2051199](https://bugs.launchpad.net/bugs/2051199)"
+msgstr ""
+
+#: ../../22.04/5.md 219c3c4da7c147759137ee4885a2f689
+msgid "add mt8395 HDMI RX support"
+msgstr ""
+
+#: ../../22.04/5.md a14c8c8a5bf54f9f9c07da0a0813ed48
+#: c7283ba1fc3a4a1ea3d6094d2be10e2c
+msgid "cups"
+msgstr ""
+
+#: ../../22.04/5.md e8895f5e45974a7097a722cf69d8c3c8
+msgid "[2070315](https://bugs.launchpad.net/bugs/2070315)"
+msgstr ""
+
+#: ../../22.04/5.md 48f492b064d84d5681bb38c0cdcead67
+msgid ""
+"d/p/fix-scheduler-start-if-only-domain-socket-to-listen.patch: don't exit"
+" if no valid Listen or Port found"
+msgstr ""
+
+#: ../../22.04/5.md 455441f905424027ad77699f38cfb462
+msgid "xdg-desktop-portal-gnome"
+msgstr ""
+
+#: ../../22.04/5.md 33b328df5b1142cf9c15433a09bdbb3b
+msgid "[1971168](https://bugs.launchpad.net/bugs/1971168)"
+msgstr ""
+
+#: ../../22.04/5.md 1a342e4f984e4c6e8aede491a6576f5e
+msgid "New upstream bugfix release"
+msgstr ""
+
+#: ../../22.04/5.md 0ed74c8bf6d04a7280fb2318eee9cb41
+#: 47fd8ba6919042d08323e10256d69bb0 b772a738eb7742408ba11747d73c72ce
+msgid "[2054538](https://bugs.launchpad.net/bugs/2054538)"
+msgstr ""
+
+#: ../../22.04/5.md d027be01b98e4a5ebe564362111996e3
+msgid "d/p/fpcmoc-Support-FPC-moc-devices.patch"
+msgstr ""
+
+#: ../../22.04/5.md a7433838a9ae4d1999f595672209b953
+msgid "d/p/fpcmoc-Ensure-the-current-SSM-is-never-overwritten.patch"
+msgstr ""
+
+#: ../../22.04/5.md 2d3ac898d3fe40639b63985f65293bd2
+msgid "d/p/fpcmoc-fix-use-after-free-in-multiple-callbacks.patch"
+msgstr ""
+
+#: ../../22.04/5.md 1e30b47f5e6d40b0868b9f4d470a49a3
+msgid "[2058202](https://bugs.launchpad.net/bugs/2058202)"
+msgstr ""
+
+#: ../../22.04/5.md 446c9fab8b3f4948a302dd8f6482986d
+msgid "d/p/goodixmoc-add-PID-0x659A.patch"
+msgstr ""
+
+#: ../../22.04/5.md 05f7834ddc074015a6ee6a7fbdcd4d29
+msgid "[2058013](https://bugs.launchpad.net/bugs/2058013)"
+msgstr ""
+
+#: ../../22.04/5.md 5b8113a5671a4452b189afcf235041a3
+msgid "d/p/elanmoc-add-PID-0x0c8c-0x0c8d.patch"
+msgstr ""
+
+#: ../../22.04/5.md d906f762e9754e119e227a2ff0d4d829
+msgid "[2042394](https://bugs.launchpad.net/bugs/2042394)"
+msgstr ""
+
+#: ../../22.04/5.md b6a3fe3e66fe4a99881c3f57756bf96c
+msgid "d/p/goodixmoc-Add-PID-0x6582.patch"
+msgstr ""
+
+#: ../../22.04/5.md 67ea137c13dd4d3a816b18885b892cdf
+msgid "[2034481](https://bugs.launchpad.net/bugs/2034481)"
+msgstr ""
+
+#: ../../22.04/5.md 0bbf249680e743ae957f6a71783d14bf
+msgid "debian/patches: Fully import fix for synaptics storage-empty fix"
+msgstr ""
+
+#: ../../22.04/5.md:79 ba9c0119d1c6479d827d8861d641f9d8
+msgid "Server and Cloud related fixes"
+msgstr ""
+
+#: ../../22.04/5.md:81 c1e884dbd8ec4213bcd0209200c69ad0
+msgid ""
+"These changes mainly affect installations of Ubuntu on server systems and"
+" clouds."
+msgstr ""
+
+#: ../../22.04/5.md 14dae408861a4998af6124c17753d31a
+#: 20be59856ba54f3e9b45afe27ea80672 5794e34f34ea45a4babacc11a8d3bbb5
+#: 5e407eb6eebe4f98836163aa22854a79 69b8d7f3d8ff4b55bb9e65ad03c6b0f0
+#: 766709ba404f43779b10a2c6444f1b98 793f8d71365c4340b453acbef740d48a
+#: 82dac88d74e040bf88e7e34b6698f4f8 9875e9923cda4af784a1c56ef4aeaa6e
+#: a1001133bfb14f50a7817c798482fb0b af2e69dacb2241369e8d3a49538f923e
+#: c9e12b2dcf764f4a833eff7ca7afb2a6 ce1f89ee71ee436c82a8b57e416eeb4a
+#: d13f5dd126fb449db8fa5b5dbe80c9d6 d16aa57c3715481fb40a29f506399c17
+#: e0aaa3deedad499f9f2edb22195e28f5 ebd366574193456abbe793893f4bb74a
+msgid "cloud-init"
+msgstr ""
+
+#: ../../22.04/5.md 5c5f48bf600f476889544227ec2bf163
+msgid "[2046483](https://bugs.launchpad.net/bugs/2046483)"
+msgstr ""
+
+#: ../../22.04/5.md 5b1341b857fc4edd8b5522bdb29b0402
+msgid ""
+"Upstream snapshot based on 23.4.3. (LP: #2046483). List of changes from "
+"upstream can be found at https://raw.githubusercontent.com/canonical"
+"/cloud-init/23.4.3/ChangeLog"
+msgstr ""
+
+#: ../../22.04/5.md db6b8814f19b4b6ba03996fbca74b0f4
+#: e429e9fd9ea0493e9832db5014643489 ed4442cf4203432f8c7be2ee3f595cf3
+msgid "[2045582](https://bugs.launchpad.net/bugs/2045582)"
+msgstr ""
+
+#: ../../22.04/5.md e027b26e9b3c4b9fa8bed8e01a09aaee
+msgid ""
+"Upstream snapshot based on 23.4.2. (LP: #2045582). List of changes from "
+"upstream can be found at https://raw.githubusercontent.com/canonical"
+"/cloud-init/23.4.2/ChangeLog"
+msgstr ""
+
+#: ../../22.04/5.md 60dd067446774bad8cabe95249604112
+msgid "[2051147](https://bugs.launchpad.net/bugs/2051147)"
+msgstr ""
+
+#: ../../22.04/5.md 810a66da1f9e411da9031c926b9e2f9b
+msgid "Bugs fixed in this snapshot:"
+msgstr ""
+
+#: ../../22.04/5.md 34b0edb0a1534e39894c315b48a0a94e
+msgid "[2048522](https://bugs.launchpad.net/bugs/2048522)"
+msgstr ""
+
+#: ../../22.04/5.md 040365b46b984c42aec70023e220e3aa
+msgid ""
+"d/p/status-retain-recoverable-error-exit-code.patch: Retain exit code in "
+"cloud-init status for recoverable errors. (LP: #2048522)."
+msgstr ""
+
+#: ../../22.04/5.md 8924dfe57cd343b782a24925b957329f
+msgid ""
+"Upstream snapshot based on 23.4.1. (LP: #2045582). List of changes from "
+"upstream can be found at https://raw.githubusercontent.com/canonical"
+"/cloud-init/23.4.1/ChangeLog"
+msgstr ""
+
+#: ../../22.04/5.md 4f7d80d1288344e38208fe6fa3123012
+msgid ""
+"Upstream snapshot based on 23.4. (LP: #2045582). List of changes from "
+"upstream can be found at https://raw.githubusercontent.com/canonical"
+"/cloud-init/23.4/ChangeLog"
+msgstr ""
+
+#: ../../22.04/5.md d957e7e129a946c3b4d89c5d504ef750
+msgid "tcpdump"
+msgstr ""
+
+#: ../../22.04/5.md e05d5d9afeb44de0a28c3e8d8a94240b
+msgid "[2052493](https://bugs.launchpad.net/bugs/2052493)"
+msgstr ""
+
+#: ../../22.04/5.md cc67d225ecfc4585b133b07b6bc21c57
+msgid ""
+"debian/usr.bin.tcpdump: allow read/write to .pcapng files along with a "
+"permission to the .pcap, .pcapng, .cap files followed by a numeric suffix"
+" required by the -W parameter"
+msgstr ""
+
+#: ../../22.04/5.md 1305f3dea58a4af9b822b69339fe3f65
+msgid "[2055081](https://bugs.launchpad.net/bugs/2055081)"
+msgstr ""
+
+#: ../../22.04/5.md b9dc8045060c4d14ba080165b25b8c0f
+msgid ""
+"Upstream snapshot based on 23.4.4. (LP: #2055081). List of changes from "
+"upstream can be found at https://raw.githubusercontent.com/canonical"
+"/cloud-init/23.4.4/ChangeLog"
+msgstr ""
+
+#: ../../22.04/5.md 751ce78d1d3e47ac89f294f114fea287
+msgid "nbd"
+msgstr ""
+
+#: ../../22.04/5.md b7b1cf0cee9e45fcb3af5dd87f8e8953
+msgid "[2054470](https://bugs.launchpad.net/bugs/2054470)"
+msgstr ""
+
+#: ../../22.04/5.md c0a0dcf5eab7405e8e4c352f3e0f54c2
+msgid ""
+"Cherry-pick \"Don't disallow dots in /etc/nbdtab hostnames\" "
+"(5750003711b8050bad3d) to accept IPv4 addresses on /etc/nbdtab."
+msgstr ""
+
+#: ../../22.04/5.md a2c7029cab624eea8663c712e756c727
+msgid "apache2"
+msgstr ""
+
+#: ../../22.04/5.md 2e5b0b38e8ad4860857725e7ba375074
+msgid "[1927742](https://bugs.launchpad.net/bugs/1927742)"
+msgstr ""
+
+#: ../../22.04/5.md 249a0510da704c969abaf8605eb0461f
+msgid ""
+"d/c/m/setenvif.conf, d/p/fix-dolphin-to-delete-webdav-dirs.patch: Add "
+"dolphin and Konqueror/5 careful redirection so that directories can be "
+"deleted via webdav."
+msgstr ""
+
+#: ../../22.04/5.md 394f32b443e84cc79d356e2ae6bc2c93
+#: 5927226595684c7a9fc28fe4bea6f733 81f3f24ab28047ccb9d4a5e292337995
+msgid "openldap"
+msgstr ""
+
+#: ../../22.04/5.md 131402dcb9474735bfe5adb7e279ad5b
+msgid "[2040465](https://bugs.launchpad.net/bugs/2040465)"
+msgstr ""
+
+#: ../../22.04/5.md 68b6272c35134f02be4b491f682155f6
+msgid "New upstream version (LP: #2040465)."
+msgstr ""
+
+#: ../../22.04/5.md d603bc8e73bc44619dbde803675bfc43
+msgid "ovn"
+msgstr ""
+
+#: ../../22.04/5.md 6ebeaae1220444b192988d39e13e2c3d
+msgid "[2056769](https://bugs.launchpad.net/bugs/2056769)"
+msgstr ""
+
+#: ../../22.04/5.md 47f5910e897c4d75a57eafb3a8000f58
+msgid "d/p/lp-2056769-ftbfs.patch: Fix FTBFS (LP: #2056769)."
+msgstr ""
+
+#: ../../22.04/5.md a2c8197b11124c5392a7d345cc1e2dbe
+msgid "samba"
+msgstr ""
+
+#: ../../22.04/5.md e946f1b9c9614a3fbf0a37decf287b0c
+msgid "[2046994](https://bugs.launchpad.net/bugs/2046994)"
+msgstr ""
+
+#: ../../22.04/5.md dbe26361ea274f63a7477816e5940ecd
+msgid ""
+"d/p/lp2046994-spotlight-doesnt-work-with-latest-macos-ventura.patch: fix "
+"spotlight search function on macos ventura (LP: #2046994)."
+msgstr ""
+
+#: ../../22.04/5.md 8f8a98d0ab844bc987e4704162d33156
+msgid "ethtool"
+msgstr ""
+
+#: ../../22.04/5.md fc94079b58264694a55e30d3faa2969a
+msgid "[2043983](https://bugs.launchpad.net/bugs/2043983)"
+msgstr ""
+
+#: ../../22.04/5.md 70e45e5e58474e8e872db31947c3690f
+msgid ""
+"d/p/0001-Fix-ethtool-module-info-in-human-readable-mode.patch: add "
+"upstream patch to avoid hex dump report even in human-readable mode (LP: "
+"#2043983)."
+msgstr ""
+
+#: ../../22.04/5.md cef14dee99904288a407567e6ec70d86
+msgid "libvirt"
+msgstr ""
+
+#: ../../22.04/5.md 1c9eba5189304be7ab94c7cddc65a829
+msgid "[2059272](https://bugs.launchpad.net/bugs/2059272)"
+msgstr ""
+
+#: ../../22.04/5.md 73804f003db84a26aebca4994f86f214
+msgid ""
+"d/p/u/lp2059272-qemu-Fix-potential-crash-during-driver-cleanup.patch: On "
+"QEMU driver cleanup, release (stop) the worker thread pool _first_, "
+"before other data used by possibly running worker threads"
+msgstr ""
+
+#: ../../22.04/5.md aa6437381a5640c9bf7fe13f7551d4f5
+msgid "php8.1"
+msgstr ""
+
+#: ../../22.04/5.md 1ab028d780904bb487bc2c5f1fe95df0
+msgid "[2054621](https://bugs.launchpad.net/bugs/2054621)"
+msgstr ""
+
+#: ../../22.04/5.md 274edf4d0f9948c7b63be30689904fbf
+msgid ""
+"d/p/fix-attribute-instantion-dangling-pointer.patch: Fix sigsegv from "
+"dangling pointer on attribute observer."
+msgstr ""
+
+#: ../../22.04/5.md a0980f4d53184a12a3bdb60bb17035bb
+#: b76cf36ef2ac46b9823542d7818c3b10 dd39a2e3d6204c8986de80e9e6dc0be3
+msgid "[2056100](https://bugs.launchpad.net/bugs/2056100)"
+msgstr ""
+
+#: ../../22.04/5.md d721cfa5d4534acfb8e6117ef62f2c99
+msgid ""
+"Upstream snapshot based on 24.1.3. (LP: #2056100). List of changes from "
+"upstream can be found at https://raw.githubusercontent.com/canonical"
+"/cloud-init/24.1.3/ChangeLog"
+msgstr ""
+
+#: ../../22.04/5.md 301c75d4810a45dc805a2e83de8b7297
+msgid ""
+"Upstream snapshot based on 24.1.2. (LP: #2056100). List of changes from "
+"upstream can be found at https://raw.githubusercontent.com/canonical"
+"/cloud-init/24.1.2/ChangeLog"
+msgstr ""
+
+#: ../../22.04/5.md ac9a6032cec549ec9f35b5eab86921c4
+msgid "[2053157](https://bugs.launchpad.net/bugs/2053157)"
+msgstr ""
+
+#: ../../22.04/5.md 4a8fced662c64066b55a3b97c424f51c
+msgid "Limit perms to 600 of /etc/netplan/50-cloud-init.yaml instead of 644"
+msgstr ""
+
+#: ../../22.04/5.md 826603126b184f7abacba9aac67d1fc3
+msgid ""
+"Upstream snapshot based on 24.1.1. (LP: #2056100). List of changes from "
+"upstream can be found at https://raw.githubusercontent.com/canonical"
+"/cloud-init/24.1.1/ChangeLog"
+msgstr ""
+
+#: ../../22.04/5.md 1d6b14b271744793b225b6aa3017e445
+msgid "dpdk"
+msgstr ""
+
+#: ../../22.04/5.md 337f2fb5cf3542388550e4a3ad6b7afb
+msgid "[2040463](https://bugs.launchpad.net/bugs/2040463)"
+msgstr ""
+
+#: ../../22.04/5.md 7d03ab3d7f9c49d7a2b16daf09177951
+msgid "Merge LTS stable release 21.11.6"
+msgstr ""
+
+#: ../../22.04/5.md 3135adb76aee4850afc47baa6599716c
+#: f7004bda27674fb3b5620c7b976245fa
+msgid "google-compute-engine-oslogin"
+msgstr ""
+
+#: ../../22.04/5.md 18a32d2cdc904b3da79f477b2e8e878c
+msgid "[2052438](https://bugs.launchpad.net/bugs/2052438)"
+msgstr ""
+
+#: ../../22.04/5.md 8a94bf7698cc4656b39fc223b8bc1063
+msgid ""
+"d/control: There must be a dependency on `google-guest-agent` to match "
+"the (upstream) Google managed d/control file"
+msgstr ""
+
+#: ../../22.04/5.md 0affe11ced6648499378e6c4d61ffa27
+#: 1bb3cfe1484e428aa4578beb3eaa8f0c 1f7e8efc53a14f1599339c5bce9f54fb
+msgid "gce-compute-image-packages"
+msgstr ""
+
+#: ../../22.04/5.md c1676515c948448f88aa827e0e6aaeeb
+msgid "[2045708](https://bugs.launchpad.net/bugs/2045708)"
+msgstr ""
+
+#: ../../22.04/5.md a1dc755ec05a437aa3525f13a7b0892c
+msgid ""
+"The I/O scheduler has also been changed from \"NOOP\" to \"NONE\" which "
+"performed much better in testing. LP: #2045708."
+msgstr ""
+
+#: ../../22.04/5.md 126721fb14424e9f8f96759358a7455a
+#: 438db036b1134c728eb66afecbe440d4 c71926b0b4cd4e1cae9a9b6e28db4cac
+#: f2db6e57d96d450992276e08309799a8 fdf09b8614ab48259fd9a33654d5305a
+msgid "landscape-client"
+msgstr ""
+
+#: ../../22.04/5.md 5b7ea77600f74b98814687287b649688
+msgid "[2040189](https://bugs.launchpad.net/bugs/2040189)"
+msgstr ""
+
+#: ../../22.04/5.md 61cafc08df644ec8ae94a4006ab8b465
+msgid ""
+"d/p/0001-start-service-during-config.patch: fix landscape-config does not"
+" start landscape-client service"
+msgstr ""
+
+#: ../../22.04/5.md 8040dd80e14842c8bf5e83ad7213310c
+msgid "[2040924](https://bugs.launchpad.net/bugs/2040924)"
+msgstr ""
+
+#: ../../22.04/5.md 781e6bdd09294ba5b5f5015ff1de4d9e
+msgid "d/landscape-sysinfo.wrapper: fix handle using cache when permissions allow"
+msgstr ""
+
+#: ../../22.04/5.md 07ccaea4110f47aab24894a2bd78df6f
+msgid "[2006402](https://bugs.launchpad.net/bugs/2006402)"
+msgstr ""
+
+#: ../../22.04/5.md 4682cf0e5f514fc69c787027e9517e94
+msgid "Backporting release 23.02 for SRU (LP: #2006402):"
+msgstr ""
+
+#: ../../22.04/5.md 8a4c806cf3194973a9f45034d71e7bb4
+msgid "[2027613](https://bugs.launchpad.net/bugs/2027613)"
+msgstr ""
+
+#: ../../22.04/5.md 1e2e590997ff4dd1bd84062fe5ac9917
+msgid "Service is no longer stopped on upgrade"
+msgstr ""
+
+#: ../../22.04/5.md 04b2019e10fe4742b56ed35cff925473
+#: 3bd359d3c4dd4f9f84af41f1626f00b4 4372726c393e4b0d8c3c34e231deb9a7
+msgid "google-osconfig-agent"
+msgstr ""
+
+#: ../../22.04/5.md 24001b4b11004f81bfbfbb57a3a4920d
+#: 361207f98c1c4d0b88a8793c7790bdd4
+msgid "[2064580](https://bugs.launchpad.net/bugs/2064580)"
+msgstr ""
+
+#: ../../22.04/5.md d9b087ce4252429f89846a13c1985642
+#: ef48a862ab1b4e1f8fddefd8da0434f1
+msgid "Rebuild for Jammy."
+msgstr ""
+
+#: ../../22.04/5.md 44a650c81d0b404a95626e63cc947cd0
+#: a7b0fee60a5a4c9cb61d370bd611d9e4
+msgid "New upstream version for upstream tag 20240320.00."
+msgstr ""
+
+#: ../../22.04/5.md 1e2f22ae953942c3b68bceec46dfefda
+#: 615d08ea9f50479287f7085f812e5363
+msgid "[2064132](https://bugs.launchpad.net/bugs/2064132)"
+msgstr ""
+
+#: ../../22.04/5.md 1781ef99d2714b61bf73793525834ec9
+msgid ""
+"cherry-pick 51c6569f: fix(snapd): ubuntu do not snap refresh when snap "
+"absent"
+msgstr ""
+
+#: ../../22.04/5.md 433a9e0f19ce46529f1c42ee0560286e
+msgid "[2064300](https://bugs.launchpad.net/bugs/2064300)"
+msgstr ""
+
+#: ../../22.04/5.md 7eb96c76fa164652bb9777f2cf617eb0
+msgid ""
+"d/p/cli-retain-file-argument-as-main-cmd-arg.patch: retain ability to "
+"provide -f or --file on the command line before cloud-init subcommands "
+"init, modules or single"
+msgstr ""
+
+#: ../../22.04/5.md 7e0e366a2a2c4dc095183e45c908c912
+msgid ""
+"cherry-pick a6f7577d: bug(package_update): avoid snap refresh in images "
+"without"
+msgstr ""
+
+#: ../../22.04/5.md d1ebf6fd64fa4a39952b0d83773dd86a
+msgid "runc"
+msgstr ""
+
+#: ../../22.04/5.md f68664e1e783477781b01b0233fb2e84
+msgid "[2022390](https://bugs.launchpad.net/bugs/2022390)"
+msgstr ""
+
+#: ../../22.04/5.md 91275e1069c248e695669eda879be92f
+msgid ""
+"Do not provide the runc binary package anymore (LP: #2022390). The runc "
+"binary package is now provided by src:runc-app."
+msgstr ""
+
+#: ../../22.04/5.md d7bde18ef6ad4216a67d668f7b58a722
+msgid "[2066979](https://bugs.launchpad.net/bugs/2066979)"
+msgstr ""
+
+#: ../../22.04/5.md c53cfeb99f584711a3ac005dd1eb7bbb
+msgid "cpick-417ee551: fix(ec2): Ensure metadata exists before configuring PBR."
+msgstr ""
+
+#: ../../22.04/5.md 12e7c7303215423399fd62ed110f105f
+msgid "[2066985](https://bugs.launchpad.net/bugs/2066985)"
+msgstr ""
+
+#: ../../22.04/5.md abef48a19be7435393dfecc4f41a9664
+msgid "cpick-d771d1f4: fix(ec2): Correctly identify netplan renderer (#5361)"
+msgstr ""
+
+#: ../../22.04/5.md a586ee1e922749bf8982a4ca762d1c09
+msgid "ec2-hibinit-agent"
+msgstr ""
+
+#: ../../22.04/5.md 6713e9c6543346f4983cdf017cc3409f
+msgid "[2066999](https://bugs.launchpad.net/bugs/2066999)"
+msgstr ""
+
+#: ../../22.04/5.md 906f6c6c1a334d8696c340d467d1027f
+msgid ""
+"d/p/0015-ignore-setting-resume-offset-again-if-dev-snapshot-d.patch: do "
+"not set the snapshot swap area if /dev/snapshot does not exist. This is "
+"necessary to enable ARM hibernation."
+msgstr ""
+
+#: ../../22.04/5.md 8dc946812fe2454bb34d4e5b26fcd518
+#: 9940365c78a64a54832366b610b0e875
+msgid "netplan.io"
+msgstr ""
+
+#: ../../22.04/5.md 86c85bfa6cb34aa98a1c9c2239ac34d4
+msgid "[2066258](https://bugs.launchpad.net/bugs/2066258)"
+msgstr ""
+
+#: ../../22.04/5.md 51eb68c363b54b3b94044e917141f1b4
+msgid ""
+"d/p/lp2066258/0031-backends-escape-semicolons-in-service-units.patch: "
+"Escape isolated semicolons in systemd service units"
+msgstr ""
+
+#: ../../22.04/5.md d2c2307ad35e4765b669d71fa3f9e8f0
+#: e3dc2f2a7f634275a16f6ebd002b0964 fa4abbed8f4c462b86c1aeebfb4643bb
+msgid "horizon"
+msgstr ""
+
+#: ../../22.04/5.md 99d5c511d1324161b5e5790428827d5a
+msgid "[1728031](https://bugs.launchpad.net/bugs/1728031)"
+msgstr ""
+
+#: ../../22.04/5.md 3a33c359f56c46d5b79ecdd7502de21c
+msgid "d/p/lp1728031.patch: Fix admin unable to reset user's password."
+msgstr ""
+
+#: ../../22.04/5.md c3805d0dc8a14a0f84867f05169ed36d
+msgid "[2055409](https://bugs.launchpad.net/bugs/2055409)"
+msgstr ""
+
+#: ../../22.04/5.md 47a7d6f9ff0d487bba01acd0611ca993
+msgid ""
+"d/p/lp2055409.patch: apply config "
+"OPENSTACK_INSTANCE_RETRIEVE_IP_ADDRESSES to the instance details page"
+msgstr ""
+
+#: ../../22.04/5.md 8107ae140463422a8e5a11c40523ac31
+msgid "[2054799](https://bugs.launchpad.net/bugs/2054799)"
+msgstr ""
+
+#: ../../22.04/5.md 1a8b871603f5441fa227d9590adc1e4e
+msgid ""
+"d/p/lp2054799.patch: Fix Users/Groups tab list when a domain context is "
+"set."
+msgstr ""
+
+#: ../../22.04/5.md bc5836c9ef2e450a902172de13a1303e
+msgid "[2071333](https://bugs.launchpad.net/bugs/2071333)"
+msgstr ""
+
+#: ../../22.04/5.md c6d4afd7f8984d6fb34b7bcfe87cc573
+msgid ""
+"debian/netplan.io.postinst: Don't call the generator if no networkd "
+"configuration file exists."
+msgstr ""
+
+#: ../../22.04/5.md 9960a2bc438344c9977125ccbd83abe3
+msgid "squid"
+msgstr ""
+
+#: ../../22.04/5.md 7ddc9e47fc5946639ca194b2fcf11409
+msgid "[2040470](https://bugs.launchpad.net/bugs/2040470)"
+msgstr ""
+
+#: ../../22.04/5.md 8759b9e5e3c3436db8b41de4af47b495
+msgid "New upstream version 5.9 (LP: #2040470):"
+msgstr ""
+
+#: ../../22.04/5.md 6e66e5e338964d25a92bea97fb715bd5
+msgid "[2067745](https://bugs.launchpad.net/bugs/2067745)"
+msgstr ""
+
+#: ../../22.04/5.md 58bc95f1b11e45f8a4ee6d4e4a4381f9
+msgid "New upstream version (LP: #2067745)."
+msgstr ""
+
+#: ../../22.04/5.md 98733507397f40b199fb61774e23f3f8
+msgid "[2066983](https://bugs.launchpad.net/bugs/2066983)"
+msgstr ""
+
+#: ../../22.04/5.md c6ea82bde31140a7977a7c83374e4016
+msgid ""
+"d/landscape-sysinfo.wrapper: fix 'cores' variable to CORES in message- "
+"of-the-day load threshold calculation"
+msgstr ""
+
+#: ../../22.04/5.md 9abac41283b94b14850f89ae2d400fc7
+msgid "[2072976](https://bugs.launchpad.net/bugs/2072976)"
+msgstr ""
+
+#: ../../22.04/5.md 47b3621ff53c4ce99ae423d9d336edca
+msgid ""
+"d/p/remove-extraneous-quote-configure-ac.patch: Remove extraneous quote "
+"from configure.ac, fixing loading of back_perl."
+msgstr ""
+
+#: ../../22.04/5.md e90bd225f72b4544bea4256f412ad52b
+msgid "[2066314](https://bugs.launchpad.net/bugs/2066314)"
+msgstr ""
+
+#: ../../22.04/5.md 0f2137e892b54d46a44626a1b59dfa2f
+msgid "vsftpd"
+msgstr ""
+
+#: ../../22.04/5.md 73177db7f18a435ca61ebbd46c16301c
+msgid "[2069324](https://bugs.launchpad.net/bugs/2069324)"
+msgstr ""
+
+#: ../../22.04/5.md 3cf316abe5df438babdd2eef60c02202
+msgid ""
+"d/p/0078-0026-Prevent-hanging-in-SIGCHLD-handler.patch: avoid freeze with"
+" pam_exec"
+msgstr ""
+
+#: ../../22.04/5.md 5dd5e0fbb0ca46f79c501664c3a0f767
+msgid "[2073166](https://bugs.launchpad.net/bugs/2073166)"
+msgstr ""
+
+#: ../../22.04/5.md deee7975f98c4d4987365ea802e0df47
+msgid "[2073161](https://bugs.launchpad.net/bugs/2073161)"
+msgstr ""
+
+#: ../../22.04/5.md c2ac5210687c41089141b779a47a3f73
+msgid "New upstream version for upstream tag 20240524.03."
+msgstr ""
+
+#: ../../22.04/5.md 22e27fa09cfd4f3198acf15b6176df2e
+msgid "[2073164](https://bugs.launchpad.net/bugs/2073164)"
+msgstr ""
+
+#: ../../22.04/5.md 96969d44f1544a1cbf2989f7f55ccf8a
+msgid "New upstream version 20240607.00."
+msgstr ""
+
+#: ../../22.04/5.md ceef20a4541e40d09966ec0b43a85c1e
+#: d8ff03886872418db001c9a6ea574200
+msgid "google-guest-agent"
+msgstr ""
+
+#: ../../22.04/5.md 830b07afe6e54eb9ac234bbad2f50fe8
+msgid "[2073163](https://bugs.launchpad.net/bugs/2073163)"
+msgstr ""
+
+#: ../../22.04/5.md ec34838a718249238d6dea061d884861
+msgid "New upstream version 20240716.00."
+msgstr ""
+
+#: ../../22.04/5.md e2ee03008a8040ea8aae92adde5ea332
+msgid "[2057965](https://bugs.launchpad.net/bugs/2057965)"
+msgstr ""
+
+#: ../../22.04/5.md 970a747563384ebf966ba85409b0a90d
+msgid ""
+"d/p/0006-add-after-cloud-config-service.patch: add patch to force "
+"ordering between cloud-init and the guest agent."
+msgstr ""
+
+#: ../../22.04/5.md c83035a8ba9341fa9c91b139bc5a4997
+msgid "[2071762](https://bugs.launchpad.net/bugs/2071762)"
+msgstr ""
+
+#: ../../22.04/5.md e36b5fecf6dc448a8ee92ad38bcb24ed
+msgid ""
+"Upstream snapshot based on 24.2. (LP: #2071762). List of changes from "
+"upstream can be found at https://raw.githubusercontent.com/canonical"
+"/cloud-init/24.2/ChangeLog"
+msgstr ""
+
+#: ../../22.04/5.md 1154d5fe94304b4f81ecf1f1472671c3
+#: d5e04014972b4fe39ac1e3a4d12e980f
+msgid "nova"
+msgstr ""
+
+#: ../../22.04/5.md 5b79526689e5424dbeb0d783ba42c4dd
+msgid "[2024258](https://bugs.launchpad.net/bugs/2024258)"
+msgstr ""
+
+#: ../../22.04/5.md 1578dd4ca9fa4c97ba687c5a4f8a20ab
+msgid ""
+"d/p/lp2024258-database-Archive-parent-and-child-rows-trees-one-at-.patch:"
+" Performance degradation archiving DB with large numbers of FK related "
+"records"
+msgstr ""
+
+#: ../../22.04/5.md c34d03065972476d890e619cf727b736
+msgid "[1999814](https://bugs.launchpad.net/bugs/1999814)"
+msgstr ""
+
+#: ../../22.04/5.md 7d01fba704694faba5c1158503513dbd
+msgid ""
+"d/p/lp1999814.patch: Rework CPU comparison at startup and add ability to "
+"skip it. Addresses CascadeLake incompatibility with IceLake."
+msgstr ""
+
+#: ../../22.04/5.md:142 4a59dcb3c5424b6384512bcfe4e45488
+msgid "Base platform fixes"
+msgstr ""
+
+#: ../../22.04/5.md:144 3bdc5a7559f34bb8bc2d0fd5076a006b
+msgid ""
+"These changes affect the core fundamental components of all the Ubuntu "
+"flavors."
+msgstr ""
+
+#: ../../22.04/5.md 018470f156fb49a2ba186ffdd95b5dcc
+#: 0b3ee90bf726463cadd40ce5d8eb06f7 1256605baaf647b1a9f6ffed7b004d3f
+#: 16e6be2907464a458fa88bbf4211ab45 180ed7e4046b4fffb48069b27ed17500
+#: 20a3f9661d214ce1bd0ada0e68754d9c 28d1ac7144e745c28f2f54047eb15e90
+#: 2b622f6323ba4f30860f4129dfda75f9 2c47215b27ba40e7a20bec956e14a003
+#: 31dc0f2dcb0b4902b48a0d0a8363af0d 3cf3b4189159429dba130f736fa55b6a
+#: 3eaf4efd5b3e4fb2ae5dfa2b97718aec 409a61377b114d3da58b8a99e463fe96
+#: 526a712b11a54b5c97951be048f47786 5c71f127463d4ce4bcbd1980840521bc
+#: 63c0fb7fd0e840cb80dc1a7f8925a8e7 6ec3ad74d2574844aef502c2669d7a7b
+#: 801547ae0636414ea9d291c06e4f16ed 85c58a3da2b44357a08d692c8da6c4d2
+#: 86b088dbf5e04a588d8eae584c9ff34e c7efb2db04294f7dacd2f444700d69ad
+#: cd93ced0ad04437d9b05960ff966f8ea df6e5343326145f5a283aa32d6d43655
+#: e7695521f9404557953899d725b30e98 f3b6d42e6e6b4f0faa539d3b3ed11129
+#: f5433a312d994e568707302d72658254 fce1a2475b964b679552225288414022
+msgid "ubuntu-advantage-tools"
+msgstr ""
+
+#: ../../22.04/5.md b7abdf494d054389afc110c348b89869
+#: fe478a13cb0c488bbd5b4d8e1b3602a5
+msgid "[2048921](https://bugs.launchpad.net/bugs/2048921)"
+msgstr ""
+
+#: ../../22.04/5.md 33913c390ea94c2a82adf93ad4dfbbd7
+msgid "Backport new upstream release"
+msgstr ""
+
+#: ../../22.04/5.md d1f69a083c0c444fa168f547b7f8ef38
+msgid "[2055046](https://bugs.launchpad.net/bugs/2055046)"
+msgstr ""
+
+#: ../../22.04/5.md 76d179b7b7bd4c9698a9400c6e946b90
+msgid ""
+"properly rename logrotate conffile to avoid duplicate confiles, keep user"
+" changes and avoid unnecessary prompts"
+msgstr ""
+
+#: ../../22.04/5.md ba4dd95d0dbb4e2faab2b12d9e4179fc
+msgid "[2021988](https://bugs.launchpad.net/bugs/2021988)"
+msgstr ""
+
+#: ../../22.04/5.md 09d034943bf645c1b3bd072bc2198a7b
+msgid "removed dependency on python3 by reimplementing in sh"
+msgstr ""
+
+#: ../../22.04/5.md 4a03a79738274888bcadd4f793a269a0
+msgid "[2050022](https://bugs.launchpad.net/bugs/2050022)"
+msgstr ""
+
+#: ../../22.04/5.md ad79a4fdfe0744e5a7e94dfe3fcc4a24
+msgid "avoid deadlock when started during cloud-config.service"
+msgstr ""
+
+#: ../../22.04/5.md 80ac2bb004b545af973f9bb8c77924fe
+msgid "New upstream release 31"
+msgstr ""
+
+#: ../../22.04/5.md ea745753a67749d3b30d17ea80076e9b
+msgid "[2019997](https://bugs.launchpad.net/bugs/2019997)"
+msgstr ""
+
+#: ../../22.04/5.md d0eaa1c869d641ed877bb1cca8c61e60
+msgid "status: show warning when canonical-livepatch command fails"
+msgstr ""
+
+#: ../../22.04/5.md 3c98ee692637467792f6738469b6587b
+msgid "[2043836](https://bugs.launchpad.net/bugs/2043836)"
+msgstr ""
+
+#: ../../22.04/5.md 5b1e8fd60cb64023a018c99e19122ecf
+msgid "fix UnboundLocalError in update-check error handling"
+msgstr ""
+
+#: ../../22.04/5.md 74ea037f02b0462990d3371e6cb71e59
+msgid "coreutils"
+msgstr ""
+
+#: ../../22.04/5.md c345ebb26c134af7a49cf18148191031
+msgid "[2033892](https://bugs.launchpad.net/bugs/2033892)"
+msgstr ""
+
+#: ../../22.04/5.md 5301ee0b9c3e4804b7bba7d313e53dc8
+msgid ""
+"Fix an issue where running 'ls -l' on an autofs mount with '--ghost' or "
+"'browse_mode=yes' enabled causes the mount to be attempted, even when the"
+" underlying storage is not available. This changes behaviour of ls back "
+"to what it was previously, before statx was introduced in 8.32."
+msgstr ""
+
+#: ../../22.04/5.md 373f5daa840c46be863210899ca4a142
+#: e8294b68896949a08af9b5e848f5db75
+msgid "snapd"
+msgstr ""
+
+#: ../../22.04/5.md c162caf61bbf45158ea837358ef07386
+msgid "[2039017](https://bugs.launchpad.net/bugs/2039017)"
+msgstr ""
+
+#: ../../22.04/5.md 4f8a1138d6fa490a9ab0783ea33aa7b0
+msgid "New upstream release, LP: #2039017"
+msgstr ""
+
+#: ../../22.04/5.md 0ac6a5b92c5f4abb8f09bf458e8683aa
+#: 394d96a80e854317b1141c9235c84946 f55ec1f099a843e0a930a253dfed570f
+#: f590bc342eb94fd3aa2445129487c58b
+msgid "apt"
+msgstr ""
+
+#: ../../22.04/5.md 5750aace8b39411ab68c9a3c175be1f8
+msgid "[1995790](https://bugs.launchpad.net/bugs/1995790)"
+msgstr ""
+
+#: ../../22.04/5.md c896ac2dcef94e08844f02da50d26ae8
+msgid "Restore ?garbage by calling MarkAndSweep before parsing"
+msgstr ""
+
+#: ../../22.04/5.md 7e7e2cabcfee499687326822f9e596c8
+msgid "[2051181](https://bugs.launchpad.net/bugs/2051181)"
+msgstr ""
+
+#: ../../22.04/5.md 5bc745ed0a3847899034f868ff861bfd
+msgid ""
+"For phasing, check if current version is a security update, not just "
+"previous ones"
+msgstr ""
+
+#: ../../22.04/5.md 5c4945a34fbc4e79b1420859dd3fefba
+#: 8212dd8a1b1842f58b9be19505f5a242
+msgid "qemu"
+msgstr ""
+
+#: ../../22.04/5.md 35dc2f2aa67b47b0b60c98efb714bc1f
+msgid "[2046439](https://bugs.launchpad.net/bugs/2046439)"
+msgstr ""
+
+#: ../../22.04/5.md 7c98b27fe4824de8b1e83d973b09481e
+msgid ""
+"d/p/u/lp-2046439-s390x-*.patch: Fix emulation of \"COMPARE HALFWORD "
+"RELATIVE LONG\" on s390x."
+msgstr ""
+
+#: ../../22.04/5.md fa044971368840329ba2a4386fb23c49
+msgid "[2058934](https://bugs.launchpad.net/bugs/2058934)"
+msgstr ""
+
+#: ../../22.04/5.md d5c3dfebf8b9442bb3e795d3904cfb2b
+msgid "version.py: match version from d/changelog"
+msgstr ""
+
+#: ../../22.04/5.md 1231eaeddf034413a243f9e04da090f5
+msgid "[2057937](https://bugs.launchpad.net/bugs/2057937)"
+msgstr ""
+
+#: ../../22.04/5.md a5640470b54b4b6fbc45333c7dc1e4dc
+msgid "apt-news.service: ignore apparmor errors when starting"
+msgstr ""
+
+#: ../../22.04/5.md fe54f5c7e73d477a81aa7f00c8320f97
+msgid "openssh"
+msgstr ""
+
+#: ../../22.04/5.md 241d9572a60745d386eb9261595dae00
+msgid "[2053146](https://bugs.launchpad.net/bugs/2053146)"
+msgstr ""
+
+#: ../../22.04/5.md 31cc3532d39c49f281186cb8944cd7f2
+msgid ""
+"d/p/gssapi.patch: fix method_gsskeyex structure and userauth_gsskeyex "
+"function regarding changes introduced in upstream commit "
+"dbb339f015c33d63484261d140c84ad875a9e548 (\"prepare for multiple names "
+"for authmethods\")"
+msgstr ""
+
+#: ../../22.04/5.md 2ab2ba180db84aefa448a1584a53f2cc
+msgid "[2012763](https://bugs.launchpad.net/bugs/2012763)"
+msgstr ""
+
+#: ../../22.04/5.md 27009a240822488b9bbaf906548e41b8
+msgid "d/p/u/lp2012763-maxcpus-too-low.patch: Bump max_cpus to 1024 on amd64."
+msgstr ""
+
+#: ../../22.04/5.md c7e7b04d8ac847a298ef0f2883dbec6e
+msgid "distro-info-data"
+msgstr ""
+
+#: ../../22.04/5.md 0693788bb067477c855c6c7b9bc5ad1c
+msgid "[2064136](https://bugs.launchpad.net/bugs/2064136)"
+msgstr ""
+
+#: ../../22.04/5.md a02fa64834d448b88b434d579068d655
+msgid "Add Ubuntu 24.10 \"Oracular Oriole\""
+msgstr ""
+
+#: ../../22.04/5.md b2ca1d8e15e54fa3b8f8f28930111c75
+#: dd6df2de7346471e8de51c0c30b0fb05
+msgid "[2059952](https://bugs.launchpad.net/bugs/2059952)"
+msgstr ""
+
+#: ../../22.04/5.md 46743ee4ae9645169f594386f504f30b
+msgid "Backport new upstream release to jammy"
+msgstr ""
+
+#: ../../22.04/5.md ff647730cad447a6b55ab8e57b909545
+msgid "daemon: wait for cloud-init.service to fully activate"
+msgstr ""
+
+#: ../../22.04/5.md 428424c0ddb34358b7de7b0d599507ab
+#: a4ac04e3177d478b813bc7ce3f9a233a
+msgid "[2060732](https://bugs.launchpad.net/bugs/2060732)"
+msgstr ""
+
+#: ../../22.04/5.md 275c332786c74906825851b34caa6a91
+msgid "Backport 32.3 to jammy"
+msgstr ""
+
+#: ../../22.04/5.md 55380f7058094093b8a36ab5954788fa
+msgid "[2067319](https://bugs.launchpad.net/bugs/2067319)"
+msgstr ""
+
+#: ../../22.04/5.md 2d9f29a9cd1444858d6ffef5e6075119
+msgid "d/apparmor: adjust the profiles to account for usr-merge consequences"
+msgstr ""
+
+#: ../../22.04/5.md fb074b52d8fe4fecb844235a3f87c84f
+msgid "[2066929](https://bugs.launchpad.net/bugs/2066929)"
+msgstr ""
+
+#: ../../22.04/5.md cade61f69e2146e58c0142092e93af6d
+msgid "d/apparmor: adjust rules for violations found during testing"
+msgstr ""
+
+#: ../../22.04/5.md f9ffa81b7e9a429a9ed8108310730ef5
+msgid "[2065573](https://bugs.launchpad.net/bugs/2065573)"
+msgstr ""
+
+#: ../../22.04/5.md 49d1210f4a79403180fd5e9cbff629c5
+msgid "d/apparmor: allow access for /etc/os-release on all supported profiles"
+msgstr ""
+
+#: ../../22.04/5.md 7239ecd6ddcb4fbaad7047319ac90620
+msgid "[2065616](https://bugs.launchpad.net/bugs/2065616)"
+msgstr ""
+
+#: ../../22.04/5.md 24e4b8183aef4b56a8d1cbf1f01c1eef
+msgid "apport: get path for timer job status from the correct place"
+msgstr ""
+
+#: ../../22.04/5.md 9c3ff61ab400491cb4b416ac78823d3d
+msgid "New upstream release 32"
+msgstr ""
+
+#: ../../22.04/5.md 2948b9fcb7d04af8a231b981fc7238db
+msgid "[2033313](https://bugs.launchpad.net/bugs/2033313)"
+msgstr ""
+
+#: ../../22.04/5.md 4d31345d17064de693960b0c33211715
+msgid "collect-logs: update default output file to pro_logs.tar.gz"
+msgstr ""
+
+#: ../../22.04/5.md 6ccd31c1a0d74593b66e73d9ac11b604
+msgid "[2031192](https://bugs.launchpad.net/bugs/2031192)"
+msgstr ""
+
+#: ../../22.04/5.md bde6c2c7b209482c997b5c80ae98f6bf
+msgid "update logic that checks if a service is enabled"
+msgstr ""
+
+#: ../../22.04/5.md f742d00e19bd419a983b0316bc42aa3a
+msgid "[2061179](https://bugs.launchpad.net/bugs/2061179)"
+msgstr ""
+
+#: ../../22.04/5.md 3927448b12064c2ebdf80d945c98ba4d
+msgid "New upstream release, LP: #2061179"
+msgstr ""
+
+#: ../../22.04/5.md d46211c808774f28aaf86358519103b8
+msgid "openjdk-lts"
+msgstr ""
+
+#: ../../22.04/5.md 0c50d8709e1a4730b5687eb914270521
+msgid "[2049715](https://bugs.launchpad.net/bugs/2049715)"
+msgstr ""
+
+#: ../../22.04/5.md 257c46874e764566b9a5c7a781630930
+msgid "Merge changes from openjdk-11 11.0.22+7-1"
+msgstr ""
+
+#: ../../22.04/5.md a8e85adbfb574bd39bd6806a4d30ce24
+#: dc13b6b7bedd4f9290f3ebeaa90bbedc
+msgid "rustc"
+msgstr ""
+
+#: ../../22.04/5.md 681c0aa6632345b7ba798bec6e7167db
+msgid "[2040340](https://bugs.launchpad.net/bugs/2040340)"
+msgstr ""
+
+#: ../../22.04/5.md 1f218466b4824b488bf438ec65ff9e2e
+#: 7f5a558f11b9418caf969d976e6db31e
+msgid "Backport to Jammy"
+msgstr ""
+
+#: ../../22.04/5.md 6b5efb9363274c24bf567484e6a060a6
+msgid "openssl"
+msgstr ""
+
+#: ../../22.04/5.md 8ac59b837eea434ea0cc6cfa13289e41
+msgid "[2054090](https://bugs.launchpad.net/bugs/2054090)"
+msgstr ""
+
+#: ../../22.04/5.md 7d0222a291c04e9c8ef46d16ae6c9e6f
+msgid "SECURITY UPDATE: Implicit rejection for RSA PKCS#1"
+msgstr ""
+
+#: ../../22.04/5.md 9fb5e1cee7a54ec992ef22d498d9f6af
+msgid "[2047858](https://bugs.launchpad.net/bugs/2047858)"
+msgstr ""
+
+#: ../../22.04/5.md 8d5723f5e67848acafc3c5b417b0e0bb
+#: ec30bb90141944cb9b290bf557d64935
+msgid "tzdata"
+msgstr ""
+
+#: ../../22.04/5.md 4f6ae43f9fe34e7d899979d6ff80e884
+msgid "[2052739](https://bugs.launchpad.net/bugs/2052739)"
+msgstr ""
+
+#: ../../22.04/5.md 7eaa87c1f60c4171b4383f4207359123
+msgid "New upstream version (LP: #2052739):"
+msgstr ""
+
+#: ../../22.04/5.md e4983e4cac124e32a34d056856c9091b
+msgid "gpgme1.0"
+msgstr ""
+
+#: ../../22.04/5.md 26037977c0f941e49db6d6cee2549148
+msgid "[2037595](https://bugs.launchpad.net/bugs/2037595)"
+msgstr ""
+
+#: ../../22.04/5.md a3ef86be3cca473ea1902264ee07fcb1
+msgid ""
+"posix: Use poll instead, when available, removing use of select (LP: "
+"#2037595)."
+msgstr ""
+
+#: ../../22.04/5.md 966d4421a2d343298111c86f0c33ee85
+msgid "dpkg"
+msgstr ""
+
+#: ../../22.04/5.md 45dac2a8e54046bba8a09ece41675776
+msgid "[2054741](https://bugs.launchpad.net/bugs/2054741)"
+msgstr ""
+
+#: ../../22.04/5.md 5e0d935e11ba4b22b3bfb4e8ef97710e
+msgid "Fix dpkg-buildpackage ignoring DEB_BUILD_PROFILES"
+msgstr ""
+
+#: ../../22.04/5.md 1f32ab7579ec4477bd2a98b7f7146c77
+#: 826bc6d0020e4edc8a9e9bf18f986041
+msgid "[2067810](https://bugs.launchpad.net/bugs/2067810)"
+msgstr ""
+
+#: ../../22.04/5.md e797ce72b60d4ff186544e3738c4f664
+msgid ""
+"Adjust the esm_cache apparmor profile to allow reading of dpkg data "
+"directory (LP: #2067810):"
+msgstr ""
+
+#: ../../22.04/5.md f6ca31ec1e714a2b9a196b83908fc004
+msgid "[2055718](https://bugs.launchpad.net/bugs/2055718)"
+msgstr ""
+
+#: ../../22.04/5.md 2eb8515721614feca41322a3a9e3d8a7
+msgid ""
+"Do not replace CET, CST6CDT, EET, EST*, HST, MET, MST*, PST8PDT, WET. The"
+" replacements differed in using daylight saving."
+msgstr ""
+
+#: ../../22.04/5.md 3818bfdff7bb45fe8d9105a92a214a07
+#: e72c8af5111f421ab199890c892d5043
+msgid "ubuntu-meta"
+msgstr ""
+
+#: ../../22.04/5.md 7a8216e5e8264f7da4e895ff0147366c
+msgid "[2028769](https://bugs.launchpad.net/bugs/2028769)"
+msgstr ""
+
+#: ../../22.04/5.md b715f0954e5a4f2fba29a5b35202230b
+msgid "Add riscv64 build of ubuntu-desktop, ubuntu-desktop-minimal"
+msgstr ""
+
+#: ../../22.04/5.md 0ccde661a1fc431b875283cd570eab88
+msgid "apport"
+msgstr ""
+
+#: ../../22.04/5.md 8323fb8dac3240b0812656698183e7f4
+msgid "[2067775](https://bugs.launchpad.net/bugs/2067775)"
+msgstr ""
+
+#: ../../22.04/5.md 1fbd967a6b6f439786e63a4f4f598b95
+msgid "d/package-hooks/subiquity.py: update information collection"
+msgstr ""
+
+#: ../../22.04/5.md 41799df35d9f4e86bde6b8e60a642b64
+msgid "Removed ssh-import-id from server-minimal (LP: #1974483)."
+msgstr ""
+
+#: ../../22.04/5.md 23a3445c69454c7389bc42b86111f481
+msgid "e2fsprogs"
+msgstr ""
+
+#: ../../22.04/5.md 1beb5d9c94ba461fb713592f9b451ac7
+msgid "[2036467](https://bugs.launchpad.net/bugs/2036467)"
+msgstr ""
+
+#: ../../22.04/5.md 01a0434cadcb421ea44308b11a64e5c2
+msgid ""
+"Fix superblock checksum mismatch during resize2fs operations, most "
+"notably during online resize of cloud images during boot. Read the "
+"superblock with Direct I/O to ensure we get the correct view of the disk."
+msgstr ""
+
+#: ../../22.04/5.md 0ac76d9a6d9347d1ab818cad7b007df5
+msgid "python3-defaults"
+msgstr ""
+
+#: ../../22.04/5.md 336add1cce444d6a9cc909cf97fd6751
+msgid "[2075337](https://bugs.launchpad.net/bugs/2075337)"
+msgstr ""
+
+#: ../../22.04/5.md ce22675dd7f142bdb696fb6f799f8b4e
+msgid "Correct locale when calling dpkg -L to avoid failures in py3clean"
+msgstr ""
+
+#: ../../22.04/5.md a644322b94144c588df7f77b2c73b3ff
+#: f8d63b461664428aa4e6df6fa6095d95
+msgid "[2069237](https://bugs.launchpad.net/bugs/2069237)"
+msgstr ""
+
+#: ../../22.04/5.md 35c1bd1affcd4f978df565f9e0232c3d
+msgid "Backport 33.2 to jammy"
+msgstr ""
+
+#: ../../22.04/5.md d070bf6cffdf4dd693205a017ddbb78b
+msgid "[2072489](https://bugs.launchpad.net/bugs/2072489)"
+msgstr ""
+
+#: ../../22.04/5.md cbd61e8fb7794bdca1c8a4e5cd221770
+msgid ""
+"d/apparmor: add apt-news access to package information on the system (LP:"
+" #2072489) (GH: #3193)"
+msgstr ""
+
+#: ../../22.04/5.md c182e7de4f5d4131add694b5a119b2ed
+#: da671e5725d14b1e8c8a945e192fd03f
+msgid "[2060769](https://bugs.launchpad.net/bugs/2060769)"
+msgstr ""
+
+#: ../../22.04/5.md be93e547d180453dadc059cc771567bc
+msgid "New upstream release 33.1:"
+msgstr ""
+
+#: ../../22.04/5.md 5b3fb3d9038b4345aa2e44ba726bc78a
+msgid ""
+"d/apparmor: adjust the esm_cache apparmor profile to allow reading of "
+"dpkg data directory (LP: #2067810) (GH: #3137)"
+msgstr ""
+
+#: ../../22.04/5.md a4c3002e5df84f60a0b226da9d073dd1
+msgid "New upstream release 33"
+msgstr ""
+
+#: ../../22.04/5.md 1676a7ac11204d1db620c086056db01b
+#: bcc4ca1971f34d41a9593af1330fb3d1
+msgid ""
+"apt: use Python bindings instead of apt CLI to query for installed "
+"packages"
+msgstr ""
+
+#: ../../22.04/5.md c2054a75d8804e86b2f6953cfdcaaa48
+msgid "[2068744](https://bugs.launchpad.net/bugs/2068744)"
+msgstr ""
+
+#: ../../22.04/5.md 167bab6f660e4ae1a81c2152cf6ef5f4
+#: f26c385747e44e08baf14ee4c068d11a
+msgid "[2078720](https://bugs.launchpad.net/bugs/2078720)"
+msgstr ""
+
+#: ../../22.04/5.md 60ea259c47484a26903e824f014b7d39
+msgid "Fix keeping back removals of obsolete packages"
+msgstr ""
+
+#: ../../22.04/5.md 8d9aa53233134c4baf69bbcf9320b3d7
+msgid "Return an error if ResolveByKeep() is unsuccessful"
+msgstr ""
+
+#: ../../22.04/5.md 28cc30ee58ab4f8e89ad5847ada7d2ec
+msgid "cd-boot-images-amd64"
+msgstr ""
+
+#: ../../22.04/5.md 846d6038795247fc94c56903f949467a
+#: d5373633efa14e9fa8c8fff2b4165e44
+msgid "[2076929](https://bugs.launchpad.net/bugs/2076929)"
+msgstr ""
+
+#: ../../22.04/5.md b2a5bcd497414320ae818eabcbeec3b6
+msgid "Rebuild against shim-sigend 1.51.4+15.8-0ubuntu1"
+msgstr ""
+
+#: ../../22.04/5.md a603db728e2e4612b44977137a8fca9f
+msgid "cd-boot-images-arm64"
+msgstr ""
+
+#: ../../22.04/5.md 77f913200ffb48288a952a1cace071ff
+msgid "Rebuild against shim-signed 1.51.4+15.8-0ubuntu1"
+msgstr ""
+
+#: ../../22.04/5.md:202 c159b1b49b3c420099aa6a203925e126
+msgid "Kernel and Hardware support updates"
+msgstr ""
+
+#: ../../22.04/5.md:204 2a49b7bd793a405c96403a04324b3252
+msgid ""
+"Considerable work has been done on improving support for many specific "
+"items of hardware."
+msgstr ""
+
+#: ../../22.04/5.md 1882d1c85fc54f3b8cb912c20db0c0ba
+#: 9cf2ad2b691b4d118380398c9c9f6feb a0e28cadd78447388cb767b4441a3013
+#: bd3c7f5ba48846309dd5f4c9d82b011a c2358c561eb04a6280786dacd5f81af3
+msgid "linux-aws-6.5"
+msgstr ""
+
+#: ../../22.04/5.md 16bd3e03fcee434eb863449e9e355469
+#: 21ea8ee62ea144b9a7b869fafe29b434 4bb403dcb70b40bc84495b431c9775e4
+#: 816ab3f0080c499f8f17c54683787625
+msgid "[2042853](https://bugs.launchpad.net/bugs/2042853)"
+msgstr ""
+
+#: ../../22.04/5.md 2fa99948224a4297b88509c6155b3de5
+#: 6fbff3d2df7a42c8ab5d645b9b6849a1 9067b6ed60824cbba081654a1237b588
+#: ea42b0847ebb4663b5dad4cd5e1562c0
+msgid "UBUNTU 23.04] Kernel config option missing for s390x PCI passthrough"
+msgstr ""
+
+#: ../../22.04/5.md 1ce0369221844e1f9feb7ebf60a40da7
+#: 525d690ae0944fd0b176ee81e93e230a 5a0853ef1acd4e5e814ff01ca1bdc121
+#: 841235518666445c88fd76873bb68dba 841eca061dc942619c666c86a2967d89
+#: 94578ae2fe1641dcac1ccbd33e3cbfec a9aef43d5dfd4209b0c8ba3ef9744add
+#: bd2f0bcdda99461f93faba448c745046 c4afec0e45cf4785b0c1bbc1b0bcdf69
+#: dd4aea01ac0149cc9a83cb8889edb48c f2c9648c012249afaabff0b4cf466597
+msgid "linux-azure-6.5"
+msgstr ""
+
+#: ../../22.04/5.md 02f8a5fa05c54485add13445ee1611e5
+#: 0925912a0626435cadfebc25a2d11e9a 09cf96e64e9b406daf37b2797ab40102
+#: 17593a3c9d1e492bbad3c7d81e027308 20c20afddefc4d66ab1508c2e4a57049
+#: 25884dd28c864fd68c0f07d2e0a0e5ea 48f8cddfce6e4f22aa03168c70a70255
+#: 5856dbe7d2f748b68242536cb9ed82a9 5aa0ddef90d94ebea5ca0977f9fdfa3d
+#: 8552cda0d91c4fc986ee3ea3f940e175 8597956c3af64e1e867b2541b5d6bb9e
+#: 8c0c3161786842978df9cc09eb2584a2 9083d352f921417da4d162c4d370c9e5
+#: a025daceee934d6c910ec7910cd24158 c2588c42776d4afaaf2390cefd2323ed
+#: ce707d3cc2c14e5b8c48d9a0fcabc050 d3b62ae3415b486eb8ae18c557bf3d31
+#: d76c30d2ef964216b9c9c50a99bb7c2f dc9b58307f1943dcaeada383413d009a
+#: de32b504a0de484dbb4bfde296e8b2a2
+msgid "linux-azure-fde"
+msgstr ""
+
+#: ../../22.04/5.md 27333153fb844641b34108286dea3ed9
+#: 4a280c5e89264df885ebd62beb6660f8
+msgid "[2052224](https://bugs.launchpad.net/bugs/2052224)"
+msgstr ""
+
+#: ../../22.04/5.md 49b59936750b4a999931950fd51adc6e
+#: bff88fa5c08a4a058a99b855757ef435
+msgid "jammy/linux-azure-fde: 5.15.0-1057.65.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 01d80bb75bfa49e985fe983d920f1e03
+msgid "[2052542](https://bugs.launchpad.net/bugs/2052542)"
+msgstr ""
+
+#: ../../22.04/5.md 8ed3eb59cbff4d38b71dec836f3d1c94
+msgid "jammy/linux-azure-fde: 5.15.0-1056.64.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md ad101d2e65514d7cb5468f43f267400f
+msgid "[2048288](https://bugs.launchpad.net/bugs/2048288)"
+msgstr ""
+
+#: ../../22.04/5.md 3c89b54c700f4ec4a6275ebd77d100ea
+msgid "jammy/linux-azure-fde: 5.15.0-1055.63.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 6cfaed861c194802993b282c70515891
+msgid "firmware-sof"
+msgstr ""
+
+#: ../../22.04/5.md c8d55ba4855c4a56a967b5c18a987e25
+msgid "[2044330](https://bugs.launchpad.net/bugs/2044330)"
+msgstr ""
+
+#: ../../22.04/5.md 8d465a00d9f74e7ab145857e8457553e
+msgid "Update soundwire topology files for Intel RPL platforms. LP: #2044330"
+msgstr ""
+
+#: ../../22.04/5.md 0106de805a9441daa206010b780d7b39
+#: 1aab8acc6ecf448786f4bbfa1304d2bd 7fccd2f3086d4cbdb95517794cbab56c
+#: 811bebe809404112aae44e22e79103e8 8f95e97d3a0e4af8a6fdfb5f549ba0a5
+#: e5a395e1db904de6bea474c0ae375fab e5bd61be63b746bdabfaedae5cf8616e
+msgid "nvidia-graphics-drivers-535-server"
+msgstr ""
+
+#: ../../22.04/5.md 01dc90c5589e49a9b31f7b83f7a5632a
+#: 156215f97f0545cd8a157aac59fd3161
+msgid "[2052967](https://bugs.launchpad.net/bugs/2052967)"
+msgstr ""
+
+#: ../../22.04/5.md 0765d89c08614a1091e21aa5cfdf6011
+#: ef8614bce7e945a9bacd5fc4425e0d5e
+msgid ""
+"Install all ABI builds of the libnvidia-pkcs11 plugin for host/container "
+"compatibility."
+msgstr ""
+
+#: ../../22.04/5.md 37e67ba9b4194a729b7a265207a4f698
+#: f83b7fc829fa43d0aa00e16e2f27873d
+msgid "nvidia-graphics-drivers-470"
+msgstr ""
+
+#: ../../22.04/5.md 8e924db467b04c4dbd2ffccd14578124
+#: b41d711ee27c4d7f9e81f7adffb47950
+msgid "[2052640](https://bugs.launchpad.net/bugs/2052640)"
+msgstr ""
+
+#: ../../22.04/5.md 0aa112b09a44415286a92e371c3755fe
+#: 1500befb4a484a8c91568d489ba96919 206b96b9262c4964a2a8bc9d532e60e0
+#: 2b100053985d4a5abb13783ac6be2e13 2bd468ce4e6948d486c29c3ee81d96f6
+#: 56a7b1ffb0dd425894598cb8c16971f7 5ada540b485946e0b6ba7ee14357b215
+#: 6e9dec3ac5504f9faa1befd4dad71939 734a09b872014bb7a54a78a9c601b647
+#: 921de12a59804fceb5716e5e82adb0ad 9cbb0c94dda441d3940ed4946dc7e93e
+#: a7f63df847864f8eac7c662be2fd3a85 cfdd1a02683f4641a4a67926cfd1552c
+#: e0bd391b0d614bfab1c0e059e0cea8c2 ec8f6560111c46a59e5849b4e0be8972
+#: fb6d12b6d1ab4a52992c12ecc3cf59d2
+msgid "New upstream release"
+msgstr ""
+
+#: ../../22.04/5.md 1f795a203bfe44dea0959df0a95b8c97
+#: a6c7e336c09542669de5703e71467b32 a7b35148118946c3bd982765091dfa5a
+#: c20beccb39644b42aed01a754bf2e390
+msgid "nvidia-graphics-drivers-535"
+msgstr ""
+
+#: ../../22.04/5.md 522a6276d99443b39f26f06b85d82986
+#: 5b3d4bd297f440cd968dfe85af40f72a
+msgid "[2054571](https://bugs.launchpad.net/bugs/2054571)"
+msgstr ""
+
+#: ../../22.04/5.md 5c8427ff19764856be668c4fa05f3c77
+#: b032a08ca1a047feb6945bb7dc6fec2d
+msgid "nvidia-graphics-drivers-470-server"
+msgstr ""
+
+#: ../../22.04/5.md 1c50675124a545978caa4e32b88d9554
+#: 4619b4b5152946a4823fbd68bd34bdc6 4a3a7c1d32594f1f9570ea01f8a51848
+#: 5dfc63b1d5414febbe43b587a23137b6 90c20547fbd142f68b9d5c3937af83a6
+#: 99c359668e754f12af15108815faa01c ab9c3325fcac43ffaa705c3f6288bf97
+#: c744a318e3c8405a8f2dc46cf27580e6
+msgid "linux-nvidia-6.5"
+msgstr ""
+
+#: ../../22.04/5.md f7735a67844f4f9a91586da0e613dc06
+msgid "[2053169](https://bugs.launchpad.net/bugs/2053169)"
+msgstr ""
+
+#: ../../22.04/5.md c2d437ebb7fd4f4cb8e1c43312f24355
+msgid "jammy/linux-nvidia-6.5: 6.5.0-1013.13 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 2e89aa850261497b94c7bf9a72c8a4e1
+msgid "[2048966](https://bugs.launchpad.net/bugs/2048966)"
+msgstr ""
+
+#: ../../22.04/5.md 4d839e0aa45b49e0a555778f11557361
+msgid "Fix soft lockup triggered by arm_smmu_mm_invalidate_range"
+msgstr ""
+
+#: ../../22.04/5.md 0fb2aa7f46c54aaa8ad19e6e35d92c08
+msgid "[2053148](https://bugs.launchpad.net/bugs/2053148)"
+msgstr ""
+
+#: ../../22.04/5.md ec48daba5908417a89a7fba7f95eab27
+msgid "Pull request: address GPIO initialization regression  on Grace systems"
+msgstr ""
+
+#: ../../22.04/5.md 66bc457301394fc690d03ddaf1e9e03e
+#: 8522d770bd97420eaf2b7f7ab6158631 9bfe9829d3264b429311191a9194785f
+#: db6ce7d8a84b4e9f99fe94752ae6a731 ed04c88c3f5d421bad42e1276dad0e6a
+#: f509e7195b0c4f7c8d390990bb3fb24d
+msgid "linux-oracle-6.5"
+msgstr ""
+
+#: ../../22.04/5.md 0004d0f859f644afac6258c01f75ba56
+msgid "[2054122](https://bugs.launchpad.net/bugs/2054122)"
+msgstr ""
+
+#: ../../22.04/5.md 8056c825fe724f5d8f165f4cbdd55adf
+msgid "jammy/linux-oracle-6.5: 6.5.0-1018.18~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md f5e6dc3cd6544d5d80aa346ad066f97c
+msgid "[2054120](https://bugs.launchpad.net/bugs/2054120)"
+msgstr ""
+
+#: ../../22.04/5.md e7d6b0a8ea2c4b25a1f0fcbd0ce99710
+msgid "mantic/linux-oracle: 6.5.0-1018.18 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 06355ef11e064b699f49e7f1431fe7bf
+#: 0be532efaf0a4c139a273e5fb1fd44c4 1910d91bba204409b3aba3b4ef20d8a1
+#: 541691e48ea4401f80b721892e087043
+msgid "[2052469](https://bugs.launchpad.net/bugs/2052469)"
+msgstr ""
+
+#: ../../22.04/5.md 680823f1d37a49c5a1fcdac60624b35f
+#: b1476c8662b549328bd0932bf3ac80fc d0de9eff01de47abace40b74a5e02cb4
+#: dd11685033ea479ca15e801caca1153f
+msgid "Provide an arm64 linux-oracle 64k kernel variant"
+msgstr ""
+
+#: ../../22.04/5.md 723d733f3a5b4e72a70716372776d3ca
+msgid "linux-signed-oracle-6.5"
+msgstr ""
+
+#: ../../22.04/5.md 17c5668e7b0d4bc39f17649c9ad17a00
+#: 6168c0b7d32848f18cae4f7d6c5d96e1
+msgid "linux-meta-oracle-6.5"
+msgstr ""
+
+#: ../../22.04/5.md 2b5792b89ccc48a0b3436148d151c804
+msgid "flash-kernel"
+msgstr ""
+
+#: ../../22.04/5.md e5ad19093c2b40ba897f3933f3c7a73b
+msgid "[2054556](https://bugs.launchpad.net/bugs/2054556)"
+msgstr ""
+
+#: ../../22.04/5.md eb40469213af43109904518529b560ae
+msgid "Update Xilinx board support"
+msgstr ""
+
+#: ../../22.04/5.md dea6ca18870d4632b77ccd1801674a03
+msgid "[2052045](https://bugs.launchpad.net/bugs/2052045)"
+msgstr ""
+
+#: ../../22.04/5.md 4f98d078d6c74f78bfdbdc7dd1468597
+msgid "jammy/linux-azure-fde: 5.15.0-1058.66.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 0e8242258c1d43528ab765ac5a1a347c
+#: 28ec98a1afd04097adc2ec893363772e 3da93b34cf4c43c4aac367053e637f02
+#: 6ba0c2f736d64ffa961b90a2890b305e 970ce63026ee4bcdbb87177f28e4f46b
+#: badee2ed8bea4f089cf425acd2d0bd72 c30d14844b9e4e59b44cbde4d32d988d
+#: f320cda2e1b8433cbc1811393c33fd29
+msgid "linux-firmware"
+msgstr ""
+
+#: ../../22.04/5.md 52f44b5893104904aad3b6f345378838
+#: de2dffe87bc54848a5c04cc714970957
+msgid "[2049220](https://bugs.launchpad.net/bugs/2049220)"
+msgstr ""
+
+#: ../../22.04/5.md a7f39942c8e14b05b8cac03c7464593e
+#: fcaffab72e434007a5229260082d58c4
+msgid "Update firmware for MT7921 in order to fix Framework 13 AMD 7040"
+msgstr ""
+
+#: ../../22.04/5.md 1440cc264f4d4adaabc734f3292e034a
+msgid "[2034103](https://bugs.launchpad.net/bugs/2034103)"
+msgstr ""
+
+#: ../../22.04/5.md 6cdd01ecfa8d42af94851be1134ae180
+msgid "Missing firmware for AMD GPU GC 11.0.3"
+msgstr ""
+
+#: ../../22.04/5.md 0824ec7bed1846dcbc4dec31995c5d48
+msgid "[2051636](https://bugs.launchpad.net/bugs/2051636)"
+msgstr ""
+
+#: ../../22.04/5.md 1ff16bf20b87464d9e43b878f4a7b5a7
+msgid ""
+"AMD phoenix/phoenix2 platforms facing amdgpu(PHX) freezes during stress "
+"loading"
+msgstr ""
+
+#: ../../22.04/5.md 3a56b0a95db34eac8c90390e0c44d988
+msgid "[2048977](https://bugs.launchpad.net/bugs/2048977)"
+msgstr ""
+
+#: ../../22.04/5.md 0a49f11fc01f468794e64b466f784528
+msgid "WCN6856 Wi-FI Unavailable and no function during suspend stress"
+msgstr ""
+
+#: ../../22.04/5.md 02a1c75a5dc2489cb70ae01a87e898f7
+#: 3191676ee98c4c34839986f3e487961b ac1f6688d94d415f835f5baed6e48303
+#: b5b861522bcd49d59c8e1167d3b2f4fa c0edfc6195f943b1bf8d680acedbf626
+#: f375ea94e7904848b38505b9b8d02fcf
+msgid "linux-oem-6.1"
+msgstr ""
+
+#: ../../22.04/5.md 9912edd186f74133a21d9a9e85817cb4
+msgid "[2052090](https://bugs.launchpad.net/bugs/2052090)"
+msgstr ""
+
+#: ../../22.04/5.md 3992212d18db455793a0ec8b1e6532d2
+msgid "jammy/linux-oem-6.1: 6.1.0-1035.35 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 02f943ad9a424a05bc52e0f5b8312bfe
+msgid "[2054541](https://bugs.launchpad.net/bugs/2054541)"
+msgstr ""
+
+#: ../../22.04/5.md 13adc387255845e79766c9cab841d320
+msgid "Jammy update: v6.1.78 upstream stable release"
+msgstr ""
+
+#: ../../22.04/5.md d75277d943d84cfcbee11694e7ce598d
+msgid "[2052631](https://bugs.launchpad.net/bugs/2052631)"
+msgstr ""
+
+#: ../../22.04/5.md 35822066964d4ae58fe439d10dda4d0b
+msgid "Jammy update: v6.1.77 upstream stable release"
+msgstr ""
+
+#: ../../22.04/5.md dab672c737ac4ccd93db0adf68a24d7d
+msgid "[2052623](https://bugs.launchpad.net/bugs/2052623)"
+msgstr ""
+
+#: ../../22.04/5.md 05da378d726949aabf94f47f8d3f673c
+msgid "Jammy update: v6.1.76 upstream stable release"
+msgstr ""
+
+#: ../../22.04/5.md 6d21b277a02d49bdbd13efea0f91fd73
+msgid "[2052622](https://bugs.launchpad.net/bugs/2052622)"
+msgstr ""
+
+#: ../../22.04/5.md d695be6f54294cf8be1549c5e5c45c12
+msgid "Jammy update: v6.1.75 upstream stable release"
+msgstr ""
+
+#: ../../22.04/5.md e62f43549cf3428aba8234bdf5f06499
+msgid "[2052599](https://bugs.launchpad.net/bugs/2052599)"
+msgstr ""
+
+#: ../../22.04/5.md 90e82f83f8b042468b3a2f26ae9eca2e
+msgid "Jammy update: v6.1.74 upstream stable release"
+msgstr ""
+
+#: ../../22.04/5.md 14905342fc0f45e78f79cedea3c7b1dd
+#: 14ea9eec423e499ea695195dec9767bc 233009261f054eba9b9d8718eef539eb
+#: 288b8afa7cd24202af6558f96a678b60 2cbe6959260c41e4ad5fe44724ce9eb0
+#: 2e8e943d8a564473830ff368764794cb 6173f0f15e3c428cbe87acaf3044dfac
+#: 6d05ef352d194309b7426b93bb64bc67 9153f7f267454dd687c7568b8d386945
+#: a32626a261244703b4d5f27b9923e263 ba928dce749b456c87996c979c2f0dc9
+#: c3c24a82609d4e469f06b7e360e7ce18 dc100e58463b45ec9aabd93161a71708
+#: f752647a1cd44857956fd6f0da6e0012 fc3cd2c5260c4309a6048fb8335e05e2
+msgid "linux-nvidia-tegra-igx"
+msgstr ""
+
+#: ../../22.04/5.md e286b77a4d5648c1b8fa846e5672ab95
+msgid "[2052611](https://bugs.launchpad.net/bugs/2052611)"
+msgstr ""
+
+#: ../../22.04/5.md 68a2a6f160e948d6873253cc44b7dfad
+msgid "jammy/linux-realtime: 5.15.0-1055.62 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md f5b51923538841de9de29a8960216558
+msgid "[2048310](https://bugs.launchpad.net/bugs/2048310)"
+msgstr ""
+
+#: ../../22.04/5.md e007fb0611924d31bc8861d241962319
+msgid "jammy/linux-realtime: 5.15.0-1054.60 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 7f8e2a1f98fe4e978e0318878ba988ee
+msgid "[2049522](https://bugs.launchpad.net/bugs/2049522)"
+msgstr ""
+
+#: ../../22.04/5.md 3b8744111def455b83c05f9cda09586e
+msgid "Jammy real-time patch set update: v5.15.145-rt73"
+msgstr ""
+
+#: ../../22.04/5.md 622c6f9c47bc4051be1720e9d87a56d6
+#: fa466fc0d3e2421a87e5b660cf15fa3d ffd414b542254ecd8ca018bbfff8fabd
+msgid "linux-nvidia-tegra-igx-modules"
+msgstr ""
+
+#: ../../22.04/5.md 1ade95cc296c42a49c6e330d771ed70a
+#: 6957f097d74a499ebb7e411bc179590e
+msgid "[2054483](https://bugs.launchpad.net/bugs/2054483)"
+msgstr ""
+
+#: ../../22.04/5.md 76c364515ec84ca081d26bd0750addaa
+#: 80e333f167ba4ce7a01e9f2898d443a0
+msgid "Add headers package for IGX out-of-tree modules"
+msgstr ""
+
+#: ../../22.04/5.md 6fc03c101bf04856b04071cda4d5f97a
+#: bb35a1e529774002a6bae6ef60262675
+msgid "linux-nvidia-tegra-igx-modules-signed"
+msgstr ""
+
+#: ../../22.04/5.md e80a9cf09aaf446f81949fef4fe93bbe
+msgid "zfs-linux"
+msgstr ""
+
+#: ../../22.04/5.md 7daf0281505f4f2f99ede984b69e8251
+msgid "[2044657](https://bugs.launchpad.net/bugs/2044657)"
+msgstr ""
+
+#: ../../22.04/5.md 731745b84c9a41e5a963396d59b37445
+msgid ""
+"d/p/77b0c6f0403b2b7d145bf6c244b6acbc757ccdc9.patch Cherry-pick "
+"\"dnode_is_dirty: check dnode and its data for dirtiness\" fix from "
+"zfs-2.1.14. LP: #2044657"
+msgstr ""
+
+#: ../../22.04/5.md 602e0f687fb24fc79e3a0a98e1a50b9d
+msgid "[2055983](https://bugs.launchpad.net/bugs/2055983)"
+msgstr ""
+
+#: ../../22.04/5.md 510c3e3f59ea495797c1dc07f7acaa9d
+msgid "jammy/linux-azure-fde: 5.15.0-1059.67.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md cbf6ec4d668841a986fc3333a9790307
+#: feb224111b704b1ba5c84bec2817608a
+msgid "linux-aws"
+msgstr ""
+
+#: ../../22.04/5.md c4da047c139e4eb88dde14909e695845
+msgid "[2043811](https://bugs.launchpad.net/bugs/2043811)"
+msgstr ""
+
+#: ../../22.04/5.md 33a29531b68346d38e7282e5d785d60b
+msgid "AWS: arm64: pauth: don't sign leaf functions"
+msgstr ""
+
+#: ../../22.04/5.md 3e5eab73b3e742bd97a560b2dd3d1764
+msgid "nvidia-graphics-drivers-525"
+msgstr ""
+
+#: ../../22.04/5.md 4529194d544a4600a33625018d34d75d
+#: 46c0048096de4529944648954b9870ea
+msgid "[2049635](https://bugs.launchpad.net/bugs/2049635)"
+msgstr ""
+
+#: ../../22.04/5.md 2108934398ea4fecb4fabeba84f5917b
+#: 41a41a444f654cf0892fb5c95cccae67
+msgid "End of support for 525 series, transition to 535. LP: #2049635"
+msgstr ""
+
+#: ../../22.04/5.md 7a2b42ab2ebf40fe826fcec111d97bb7
+msgid "nvidia-graphics-drivers-525-server"
+msgstr ""
+
+#: ../../22.04/5.md 55eaa4e87d2b426cab546e0e7a331531
+#: e54b43406c1145cbab67d4b0d0f06821
+msgid "linux"
+msgstr ""
+
+#: ../../22.04/5.md 0331cfb622e7493cbdb4287bf69db58e
+#: 0405e1aea189423a9311aa9c7636bf35 144617814b5444e69b99c18bfe3e701b
+#: 1e900c28a38c43fdad9ab9b7c9bfc423 2f296bc7d96a4c7fa20b86c653132500
+#: 2ff88506ab274c779545905a4cfd6a54 57edb6d4539b41f391d0b6ea27cdb67f
+#: 749dac0611754621bd0042e8ac1e59c2 940cc32a524c44fdaa23862981a21de2
+#: 9aa68e459c0e40c8a548490904378d86 ae666fdbb74c431eb463336f166dbbf9
+#: b47ce046f261468186ee72f9b51fc1c2 ee4a2d9b165541529fba78a4c372d697
+#: ef75701003ba4f75a0daf0849b753210 f4fbd4b264cc42e0b508dc890c10a0e0
+msgid "[1971699](https://bugs.launchpad.net/bugs/1971699)"
+msgstr ""
+
+#: ../../22.04/5.md 06ef4a28ed73407d8dca7eff44e61bc7
+#: 2c5050962495467783b3838aff687eff 32f01bcc7b1546f9bd1678030ea236e6
+#: 3412bfb904ce494e9e938acbf1bb4000 43a03181a45a434caf8fa1a18b89c583
+#: 463bc269a5314b4fa018281ff7ca14db 52b7438108624a468e5a9cae1c9d7e00
+#: 67d0e41af9f54566ba6ea084333ac3f2 6da47cfe98c04399b5f5a3937ee6bc9f
+#: 833342b8c31543d58c9ea1d1e386e9a8 888cf18a707a47eaac715c3b07534086
+#: 9ceea867699448889acaf03a9992be55 a4bfaca2a994464bb0fb3d4f2f0f6254
+#: a9e2263f44b74170a99903e289f168af eace3db357c54baf8ea5ae69ee5bb9b7
+msgid "disable Intel DMA remapping by default"
+msgstr ""
+
+#: ../../22.04/5.md 129c8a9f2dfd4389b2110a1e2c1342dd
+#: 2765ff5275724efca1597af649b8862f 304335436d5e49d694601425daaf24e9
+msgid "linux-azure"
+msgstr ""
+
+#: ../../22.04/5.md 3f1c9ef2fb6244d9bc7705792575a922
+#: 9a056eb4b37a485eb57fc8fc8cd41b70
+msgid "[2055588](https://bugs.launchpad.net/bugs/2055588)"
+msgstr ""
+
+#: ../../22.04/5.md 8a55654c53bb457681f7ae7f96c09c72
+#: c3ebffc78d2a4720badb289e5551dab6
+msgid "jammy/linux-azure-fde: 5.15.0-1060.69.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 1d84bbd7b8b54f6eab3b131ddd736239
+#: 808ea6f59ce34c4b85b2ae83fba29f85
+msgid "linux-gcp"
+msgstr ""
+
+#: ../../22.04/5.md 2d458fd5f2b04144b8fa4a05a2af59ad
+#: 64586e1b038d462786e3875cded3bde7
+msgid "linux-gke"
+msgstr ""
+
+#: ../../22.04/5.md 08fd72f92588430fa2f850d5386ded6d
+#: a0c6cbdc83f9414d831c76cfb5275f99
+msgid "linux-gkeop"
+msgstr ""
+
+#: ../../22.04/5.md 16660083c4ac477dab0f8f312700743b
+#: 59670a2ca38c448f8c89987512630e70
+msgid "linux-ibm"
+msgstr ""
+
+#: ../../22.04/5.md 7a0b6361e4ed4a1cb2b5d3a30413c452
+#: a3ea474ed641461284354fdbc9edbd5a
+msgid "linux-kvm"
+msgstr ""
+
+#: ../../22.04/5.md a0b99708c99e47b992ac4b05c297eb3a
+#: c7f9ae058d7b4530b9d690670af8e76c
+msgid "linux-lowlatency"
+msgstr ""
+
+#: ../../22.04/5.md 6bc05a7322d749c697cec86ede14d62e
+#: 817c4ffb9fdd4daf9411a6c6fd3bac28 fc8f113908774f5a951d233c27dab586
+msgid "linux-nvidia"
+msgstr ""
+
+#: ../../22.04/5.md d2712352bd534cd59d500824db48afe4
+msgid "[2055712](https://bugs.launchpad.net/bugs/2055712)"
+msgstr ""
+
+#: ../../22.04/5.md 3f56b83a1b58437f9195c6655bfffefb
+msgid "Pull-request to address bug in mm/page_alloc.c"
+msgstr ""
+
+#: ../../22.04/5.md 0d6539f37a4f4557a3cdddd8249fd17c
+msgid "linux-restricted-modules-oem-6.5"
+msgstr ""
+
+#: ../../22.04/5.md 1d316afe32ea40a7b4c70635f4c715e1
+#: 57f248559db14723bee692ea6665f290 d91e3e693511427fa11b5279144e628b
+msgid "[2048077](https://bugs.launchpad.net/bugs/2048077)"
+msgstr ""
+
+#: ../../22.04/5.md 077b401b3e124973b092e76338dcbc7b
+#: ca39e1763004460abebed1b45471e204 fc36840aa3334954aa36926ab463952a
+msgid "Migrate oem-6.1 to oem-6.5"
+msgstr ""
+
+#: ../../22.04/5.md afed1bac9e1746c2b6286f2f5211ca02
+msgid "linux-restricted-signatures-oem-6.5"
+msgstr ""
+
+#: ../../22.04/5.md e1255545c8b943138cf13500c2b45f8c
+msgid "linux-meta-oem-6.5"
+msgstr ""
+
+#: ../../22.04/5.md 6d65fe48a0f3462dbf09c7299e6627eb
+#: b34e3a26358c4769887c46134a9f80c9
+msgid "linux-oracle"
+msgstr ""
+
+#: ../../22.04/5.md 8f95df1fcca649409923d191d8a536f5
+#: a2831a0c34db4b82b4ed3e791d779dcd
+msgid "linux-raspi"
+msgstr ""
+
+#: ../../22.04/5.md 8eb834f9198049cabee5d6b9851a789d
+#: f3476b397a1e4a368b8492f05d90865b feeb2c2c6e7040baa0e08f9d1dc27ce8
+msgid "linux-intel-iotg"
+msgstr ""
+
+#: ../../22.04/5.md 39cb24cc5eb94cdebe06f6b14657b261
+#: 96112c61b1f94a6ba809a4fa5e95338b b4ebf55b59674f0eac34b1d5c2b2d967
+#: be2b837fbf8b4d05987c08aff16bdb12 d0921a8d2a074d4e9c8c1d7170a8af0c
+msgid "nvidia-graphics-drivers-550"
+msgstr ""
+
+#: ../../22.04/5.md 2d35222940f14723a4d9c5aa607361de
+#: d8d507280fe54ed1b88227cd0eba4f8a
+msgid "[2055384](https://bugs.launchpad.net/bugs/2055384)"
+msgstr ""
+
+#: ../../22.04/5.md 962871e94c1543b89cb3bf15a5c054ec
+#: ae488cbc33ac44829ace3691cc86c317
+msgid "Initial release"
+msgstr ""
+
+#: ../../22.04/5.md 7d692fa1ad144c97bbf0aaa9d9e8edfd
+msgid "[2059147](https://bugs.launchpad.net/bugs/2059147)"
+msgstr ""
+
+#: ../../22.04/5.md 78a91b9403704565a4db2726b38f44ea
+msgid "[2058740](https://bugs.launchpad.net/bugs/2058740)"
+msgstr ""
+
+#: ../../22.04/5.md 52e988cd3b094982858ace23fc09f11d
+msgid "New Upstream release"
+msgstr ""
+
+#: ../../22.04/5.md 523be60633fb4f9cba740cad8e4de295
+#: 6910b3b781404cf1be47df97d67a2fbe
+msgid "[2061830](https://bugs.launchpad.net/bugs/2061830)"
+msgstr ""
+
+#: ../../22.04/5.md 8cbca9059c5849be9f49465aeca263a8
+#: f7af6fac31144628a0defa56f4ae9063
+msgid "Limit supported pci-id's to the new ones added by this release."
+msgstr ""
+
+#: ../../22.04/5.md 0893c18bcbca4b6ba9b421eb0a11ff51
+#: 4bd5e71f6f8a43c5ad725a63a1ee64ee
+msgid "nvidia-graphics-drivers-550-server"
+msgstr ""
+
+#: ../../22.04/5.md a41f9f80b1dd493d8b21f337528832ce
+msgid "[2059638](https://bugs.launchpad.net/bugs/2059638)"
+msgstr ""
+
+#: ../../22.04/5.md e6632d12bab44bf899e3b3b83db3eaa6
+msgid "jammy/linux-azure-fde: 5.15.0-1061.70.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md c17ed37537a0404e9f8b910bb38d57e5
+msgid "[2062581](https://bugs.launchpad.net/bugs/2062581)"
+msgstr ""
+
+#: ../../22.04/5.md 992debd290644cd8a447bc8bc2051faa
+msgid "jammy/linux-nvidia: 5.15.0-1053.54 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 37f4680586a745e7bb27d74353d4d4a2
+msgid "[2063265](https://bugs.launchpad.net/bugs/2063265)"
+msgstr ""
+
+#: ../../22.04/5.md ba675823f4d34884ab63418df8c9447f
+msgid "jammy/linux-nvidia-tegra-igx: 5.15.0-1012.12 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 23d0ffafaf3f4a8a8027bd1711d5377e
+#: 8d9045f845e94bc7bc8457c73334830b af724c2235e9482896d0ba1452136c03
+msgid "[2061900](https://bugs.launchpad.net/bugs/2061900)"
+msgstr ""
+
+#: ../../22.04/5.md 211b2641ed564f0284db7980e28330ee
+#: 76209b2dad964eb3a92dc4d3e906979a af93eb3d8651449d9d1589b20e3bf4e0
+msgid "apply NVIDIA patches April 6-16, 2024"
+msgstr ""
+
+#: ../../22.04/5.md d02b4f8d5d624e0ab067cddf4494cbdf
+msgid "[2063258](https://bugs.launchpad.net/bugs/2063258)"
+msgstr ""
+
+#: ../../22.04/5.md 81fda85930d74854850cda02ffafe568
+msgid "jammy/linux-nvidia-tegra: 5.15.0-1025.25 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md b8c088107f6847d99ee36e9a3dfabb17
+msgid "[2060337](https://bugs.launchpad.net/bugs/2060337)"
+msgstr ""
+
+#: ../../22.04/5.md 5e76af84da1245d890af6e27c8730d75
+msgid "apply NVIDIA patches Mar 22 - April 5, 2024"
+msgstr ""
+
+#: ../../22.04/5.md 93edb3b8dbf84cc1b4d80bae81206802
+#: 9bc1fd44a05e4c7eb519ce97a0e59eb4
+msgid "linux-meta-nvidia-tegra-igx"
+msgstr ""
+
+#: ../../22.04/5.md 5758863696e54390bd090250d47010c3
+msgid "[2060071](https://bugs.launchpad.net/bugs/2060071)"
+msgstr ""
+
+#: ../../22.04/5.md 90b2405f2c5842eeb45ae4e77a0e3150
+msgid "Add initial r36.3 out-of-tree module meta packages"
+msgstr ""
+
+#: ../../22.04/5.md 3321944ae57c48b682c54fc5bad428aa
+msgid "[2055283](https://bugs.launchpad.net/bugs/2055283)"
+msgstr ""
+
+#: ../../22.04/5.md f436204b671c4a539145e597d669374e
+msgid "Intel Bluetooth AX201 needs firmware intel/ibt-0180-4150.sfi"
+msgstr ""
+
+#: ../../22.04/5.md c404c67d9f684e56bf6fa6ea5c8d66cf
+msgid "[2053277](https://bugs.launchpad.net/bugs/2053277)"
+msgstr ""
+
+#: ../../22.04/5.md beaaea18a947403682bfa8fe69d256f4
+msgid "add the updated navi3.x DMCUB FW (ver 0x07002600) to 22.04 Jammy"
+msgstr ""
+
+#: ../../22.04/5.md 8082bd38a5434243add2e4ad9c1396fb
+msgid "[2063373](https://bugs.launchpad.net/bugs/2063373)"
+msgstr ""
+
+#: ../../22.04/5.md 9bd877b2e67c4fe5a18715720e499ebd
+msgid "jammy/linux-nvidia-6.5: 6.5.0-1018.18 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 26dcd36710a040ae9c854db013060f9d
+#: 383ce23ee7624468995f70f2279c6d2f 8576c26d42b54197a4e9d66d0e99576a
+msgid "[2061930](https://bugs.launchpad.net/bugs/2061930)"
+msgstr ""
+
+#: ../../22.04/5.md 02684defc04147328de08cef26e94e1b
+msgid ""
+"linux-nvidia-6.5_6.5.0-1014.14 breaks with earlier BIOS release, and "
+"modeset/resolutions are wrong"
+msgstr ""
+
+#: ../../22.04/5.md 5b4273f55b694c87a48d71ea91b090bc
+#: f61474e7b0c94db8ad7b790821e30c12
+msgid "linux-oem-6.5"
+msgstr ""
+
+#: ../../22.04/5.md 21b5ae1b43a144c5ae301655f1eb7fdd
+msgid "[2063441](https://bugs.launchpad.net/bugs/2063441)"
+msgstr ""
+
+#: ../../22.04/5.md 5259b015ed2c4640bea535987b664d94
+msgid "jammy/linux-oem-6.5: 6.5.0-1022.23 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 7c7d44588f19441cb13713fdacb2cf14
+#: d1c6fc1caec24c478a61ba305fd4228e
+msgid "[2061763](https://bugs.launchpad.net/bugs/2061763)"
+msgstr ""
+
+#: ../../22.04/5.md 82d2c4a177584c9397025d4a58957def
+#: da98fec4b8d140519763a146d249d1e2
+msgid "jammy/linux-azure-fde: 5.15.0-1063.72.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md d9e8c3e67e8744c2859bf01d426fd2f0
+#: db72492e2e7044f8864480101bd4404f
+msgid "[2061443](https://bugs.launchpad.net/bugs/2061443)"
+msgstr ""
+
+#: ../../22.04/5.md 597623b24476454e8084fe81ce895171
+#: a671b7d303744c64afff8f60ea98ea04
+msgid "mantic/linux: 6.5.0-34.34 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 1b5c14582f134814bc77f8c6418843b1
+#: 9f5d4f3ac6604366a0c1757c2f37de53
+msgid "[2060448](https://bugs.launchpad.net/bugs/2060448)"
+msgstr ""
+
+#: ../../22.04/5.md b10db86f8c2842a488f2d0b8d983dfc6
+#: b3aa861915144efd80677b527fb0a471
+msgid "mantic/linux: 6.5.0-33.33 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 4d499e776618441c90a5d275c6ee157a
+#: eda3f621558b4e4c934fe30e2d486cd5
+msgid "[2059443](https://bugs.launchpad.net/bugs/2059443)"
+msgstr ""
+
+#: ../../22.04/5.md 314dbf36387845efb7d64ff4ac720e43
+#: f77217e0ed6c4b15a76b365e8b168a30
+msgid "mantic/linux: 6.5.0-32.32 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 0b56955037c840e3a1a4c56adc054c1f
+#: 2e6b383d4f8945b186ac01efaff7bf35
+msgid "[2063585](https://bugs.launchpad.net/bugs/2063585)"
+msgstr ""
+
+#: ../../22.04/5.md a7fcf1d65026448e8be6113adedba2da
+#: c98142a780774675a5b753e8ca285f00
+msgid "jammy/linux-azure-fde: 5.15.0-1064.73.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 66557ca41ad744d391f3b74626ce5a68
+msgid "[2065182](https://bugs.launchpad.net/bugs/2065182)"
+msgstr ""
+
+#: ../../22.04/5.md bed4a100604e4d7895bdf4c79da772e4
+msgid "Update Tegra out-of-tree modules to r36.3 05-05-2024"
+msgstr ""
+
+#: ../../22.04/5.md e5a28ea8cdb6409a9a091b2f56a043f8
+msgid "crash"
+msgstr ""
+
+#: ../../22.04/5.md e7c48ad5487441a28222c6aa34b79e47
+msgid "[2038249](https://bugs.launchpad.net/bugs/2038249)"
+msgstr ""
+
+#: ../../22.04/5.md 7568ffda58de4b82aa5597f452e2c350
+msgid ""
+"Fix the dump file parsing issue arises from structural changes in Linux "
+"kernel 6.5"
+msgstr ""
+
+#: ../../22.04/5.md 0cbc7e9541824c3c88d224032a0b7cb9
+msgid "[2062129](https://bugs.launchpad.net/bugs/2062129)"
+msgstr ""
+
+#: ../../22.04/5.md 10bb217a59c24d3ca8bc4f955169025e
+msgid "RT-GA] igc device error"
+msgstr ""
+
+#: ../../22.04/5.md 6e012d37ffbb47c1816e319f2f9947ca
+msgid "oem-somerville-lapras-meta"
+msgstr ""
+
+#: ../../22.04/5.md 039f0ade436c4d16bf6c0c3d7b6af706
+msgid "[1997655](https://bugs.launchpad.net/bugs/1997655)"
+msgstr ""
+
+#: ../../22.04/5.md 59a39a68d0e547babd0c5d699b48a73e
+msgid "Meta package for Somerville Lapras."
+msgstr ""
+
+#: ../../22.04/5.md 7f009c71fa7547518fa00a372f18e50a
+msgid "oem-somerville-hoppip-meta"
+msgstr ""
+
+#: ../../22.04/5.md 2f7f475e72f64293bc88ec57e205ab95
+msgid "[1997653](https://bugs.launchpad.net/bugs/1997653)"
+msgstr ""
+
+#: ../../22.04/5.md 6492d5cfba69432fa63bc4fcff9593f8
+msgid "Meta package for Somerville Hoppip."
+msgstr ""
+
+#: ../../22.04/5.md 210c6a1ba085463cac353e82023432c9
+msgid "oem-somerville-lapras-13-meta"
+msgstr ""
+
+#: ../../22.04/5.md d95c8514d8204a8c8c9b5284a4cde9d3
+msgid "[1997654](https://bugs.launchpad.net/bugs/1997654)"
+msgstr ""
+
+#: ../../22.04/5.md cd64bf2eb6684db5b7337be868af6059
+msgid "Meta package for Somerville Lapras-13."
+msgstr ""
+
+#: ../../22.04/5.md f4dcc110bcd64b99a00bfe14d936aedf
+msgid "oem-somerville-marill-meta"
+msgstr ""
+
+#: ../../22.04/5.md 93b0d955a6014437b1ebca17eece6c54
+msgid "[1997656](https://bugs.launchpad.net/bugs/1997656)"
+msgstr ""
+
+#: ../../22.04/5.md d60d4e6d1ab643279867aed2a5418ccd
+msgid "Meta package for Somerville Marill."
+msgstr ""
+
+#: ../../22.04/5.md b158e2dc2ace44668ea7b0953ae5c3ce
+msgid "oem-somerville-muk-meta"
+msgstr ""
+
+#: ../../22.04/5.md dd06de7474da45ceb7a063eb41589cdb
+msgid "[1998754](https://bugs.launchpad.net/bugs/1998754)"
+msgstr ""
+
+#: ../../22.04/5.md 813fcf1f60bf4eb798a1cb81c928ebdb
+msgid "Meta package for Somerville Muk."
+msgstr ""
+
+#: ../../22.04/5.md 450c6906869843aaaebf979ae5d74415
+msgid "oem-stella-beldum-meta"
+msgstr ""
+
+#: ../../22.04/5.md bb0f6999582e4b75b76d5fc38ffb7d91
+msgid "[1955908](https://bugs.launchpad.net/bugs/1955908)"
+msgstr ""
+
+#: ../../22.04/5.md c2611978a9e24104b6098ca54b515653
+msgid "Meta package for Stella Beldum."
+msgstr ""
+
+#: ../../22.04/5.md 0bb12203a563457fa5b3d7309e4ff9ec
+msgid "linux-azure-6.8"
+msgstr ""
+
+#: ../../22.04/5.md 99cd152e9c894a48abb85463f724289f
+msgid "[2064326](https://bugs.launchpad.net/bugs/2064326)"
+msgstr ""
+
+#: ../../22.04/5.md 876d8e84e2a448f99e2d7a16db8db9e5
+msgid "jammy/linux-azure-6.8: 6.8.0-1008.8~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 6ba5ca097b174ffa8946bf710cdbc0f0
+#: c03cb376853a4fb9b19550a435950354
+msgid "[2063713](https://bugs.launchpad.net/bugs/2063713)"
+msgstr ""
+
+#: ../../22.04/5.md 31402c0da6d24cf4bab6ccba72b5ad91
+#: 88e3d5d16e90449cb865968782fad0fa
+msgid "jammy/linux-azure-fde: 5.15.0-1065.74.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 2cfba28678d444a19ec99ced43f1561a
+msgid "[2058830](https://bugs.launchpad.net/bugs/2058830)"
+msgstr ""
+
+#: ../../22.04/5.md 172f88bcae4e4dfabd807743d5e0512e
+msgid "vp9 hw decode broken on modern AMD apus, needs amdgpu update"
+msgstr ""
+
+#: ../../22.04/5.md 8673f7361cc5476391f77d041bcca1d0
+msgid "libnvidia-nscq-550"
+msgstr ""
+
+#: ../../22.04/5.md 47264325ed514e6d89c02d837c140123
+#: afa08312ab074918a1b851e1f4136d6c da8f7f927f224eb797f4a99bdb47539d
+#: fc2a3ee98b5c4bc3a27ec49023c15df3
+msgid "[2067041](https://bugs.launchpad.net/bugs/2067041)"
+msgstr ""
+
+#: ../../22.04/5.md 005f939c9b66486e9bcd763a41b53f23
+msgid "fabric-manager-550"
+msgstr ""
+
+#: ../../22.04/5.md 1a7b8e8699ad4ce39ff674c39cc33cce
+msgid "nvidia-imex-550"
+msgstr ""
+
+#: ../../22.04/5.md d7a77b5f11354a22b9d09712a63390cf
+msgid "[2067598](https://bugs.launchpad.net/bugs/2067598)"
+msgstr ""
+
+#: ../../22.04/5.md 95d137c940ae4bd7bb18508662205d16
+msgid "[2067597](https://bugs.launchpad.net/bugs/2067597)"
+msgstr ""
+
+#: ../../22.04/5.md 890449aaace3491dbd7f16042f774b98
+msgid "[2067881](https://bugs.launchpad.net/bugs/2067881)"
+msgstr ""
+
+#: ../../22.04/5.md aee2342a3f714c6893870be719ee5add
+msgid "[2066904](https://bugs.launchpad.net/bugs/2066904)"
+msgstr ""
+
+#: ../../22.04/5.md 59166cc7f6424e0c8d265871d4e2409f
+msgid "[2066367](https://bugs.launchpad.net/bugs/2066367)"
+msgstr ""
+
+#: ../../22.04/5.md dc046b896ffb4656905149e2d01dbbed
+#: fddb0f108ebc48a3aa8ce7a7365e049f
+msgid "[2068192](https://bugs.launchpad.net/bugs/2068192)"
+msgstr ""
+
+#: ../../22.04/5.md 434f8fcafc8e4210bcbbe2f853ad7729
+#: ebba92cacc664cd1bdfade6b8e3f9ce9
+msgid "jammy/linux-azure-fde: 5.15.0-1067.76.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 966d1c50351d4aebb24c491167082214
+#: a4688cb857ac492db4dc656d57a1aca3 a6216c062eb541789d25aa30288e7259
+#: cde724d3d2424ffe933d6a445649ece5 ee43fd60574d4d5b9f8f5b816b4aa1fd
+#: f16bd4c11cc14215b6ec185f8aaf4b2a
+msgid "linux-nvidia-6.8"
+msgstr ""
+
+#: ../../22.04/5.md 5b72b576beac41c4a483d0ca4ccd0616
+#: 830252e90cf04eed864093bc4021e06f
+msgid ""
+"linux-nvidia-6.5_6.5.0-1014.14 breaks with earlier BIOS release, and "
+"modeset/resolutions are wrong (LP: #2061930) // Blocklist coresight_etm4x"
+msgstr ""
+
+#: ../../22.04/5.md 7c680bbb5d4e44dea64fc331b746f6b6
+#: 889b824b560a48a987265b3014117252 98d72b54342f4904b9230794d5a0a3b6
+#: db88a53576aa494580a404043d03e53b
+msgid "[1975592](https://bugs.launchpad.net/bugs/1975592)"
+msgstr ""
+
+#: ../../22.04/5.md 96c6b4be3fa0434da9c26b2f9c9b1980
+#: 9c4c07b962d1421eae0437d92b7f40e6
+msgid "Enable Nezha board"
+msgstr ""
+
+#: ../../22.04/5.md 1999071e6c14430f82eb08ed3f659807
+#: 6d4e016a18be460fa7b74887de56387d 745fe5b702ef44639a126581084ecee7
+#: b533db4339a4492b9496b1a5e8e501be
+msgid "Enable Nezha board (LP: #1975592) // Enable StarFive VisionFive 2 board"
+msgstr ""
+
+#: ../../22.04/5.md ab3c0696be6b4da29b73f7f2e2e93e0c
+#: d24e90523ccb4da98ce98e8aefea6bf6 f17b685c53d649439c10e9dd4d95d9a0
+msgid "[2013232](https://bugs.launchpad.net/bugs/2013232)"
+msgstr ""
+
+#: ../../22.04/5.md bedc2c8e14e242f493f3de68dd8a2579
+#: fd1ca13b3abd4afc89b878708d038f10
+msgid "[1981437](https://bugs.launchpad.net/bugs/1981437)"
+msgstr ""
+
+#: ../../22.04/5.md 185c6d5669674515af466081d10010bc
+#: 6fcf42644051493aac8dc52f126d2a5c
+msgid "RISC-V kernel config is out of sync with other archs"
+msgstr ""
+
+#: ../../22.04/5.md 1f9f2c2051074e99bef5e7141b054ed8
+#: 1fc355d038eb4a2db8bacb05d1f33104 a604bca7578c45529814a2a0baf6e115
+#: b2ce4b0c1bc746449d14f47b0263dbbc d954f947c3b9486ca7b44d4a0f06a6ee
+msgid "linux-aws-6.8"
+msgstr ""
+
+#: ../../22.04/5.md 7e781cea49a84017a37854afed934523
+msgid "[2064324](https://bugs.launchpad.net/bugs/2064324)"
+msgstr ""
+
+#: ../../22.04/5.md 4d77402021684f1e9a4ae7bf8a89f10f
+msgid "jammy/linux-aws-6.8: 6.8.0-1009.9~22.04.2 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md c15ce45aef694207936f79d7762c65ab
+msgid "[2068131](https://bugs.launchpad.net/bugs/2068131)"
+msgstr ""
+
+#: ../../22.04/5.md 8eb759b5a534447daee55bcd858a4af9
+msgid "jammy/linux-aws-6.8: 6.8.0-1010.10~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 35f6601ee95045fb912947e6419bebf2
+msgid "[2068323](https://bugs.launchpad.net/bugs/2068323)"
+msgstr ""
+
+#: ../../22.04/5.md f7afdf4a47d347f0a0c43603d3362e4b
+msgid "mantic/linux-azure: 6.5.0-1024.25 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 1f5e00707cf7445ba01fde169f29640d
+msgid "python-rtslib-fb"
+msgstr ""
+
+#: ../../22.04/5.md d40bc72a459e413c8c49f00676082935
+msgid "[1988366](https://bugs.launchpad.net/bugs/1988366)"
+msgstr ""
+
+#: ../../22.04/5.md 410bd3581f334276b2192877a7469650
+msgid ""
+"d/p/lp1988366-handle-target-kernel-module-new-attribute-cpus_allow.patch "
+"Handle new Linux kernel module attribute \"cpus_allowed_list\", fixing "
+"the error \"Not a directory: "
+"'/sys/kernel/config/target/iscsi/cpus_allowed_list'\""
+msgstr ""
+
+#: ../../22.04/5.md c53b5a77f240479a90d8cb28b5c16934
+msgid "linux-ibm-6.8"
+msgstr ""
+
+#: ../../22.04/5.md 75d17f4226a944d288d6f2edf6a88d1f
+#: 7cdaa6d8140f4d55a85ca4ea1a446d69 7e6ead921d4b4abb99bd1c83299d3fe9
+msgid "[2068301](https://bugs.launchpad.net/bugs/2068301)"
+msgstr ""
+
+#: ../../22.04/5.md 2bcaa46c3a364062a213ad2e503fe6d4
+#: 493429e40b0c4188bd26b064dbc29ba1 c592e4b031a14084a9971d2028282c6a
+msgid "jammy/linux-ibm-6.8: 6.8.0-1008.8~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md e855e7a89dcc4282bf8c00708075847d
+msgid "linux-signed-ibm-6.8"
+msgstr ""
+
+#: ../../22.04/5.md e2926ffdcec94192b3cfdf4fabf67376
+msgid "[1989705](https://bugs.launchpad.net/bugs/1989705)"
+msgstr ""
+
+#: ../../22.04/5.md d33828645d0f4c298d33d0329b1d8ed4
+msgid "SIGNEDv3: add a linux-generate ancillary package"
+msgstr ""
+
+#: ../../22.04/5.md 0efa75c9c4df485b8e3bf2c1ac499105
+msgid "linux-restricted-modules-ibm-6.8"
+msgstr ""
+
+#: ../../22.04/5.md 323c34ff4e5d4a309ab2a63b07e91237
+msgid "linux-restricted-signatures-ibm-6.8"
+msgstr ""
+
+#: ../../22.04/5.md 00af557bc7224118bb2d04210ff95669
+#: 0e1a4eac32e54e15bbb1bfa10719425e 0ff32a736d1548d2b472add32144c66b
+#: 1075a45514174de1aedd8be95c434500 1a0b2b5898844a38a832b39070ed6b66
+#: 1bca5edf5d694ca58ec8a0f5d748385d 268658169f904b189d95423e445e6477
+#: 2b7a401119454962835f9a0dfc0dfe39 2ec7e056f8f347a5a0e0f28db6db0291
+#: 37afa35b93f34fa5ba60a117bb0dc7b0 3a18979f0b9a44bb8e11317ee277f54d
+#: 3fa3d1bd3ba64f4bac16605137d92cd6 3fe87598a22145ec89f3768482849811
+#: 4141f5ff75044f83bc93c07367a74ca3 442581b9385c4309ac101491bff8fe06
+#: 4afe9d1371c1478aa0c54fcff74c9bd9 4c2b67601b8a4c2eacc1a357336b7f6d
+#: 5b33d8940caa49448e1379f47a81a51e 5ebffa4f991b4635a6cbac10f8294629
+#: 6e37c820d3114d9697866a2b6545fd01 792cb32410d84edd91366fb9e1a2140a
+#: 7a8cce952ff64680a1991b98567e529f 7e1fad44658344e3bc9998782a104fcc
+#: 7f34dfd3e7c24a08bff8bc26f0cc0a0b 80df3bdc55cd44ec840f434782c73ccd
+#: 820ab525196449529d3d49b148492b29 86e8527b4a4f43ea913980ef86632955
+#: 9078b179fba14922bd7414e2174a434c 9d40301a9d4044b097aae4a50fe4039b
+#: 9df0cd4e61e649ef8b9f3ee1232df4cd a0a30f919a824de29ce8326a3af5ee25
+#: abf9d4c458054e33ae5c75a783dd2524 adab56632115420a8ff9b7ee51818488
+#: adb62c478c164d08ac51481aa27b162c add33616079e4686a50f664f526a179a
+#: b216d9b34f6144948f00fec534524653 b2c4f05b187b4b4c9fcf27a875d2c399
+#: b635750241e240d9af61e27f91727250 b7a013e39097451c807e36a89902441c
+#: cabdd9983cb64482bb2d5068d2187df6 cb3d5e735552421585b81820c2880b40
+#: d579de3fb5a1411e8674d5f8a29e22a2 d66a9395fbca458fa257ac30bfb24d65
+#: dbe19ce30a814edd8a7d2dbc2c75776a df19887defdb45b1b346c6f0de5efcc9
+#: e06cc0e078a44a5ebb111a8e17394111 e67d21ba9d634c8b8511ae51308b7396
+#: e784bee32d1643488b642dd96a757569 ece3a22a21564ecd93f8e5bd26e65d0c
+#: ef5755223c054c739f6f8b86999c3f6e fd9fa4feab2c414991dd8f3499c2da65
+#: fe11e75ba3a44c3cab1f834f200d3640
+msgid "linux-lowlatency-hwe-6.8"
+msgstr ""
+
+#: ../../22.04/5.md 65a946d4a7c9445a9c850aab9b011597
+#: ce24eefc06194d33bbd20989c31f34d4 dbc8cafaa67b49c4b1f366d3498dca75
+msgid "[2068594](https://bugs.launchpad.net/bugs/2068594)"
+msgstr ""
+
+#: ../../22.04/5.md 52dcd51cd3a44e90a2a6cbde6a847e6d
+#: c38106e63a164830be19c1bcab570cd2 d7b7336d1fde44ada84853908a859856
+msgid "jammy/linux-lowlatency-hwe-6.8: 6.8.0-38.38.1~22.04.2 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 3f53161067ab4dbbac5f780e99f23dc7
+msgid "[2062933](https://bugs.launchpad.net/bugs/2062933)"
+msgstr ""
+
+#: ../../22.04/5.md bbdd3b940ca64bfeb1ddf87ee2cedea4
+msgid "noble/linux: 6.8.0-31.31 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md e335df05ba794c9eb4935e6a720a5c5e
+msgid "[2061893](https://bugs.launchpad.net/bugs/2061893)"
+msgstr ""
+
+#: ../../22.04/5.md 802053ce275c4ef9bdfe0f15aa06f5a8
+msgid "noble/linux: 6.8.0-30.30 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md b5da4a7f0e0d4b94b597cda33700e6fb
+msgid "[2056706](https://bugs.launchpad.net/bugs/2056706)"
+msgstr ""
+
+#: ../../22.04/5.md 0b926620d26747c7978ff8403b6320ee
+msgid ""
+"System unstable, kernel ring buffer flooded with \"BUG: Bad page state in"
+" process swapper/0\""
+msgstr ""
+
+#: ../../22.04/5.md 16713614336543b5ba1bb9c9d2b94280
+msgid "[2061888](https://bugs.launchpad.net/bugs/2061888)"
+msgstr ""
+
+#: ../../22.04/5.md 34f3e64f6fec452fad14952f9cb07832
+msgid "noble/linux: 6.8.0-29.29 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md d9b11796661b4281a0e83698c8d7286e
+msgid "[2050019](https://bugs.launchpad.net/bugs/2050019)"
+msgstr ""
+
+#: ../../22.04/5.md fcf2dd655f2f4c94aa86ed0e9b43071b
+msgid ""
+"24.04 FEAT] [SEC2353] zcrypt: extend error recovery to deal with device "
+"scans"
+msgstr ""
+
+#: ../../22.04/5.md f8285f74849e4eabbef82dcda82c72bd
+msgid "[2051835](https://bugs.launchpad.net/bugs/2051835)"
+msgstr ""
+
+#: ../../22.04/5.md 908931e5d2f64e49a0adaf10d51893ff
+msgid "24.04 FEAT] Memory hotplug vmem pages (s390x)"
+msgstr ""
+
+#: ../../22.04/5.md 897b15de5a6b4e93a2cdd49a7a0ab232
+msgid "[2061867](https://bugs.launchpad.net/bugs/2061867)"
+msgstr ""
+
+#: ../../22.04/5.md 304397322d0d4cc39cd70e6da4b13f53
+msgid "noble/linux: 6.8.0-28.28 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 566cdc9e1a0e4e50a6726f817eae3220
+msgid "[2061851](https://bugs.launchpad.net/bugs/2061851)"
+msgstr ""
+
+#: ../../22.04/5.md 064580757e1d48af820ed67e94626b25
+msgid ""
+"linux-gcp 6.8.0-1005.5 (+ others) Noble kernel regression with new "
+"apparmor profiles/features"
+msgstr ""
+
+#: ../../22.04/5.md 96cce805543d48bc87f9e66eeecb2721
+msgid "[2061083](https://bugs.launchpad.net/bugs/2061083)"
+msgstr ""
+
+#: ../../22.04/5.md 347f4b3b34fb4fa783e09bf5d35ac2d9
+msgid "noble/linux: 6.8.0-25.25 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 26bdbc2b637147678162a159560f7283
+msgid "[2060909](https://bugs.launchpad.net/bugs/2060909)"
+msgstr ""
+
+#: ../../22.04/5.md 1b1d630a20f9428a87e6ec7928f5189d
+msgid "Apply mitigations for the native BHI hardware vulnerability"
+msgstr ""
+
+#: ../../22.04/5.md 3f91b63e097d4ad7897a584697377cf6
+#: 59d4f9be043640ab943afd066f01b1c3 a5aa863ab8eb4750a5e9c2cbd007193f
+#: b8416905bdcd437a85d39491b0cd62f4
+msgid "[2028253](https://bugs.launchpad.net/bugs/2028253)"
+msgstr ""
+
+#: ../../22.04/5.md 1da126e8e52c41f28473a7f7375adc05
+#: b106687d3e3448b4b89c72852135b10e
+msgid "update apparmor and LSM stacking patch set"
+msgstr ""
+
+#: ../../22.04/5.md 2e9369c8a7c44e5ca044b7dd3f8a1862
+#: 4c9de0f328a44da5b0fa3c52a095dfa7 dc24bf5737ef4d8a899d10030441b95e
+#: fd535f03a1984982b2cb2e5fa43ed719
+msgid ""
+"update apparmor and LSM stacking patch set (LP: #2028253) // [FFe] "
+"apparmor-4.0.0-alpha2 for unprivileged user namespace restrictions in "
+"mantic"
+msgstr ""
+
+#: ../../22.04/5.md 39a167ace4e04c198de4abdd3a808dd1
+#: b8108e1ee464481da5595e03e147c4e1
+msgid "[2032602](https://bugs.launchpad.net/bugs/2032602)"
+msgstr ""
+
+#: ../../22.04/5.md c5c7b0a799384cdb8a08c04ba0f9258f
+msgid "[2049793](https://bugs.launchpad.net/bugs/2049793)"
+msgstr ""
+
+#: ../../22.04/5.md 6d763571f1ce43269e5350152a39f5be
+msgid "MTL] x86: Fix Cache info sysfs is not populated"
+msgstr ""
+
+#: ../../22.04/5.md e7c87ef09c684619a41b36485a16489d
+msgid "[2060238](https://bugs.launchpad.net/bugs/2060238)"
+msgstr ""
+
+#: ../../22.04/5.md 67c3e848e64e45d68ceaaae9fe2096a3
+msgid "noble/linux: 6.8.0-22.22 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 26cc64d91e6b489c8eaa045da0fd5bed
+msgid "[2060225](https://bugs.launchpad.net/bugs/2060225)"
+msgstr ""
+
+#: ../../22.04/5.md 8bb6364a33ad46e7a36786734ec52e1f
+msgid "noble/linux: 6.8.0-21.21 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 02d5ce6896604122847f06a201b637ae
+msgid "[2058221](https://bugs.launchpad.net/bugs/2058221)"
+msgstr ""
+
+#: ../../22.04/5.md 938b17b6085045aea853f7fedaa710ab
+msgid "noble/linux: 6.8.0-20.20 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 77c6b7c4a5e045388facc1d37b112354
+msgid "[2058224](https://bugs.launchpad.net/bugs/2058224)"
+msgstr ""
+
+#: ../../22.04/5.md afc322807e6a4132a9c22bde5b1f8ba2
+msgid "Noble update: v6.8.1 upstream stable release"
+msgstr ""
+
+#: ../../22.04/5.md dedd36f5cdb24b33bd9db549775005f3
+msgid "[2048768](https://bugs.launchpad.net/bugs/2048768)"
+msgstr ""
+
+#: ../../22.04/5.md 84240079aab943ecafc98152ae0dce5c
+msgid "Autopkgtest failures on amd64"
+msgstr ""
+
+#: ../../22.04/5.md f569bf680c4140ec949dca76b7f638a7
+msgid "[2057910](https://bugs.launchpad.net/bugs/2057910)"
+msgstr ""
+
+#: ../../22.04/5.md dc996b95e7d94c7a95f96e224dc4724d
+msgid "noble/linux: 6.8.0-19.19 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md e553f6d360bb443f80232727215b2196
+msgid "[2057456](https://bugs.launchpad.net/bugs/2057456)"
+msgstr ""
+
+#: ../../22.04/5.md 0ba45b3616284c91afd0c03ee5317dbd
+msgid "noble/linux: 6.8.0-18.18 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md a90489a903224f549cc3c35e94daea4d
+msgid "[2056745](https://bugs.launchpad.net/bugs/2056745)"
+msgstr ""
+
+#: ../../22.04/5.md 0773836e41574969aa4ba72bc1e58753
+msgid "noble/linux: 6.8.0-17.17 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 44b92c53f4ff4911a2a0de5f08ac4095
+msgid "[2056738](https://bugs.launchpad.net/bugs/2056738)"
+msgstr ""
+
+#: ../../22.04/5.md 5291daf4508a4244b584f34b71d0a30e
+msgid "noble/linux: 6.8.0-16.16 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 425e8ce39ec741f59487635cd6db2f96
+msgid "[2056616](https://bugs.launchpad.net/bugs/2056616)"
+msgstr ""
+
+#: ../../22.04/5.md 3280bf7605044f8885aebf951afccd79
+msgid "left-over ceph debugging printks"
+msgstr ""
+
+#: ../../22.04/5.md fb71c8a7062b434686beacbea7ceb29c
+msgid "[2056354](https://bugs.launchpad.net/bugs/2056354)"
+msgstr ""
+
+#: ../../22.04/5.md b5ed7ad525f24a0382922ce94c5c0f41
+msgid "qat: Improve error recovery flows"
+msgstr ""
+
+#: ../../22.04/5.md e4ab6a0534404f7db3df2599c7625764
+msgid "[2051342](https://bugs.launchpad.net/bugs/2051342)"
+msgstr ""
+
+#: ../../22.04/5.md 1e5a08827ca44d9a9958c6ee499072fa
+msgid "Enable lowlatency settings in the generic kernel"
+msgstr ""
+
+#: ../../22.04/5.md ececff8f714d4dbab06471ddda1ba78a
+msgid "[2056126](https://bugs.launchpad.net/bugs/2056126)"
+msgstr ""
+
+#: ../../22.04/5.md fadf527008924842b62077395136203c
+msgid "hwmon: (coretemp) Fix core count limitation"
+msgstr ""
+
+#: ../../22.04/5.md b69d0392c7a340a0bc4d6dbef3af1d65
+msgid "[2055871](https://bugs.launchpad.net/bugs/2055871)"
+msgstr ""
+
+#: ../../22.04/5.md 31b7e9b6702846dfad58a479eb58e413
+msgid "noble/linux: 6.8.0-15.15 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 5bc59f14846a48adbf8ba63dc6e211ef
+msgid "[2055551](https://bugs.launchpad.net/bugs/2055551)"
+msgstr ""
+
+#: ../../22.04/5.md 02e1bfc1a9c8491f9b0a86d8fdeb2e82
+msgid "noble/linux: 6.8.0-14.14 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 972ad5dc6d06492d9879a1500c4dff64
+msgid "[2049390](https://bugs.launchpad.net/bugs/2049390)"
+msgstr ""
+
+#: ../../22.04/5.md b1a383574ab04403aa1de1c507d5a3c7
+msgid "Please change CONFIG_CONSOLE_LOGLEVEL_QUIET to 3"
+msgstr ""
+
+#: ../../22.04/5.md 7cbb3553d0aa4e76bd3390884fcfd56a
+#: e5b2c9c35d14450b90c915bff973de20
+msgid "[1951440](https://bugs.launchpad.net/bugs/1951440)"
+msgstr ""
+
+#: ../../22.04/5.md 1eb6d8feba5242dd837cc6cdc8839d62
+#: 23106b46e9b24b378a8fe645f1da484e
+msgid ""
+"Enable CONFIG_INTEL_IOMMU_DEFAULT_ON and "
+"CONFIG_INTEL_IOMMU_SCALABLE_MODE_DEFAULT_ON"
+msgstr ""
+
+#: ../../22.04/5.md 1e36a7f144a24c8a9997caebe82cb95f
+msgid "[2055421](https://bugs.launchpad.net/bugs/2055421)"
+msgstr ""
+
+#: ../../22.04/5.md df9ef343374c46d6ab99c3f162b1579a
+msgid "noble/linux: 6.8.0-13.13 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 420a6a84b4ce4fa696d5810576ca7bfd
+msgid "[2038583](https://bugs.launchpad.net/bugs/2038583)"
+msgstr ""
+
+#: ../../22.04/5.md b7df0799287e4665a8929d790b1d1c25
+msgid "Turning COMPAT_32BIT_TIME off on s390x"
+msgstr ""
+
+#: ../../22.04/5.md f56d1010e8f444b79ac9d9d47cdcea2e
+msgid "[2052439](https://bugs.launchpad.net/bugs/2052439)"
+msgstr ""
+
+#: ../../22.04/5.md e8e68a27452d4afcb3ecfc58d844a1bf
+msgid "Don't produce `linux-*-source-<version>` package"
+msgstr ""
+
+#: ../../22.04/5.md 7b354b410598493cb823bd32fc27836c
+msgid "[2048183](https://bugs.launchpad.net/bugs/2048183)"
+msgstr ""
+
+#: ../../22.04/5.md 8aaf88fa668341bf952d805dbe7ea962
+msgid ""
+"Don't produce `linux-*-cloud-tools-common`, `linux-*-tools-common` and "
+"`linux-*-tools-host` binary packages"
+msgstr ""
+
+#: ../../22.04/5.md 5ca33235b23949bc87478cb676155b3d
+msgid "[2053094](https://bugs.launchpad.net/bugs/2053094)"
+msgstr ""
+
+#: ../../22.04/5.md c4a403fa2fbc4b4e86436d2a2cf89ce3
+msgid "noble/linux: 6.8.0-11.11 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 51bcc30f6a124745ba8fbb2ea366c058
+msgid "[2053015](https://bugs.launchpad.net/bugs/2053015)"
+msgstr ""
+
+#: ../../22.04/5.md 05fb706cb3e44ecfadc0149c5041d642
+msgid "noble/linux: 6.8.0-10.10 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 5dd64370987d40429da0ba732fca1f30
+msgid "[2052945](https://bugs.launchpad.net/bugs/2052945)"
+msgstr ""
+
+#: ../../22.04/5.md f27327e81d0444a198d05dc43144e49c
+msgid "noble/linux: 6.8.0-9.9 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 49c57d22ddc84076944a5ff3acb99c37
+msgid "[2052918](https://bugs.launchpad.net/bugs/2052918)"
+msgstr ""
+
+#: ../../22.04/5.md 0c56e7290aa74593a78223f7afa69c05
+msgid "noble/linux: 6.8.0-8.8 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 30fd703cf51f40b38061e4f52f3c542b
+#: a23fa9a22ba04dd9a4df66db19090a1a
+msgid "linux-restricted-modules-lowlatency-hwe-6.8"
+msgstr ""
+
+#: ../../22.04/5.md 1d14d168ec774291bc2a5efdd853057c
+#: 829a428a9a404eff9e6fcf39d734bbc4
+msgid "linux-restricted-signatures-lowlatency-hwe-6.8"
+msgstr ""
+
+#: ../../22.04/5.md e88d3ef5140a47e28bd8ff08bfe10b83
+#: ef0b7c5ad73343dbb0465c6d3132d7bd f9a96b331f0d46929a8992c6c9b0a5b5
+msgid "linux-starfive-6.5"
+msgstr ""
+
+#: ../../22.04/5.md b642792abdea4b6382ba0aeec147c3ea
+msgid "[2068335](https://bugs.launchpad.net/bugs/2068335)"
+msgstr ""
+
+#: ../../22.04/5.md d61a9dce8c98487491da586392d74cc5
+msgid "mantic/linux-starfive: 6.5.0-1017.18 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 4bff94e0a2f74d179d256a106f99e147
+#: 82969c23be144dcd85f0a8db897f0f8c
+msgid "[2068321](https://bugs.launchpad.net/bugs/2068321)"
+msgstr ""
+
+#: ../../22.04/5.md 5e68c0669988426c8e216d06d7c7b105
+#: ff26a33f983d4614b9c7ac6cd97ad749
+msgid "mantic/linux-aws: 6.5.0-1023.23 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 6133fdb06c3c4b27bc4e57eae9611a08
+msgid "[2068346](https://bugs.launchpad.net/bugs/2068346)"
+msgstr ""
+
+#: ../../22.04/5.md 7cb4b4a8282d4d8fa076b525c8afea5f
+msgid "jammy/linux-azure-fde: 5.15.0-1068.77.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 0362758bc3ef4cb0ae926cb3dcfc1a96
+#: b3d85dd26889491dbdd07cc3b264ec9b f61e55dcf4734da19b21498aa754988f
+msgid "linux-lowlatency-hwe-6.5"
+msgstr ""
+
+#: ../../22.04/5.md dbbfb4a4ee354646adf97865f6ae84e5
+msgid "[2068328](https://bugs.launchpad.net/bugs/2068328)"
+msgstr ""
+
+#: ../../22.04/5.md 9cd3821a92bc413bafe3dfab8ef3ff78
+msgid "mantic/linux-lowlatency: 6.5.0-44.44.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 63310bb026824ad5bf6f1e8ce9dd9bab
+msgid "[2068330](https://bugs.launchpad.net/bugs/2068330)"
+msgstr ""
+
+#: ../../22.04/5.md 0f028555df774ce8a9c634e57351a209
+msgid "mantic/linux-oracle: 6.5.0-1026.26 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 46a9158ee6a1436e951f6aa15d8ae9f2
+#: 62683bbf6c04403ba453b9a5eea42aa1 72582715e76a42d98e4669d76f528434
+#: 7323460bcedf41c1856779f7c4de49d4
+msgid "linux-riscv-6.8"
+msgstr ""
+
+#: ../../22.04/5.md a7e81d1901bc4ca2a7e5b4ee201aec19
+msgid "[2068315](https://bugs.launchpad.net/bugs/2068315)"
+msgstr ""
+
+#: ../../22.04/5.md ab607fd6057b438384c52207b1dec600
+msgid "jammy/linux-riscv-6.8: 6.8.0-38.38.1~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 97cfef5207b3402db9c95d516a4ab43a
+msgid "[2068295](https://bugs.launchpad.net/bugs/2068295)"
+msgstr ""
+
+#: ../../22.04/5.md 88a1c09657f04a43a475f1cd30b84da1
+msgid "jammy/linux-aws-6.8: 6.8.0-1011.12~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 580dd95329b845e1827dd43a9f6b850e
+msgid "[2070059](https://bugs.launchpad.net/bugs/2070059)"
+msgstr ""
+
+#: ../../22.04/5.md 61768c08c45043209e8d72101b862998
+msgid "noble/linux-aws: 6.8.0-1011.12 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 64b0da36c79d4afeb30a932519029c74
+msgid "[2068296](https://bugs.launchpad.net/bugs/2068296)"
+msgstr ""
+
+#: ../../22.04/5.md cff382e669024906b87ba6e5dc595a12
+msgid "noble/linux-aws: 6.8.0-1011.11 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 4728e378dd3a433594a9c45973a2c88c
+#: 791d9797673d429c821bef3c1dd387bb f283876c5ec049dfa79386fe2772dc63
+msgid "linux-gcp-6.8"
+msgstr ""
+
+#: ../../22.04/5.md 24e9687792464d29a8c7b02b3baf4a69
+msgid "[2069423](https://bugs.launchpad.net/bugs/2069423)"
+msgstr ""
+
+#: ../../22.04/5.md 40b579437ae448e69439ada77103ac0b
+msgid "jammy/linux-gcp-6.8: 6.8.0-1010.11~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 99ca6c75aa7f41e88dd2186432490e5b
+msgid "linux-oracle-6.8"
+msgstr ""
+
+#: ../../22.04/5.md 2c7fa1cd152546c0ac1be670fa6a73e2
+msgid "[2068308](https://bugs.launchpad.net/bugs/2068308)"
+msgstr ""
+
+#: ../../22.04/5.md fefa6fa71ce44272a49aa312607b1808
+msgid "jammy/linux-oracle-6.8: 6.8.0-1008.8~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 8eaf0516319b4c4fbd5497e815fd9658
+msgid "[2071988](https://bugs.launchpad.net/bugs/2071988)"
+msgstr ""
+
+#: ../../22.04/5.md 5f7e1dcc5ddb482486e45d09841d1eda
+msgid "mantic/linux-azure: 6.5.0-1025.26 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 0e2dff94aed946aa91de73337dbe5b4c
+#: 77855054db724d54a27cab82e536de90 b3b8f668987e4499bf7fb5f997818e51
+#: cef5ca6bf65240d3a6e6f27e465f9c23 d0696a0536884a38b6010fded2d9d00a
+#: daa06d7c5f364ace8f6afd41052327e9 e1becc0caa7d4606bd21232d15e6b0d3
+#: f74ee230435f41c2ab2a8bbe693b91fb ff25c522860e4f5bb7b6cb7851a1d0da
+msgid "[2072006](https://bugs.launchpad.net/bugs/2072006)"
+msgstr ""
+
+#: ../../22.04/5.md 08e4b0927ad7439aa854e2e15ce3141b
+#: 1ef74a4695ef439d818c85f7d50f82ad 368b279953234f099d74a22abe7047d7
+#: 407a7bb6369f4215b533eb83a5fb596b 41998b69e3734c1c8736242eea49f51d
+#: 7fe7cf9e8b7c4b42901acc62ca19fef0 ad105a5213814319917dc3a9e72b4864
+#: b62f578a25bf4acba699167967774388 c83fc9bf95394436a25bc5ac49974db8
+msgid "mantic/linux: 6.5.0-45.45 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 024e4c364d384938a8f8cc173eebb8e8
+#: 4e79595d87cc486a9640015efe454761
+msgid "linux-gcp-6.5"
+msgstr ""
+
+#: ../../22.04/5.md d9ecb7e34efc42018108e42a3cf568bc
+msgid "[2071990](https://bugs.launchpad.net/bugs/2071990)"
+msgstr ""
+
+#: ../../22.04/5.md 52039e8b96c440bd856918cfaae98ebe
+msgid "mantic/linux-gcp: 6.5.0-1025.27 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 965fd61c42dc4971addc043cc7575ee7
+msgid "linux-hwe-6.5"
+msgstr ""
+
+#: ../../22.04/5.md 18a4513c45d54f5cbee498bcf12757bc
+msgid "[2071978](https://bugs.launchpad.net/bugs/2071978)"
+msgstr ""
+
+#: ../../22.04/5.md d047c688837e4693999a5371ba573484
+msgid "jammy/linux-riscv-6.8: 6.8.0-39.39.1~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 2875ade053c64b5eaf2bde6933aca86b
+msgid "[2072000](https://bugs.launchpad.net/bugs/2072000)"
+msgstr ""
+
+#: ../../22.04/5.md a673ae0314d14fb4bb715ee270aa7ed8
+msgid "mantic/linux-starfive: 6.5.0-1018.19 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 8a5edf696605410d8a9a67444c6e86d1
+msgid "[2071986](https://bugs.launchpad.net/bugs/2071986)"
+msgstr ""
+
+#: ../../22.04/5.md dad1377654c343ffbe48e1527e6e6fb1
+msgid "mantic/linux-aws: 6.5.0-1024.24 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md ff8d4d2e7647429eb6ef90bf21cdab57
+msgid "[2071957](https://bugs.launchpad.net/bugs/2071957)"
+msgstr ""
+
+#: ../../22.04/5.md 9cf947ad20be4069af6801ed014a651c
+msgid "jammy/linux-gcp-6.8: 6.8.0-1011.12~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md e6d1cc73ea9e473ba55cbb5814ee2636
+msgid "[2071995](https://bugs.launchpad.net/bugs/2071995)"
+msgstr ""
+
+#: ../../22.04/5.md 1540b78e9d9e46fc8e42064d9771b613
+msgid "mantic/linux-oracle: 6.5.0-1027.27 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 6099cf6fb2b94e1cadf02f2463033e56
+#: 798a841a64e44554b8ee6e425ccba30d 7f49c3d0505542038dc2b702ca359e13
+msgid "linux-riscv-6.5"
+msgstr ""
+
+#: ../../22.04/5.md 53f6b4fefefb4f9781fe54e843c3ee35
+msgid "[2071998](https://bugs.launchpad.net/bugs/2071998)"
+msgstr ""
+
+#: ../../22.04/5.md 17e2248cafc54da6871600c95ebaa289
+msgid "mantic/linux-riscv: 6.5.0-45.45.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 5a7ba0253ec84a5d931e38a4440911c7
+msgid "[2068333](https://bugs.launchpad.net/bugs/2068333)"
+msgstr ""
+
+#: ../../22.04/5.md e8d1aba4fcc94c3e8802a0a072882028
+msgid "mantic/linux-riscv: 6.5.0-44.44.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md c99b036c596d4f6ab168dcce943bb7d1
+msgid "[2071993](https://bugs.launchpad.net/bugs/2071993)"
+msgstr ""
+
+#: ../../22.04/5.md 01827c688a694c4d869fa65d72db4e7b
+msgid "mantic/linux-lowlatency: 6.5.0-45.45.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 484b39e20a444ce38cb792c1ec629e87
+msgid "[2073849](https://bugs.launchpad.net/bugs/2073849)"
+msgstr ""
+
+#: ../../22.04/5.md 095c308a44754aa58428756bcd7d3241
+msgid "jammy/linux-oem-6.5: 6.5.0-1027.28 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 0ac27c6b723d473f93b5ab6c205a66a5
+#: 0ec20829f94949d588d3f4f2d33ca446 137c71450ec74973a85513166468a359
+#: 14932d29ab5b45cf8122b01ac1c3a931 46acacc7ea90440c92cc63fe8707fdbe
+#: 47389927d5514206b83215c1e634cac8 58621269e487484daa51d69321a6c521
+#: 765d539792e248f3a9d27b632388bd25 79ade3b7dc224c5f81cfb1ac4a73621d
+#: ab8e22b6c56c45daa1fb79dabf3109a7 ce98e8eadba0425a9e4d2866701fb02f
+#: d5c06557e79a42019f8510217a529e70 e73fb902101945f8935c055232803080
+#: ff5cb1d2d2b24bb09cbcce71820b088c
+msgid "[2061091](https://bugs.launchpad.net/bugs/2061091)"
+msgstr ""
+
+#: ../../22.04/5.md 16858bd390d94886849caf575d0e8b14
+#: 18c840b3dda943ee93652b7d9dfd03d5 1fa55686ce914407af5b9770ea4a188b
+#: 3ce375ef75d54250b8525f82233faf19 4774e2171c8e422485cb5e7a487050dc
+#: 516fe8b03b384f8f972a573c9d3b5b76 57b622c0a1c74ee88d99f13ad17b27ee
+#: 57bb0b5faebd49aa9d8e6148430c885f 6605d9efb67746439360000149b50b64
+#: 825e47ec21b74af0871bb5b91f5fb507 95e023cfdaea42069b151215250d0ce0
+#: a1f0a9a1fdf246bbb6b64a84efa2ca8d f02267571ce949b388f8c463d7e218bb
+#: ff5b566b4cf6450daf7619447d947798
+msgid ""
+"Freezing user space processes failed after 20.008 seconds (1 tasks "
+"refusing to freeze, wq_busy=0)"
+msgstr ""
+
+#: ../../22.04/5.md 59aca0b1482443bcbdc895a21320891c
+msgid "[2072176](https://bugs.launchpad.net/bugs/2072176)"
+msgstr ""
+
+#: ../../22.04/5.md 789f57f41d594bb68359edc809668ebb
+msgid "jammy/linux-gcp-6.8: 6.8.0-1012.13~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 37561bca76574f87b726c723f35bb659
+msgid "[2072205](https://bugs.launchpad.net/bugs/2072205)"
+msgstr ""
+
+#: ../../22.04/5.md 3d689c3247a54ccf83766ac233c91b9f
+msgid "jammy/linux-azure-fde: 5.15.0-1070.79.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 61c03783085440aaa5e54a47f36ae70a
+msgid "[2072515](https://bugs.launchpad.net/bugs/2072515)"
+msgstr ""
+
+#: ../../22.04/5.md 2dd8ebe46aa7459395505b77da9dbbd2
+msgid "jammy/linux-nvidia-tegra-igx: 5.15.0-1013.13 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 230c158930894b33bab32234ebac724a
+#: 4d7b30a0a4e84a4d9d12a68af52301dc af7d7bb0f5974aacba29bc79fab74894
+#: b77fd2144d7647f4a4dc94d0330b0042
+msgid "[2072413](https://bugs.launchpad.net/bugs/2072413)"
+msgstr ""
+
+#: ../../22.04/5.md 527f0c6de79a437f8870a2e9673facd1
+#: 69f48623644e4d5d9ca00819c3d04bff aa1add8a566042aa9c8ad87856283a95
+#: f98e5b37e0f14dca942f97d46828def0
+msgid "Add OOTM branching to fix GPU driver version mismatch"
+msgstr ""
+
+#: ../../22.04/5.md c87c055c89084bfb94d597c75ba45d5a
+msgid "linux-signed-nvidia-tegra-igx"
+msgstr ""
+
+#: ../../22.04/5.md 3400b9b651684feaae932ac6258c419f
+msgid "[2072196](https://bugs.launchpad.net/bugs/2072196)"
+msgstr ""
+
+#: ../../22.04/5.md 06dfcdd5ce3b4eb298ee2c2799114ad7
+msgid "jammy/linux-riscv-6.8: 6.8.0-40.40.1~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 9dc72d8bea264a1db1938d5f173bb53b
+msgid "Enable StarFive VisionFive 2 board"
+msgstr ""
+
+#: ../../22.04/5.md 6bf5e13df54145d0ad075db177f2e878
+#: 79dda45b73894229856a0a9bf343c20f
+msgid "[2071853](https://bugs.launchpad.net/bugs/2071853)"
+msgstr ""
+
+#: ../../22.04/5.md 3bcb0089835e4e28b19acc3640f7e3de
+#: a3bd251c416b46c3913a752b5a354ca2
+msgid "Disable DEBUG_PREEMPT in jammy and noble realtime kernels"
+msgstr ""
+
+#: ../../22.04/5.md 939349f790c14145845c314ed468895e
+msgid "[2072232](https://bugs.launchpad.net/bugs/2072232)"
+msgstr ""
+
+#: ../../22.04/5.md 819aaacb7fa9405b886425ae5b80116e
+msgid "jammy/linux-realtime: 5.15.0-1068.76 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md fbfea68f881e411cb9cd75ca22143b68
+msgid "[2072037](https://bugs.launchpad.net/bugs/2072037)"
+msgstr ""
+
+#: ../../22.04/5.md c7a4cd9297dc41cf89a93f73b90d0f8a
+msgid "jammy/linux-realtime: 5.15.0-1067.75 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md ad216a4b913d464b908cddc64b4717ed
+#: beb8ae61d5d24dd3a6ae06a553bf03bd e69e086f399041db87839ccef0f20f98
+msgid "[2072183](https://bugs.launchpad.net/bugs/2072183)"
+msgstr ""
+
+#: ../../22.04/5.md 0165ac188f6248a0b6e815776529bbb9
+#: 36c306b345a24dfc92ee1a29e3e92ce1 496cc036ccab455eb868b39fd1c25125
+msgid "jammy/linux-lowlatency-hwe-6.8: 6.8.0-40.40.1~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md 58fe27ca73494ae9a72869509591d05f
+msgid "[2071964](https://bugs.launchpad.net/bugs/2071964)"
+msgstr ""
+
+#: ../../22.04/5.md 0b556d5211314ba29d74edf98d8bde90
+msgid "jammy/linux-lowlatency-hwe-6.8: 6.8.0-39.39.1~22.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md b99816df321643f2b327f135e27d9254
+msgid "[2075616](https://bugs.launchpad.net/bugs/2075616)"
+msgstr ""
+
+#: ../../22.04/5.md 257e927a364e441e80c6d79f2ba34bc8
+msgid "jammy/linux-azure-fde: 5.15.0-1071.80.1 -proposed tracker"
+msgstr ""
+
+#: ../../22.04/5.md b92afddb0fa34001876190755eed7ccd
+msgid "[2075327](https://bugs.launchpad.net/bugs/2075327)"
+msgstr ""
+
+#: ../../22.04/5.md 941bfcfca3464572b8bf78e1a858d951
+msgid "[2071933](https://bugs.launchpad.net/bugs/2071933)"
+msgstr ""
+
+#: ../../22.04/5.md 6a22904b74e14566a21ee3a669f5707c
+msgid "[2063827](https://bugs.launchpad.net/bugs/2063827)"
+msgstr ""
+
+#: ../../22.04/5.md 890ec17e09d24282a96f78213d38e6ba
+#: ae24b678dbd84812a2090ecb1bd6ef4a
+msgid ""
+"Add runtime dependency on libnvidia-egl-wayland1. While it is technically"
+" an optional plugin, it is needed to properly support wayland sessions."
+msgstr ""
+
+#: ../../22.04/5.md b757f2ca94ac43e4b07340c3f0798aec
+msgid "[2062082](https://bugs.launchpad.net/bugs/2062082)"
+msgstr ""
+
+#: ../../22.04/5.md 275de68cb4f54f0f944eff94dcd9aafa
+#: 2b582e3d22e149ac9c061281b77f6e98 8a6166e6aac441749358caf8e4e304c0
+#: d66506e4aefa4896bc3bebc1e6157c45
+msgid "ubuntu-drivers-common"
+msgstr ""
+
+#: ../../22.04/5.md 257d9d41d9d54556bfbfe298dc2010c3
+#: 7fab544c7dfe445e8bf33ee3f8b683c3
+msgid "[2060268](https://bugs.launchpad.net/bugs/2060268)"
+msgstr ""
+
+#: ../../22.04/5.md 7f1422e787104855a24cb29683497183
+msgid "Remove SimpleDRM device when nvidia-drm loads"
+msgstr ""
+
+#: ../../22.04/5.md 858c02f76f35414e856572c3adcb4273
+msgid "Wait for nvidia-drm to settle before opening /dev/dri/card*"
+msgstr ""
+
+#: ../../22.04/5.md dc119f33aade4567be13d168662c36ba
+msgid "[2077654](https://bugs.launchpad.net/bugs/2077654)"
+msgstr ""
+
+#: ../../22.04/5.md 3b1937f35e88497e8d1f1d70b7886ab6
+msgid "Split a test to fix a race condition"
+msgstr ""
+
+#: ../../22.04/5.md a47dffa62c624957ab062ee6534d7fb1
+msgid "[2077646](https://bugs.launchpad.net/bugs/2077646)"
+msgstr ""
+
+#: ../../22.04/5.md a638ed963b5341919116b32cd76fd554
+msgid "revert RLIMIT_NOFILE set and test"
+msgstr ""
+
+#: ../../22.04/5.md:468 033a4f669a3b4982b4dd735acb30ed6c
+msgid "Unsorted changes"
+msgstr ""
+
+#: ../../22.04/5.md 8a3f8a4ea49f4c24802422ce31021f0d
+#: ddef2b21313c4273af7035e609b03979
+msgid "tracker-miners"
+msgstr ""
+
+#: ../../22.04/5.md 46ff4bd970c742b9b40d608d8cc459b5
+msgid "[1779890](https://bugs.launchpad.net/bugs/1779890)"
+msgstr ""
+
+#: ../../22.04/5.md b3d417b8408646e88121a8547aebd83a
+msgid ""
+"Removes install section from tracker-extract.service to prevent it from "
+"being enabled by systemd. It is a helper service that should be managed "
+"by tracker-miner-fs.service, not systemd."
+msgstr ""
+
+#: ../../22.04/5.md 0e03b520c08d4c90a2c55a29cc0e0e38
+#: 6bff2a66ed8e441c8b5a11448c456c3a
+msgid "debootstrap"
+msgstr ""
+
+#: ../../22.04/5.md 8c6b27a42d554b138d668d8cf4c7a7ae
+msgid "[2054925](https://bugs.launchpad.net/bugs/2054925)"
+msgstr ""
+
+#: ../../22.04/5.md e4605258179a4439be6810bea683111d
+msgid ""
+"Disable usrmerge code on noble+ as they ship symlinks in base-files, and "
+"the code is incompatible (and no longer needed)"
+msgstr ""
+
+#: ../../22.04/5.md 6b97af089cbb47ff8421c2244a0d5952
+msgid "[1990856](https://bugs.launchpad.net/bugs/1990856)"
+msgstr ""
+
+#: ../../22.04/5.md 17f80fa188cf4d53969dd38330cda0a9
+msgid ""
+"Support Packages files which are not ordered alphabetically by Package "
+"field, by backporting upstream commit "
+"86ca8bcc736ceba53ad4a7d9b10b4c2ab65d739d"
+msgstr ""
+
+#: ../../22.04/5.md 4f6cc61affe8459da08df8c62f1aa3e0
+msgid "[2052925](https://bugs.launchpad.net/bugs/2052925)"
+msgstr ""
+
+#: ../../22.04/5.md 89c1384b2a2744d2bb44764d9bff7e7f
+msgid ""
+"The \"lpoptions\" utility, when run as root was writing into the file "
+"/root/.cups/lpoptions instead of /etc/cups/lpoptions. System software "
+"should never write into /root/ (LP: #2052925)."
+msgstr ""
+
+#: ../../22.04/5.md 9d88111df122474980c6b9cb37345aa6
+msgid "autopkgtest"
+msgstr ""
+
+#: ../../22.04/5.md 3393189a80fb4dd298b63027d6856af0
+msgid "[2051939](https://bugs.launchpad.net/bugs/2051939)"
+msgstr ""
+
+#: ../../22.04/5.md b09204c308804e23be37194600fbe62f
+msgid "SRU to jammy"
+msgstr ""
+
+#: ../../22.04/5.md 585da583b5e148f3b6e77d9c8b0f9092
+msgid "dotnet6"
+msgstr ""
+
+#: ../../22.04/5.md 0f30635a695647b69e1d048f51822655
+#: 394f63c3f2ee4cb997890a34e4ed9010
+msgid "[2057982](https://bugs.launchpad.net/bugs/2057982)"
+msgstr ""
+
+#: ../../22.04/5.md b175bcf1952845f6b76ffc4e8588c219
+msgid "Add ca-certificates to dotnet-sdk-6.0 depends (LP: #2057982)."
+msgstr ""
+
+#: ../../22.04/5.md af827808f430471984b55bed77abc76d
+msgid "dotnet8"
+msgstr ""
+
+#: ../../22.04/5.md 63f2ffed4b1b4b5b81f3232b376efcb6
+msgid "Add ca-certificates to dotnet-sdk-8.0 depends (LP: #2057982)."
+msgstr ""
+
+#: ../../22.04/5.md 78b509f90a8f40bd9959c4ba706e11b8
+#: 78bc559ef7774a2da4d1fee0dac776c2
+msgid "ruby3.0"
+msgstr ""
+
+#: ../../22.04/5.md 1606f020bd34460baefe6f775eda501a
+msgid "[2049197](https://bugs.launchpad.net/bugs/2049197)"
+msgstr ""
+
+#: ../../22.04/5.md 1facee32955c4fe4a865e57ec79d67ec
+msgid "d/p/fix-ruby_xfree-segfault.patch: fix occasional segfault (LP: #2049197)."
+msgstr ""
+
+#: ../../22.04/5.md 9010e215300b45039096debb7e19c823
+msgid "[1990630](https://bugs.launchpad.net/bugs/1990630)"
+msgstr ""
+
+#: ../../22.04/5.md b22954b530c34bb985b30f6522b8e684
+msgid "Allow epoll_create1 call in seccomp allowlist"
+msgstr ""
+
+#: ../../22.04/5.md 80b0b52f7ff042ea973f9708e2d94d8f
+msgid "[2051380](https://bugs.launchpad.net/bugs/2051380)"
+msgstr ""
+
+#: ../../22.04/5.md 22cf78aa34fd466ea92c5a62876dd317
+msgid "Replace expired certificate in tests with upstream patch (LP: #2051380)."
+msgstr ""
+
+#: ../../22.04/5.md a152ca0ebcae4c3881da7551dad2c1d9
+msgid "s390-tools"
+msgstr ""
+
+#: ../../22.04/5.md 7e495e38b6e74abc8e771ac7e55bae73
+#: 9bfa0a9aa1994807a9226f451e449e21
+msgid "[2059303](https://bugs.launchpad.net/bugs/2059303)"
+msgstr ""
+
+#: ../../22.04/5.md 1f85495eaada412cb2f6f74a008fcc06
+msgid ""
+"d/p/lp-2059303-pvattest-Fix-root-ca-parsing.patch to fix Secure Execution"
+" tooling and accept new IBM host-key subject locality. LP: #2059303"
+msgstr ""
+
+#: ../../22.04/5.md cddad2a470434ebeb2f5f211d616fafd
+msgid "s390-tools-signed"
+msgstr ""
+
+#: ../../22.04/5.md a10fed8e861242a7a35aec5346fa1933
+msgid "Rebuild against 2.20.0-0ubuntu3.3"
+msgstr ""
+
+#: ../../22.04/5.md f5afaacc620245ca83bfdd66daf6c904
+msgid "lintian"
+msgstr ""
+
+#: ../../22.04/5.md cad035f82323497ca350700077918aa3
+msgid "[2064686](https://bugs.launchpad.net/bugs/2064686)"
+msgstr ""
+
+#: ../../22.04/5.md 9fd02b56510040a6ba9393432498bce4
+msgid "Add \"oracular\" as a known Ubuntu distribution (LP: #2064686)."
+msgstr ""
+
+#: ../../22.04/5.md c448b173a28d49f2bd21c2af42196ac3
+msgid "vim"
+msgstr ""
+
+#: ../../22.04/5.md 8b297f03cc934410a98c7d3b3326c0c1
+msgid "[2064687](https://bugs.launchpad.net/bugs/2064687)"
+msgstr ""
+
+#: ../../22.04/5.md d63fb43be2ab49b0b359860c8b3ce7de
+msgid "Ensure Ubuntu codenames are current (LP: #2064687)."
+msgstr ""
+
+#: ../../22.04/5.md 8da2f2e577a5460a8f80df0f2e29d7dd
+msgid "nvme-cli"
+msgstr ""
+
+#: ../../22.04/5.md b476ff169e7749b5ab9a68e5065602a0
+msgid "[2051299](https://bugs.launchpad.net/bugs/2051299)"
+msgstr ""
+
+#: ../../22.04/5.md 534092fd0a95499f9cb80a777e860eca
+msgid ""
+"Fix 'id-ctrl' command to correctly output the value of fguid, as a proper"
+" UUID instead of binary data. This corrects an issue in MAAS where it "
+"cannot parse the results of 'id-ctrl' due to the binary data not being "
+"utf-8 formatted."
+msgstr ""
+
+#: ../../22.04/5.md cc8f636cd1fe46129a7c7693fcf7e14a
+#: def337d43a8f44ed9570d0e00813c28e
+msgid "swtpm"
+msgstr ""
+
+#: ../../22.04/5.md ff18d5f5b34947278f4cf14c7430b7b2
+msgid "[2071478](https://bugs.launchpad.net/bugs/2071478)"
+msgstr ""
+
+#: ../../22.04/5.md cba19a1676a847d888d34633e33dec6b
+msgid ""
+"Add sys_admin capability to apparmor profile to allow access to kernel "
+"modules such as tpm_vtpm_proxy"
+msgstr ""
+
+#: ../../22.04/5.md 96e853fadf514d6082a21e9df74cc9a5
+msgid "[2072524](https://bugs.launchpad.net/bugs/2072524)"
+msgstr ""
+
+#: ../../22.04/5.md 397e48c946a94f93a8bc5a615603cf7f
+msgid ""
+"Allow non-owned lockfile write access in /var/lib/libvirt/swtpm/ to fix "
+"apparmor denials when working with TPM2 locks"
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/22.04/index.po
+++ b/docs/locale/ja/LC_MESSAGES/22.04/index.po
@@ -1,0 +1,2670 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../22.04/index.md:12
+msgid "22.04.5"
+msgstr ""
+
+#: ../../22.04/index.md:12
+msgid "22.04.4"
+msgstr ""
+
+#: ../../22.04/index.md:12
+msgid "22.04.3"
+msgstr ""
+
+#: ../../22.04/index.md:12
+msgid "22.04.2"
+msgstr ""
+
+#: ../../22.04/index.md:12
+msgid "22.04.1"
+msgstr ""
+
+#: ../../22.04/index.md:24
+msgid "Release schedule"
+msgstr ""
+
+#: ../../22.04/index.md:6 57c4baaf35e448d28af90285f8dc476a
+msgid "Ubuntu 22.04 LTS release notes"
+msgstr ""
+
+#: ../../22.04/index.md:8 49f17d079e174041ba56f9460504d07f
+msgid ""
+"These release notes for **Ubuntu 22.04 LTS** (Jammy Jellyfish) provide an"
+" overview of the release and document the known issues with Ubuntu and "
+"its flavors."
+msgstr ""
+
+#: ../../22.04/index.md:10 facc242318a54bf19fa05811a81ef50a
+msgid ""
+"For details of the changes applied since 20.04, refer to the following "
+"posts:"
+msgstr ""
+
+#: ../../22.04/index.md:22 9ce772e73b1646eba6ca7803ceeda2dc
+msgid ""
+"For the release schedule of Ubuntu 22.04 LTS and its point releases, "
+"refer to:"
+msgstr ""
+
+#: ../../22.04/index.md:31 50d10d6e67b04604bfc29d75e739f785
+msgid "Support lifespan"
+msgstr ""
+
+#: ../../22.04/index.md:33 cde51ed17d9148b88a0b0728d8e94fe6
+msgid ""
+"Maintenance updates will be provided for 5 years until [April "
+"2027](https://wiki.ubuntu.com/Releases) for Ubuntu Desktop, Ubuntu "
+"Server, Ubuntu Cloud, and Ubuntu Core. All the remaining flavors will be "
+"supported for 3 years. Additional security support is available with [ESM"
+" (Extended Security Maintenance).](https://ubuntu.com/security/esm)"
+msgstr ""
+
+#: ../../22.04/index.md:36 ffe90076de70499396370ede64c34498
+msgid "Get Ubuntu 22.04 LTS"
+msgstr ""
+
+#: ../../22.04/index.md:38 78a81ebfe95a4443a5d1ff28c0c393e3
+msgid "Images can be downloaded from a location near you."
+msgstr ""
+
+#: ../../22.04/index.md:40 6c370847a67d4227af6f129cca2d3e26
+msgid "You can download ISOs and flashable images from:"
+msgstr ""
+
+#: ../../22.04/index.md:42 af03096ee7cf47bbaf9fd28114fd7ed4
+msgid ""
+"[Ubuntu Desktop and Server for 64-bit x86 (AMD64) "
+"](http://releases.ubuntu.com/22.04/)"
+msgstr ""
+
+#: ../../22.04/index.md:43 685b6906309a4139bc9e9c0f985a4bd4
+msgid ""
+"[Less Frequently Downloaded Ubuntu "
+"Images](http://cdimage.ubuntu.com/ubuntu/releases/22.04/release/)"
+msgstr ""
+
+#: ../../22.04/index.md:44 d722ab23fac8496a83a36350b9ecda54
+msgid ""
+"[Ubuntu Cloud Images](http://cloud-"
+"images.ubuntu.com/daily/server/jammy/current/)"
+msgstr ""
+
+#: ../../22.04/index.md:45 9f282334d1284d9da69e60b366436650
+msgid "[Lubuntu](http://cdimage.ubuntu.com/lubuntu/releases/22.04/release/)"
+msgstr ""
+
+#: ../../22.04/index.md:46 f3c99e18c22e40a999c95021f489af13
+msgid "[Kubuntu](http://cdimage.ubuntu.com/kubuntu/releases/22.04/release/)"
+msgstr ""
+
+#: ../../22.04/index.md:47 fc03f20db7ba4e19b6920f4d662e0ca5
+msgid ""
+"[Ubuntu Budgie](http://cdimage.ubuntu.com/ubuntu-"
+"budgie/releases/22.04/release/)"
+msgstr ""
+
+#: ../../22.04/index.md:48 885ff1c53bdd43b5ba2b06a1ddaffdbc
+msgid ""
+"[Ubuntu "
+"Kylin](http://cdimage.ubuntu.com/ubuntukylin/releases/22.04/release/)"
+msgstr ""
+
+#: ../../22.04/index.md:49 d59e54745d5b4901a9bd6d9039ed78de
+msgid ""
+"[Ubuntu MATE](http://cdimage.ubuntu.com/ubuntu-"
+"mate/releases/22.04/release/)"
+msgstr ""
+
+#: ../../22.04/index.md:50 c1741506f62d4ffdb2dd957789d5a0b5
+msgid ""
+"[Ubuntu "
+"Studio](http://cdimage.ubuntu.com/ubuntustudio/releases/22.04/release/)"
+msgstr ""
+
+#: ../../22.04/index.md:51 241e385ae99144329508303985b90250
+msgid "[Xubuntu](http://cdimage.ubuntu.com/xubuntu/releases/22.04/release/)"
+msgstr ""
+
+#: ../../22.04/index.md:54 3f249689e5694c1488ed4b4a2fd92d43
+msgid "Upgrading from Ubuntu 21.10"
+msgstr ""
+
+#: ../../22.04/index.md:56 0a264db8e0d44e38a96460f5646194f2
+msgid "To upgrade on a desktop system:"
+msgstr ""
+
+#: ../../22.04/index.md:58 37b9cbbac00b482293102f508775cd96
+msgid "Open the \"Software & Updates\" Setting in System Settings."
+msgstr ""
+
+#: ../../22.04/index.md:59 12e1e07765b94703aaf65e2a37247825
+msgid "Select the 3rd Tab called \"Updates\"."
+msgstr ""
+
+#: ../../22.04/index.md:60 bf74674574fa4916988c386d46ac2bee
+msgid ""
+"Set the \"Notify me of a new Ubuntu version\" dropdown menu to \"For any "
+"new version\"."
+msgstr ""
+
+#: ../../22.04/index.md:61 aba07b8a71184255af06c392e373777d
+#, python-brace-format
+msgid "Press {kbd}`Alt+F2` and type in `update-manager -c` into the command box."
+msgstr ""
+
+#: ../../22.04/index.md:62 852f8d2f02aa47b3b5b5a29abb862b1a
+msgid ""
+"Update Manager should open up and tell you: **\"New distribution release "
+"'22.04' is available.\"**"
+msgstr ""
+
+#: ../../22.04/index.md:63 8378787f0dca49fea632754543a995c0
+msgid ""
+"If not you can also use `/usr/lib/ubuntu-release-upgrader/check-new-"
+"release-gtk`"
+msgstr ""
+
+#: ../../22.04/index.md:64 0d4edc1ffff54f9c92ee20765626e75c
+msgid "Click Upgrade and follow the on-screen instructions."
+msgstr ""
+
+#: ../../22.04/index.md:66 77d3e287dfc54ed99e2a3e84b7884843
+msgid "To upgrade on a server system:"
+msgstr ""
+
+#: ../../22.04/index.md:68 4400c4134f444c07aab45793f5230699
+msgid ""
+"Make sure the Prompt line in `/etc/update-manager/release-upgrades` is "
+"set to normal."
+msgstr ""
+
+#: ../../22.04/index.md:69 dbac6b54e8f348acb310bbb571e59882
+msgid "Launch the upgrade tool with the command `sudo do-release-upgrade`."
+msgstr ""
+
+#: ../../22.04/index.md:70 8174077a510a4b6583848693d7d168e0
+msgid "Follow the on-screen instructions."
+msgstr ""
+
+#: ../../22.04/index.md:72 2bd1d20788ef4c79bbcb65b677d6cfb1
+msgid ""
+"Note that the server upgrade will use GNU screen and automatically re-"
+"attach in case of dropped connection problems."
+msgstr ""
+
+#: ../../22.04/index.md:74 edea4c4e36f441f2bd1fe528cd4e8625
+msgid ""
+"There are no offline upgrade options for Ubuntu Desktop and Ubuntu "
+"Server. Please ensure you have network connectivity to one of the "
+"official mirrors or to a locally accessible mirror and follow the "
+"instructions above."
+msgstr ""
+
+#: ../../22.04/index.md:77 32057efcfd6f4cc1acdcc84720a63c33
+msgid "Changes since 20.04 LTS"
+msgstr ""
+
+#: ../../22.04/index.md:79 aa686e8da3b2412d880329a3f7d53de1
+msgid ""
+"If you’re upgrading from Ubuntu 20.04 LTS to 22.04 LTS, you get all the "
+"changes that happened in the six months since Ubuntu 21.10, as well as "
+"the changes in all the interim releases between 20.04 LTS and 22.04 LTS."
+msgstr ""
+
+#: ../../22.04/index.md:81 7b682cb8bf9d4e5eb961acda727d3f4f
+msgid ""
+"For details, see the complete interim release notes: "
+"[20.10](https://discourse.ubuntu.com/t/groovy-gorilla-release-"
+"notes/15533), [21.04](https://discourse.ubuntu.com/t/hirsute-hippo-"
+"release-notes/19221) and [21.10](https://discourse.ubuntu.com/t/impish-"
+"indri-release-notes/21951). Finally, review the following changes since "
+"Ubuntu 21.10."
+msgstr ""
+
+#: ../../22.04/index.md:85 727cb991db294d1bbd396fe6207fc75b
+msgid "New features in 22.04 LTS"
+msgstr ""
+
+#: ../../22.04/index.md:87 cb1c4ea72ad647298cb14e17a3052c9e
+msgid "Updated Packages"
+msgstr ""
+
+#: ../../22.04/index.md:89 9b3e1762f28d469799abf67bf7cd8447
+msgid "Linux kernel 🐧"
+msgstr ""
+
+#: ../../22.04/index.md:91 8e28c0e4d2b04fa588d2d36f2086fa29
+msgid "Ubuntu 22.04 LTS ships multiple optimized kernels on per-product basis:"
+msgstr ""
+
+#: ../../22.04/index.md:93 876af81cec68435a8c5bb9960ffcbf27
+msgid ""
+"Ubuntu Desktop will automatically opt-into "
+"[v5.17](https://kernelnewbies.org/Linux_5.17) kernel on the latest "
+"generations of certified devices (`linux-oem-22.04`)"
+msgstr ""
+
+#: ../../22.04/index.md:94 bf01125f8259408db3a05613d8c3ad6d
+msgid ""
+"Ubuntu Desktop uses a rolling HWE kernel (`linux-hwe-22.04`) on all other"
+" generations of hardware. The rolling HWE kernel is based on the "
+"[v5.15](https://kernelnewbies.org/Linux_5.15) kernel for 22.04.0 and "
+"22.04.1 point releases"
+msgstr ""
+
+#: ../../22.04/index.md:95 30ea7e4cef10412ea06c4839cece1bcd
+msgid "Ubuntu Server defaults to a non-rolling LTS kernel v5.15 (`linux-generic`)"
+msgstr ""
+
+#: ../../22.04/index.md:96 11ab9a568c324ff090d7dc76cfe78881
+msgid ""
+"Ubuntu Cloud and Devices use optimized kernels in collaboration with "
+"partners (v5.15+ with additional backports and features)"
+msgstr ""
+
+#: ../../22.04/index.md:98 c9546eea5f7b48839a920e6ee37448f3
+msgid ""
+"Additional optimized and certified kernel flavors will become available "
+"in Ubuntu 22.04 LTS in due course."
+msgstr ""
+
+#: ../../22.04/index.md:100 b288391633c145f9892e3bf3e34d94c6
+msgid "UDP disabled for NFS mounts"
+msgstr ""
+
+#: ../../22.04/index.md:101 afdd56801feb4ceeae46f771e9ff11b4
+msgid ""
+"Since Ubuntu 20.10 (Groovy Gorilla), the kernel option "
+"`CONFIG_NFS_DISABLE_UDP_SUPPORT=y` is set and this disables using UDP as "
+"the transport for NFS mounts, regardless of NFS version."
+msgstr ""
+
+#: ../../22.04/index.md:103 804e7d4df1214aff910b8186170cdc4a
+msgid "In practice, if you try to use `udp`, you will get this error:"
+msgstr ""
+
+#: ../../22.04/index.md:111 7cf50e0937404da9a3b9ef703386b789
+msgid "Toolchain Upgrades 🛠️"
+msgstr ""
+
+#: ../../22.04/index.md:113 2fbe27326ae442929b6b6464cde2ea98
+msgid ""
+"GCC was updated to the 11.2.0 release, `binutils` to 2.38, and `glibc` to"
+" 2.35. Python 🐍 now ships at version 3.10.4, Perl 🐪 at version 5.34.0. "
+"LLVM now defaults to version 14. golang defaults to version 1.18.x. "
+"`rustc` defaults to version 1.58."
+msgstr ""
+
+#: ../../22.04/index.md:115 5fbe32f24e7a4c82b8a4f93f531cbb91
+msgid ""
+"In addition to OpenJDK 11, OpenJDK 18 is now provided (but not used for "
+"package builds)."
+msgstr ""
+
+#: ../../22.04/index.md:117 48bee0fb40f1402fa054fc7306b2af3f
+msgid "Ruby 💎 was updated from v2.7.4 to v3.0."
+msgstr ""
+
+#: ../../22.04/index.md:119 a6a66bc273094c2990d50b3f921f8f40
+msgid "systemd v249.11"
+msgstr ""
+
+#: ../../22.04/index.md:120 3bd6c12a64794bdaaedd318a6a9698a5
+msgid ""
+"The init system was updated to systemd v249, using a solid .11 patchlevel"
+" for the LTS. Please refer to the upstream "
+"[changelog](https://github.com/systemd/systemd/releases/tag/v249) for "
+"more information about the individual features. We've enabled the "
+"userspace OOMD service and are shipping the `systemd-oomd` package by "
+"default on the \"Ubuntu Desktop\" flavor, to avoid overloaded systems and"
+" the need of the kernel's OOM killer to kick in. The OOMD status can be "
+"checked using `oomctl`."
+msgstr ""
+
+#: ../../22.04/index.md:122 d28a743d2c4c4f96935c943b30768fae
+msgid "OpenSSL 3.0"
+msgstr ""
+
+#: ../../22.04/index.md:124 6f5237941571407482aafdb9607ad43f
+msgid ""
+"We've upgraded the OpenSSL library to the new 3.0 version, which disables"
+" a lot of legacy algorithms by default, as detailed in their [migration "
+"guide](https://www.openssl.org/docs/manmaster/man7/migration_guide.html)."
+" In particular, certificates using SHA1 or MD5 as hash algorithms are now"
+" invalid under the default security level."
+msgstr ""
+
+#: ../../22.04/index.md:126 6bd282afca5c4060b4a720ddeba46d0e
+msgid ""
+"In addition to the upstream deprecations, please note that since Ubuntu "
+"20.04 LTS (Focal Fossa), the security level 2 (which is the default) "
+"disables the (D)TLS protocols below 1.2 (included)."
+msgstr ""
+
+#: ../../22.04/index.md:128 5eb654570ea04f1ba979890820f4c676
+msgid ""
+"Since the new version has an API bump, third-party packages that depend "
+"on libssl1.1 will need to be rebuilt to instead depend on libssl3, as the"
+" older ABI isn't provided anymore."
+msgstr ""
+
+#: ../../22.04/index.md:130 20fc79e7cd1946a691b8d67d4da9da51
+msgid "plocate"
+msgstr ""
+
+#: ../../22.04/index.md:132 5617ae86a9754146afc569317c97f52f
+msgid ""
+"plocate is now the default `locate` implementation, replacing mlocate. "
+"The mlocate package is now a transitional package and will install "
+"plocate. plocate is largely argument-compatible with mlocate, but some "
+"incompatibilities do exist. For details, see the [manual for "
+"plocate](https://manpages.ubuntu.com/manpages/jammy/en/man1/plocate.1.html)."
+msgstr ""
+
+#: ../../22.04/index.md:134 36a24d4669cc4474af1931a4e4a9be14
+msgid "Security Improvements 🔒"
+msgstr ""
+
+#: ../../22.04/index.md:136 146b5b32c1554a4db0bd166cf61fbf1c
+msgid ""
+"nftables is now the default backend for the firewall. All applications on"
+" the system must agree on whether they will use the legacy `xtables` "
+"backend or the newer `nftables` backend. [Bug "
+"1968608](https://bugs.launchpad.net/bugs/1968608) provides some context "
+"that may be helpful. [Docker may not be ready for the new `nftables` "
+"backend](https://github.com/docker-snap/docker-snap/issues/68)."
+msgstr ""
+
+#: ../../22.04/index.md:138 ac9ed413911f465bb3acd315b002d3f8
+msgid ""
+"`ssh-rsa` is now [disabled by default in "
+"OpenSSH](https://www.openssh.com/txt/release-8.8). See [bug "
+"1961833](https://bugs.launchpad.net/ubuntu/+source/openssh/+bug/1961833) "
+"to learn how to selectively re-enable it if necessary.  If you are "
+"upgrading a system remotely over SSH, you should check that you are not "
+"relying on this to ensure that you will retain access after the upgrade."
+msgstr ""
+
+#: ../../22.04/index.md:140 d498e03778d64847b9e3bd33e5283450
+msgid ""
+"`scp` offers a [`-s` command line "
+"option](http://manpages.ubuntu.com/manpages/jammy/en/man1/scp.1.html) to "
+"use [sftp mode rather than scp "
+"mode](https://www.openssh.com/txt/release-8.9) when handling remote "
+"filenames. This new, safer, behaviour will eventually become the default."
+msgstr ""
+
+#: ../../22.04/index.md:142 ../../22.04/index.md:671
+#: 08ee401377d94c9fb4f3e6c0376f0957 b2c44022ebdb4e8fbdfb008021e8b78f
+msgid "Ubuntu Desktop"
+msgstr ""
+
+#: ../../22.04/index.md:144 20b7558613b746a995bafda3c1af4fe3
+msgid ""
+"Ubuntu now offers [10 color choices](https://discourse.ubuntu.com/t/yaru-"
+"accent-colors-are-coming-to-jammy/27200) each in dark and light styles"
+msgstr ""
+
+#: ../../22.04/index.md:145 c25ccfa91bc743afbe0b1592c7046c22
+msgid "Firefox is now only provided in Ubuntu as a snap. Some benefits include"
+msgstr ""
+
+#: ../../22.04/index.md:146 746ec7e15d6449fea52195c60483d8f1
+msgid "Directly maintained by Mozilla"
+msgstr ""
+
+#: ../../22.04/index.md:147 d6af5039b5a74c3381076548f379f8f4
+msgid "More maintainable for the entire Ubuntu LTS lifecycle"
+msgstr ""
+
+#: ../../22.04/index.md:148 fb370b9c5ead45a5a408913325ad3821
+msgid "… Which means faster access to the newest Firefox versions"
+msgstr ""
+
+#: ../../22.04/index.md:149 a72c5172128b4d45ab9824eb107d7db0
+msgid ""
+"Easily switch to a different Firefox flavor with snap channels including "
+"`esr/stable`, `latest/candidate`, `latest/beta`, and `latest/edge`"
+msgstr ""
+
+#: ../../22.04/index.md:150 a9b3d0c88b7c4d19b003f918b9513ba9
+msgid "Sandboxed for improved security hardening for this critical app"
+msgstr ""
+
+#: ../../22.04/index.md:151 ae49ec0b840a45e1997093c4ff4bf69f
+msgid ""
+"Improved in 22.04.1: Firefox startup speed is [significantly "
+"faster](https://ubuntu.com/blog/improving-firefox-snap-performance-"
+"part-3) now compared to the original Ubuntu 22.04 LTS release."
+msgstr ""
+
+#: ../../22.04/index.md:152 32646405a8f148e5a7c8485427b8ccce
+msgid ""
+"Desktop icons are shown in the bottom right by default but this can be "
+"changed through new settings added to the Appearance panel of the "
+"Settings app."
+msgstr ""
+
+#: ../../22.04/index.md:153 318e5dc94f6849049c77f8f11c004dc4
+msgid "Also there are new settings to control the Dock look and behavior"
+msgstr ""
+
+#: ../../22.04/index.md:154 cfe24a412bc0442c89cf81d26c99523b
+msgid "Dock devices and filemanager integration has been improved"
+msgstr ""
+
+#: ../../22.04/index.md:156 79fc5c63322548468cc45758d1720263
+msgid "GNOME 👣"
+msgstr ""
+
+#: ../../22.04/index.md:158 45ee260214c041748db0beb0438e6191
+msgid ""
+"GNOME has been updated to include new features and fixes from [GNOME "
+"41](https://release.gnome.org/41/) and [GNOME "
+"42](https://release.gnome.org/42/)"
+msgstr ""
+
+#: ../../22.04/index.md:159 62c3175f530c48b1854ee8d3402c109d
+msgid ""
+"Several apps are still at their 41 version numbers to provide a more "
+"time-tested experience for the LTS desktop by mostly avoiding libadwaita."
+msgstr ""
+
+#: ../../22.04/index.md:160 1edebaa52b914fa29cb1a3086468cfb6
+msgid ""
+"The new cross-desktop [dark "
+"style](https://discourse.ubuntu.com/t/ubuntu-22-04-lts-dark-style-"
+"changes/27206) preference is supported."
+msgstr ""
+
+#: ../../22.04/index.md:161 ac6ef0aecdbb4fa795580dce471a627f
+msgid ""
+"GNOME Shell and mutter have lots of performance improvements including "
+"the triple buffering patch."
+msgstr ""
+
+#: ../../22.04/index.md:162 5ed5a6351f284e9d805d8218c7a7a3bf
+msgid ""
+"The default session for most systems that don't have an Nvidia desktop "
+"graphics card is now Wayland. If you need a non-Wayland session, you can "
+"choose the *Ubuntu on Xorg* session by clicking the gear button after "
+"selecting your name on the login screen."
+msgstr ""
+
+#: ../../22.04/index.md:163 11d18130682243659c0550e32da681d3
+msgid "Hardware with privacy screen support is now supported"
+msgstr ""
+
+#: ../../22.04/index.md:164 ae55e6154be24d0185e27d6984216abe
+msgid ""
+"RDP is now available for sharing your desktop remotely. Legacy VNC is "
+"still available, but it is strongly recommended to use RDP for better "
+"security, privacy, and performance. If you were previously using VNC, "
+"you'll need to manually re-enable desktop sharing in the Settings app and"
+" get your new login information."
+msgstr ""
+
+#: ../../22.04/index.md:166 8a732831c65f4973b081d359e1609924
+msgid "Updated Applications"
+msgstr ""
+
+#: ../../22.04/index.md:168 f59ae3a0c9c14659ae509f35404b2c9d
+msgid "Firefox 103 🔥🦊"
+msgstr ""
+
+#: ../../22.04/index.md:169 2202ed29d0f0413f83bf6a36cc59f673
+msgid "[LibreOffice 7.3](https://wiki.documentfoundation.org/ReleaseNotes/7.3) 📚"
+msgstr ""
+
+#: ../../22.04/index.md:170 8770567f71224d74a27bf1a5e0bbdd9b
+msgid "Thunderbird 91 🌩️🐦"
+msgstr ""
+
+#: ../../22.04/index.md:172 b75e0627e8bb41b3b3482e37c3060ad3
+msgid "Updated Subsystems"
+msgstr ""
+
+#: ../../22.04/index.md:174 998565876f1b483b892b7286a3713d7d
+msgid ""
+"[BlueZ "
+"5.63](https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/ChangeLog?id=5.63)"
+msgstr ""
+
+#: ../../22.04/index.md:175 1658141f332c475e99399605742603da
+msgid "[CUPS 2.4](https://github.com/OpenPrinting/cups/blob/v2.4.1/CHANGES.md)"
+msgstr ""
+
+#: ../../22.04/index.md:176 1370986ce14d451aad85a0f96e35662a
+msgid ""
+"[NetworkManager "
+"1.36](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/nm-1-36/NEWS)"
+msgstr ""
+
+#: ../../22.04/index.md:177 c6d719e83a714404947f472fefb501d5
+msgid "[Mesa 22](https://docs.mesa3d.org/relnotes/22.0.0.html)"
+msgstr ""
+
+#: ../../22.04/index.md:178 3935d16eed6847bda891e47602e1205b
+msgid ""
+"[Poppler "
+"22.02](https://gitlab.freedesktop.org/poppler/poppler/-/blob/poppler-22.02.0/NEWS)"
+msgstr ""
+
+#: ../../22.04/index.md:179 9f99df3a0dfc4d5ebb099a355f79eeae
+msgid ""
+"[PulseAudio "
+"16](https://www.freedesktop.org/wiki/Software/PulseAudio/Notes/16.0/)"
+msgstr ""
+
+#: ../../22.04/index.md:180 55220afa80954ea7aaf6056c3f94de0b
+msgid ""
+"[xdg-desktop-portal 1.14](https://github.com/flatpak/xdg-desktop-"
+"portal/blob/1.14.2/NEWS)"
+msgstr ""
+
+#: ../../22.04/index.md:182 ../../22.04/index.md:684
+#: 3f47b240e76146e38a3f048007fa6096 d01e7c1162874e479eb4f5eb9c20cfba
+msgid "Ubuntu Server"
+msgstr ""
+
+#: ../../22.04/index.md:184 b734ead3dae54a62ac63691b0dc74b3e
+msgid "Ubuntu HA/Clustering"
+msgstr ""
+
+#: ../../22.04/index.md:186 fb825c7934e14a548381c4a6dbe8b88b
+msgid "Corosync"
+msgstr ""
+
+#: ../../22.04/index.md:188 c0d912c059a1490982abef025ef5198e
+msgid "It was updated to version 3.16 which includes some new features:"
+msgstr ""
+
+#: ../../22.04/index.md:190 89e8293b71494e0c8882901812e70eda
+msgid ""
+"Support for changing crypto configuration during runtime. This includes "
+"turning cryptography on or off, changing *crypto_cipher* and "
+"*crypto_hash* and also changing of crypto key."
+msgstr ""
+
+#: ../../22.04/index.md:191 1a44c1a5652c4a7d9723365f03233340
+msgid "Default token timeout was changed from 1 seconds to 3 seconds."
+msgstr ""
+
+#: ../../22.04/index.md:192 73fc7d2980d9421b9fc8a8346de00634
+msgid ""
+"Run *corosync -v* to get the list of supported crypto and compression "
+"models which can be used in corosync.conf"
+msgstr ""
+
+#: ../../22.04/index.md:193 0a4b7cb287644f4a98a37046b8e9deac
+msgid "Cgroup v2 support."
+msgstr ""
+
+#: ../../22.04/index.md:195 de3346ff5d8046af849f4599c5a580dc
+msgid ""
+"For the complete list of changes please refer to the [upstream release "
+"notes](https://github.com/corosync/corosync/releases)."
+msgstr ""
+
+#: ../../22.04/index.md:197 de5219e932fc4e99836edf9e8e4b4078
+msgid "Pacemaker"
+msgstr ""
+
+#: ../../22.04/index.md:199 cda127bdd9914e4295de94d8fea039c3
+msgid "It was updated to version 2.1.2 which includes some new features:"
+msgstr ""
+
+#: ../../22.04/index.md:201 12f7a3701044412391119da454ee22a1
+msgid ""
+"Add a new feature *priority-fencing-delay*. Optionally derive the "
+"priority of a node from the resource-priorities of the resources it is "
+"running."
+msgstr ""
+
+#: ../../22.04/index.md:202 d507d2b99df74a919ab4e5d8559d2431
+msgid ""
+"Add *on-fail=demot*e and *no-quorum-policy=demote* recovery policies for "
+"promoted resources."
+msgstr ""
+
+#: ../../22.04/index.md:203 a21dc7bca7f24ebf999511b16f5b45e8
+msgid "support for OCF Resource Agent API 1.1 standard."
+msgstr ""
+
+#: ../../22.04/index.md:204 66d4db51981f4526a3b3610e9a55fe7f
+msgid "Many improvements in *crm_mon* and *crm_resource*."
+msgstr ""
+
+#: ../../22.04/index.md:206 34d2bc3832254d339c5327f056feb51c
+msgid ""
+"For the complete list of changes please refer to the [upstream release "
+"notes](https://github.com/ClusterLabs/pacemaker/releases)."
+msgstr ""
+
+#: ../../22.04/index.md:208 a9bc91673be24be7b6d15b6193239f8d
+msgid ""
+"A notable difference from the version in Ubuntu Focal 20.04 is that the "
+"default configuration file does not define the node name as node1 "
+"anymore, now the output of uname -n is used as the default node name."
+msgstr ""
+
+#: ../../22.04/index.md:210 984d727fd4704283a90ce08bce34164a
+msgid "Resource agents"
+msgstr ""
+
+#: ../../22.04/index.md:212 82f0d68dbad04ef6b0525245477c5f60
+msgid ""
+"It was updated to version 4.7.0. Check the list of changes since Ubuntu "
+"Focal 20.04 [here](https://github.com/ClusterLabs/resource-"
+"agents/blob/main/ChangeLog#L95-L219)."
+msgstr ""
+
+#: ../../22.04/index.md:214 2e6b30b7367d46f88bb76f8f4153350f
+msgid ""
+"The agents are now separated in two packages: resource-agents-base and "
+"resource-agents-extra. The resource-agents-base package contains the "
+"agents which are curated by the Ubuntu Server team, which means that "
+"automated tests are running in a continuous integration system to "
+"guarantee the quality of those agents. The resource-agents package is now"
+" a metapackage which depends on both resource-agents-base and resource-"
+"agents-extra. Please note that the resource-agents package will be "
+"removed in future releases; we recommend that you do not rely on its "
+"existence."
+msgstr ""
+
+#: ../../22.04/index.md:216 c8009aa1a8fe4befb6a8b24263a0851f
+msgid "Fence agents"
+msgstr ""
+
+#: ../../22.04/index.md:218 0919889152fc4950a6d75b193ae22e53
+msgid "It was updated to version 4.7.1."
+msgstr ""
+
+#: ../../22.04/index.md:220 d5944e68ed8348c18282da6490682be1
+msgid ""
+"The agents are now separated in two packages: fence-agents-base and "
+"fence-agents-extra. The fence-agents-base package contains the agents "
+"which are curated by the Ubuntu Server team, which means that automated "
+"tests are running in a continuous integration system to guarantee the "
+"quality of those agents. The fence-agents package is now a metapackage "
+"which depends on both fence-agents-base and fence-agents-extra. Please "
+"note that fence-agents will be removed in releases; we recommend that you"
+" do not rely on its existence."
+msgstr ""
+
+#: ../../22.04/index.md:222 47114cbd3a3d4627a1eb412b50eb0dce
+msgid "Containers runtime"
+msgstr ""
+
+#: ../../22.04/index.md:224 b9a907da3c9b475fa45c5ae29a94c888
+msgid "containerd"
+msgstr ""
+
+#: ../../22.04/index.md:226 d735d7ddf0a94f2c8545a5dce9f6b401
+msgid "It was updated to version 1.5.9. Some interesting changes are:"
+msgstr ""
+
+#: ../../22.04/index.md:228 937f4f17536e4c828265683b8f02cc92
+msgid "Update pull to handle of non-https urls in descriptors"
+msgstr ""
+
+#: ../../22.04/index.md:229 a87f83e5878f493896cbde1c5b21c76e
+msgid "Install AppArmor parser for arm64 and update seccomp to 2.5.1"
+msgstr ""
+
+#: ../../22.04/index.md:230 a3f6d9dc1e3f4e8da2398af006b27c62
+msgid ""
+"Add support for *clone3* syscall to fix issue with certain images when "
+"seccomp is enabled"
+msgstr ""
+
+#: ../../22.04/index.md:231 42b45451a43f402981ced52257ea4cee
+msgid "Add image config labels in CRI container creation"
+msgstr ""
+
+#: ../../22.04/index.md:233 2e25b3575f0c401a91cf69ef9617f2d8
+msgid ""
+"For the complete list of changes please refer to the [upstream release "
+"page](https://github.com/containerd/containerd/releases)."
+msgstr ""
+
+#: ../../22.04/index.md:235 10d9a6395fce4faba7d2785661c43cda
+msgid "`runc`"
+msgstr ""
+
+#: ../../22.04/index.md:237 e4dffaea974e4ac9be3b98909e0d4bea
+msgid ""
+"It was updated to version 1.1.0. There are many improvements and bug "
+"fixes which can be found in the [upstream release "
+"page](https://github.com/opencontainers/runc/releases). Some deprecations"
+" and removals which might impact the upgrade are presented below:"
+msgstr ""
+
+#: ../../22.04/index.md:239 012e761003374ebeb1aa132340ae9543
+msgid "Deprecation"
+msgstr ""
+
+#: ../../22.04/index.md:241 fc11d03f33314720a5e844fa92a32c05
+msgid ""
+"runc run/start now warns if a new container cgroup is non-empty or "
+"frozen; this warning will become an error in `runc` 1.2"
+msgstr ""
+
+#: ../../22.04/index.md:243 90e9bf2d449e4db29bf02bd69a2334c4
+msgid "Removals"
+msgstr ""
+
+#: ../../22.04/index.md:245 0f6d2586ee944e51ba4dedd3b9d96049
+msgid ""
+"cgroup.GetHugePageSizes has been removed entirely, and been replaced with"
+" cgroup.HugePageSizes which is more efficient"
+msgstr ""
+
+#: ../../22.04/index.md:246 7bd2bbbe29324b38bcef88c96ae486d3
+msgid ""
+"intelrdt.GetIntelRdtPath has been removed. Users who were using this "
+"function to get the intelrdt root should use the new intelrdt.Root "
+"instead."
+msgstr ""
+
+#: ../../22.04/index.md:248 c78db54998a844e390214a1e7780e4ca
+msgid "Ruby 3.0"
+msgstr ""
+
+#: ../../22.04/index.md:250 730f01033f8b417c998abdbc3d69285e
+msgid ""
+"The default Ruby interpreter was updated to version 3.0, whose goal is "
+"performance, concurrency, and Typing. To have a broad overview about the "
+"cool features and improvements check out the [Ruby 3.0 Release "
+"Announcement](https://www.ruby-"
+"lang.org/en/news/2020/12/25/ruby-3-0-0-released/)."
+msgstr ""
+
+#: ../../22.04/index.md:252 fd21fe0083424bea87f7f834e4c32268
+msgid ""
+"Users coming from previous Ubuntu releases ( Ubuntu Focal 20.04 onward) "
+"will be moving from Ruby 2.7 to 3.0. In this case the [Ruby 2.7 Release "
+"Announcement](https://www.ruby-"
+"lang.org/en/news/2019/12/25/ruby-2-7-0-released/) might be useful as "
+"well. An important thing to keep in mind is that the following libraries "
+"are not bundled anymore in Ruby:"
+msgstr ""
+
+#: ../../22.04/index.md:254 855f71b5dde64399ae4275db6f5fbfdd
+msgid "sdbm"
+msgstr ""
+
+#: ../../22.04/index.md:255 f08a4cb6b89f45b7afde519d97f9f155
+msgid "webrick"
+msgstr ""
+
+#: ../../22.04/index.md:256 68142671cd8b4b4f980736011c410964
+msgid "net-telnet"
+msgstr ""
+
+#: ../../22.04/index.md:257 c31603a978fb460ba448733aa6999deb
+msgid "xmlrpc"
+msgstr ""
+
+#: ../../22.04/index.md:259 718d76b78e354167ba0f7d17aed19f87
+msgid "If you need these libraries, please install them separately."
+msgstr ""
+
+#: ../../22.04/index.md:261 5293a47d905445c28174d7e851752e97
+msgid ""
+"Please pay attention to the Other Notable Changes since 2.7 section in "
+"the Ruby 3.0 Release announcement when migrating your application to Ruby"
+" 3.0."
+msgstr ""
+
+#: ../../22.04/index.md:263 78fa013ffd494791ba78cd7bc65996b7
+msgid "PHP now defaults to version 8.1.2"
+msgstr ""
+
+#: ../../22.04/index.md:265 83d20020d6084a8996febd6619f25351
+msgid ""
+"PHP 8.1 contains many new features:  Enumerations allow defining custom "
+"types limited to a specific set of possible values, like using consts but"
+" with better type checking. Readonly properties prevent their value to be"
+" changed after initialization.  With first-class callable syntax, static "
+"analysis is easier to perform on PHP code, and allows creating anonymous "
+"functions such as Closures.  Intersection types allow specifying function"
+" parameters that must satisfy multiple type constraints; much like a "
+"union type expresses an A|B type relationship, intersection types allow "
+"expressing A&B types.  Many other new features, such as fibers, final "
+"class constraints, never return values, explicit octal numeral notation, "
+"use of new inside initializers, and more will allow writing tighter, more"
+" expressive PHP code."
+msgstr ""
+
+#: ../../22.04/index.md:267 60d68664a9804ab59465c1fbbc875bb2
+#, python-format
+msgid ""
+"PHP 8.1 also received significant attention to performance, with a 23% "
+"speedup for the Symfony Demo test, and a 3.5% speedup for WordPress, as "
+"compared with PHP 8.0.  A few of the performance-related features "
+"included in PHP 8.1 include an inheritance cache, fast class name "
+"resolution, and various optimizations to timelib, ext/date, SPL file-"
+"system interators, serialize/unserialize, and several heavily used "
+"internal functions."
+msgstr ""
+
+#: ../../22.04/index.md:269 8edf1d793b774cc0b9f0fc46bac35aaf
+msgid ""
+"Users of PHP 7.4 should note that version 8 removes a [number of "
+"deprecated "
+"functionalities](https://wiki.php.net/rfc/deprecations_php_7_4) and when "
+"upgrading should be prepared to make the appropriate changes to their "
+"applications."
+msgstr ""
+
+#: ../../22.04/index.md:271 4113016fd0cc481a9da454d619ece1b3
+msgid "OpenLDAP 2.5.x series"
+msgstr ""
+
+#: ../../22.04/index.md:273 a4a2c82f655c49deb0f08eef97bb6cf5
+msgid ""
+"If you are updating from Ubuntu Focal 20.04, you will encounter a new "
+"major OpenLDAP release on Ubuntu Jammy 22.04: version 2.5.11.  This "
+"release brings several changes, new features and deprecations/removals. A"
+" non-exhaustive list of things to be aware of during the upgrade process "
+"is:"
+msgstr ""
+
+#: ../../22.04/index.md:275 677329afaa1e4fb2bd8199297472500c
+msgid ""
+"The shell (`slapd-shell`), the BDB and the HDB backends have all been "
+"removed."
+msgstr ""
+
+#: ../../22.04/index.md:276 1d9c0ed5050d4c55bbb53a2076d6d6b2
+msgid ""
+"The `ppolicy` module now provides its own built-in schema. The external "
+"`ppolicy` schema has been removed."
+msgstr ""
+
+#: ../../22.04/index.md:277 07caa506290b40e2abbf17f5ad9f0eec
+msgid "The `nssov` module has been removed."
+msgstr ""
+
+#: ../../22.04/index.md:279 caa964103e0243b4a6a1a4786a65cf78
+msgid ""
+"In certain situations, it is possible that the post-installation scripts "
+"will **not** be able to successfully migrate your current installation to"
+" new formats (e.g., when you are using an old backend like BDB/HDB). If "
+"this happens, you will be notified about the failure and the `slapd` "
+"server will **not** be (re)started; you will then have to take manual "
+"action in order to migrate your data and start the service. Please look "
+"at the [README.Debian "
+"](https://git.launchpad.net/ubuntu/+source/openldap/tree/debian/slapd.README.Debian?h=ubuntu"
+"/impish-devel) file (under `/usr/share/doc/slapd/`) for more information."
+msgstr ""
+
+#: ../../22.04/index.md:281 bbca09df62c9468f95d4cf4aa0a76a63
+msgid "BIND 9.18"
+msgstr ""
+
+#: ../../22.04/index.md:283 a712dbe78f8b4255a92596eab37c9e11
+msgid ""
+"BIND 9 has been updated to [version "
+"9.18.1](https://bind9.readthedocs.io/en/v9_18_1/notes.html). This new "
+"version includes"
+msgstr ""
+
+#: ../../22.04/index.md:285 85fb6af3528d41bca30b39414f1b13b6
+msgid "Support for DNS over TLS (DoT) and DNS over HTTPS (DoH)."
+msgstr ""
+
+#: ../../22.04/index.md:286 9ab5f61f685b44cbb39716582a9e2f69
+msgid ""
+"`named` now supports zone transfers over TLS (XFR-over-TLS, XoT) for both"
+" incoming and outgoing zone transfers."
+msgstr ""
+
+#: ../../22.04/index.md:287 6a2e3cbaba2a4d48a8f8282cc7230ca5
+msgid "`dig` is now able to send DoT queries."
+msgstr ""
+
+#: ../../22.04/index.md:289 d795e6183966477fba2fc859354de5ee
+msgid ""
+"Users upgrading from previous versions should be aware of the following "
+"changes:"
+msgstr ""
+
+#: ../../22.04/index.md:291 34fe0eb23435444686a3be09894ba3ac
+msgid ""
+"The binary files which are neither daemons nor administrative programs "
+"have been moved from `/usr/sbin` to `/usr/bin`."
+msgstr ""
+
+#: ../../22.04/index.md:292 e38251b932fb4e6883513dde7cd6837d
+msgid ""
+"Support for the map zone file format has been removed. Users relying on "
+"such zone file format should convert their zones to use the raw format "
+"and change configurations accordingly before upgrading."
+msgstr ""
+
+#: ../../22.04/index.md:293 a45f205da1c140fcbf476b4cd77b340a
+msgid ""
+"Several obsolete, non-working configuration options have been removed and"
+" are now treated as configuration failures when present. A complete list "
+"of such configurations is available in the [upstream release "
+"notes](https://bind9.readthedocs.io/en/v9_18_1/notes.html#removed-"
+"features)."
+msgstr ""
+
+#: ../../22.04/index.md:295 af82809449ea4cf387112f4291045fdd
+msgid "Apache has been updated to 2.4.52 from 2.4.48"
+msgstr ""
+
+#: ../../22.04/index.md:297 03a7a76938074ed0b1849c1a68999776
+msgid ""
+"OpenSSL support is improved to support OpenSSL v3.  mod_ssl also received"
+" various refinements for outgoing connection behaviors, backwards "
+"compatibility, and wireshark logging."
+msgstr ""
+
+#: ../../22.04/index.md:298 f2acf76c5a1e42e1a7d420204d4f54a3
+msgid ""
+"mod_md adds support for ACME External Account Binding (EAB) along with a "
+"host of other enhancements and fixes."
+msgstr ""
+
+#: ../../22.04/index.md:299 9cf6625d95be4f6fb19c6b8631b86610
+msgid ""
+"Numerous fixes, including better hostname and UDS URI checking and "
+"handling, status code responses, and so on."
+msgstr ""
+
+#: ../../22.04/index.md:302 cb264b342c4f4b8c895ac50bce4bad24
+msgid "PostgreSQL 14"
+msgstr ""
+
+#: ../../22.04/index.md:304 745df9a0c2884389b4184a53804c0f8c
+msgid "PostgreSQL has been updated to version 14.2."
+msgstr ""
+
+#: ../../22.04/index.md:306 19bf6470421046d3b2f9640b02309a71
+msgid "This update contains many new features and enhancements, including:"
+msgstr ""
+
+#: ../../22.04/index.md:308 c008806c703942b2a9e999fcae27984a
+msgid "Stored procedures can now return data via OUT parameters."
+msgstr ""
+
+#: ../../22.04/index.md:309 b51785a6b2ca4bd28b634a0037817215
+msgid ""
+"The SQL-standard SEARCH and CYCLE options for common table expressions "
+"have been implemented."
+msgstr ""
+
+#: ../../22.04/index.md:310 82c624345cd24b5198a8179a1153c4c9
+msgid ""
+"Subscripting can now be applied to any data type for which it is a useful"
+" notation, not only arrays. In this release, the jsonb and hstore types "
+"have gained subscripting operators."
+msgstr ""
+
+#: ../../22.04/index.md:311 a6b8fa31406c4cfcafb9a0ba994b41c8
+msgid ""
+"Range types have been extended by adding multiranges, allowing "
+"representation of noncontiguous data ranges."
+msgstr ""
+
+#: ../../22.04/index.md:312 ec83c65fb5234eceb172b8be64263a9f
+msgid ""
+"Numerous performance improvements have been made for parallel queries, "
+"heavily-concurrent workloads, partitioned tables, logical replication, "
+"and vacuuming."
+msgstr ""
+
+#: ../../22.04/index.md:313 44c9aa7bfbdb413b84ebd2c72794bf6d
+msgid "B-tree index updates are managed more efficiently, reducing index bloat."
+msgstr ""
+
+#: ../../22.04/index.md:314 218ae7bd9b6a4d8f9570caef0e2d9514
+msgid ""
+"VACUUM automatically becomes more aggressive, and skips inessential "
+"cleanup, if the database starts to approach a transaction ID wraparound "
+"condition."
+msgstr ""
+
+#: ../../22.04/index.md:315 a1fba7bce8dd4532a8ed5e7bba06c04d
+msgid ""
+"Extended statistics can now be collected on expressions, allowing better "
+"planning results for complex queries."
+msgstr ""
+
+#: ../../22.04/index.md:316 a3ee7188c19f4384a42cce6a8316c017
+msgid ""
+"libpq now has the ability to pipeline multiple queries, which can boost "
+"throughput over high-latency connections."
+msgstr ""
+
+#: ../../22.04/index.md:318 fa33609cb9854146b47ebc3b6c4c0e6b
+msgid ""
+"These and a long list of further enhancements as well as bug fixes can be"
+" found in the release notes of "
+"[v14](https://www.postgresql.org/docs/14/release-14.html), "
+"[v14.1](https://www.postgresql.org/docs/release/14.1/), and "
+"[v14.2](https://www.postgresql.org/docs/release/14.2/)."
+msgstr ""
+
+#: ../../22.04/index.md:320 402248c067d94557be772a50bdf3e003
+msgid "Django 3.2.12"
+msgstr ""
+
+#: ../../22.04/index.md:322 12128b7717034939bddc583a81a06f9f
+msgid ""
+"Django was updated from the previous LTS version 2.2 to the new LTS "
+"version 3.2."
+msgstr ""
+
+#: ../../22.04/index.md:324 35dcc3c94e194052bd93888177033cd8
+msgid "The update contains many new features and bug fixes such as:"
+msgstr ""
+
+#: ../../22.04/index.md:326 b836d9d0fff3445b8a527e224eefece4
+msgid "Automatic AppConfig discovery"
+msgstr ""
+
+#: ../../22.04/index.md:327 edb24cace16141e1b3c4ff1d02d50c30
+msgid "Type customization of auto-created primary keys"
+msgstr ""
+
+#: ../../22.04/index.md:328 69f2c5aef26d4ef5b1be4da3683c71fe
+msgid "Functional indexes"
+msgstr ""
+
+#: ../../22.04/index.md:329 d12981d026ca40949e6b7e1a48857db2
+msgid "Asynchronous views and middleware support"
+msgstr ""
+
+#: ../../22.04/index.md:330 0ec93cc861eb4980b34537afd700cc99
+msgid "JSONField for all supported database backends"
+msgstr ""
+
+#: ../../22.04/index.md:331 be4b426fb8e24b1497d379c8853e69f2
+msgid ""
+"And various further major and minor features, see the see the [release "
+"notes](https://docs.djangoproject.com/en/4.0/releases/3.2/) for more"
+msgstr ""
+
+#: ../../22.04/index.md:333 9e07e7a86d80425798d21637fc8000b6
+msgid ""
+"Users upgrading from previous versions should be aware of the following "
+"backwards incompatibilities:"
+msgstr ""
+
+#: ../../22.04/index.md:335 87169b7b8d644671833d5195da589260
+msgid "Changes have been made to:"
+msgstr ""
+
+#: ../../22.04/index.md:336 1b3bed118d84484991c5289a9781affc
+msgid "The Database backend API"
+msgstr ""
+
+#: ../../22.04/index.md:337 affd6a4b515c481abcafe93b10b9466c
+msgid "django.contrib.admin"
+msgstr ""
+
+#: ../../22.04/index.md:338 d1f46eefb2754e4ab7befd213285fc59
+msgid "AbstractUser.first_name max_length - changed to 150"
+msgstr ""
+
+#: ../../22.04/index.md:339 39592a48a25240d180e20e3a430479fe
+msgid "Model.save() when providing a default for the primary key"
+msgstr ""
+
+#: ../../22.04/index.md:340 3e87cb4287c54c76876cace88a7dc084
+msgid "Along with various minor module changes"
+msgstr ""
+
+#: ../../22.04/index.md:342 a66b5ee9296c4fb68cf330931aa225f4
+msgid ""
+"For additional information, especially since an upgrade would be from the"
+" former v2.2 LTS to v3.2 LTS do not only check the Django project release"
+" notes of [3.2](https://docs.djangoproject.com/en/4.0/releases/3.2/) but "
+"also [3.1](https://docs.djangoproject.com/en/4.0/releases/3.1) and "
+"[3.0](https://docs.djangoproject.com/en/4.0/releases/3.0) as well as the "
+"various minor releases included up to 3.2.12 that is in Ubuntu 22.04 LTS."
+msgstr ""
+
+#: ../../22.04/index.md:344 1b05b04767cc4db09d076172fe617820
+msgid "MySQL 8.0"
+msgstr ""
+
+#: ../../22.04/index.md:346 1f68cd52b458452c9504b12260b7d160
+msgid ""
+"MySQL has been updated to version 8.0.28 in Jammy Jellyfish alongside "
+"Focal Fossa and Impish Indri. It contains new features such as:"
+msgstr ""
+
+#: ../../22.04/index.md:349 c76a96d5b7504ac1927ec5a462867c07
+msgid "The audit_log_disable system"
+msgstr ""
+
+#: ../../22.04/index.md:350 9fa3ef804c2a430ab5a483d53248a208
+msgid "Data type updates"
+msgstr ""
+
+#: ../../22.04/index.md:351 54152c7492774a2e86932f1bef5ec498
+msgid "The CPU_TIME statement metric"
+msgstr ""
+
+#: ../../22.04/index.md:353 d71ae1bf38384f9fb47e0202572e8bb5
+msgid ""
+"See the [8.0.28 upstream release "
+"notes](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-28.html) "
+"for more information."
+msgstr ""
+
+#: ../../22.04/index.md:356 1de111bee82f4ffe87d6b7c3cd48b979
+msgid "NFS server"
+msgstr ""
+
+#: ../../22.04/index.md:357 441c081c972742d99377e8f457be05a4
+msgid ""
+"The NFS server and client packages have finally been updated to the "
+"latest upstream version."
+msgstr ""
+
+#: ../../22.04/index.md:359 9ed6dd434e664266a737ed1f918c6b31
+msgid ""
+"All NFS services now read their configuration from `/etc/nfs.conf` and "
+"`/etc/nfs.conf.d/*.conf`, which is an INI-style configuration file, where"
+" each section is about one daemon or aspect of the NFS service. The old "
+"`/etc/defaults/nfs-*` configuration files are still left around, but are "
+"unused."
+msgstr ""
+
+#: ../../22.04/index.md:361 c12484ea5f3c4417ba6ec03e29abdbd4
+msgid ""
+"During upgrade, a conversion script is run if the package detects that "
+"the `/etc/default/nfs-*` files have been changed. This script is "
+"`/usr/share/nfs-common/nfsconvert.py` and it will read the options from "
+"`/etc/defaults/nfs-*` and generate `/etc/nfs.conf.d/local.conf`, which "
+"overrides the defaults in `/etc/nfs.conf`."
+msgstr ""
+
+#: ../../22.04/index.md:363 0cd666cce22742e5a0410074c87c193b
+msgid ""
+"If the conversion script fails for some reason, the package installation "
+"or upgrade will fail, and the issue will have to be resolved. Please "
+"[file a bug against `nfs-utils` in "
+"Launchpad](https://bugs.launchpad.net/ubuntu/+source/nfs-utils/+filebug) "
+"if you encounter such a scenario."
+msgstr ""
+
+#: ../../22.04/index.md:365 875f0a3589904cb9998fdc479a73f513
+msgid ""
+"A new tool called `nfsconf(8)` can be used to query the configuration "
+"settings of `/etc/nfs.conf` and `/etc/nfs.conf.d/*.conf`."
+msgstr ""
+
+#: ../../22.04/index.md:367 4679a38bcf9b4760aa7c74fb89ef5fd7
+msgid "Samba server"
+msgstr ""
+
+#: ../../22.04/index.md:368 525e366916914b75a0c8f775e47736b1
+msgid ""
+"Samba was updated to 4.15.5, which brings some noteworthy changes. Please"
+" see the [upstream release notes for "
+"details](https://www.samba.org/samba/history/samba-4.15.0.html), but here"
+" are some highlights:"
+msgstr ""
+
+#: ../../22.04/index.md:370 ad1beec7b7264006b969b08bc9f57f3d
+msgid ""
+"The development SMB versions SMB2_22, SMB2_24 and SMB3_10 are no longer "
+"recognized. SMB2_22 and SMB2_24 should be replaced by SMB3_00, and "
+"SMB3_10 should be replaced by SMB3_11"
+msgstr ""
+
+#: ../../22.04/index.md:371 17a6e5c96e174e01b323118185055670
+msgid "server multi channel support is no longer experimental"
+msgstr ""
+
+#: ../../22.04/index.md:372 3aa6ad454ded4825bb338f8dcc5a8b9a
+msgid ""
+"command-line options in all CLI tooling are now using a common parser, "
+"and unknown options which might have been ignored in the past, will now "
+"be rejected. See the [upstream release "
+"notes](https://www.samba.org/samba/history/samba-4.15.0.html) for "
+"details."
+msgstr ""
+
+#: ../../22.04/index.md:373 dcb2919fba964e199ebdd3f4cd1cf602
+msgid ""
+"many `/etc/samba/smb.conf` parameters were changed, some removed. Please "
+"see the [upstream release "
+"notes](https://www.samba.org/samba/history/samba-4.15.0.html) for "
+"details."
+msgstr ""
+
+#: ../../22.04/index.md:374 b1e058090f6f4e7db6cef17028dbceaa
+msgid ""
+"the CTDB package was adjusted to work with the new NFS server version "
+"shipped in this Ubuntu 22.04 LTS"
+msgstr ""
+
+#: ../../22.04/index.md:375 087d6d3cf3b3471491ed0dc353d046d5
+msgid "`findsmb(1)` was removed"
+msgstr ""
+
+#: ../../22.04/index.md:376 4ed31fe9c9ab4183b82e38933c2273eb
+msgid ""
+"[glusterfs support "
+"enabled](https://bugs.launchpad.net/ubuntu/+source/samba/+bug/1894618) in"
+" the Ubuntu packaging. This was possible because [glusterfs was promoted "
+"to "
+"Main](https://bugs.launchpad.net/ubuntu/+source/glusterfs/+bug/1950321) "
+"during the 22.04 LTS development cycle, which allowed us to enable the "
+"glusterfs vfs module. This module is now present in the `samba-vfs-"
+"modules` package."
+msgstr ""
+
+#: ../../22.04/index.md:378 42b03c3f6df342fe8ce4dd457db0b5c0
+msgid "Quagga replaced with frr"
+msgstr ""
+
+#: ../../22.04/index.md:379 e865cfb6de424917b79276cd0393b3d5
+msgid ""
+"`quagga` was removed from Ubuntu 22.04 LTS and replaced by FRRouting "
+"(`frr`, https://frrouting.org/)."
+msgstr ""
+
+#: ../../22.04/index.md:381 5d1720d8b0c54e81aa9ff8aa8120e90d
+msgid "Chrony time synchronization"
+msgstr ""
+
+#: ../../22.04/index.md:383 3dece058e20d41e4aabd4f7a0eace458
+msgid "Chrony has been updated to version 4.2 which includes"
+msgstr ""
+
+#: ../../22.04/index.md:385 a6c2b44349884d3fb12f7985716adc7d
+msgid "Add support for AES-CMAC and hash functions in GnuTLS"
+msgstr ""
+
+#: ../../22.04/index.md:386 8593c9f6001c4d7eb2fb368a44ad8ef3
+msgid ""
+"Improve server interleaved mode to be more reliable and support multiple "
+"clients behind NAT"
+msgstr ""
+
+#: ../../22.04/index.md:387 75526b26904845a483e530afb5cb6df7
+msgid "Add statistics about interleaved mode to serverstats report"
+msgstr ""
+
+#: ../../22.04/index.md:388 a2e297dc6aa14e1c8a1285d19d58dcfe
+msgid "Adds and enabled further hardening options to the chrony service"
+msgstr ""
+
+#: ../../22.04/index.md:389 178c9b63c29845d8870a20b69465fe8c
+msgid "Allow reading timemaster created configurations"
+msgstr ""
+
+#: ../../22.04/index.md:390 2bf6261cdbc74216b2cbdd15372984f3
+msgid ""
+"For more details read the upstream [release "
+"notes](https://chrony.tuxfamily.org/news.html)"
+msgstr ""
+
+#: ../../22.04/index.md:392 c88584b714754886a245941bc4f59e4f
+msgid "Virtualization"
+msgstr ""
+
+#: ../../22.04/index.md:394 7608dcfb21db4763bdcecf3fdddb02b9
+msgid ""
+"As usual the release notes can only list a few bigger and more noteworthy"
+" changes and packages while underneath many more components have been "
+"updated as well. For an even more complete picture please have a look at "
+"the changelogs of packages and upstream releases of the respective "
+"components."
+msgstr ""
+
+#: ../../22.04/index.md:398 c551a35b6edb4784893ee134376d9250
+msgid "qemu"
+msgstr ""
+
+#: ../../22.04/index.md:400 ad2e45edda004a72a182abf28e77c50f
+msgid ""
+"Qemu was updated to version v6.2.0 which brings many major and minor "
+"improvements. Among others this version includes:"
+msgstr ""
+
+#: ../../22.04/index.md:402 7f5e2615bbdd4fc2bf745d2ff519a853
+msgid ""
+"fuse3 based non-root way to [export image "
+"files](https://www.qemu.org/2021/08/22/fuse-blkexport/)"
+msgstr ""
+
+#: ../../22.04/index.md:403 118b5da0a25b435e8732d77c7f9624dd
+msgid "Jack support for low latency audio"
+msgstr ""
+
+#: ../../22.04/index.md:404 85e33e6b7bb742f7b3131103cabc634b
+msgid "Massively improved RISC-V support"
+msgstr ""
+
+#: ../../22.04/index.md:405 8c448a3ff37c466ab95245ea8cd70a26
+msgid "Many fixes for the emulation of AMD virtualization extensions"
+msgstr ""
+
+#: ../../22.04/index.md:406 0ac9c12e51014f30a79605cc3a43bfa6
+msgid "Improved Power10 support"
+msgstr ""
+
+#: ../../22.04/index.md:407 918b17f6cfd24f59a5c66203ff20337d
+msgid ""
+"More devices for the microvm build (`virtio-gpu`, `vhost-user-gpu`, "
+"`virtio-input-host` and `vhost_user_input`)"
+msgstr ""
+
+#: ../../22.04/index.md:408 d8b063f180984fb4aa39d1b4d9892823
+msgid "Allow to remove the additional drivers of `qemu-block-extra`"
+msgstr ""
+
+#: ../../22.04/index.md:409 de115ece051a40caa6804e362a560b77
+msgid "Most common qemu features are now separate modules"
+msgstr ""
+
+#: ../../22.04/index.md:410 6ed708c625dc4132b88e74a036372886
+msgid ""
+"s390x got improved storage key emulation (e.g. fixed address handling, "
+"lazy storage key enablement for TCG, ...)"
+msgstr ""
+
+#: ../../22.04/index.md:411 7d89a03246ef4302b6b5b946471d5349
+msgid ""
+"See the upstream changelog for version "
+"[6.1](https://wiki.qemu.org/ChangeLog/6.1) and "
+"[6.2](https://wiki.qemu.org/ChangeLog/6.2) for an overview of the many "
+"further improvements. These also contain a list of suggested alternatives"
+" for removed, deprecated and incompatible features."
+msgstr ""
+
+#: ../../22.04/index.md:413 0c5b43123fda4f94bc366dc68431afc0
+msgid "libvirt"
+msgstr ""
+
+#: ../../22.04/index.md:415 834637365f184a90bcf2ca732ebad2ca
+msgid ""
+"Following the regular releases of libvirt version v8.0.0 is now provided "
+"in Ubunt 22.04 which includes:"
+msgstr ""
+
+#: ../../22.04/index.md:417 08e38cab6a2b4314ad4eab22c8907089
+msgid "Support hotplug and hotunplug for virtiofs"
+msgstr ""
+
+#: ../../22.04/index.md:418 4ec39d650be04cad8f3e206ae43064a5
+msgid "Introduce virtio-mem `<memory/>` model"
+msgstr ""
+
+#: ../../22.04/index.md:419 7d06603c59794386ac1a0a985b203a8d
+msgid "qemu: Support librbd encryption"
+msgstr ""
+
+#: ../../22.04/index.md:420 3eecee1966dd4863a1e97557015702fb
+msgid "qemu: Add new API to inject a launch secret in a domain"
+msgstr ""
+
+#: ../../22.04/index.md:421 6b218f2968cb489d8809a73abc3b3af7
+msgid "enhanced swtpm integration (see swtpm below for more)"
+msgstr ""
+
+#: ../../22.04/index.md:422 6b372dd71b8940938c31cf72e5eb6fbe
+msgid ""
+"See the upstream [Changelogs](https://libvirt.org/news.html) for the many"
+" further improvements and fixes since version 7.6 that was in [Ubuntu "
+"21.10](https://discourse.ubuntu.com/t/impish-indri-release-notes/21951)."
+msgstr ""
+
+#: ../../22.04/index.md:424 efd3b6dbbd91411f9067932cc2da0325
+msgid "virt-manager"
+msgstr ""
+
+#: ../../22.04/index.md:426 ae59f41a9dd4475ca6b40c362b9b5c40
+msgid ""
+"The new version 4.0.0 of virt-manager is the most recent update after "
+"almost 1.5 years without a new upstream version) providing a list of new "
+"features:"
+msgstr ""
+
+#: ../../22.04/index.md:428 8ddd8c0fff1847faa5591f4efddb780b
+msgid "shared memory configuration in the UI"
+msgstr ""
+
+#: ../../22.04/index.md:429 44dfced111ae47c7a0147165a2e34e1b
+msgid "virtiofs filesystem driver UI option"
+msgstr ""
+
+#: ../../22.04/index.md:430 1a778a3a20194854bfa5045125a96968
+msgid "enable a TPM by default when UEFI is used"
+msgstr ""
+
+#: ../../22.04/index.md:431 d60d38e2cc0f4b2c8fca82ef80999e25
+msgid "Use cpu host-passthrough by default on qemu x86"
+msgstr ""
+
+#: ../../22.04/index.md:432 a468229525084ff584ac900bd8796fa8
+msgid "use `virtio-gpu` video for most modern distros"
+msgstr ""
+
+#: ../../22.04/index.md:433 40bae1e8a7274d7a9b8d898ce9678c58
+msgid ""
+"More details can be found on the [news page](https://github.com/virt-"
+"manager/virt-manager/blob/main/NEWS.md) and individual commits on the "
+"[projects website](https://github.com/virt-manager/virt-manager)"
+msgstr ""
+
+#: ../../22.04/index.md:435 3c977d5d8a0142a7a021a0aaac01211e
+msgid "dpdk"
+msgstr ""
+
+#: ../../22.04/index.md:437 82b493f7b294456dad4a736d21ccc488
+msgid ""
+"Following the yearly flow of upstream DPDK LTS releases Ubuntu 22.04 LTS "
+"contains the most recent DPDK LTS 21.11. That contains various new device"
+" drivers, fixes and optimizations. Even the rather huge [release "
+"notes](http://doc.dpdk.org/guides/rel_notes/release_21_11.html) is just "
+"about 21.11 itself. Compared to the former DPDK LTS 20.11 that shipped "
+"with Ubuntu 21.10 you'd also want to read the DPDK release notes of "
+"[21.02](http://doc.dpdk.org/guides/rel_notes/release_21_02.html), "
+"[21.05](http://doc.dpdk.org/guides/rel_notes/release_21_05.html) and "
+"[21.08](http://doc.dpdk.org/guides/rel_notes/release_21_08.html)."
+msgstr ""
+
+#: ../../22.04/index.md:440 aca7fb1973ab4207ae4035833d48c41b
+msgid "openvswitch"
+msgstr ""
+
+#: ../../22.04/index.md:442 b0df8b9f035d4d82a8a848e5fa8bdce8
+msgid ""
+"The new version 2.17.0 of openvswitch is in Ubuntu 22.04 LTS and provides"
+" a general update including the following changes:"
+msgstr ""
+
+#: ../../22.04/index.md:444 a8b8073797a04829bf74282de7f0ea9d
+msgid "Various features that ease the use of a userspace datapath."
+msgstr ""
+
+#: ../../22.04/index.md:445 fa06eb74f10f4f8bb016e88a240d533b
+msgid ""
+"Performance improvements for the OVSDB and clustered OVSDB which is "
+"heavily used in OVN deployments."
+msgstr ""
+
+#: ../../22.04/index.md:446 d8878726ce2748bd904392eadb5cfb96
+msgid "Brings compatibility with DPDK 21.11 (see above)."
+msgstr ""
+
+#: ../../22.04/index.md:447 18954a8b5da341b3a82fc283f5a023df
+msgid ""
+"[The OVS News](https://www.openvswitch.org/releases/NEWS-2.17.0.txt) page"
+" holds more details about the new version."
+msgstr ""
+
+#: ../../22.04/index.md:449 3925e7af59b4424391f27f55c0392e52
+msgid "swtpm"
+msgstr ""
+
+#: ../../22.04/index.md:451 c0731522c45447e2ab1d0bb992f63a97
+msgid ""
+"The `swtpm` as well as `libtpms` package is now available and supported "
+"in Ubuntu 22.04 LTS."
+msgstr ""
+
+#: ../../22.04/index.md:453 6b7faca138fd48ef9bf3ffeb0d33dbad
+msgid ""
+"`swtpm` provides TPM emulators with different front-end interfaces to "
+"libtpms. TPM emulators provide socket interfaces (TCP/IP and unix) and "
+"the Linux CUSE interface for the creation of multiple native /dev/vtpm* "
+"devices.."
+msgstr ""
+
+#: ../../22.04/index.md:455 999b525e0f68437292ec559646fd8eee
+msgid ""
+"A common use case for `swtpm` is to use it as virtual TPM for virtual "
+"machine and container use cases. This is particular important for guest "
+"operating systems that consider TPM support mandatory."
+msgstr ""
+
+#: ../../22.04/index.md:458 1689aa6d167a40c3a254f0ff1bb6820e
+msgid ""
+"See the [upstream wiki](https://github.com/stefanberger/swtpm/wiki) for "
+"more details."
+msgstr ""
+
+#: ../../22.04/index.md:460 8f93690507b248348752ea4d617dbe0a
+msgid "Squid"
+msgstr ""
+
+#: ../../22.04/index.md:462 9463092c35e34e94968513ae95858d36
+msgid ""
+"The `squid` package links against the GnuTLS library.  If you would like "
+"to use OpenSSL, you can install the new `squid-openssl` package."
+msgstr ""
+
+#: ../../22.04/index.md:464 e6c7a8eb8bab4f55b4f21f73be9f3a44
+msgid "cloud-init"
+msgstr ""
+
+#: ../../22.04/index.md:466 a321cda1910041a588374679164c6fd4
+msgid ""
+"Version 22.1 of cloud-init has been released to 22.04, 21.10, 20.04 and "
+"18.04."
+msgstr ""
+
+#: ../../22.04/index.md:468 e2ca09ea560a4fdf857bb87210b7f9c3
+msgid "Notable features introduced since the last LTS release:"
+msgstr ""
+
+#: ../../22.04/index.md:470 c563606a25b14f7cb85a18bee91c5895
+msgid "Clouds and datasources"
+msgstr ""
+
+#: ../../22.04/index.md:471 b5b6a8a79b6d4cd18de35970892e1757
+msgid ""
+"Add LXD datasource in Jammy which reads dynamic instance data from LXD "
+"socket and applies config changes across reboot"
+msgstr ""
+
+#: ../../22.04/index.md:472 4ba5b7ff30cd495d949b29c98a09e835
+msgid "Added a native VMWare datasource"
+msgstr ""
+
+#: ../../22.04/index.md:473 2651da6e98d8443f865628ac8cca1b46
+msgid "OpenStack and ConfigDrive now support vendor_data2 config overrides"
+msgstr ""
+
+#: ../../22.04/index.md:474 8d527f578fe04188bf02384776856241
+msgid ""
+"Azure boot speed improvements, network config validation and SSH key "
+"handling"
+msgstr ""
+
+#: ../../22.04/index.md:475 876a7ae753d94e05b7de21b80d466f71
+msgid "GCE detected earlier in boot"
+msgstr ""
+
+#: ../../22.04/index.md:476 d3fd55ff2c6a4286825ce08f8e60b152
+msgid "Config Modules"
+msgstr ""
+
+#: ../../22.04/index.md:477 84b049ced6eb4339b9b3a30294a2344c
+msgid ""
+"Add [opt-in hotplug network support via user-"
+"data](https://cloudinit.readthedocs.io/en/latest/topics/modules.html"
+"#install-hotplug) for OpenStack and ConfigDrive"
+msgstr ""
+
+#: ../../22.04/index.md:478 374da069ebe04acebfe009f8979a8977
+msgid "Add deferred write_files config to emit files later in boot"
+msgstr ""
+
+#: ../../22.04/index.md:479 ../../22.04/index.md:493
+#: 085bab9502b0461da292939d93061624 2ebfb939d51442ba962b1e60dda44dd6
+msgid "Usability"
+msgstr ""
+
+#: ../../22.04/index.md:480 a70155355005455f981f7b77f71b6226
+msgid ""
+"Schema validation of `#cloud-config` userdata to annotate specific errors"
+" in user-provided configuration"
+msgstr ""
+
+#: ../../22.04/index.md:482 24ed5986307c4355b9b130f258b2161a
+msgid "ubuntu-advantage-tools"
+msgstr ""
+
+#: ../../22.04/index.md:484 ebed3e41fbae40b9a92e902bcf367186
+msgid "Ubuntu-advantage-tools version 27.8 is released with Jammy."
+msgstr ""
+
+#: ../../22.04/index.md:486 8c160025dea54912b95fe6170b2bc3d7
+msgid "Notable improvements introduced in this cycle:"
+msgstr ""
+
+#: ../../22.04/index.md:487 544a51b563c54462a67781510a2c28fb
+msgid "Service offerings:"
+msgstr ""
+
+#: ../../22.04/index.md:488 ad01c424ff77481a9446cd983d946c29
+msgid "Ubuntu Pro and Ubuntu Pro FIPS images on Azure, GCP and AWS"
+msgstr ""
+
+#: ../../22.04/index.md:489 7d45daf152f3400ab8a46955a854800d
+msgid "GCP support to add Ubuntu Advantage licenses to existing VMs"
+msgstr ""
+
+#: ../../22.04/index.md:490 e9cb816598404227953f8c0ce908f8b5
+msgid "AWS support for IPv6 IMDS"
+msgstr ""
+
+#: ../../22.04/index.md:491 5477eb3199634bbdb4509b233d3b4aab
+msgid "CIS benchmarks packaged as part of Ubuntu Security Guide (USG)"
+msgstr ""
+
+#: ../../22.04/index.md:492 9e0601639e8e495c856ac5c1b495dad2
+msgid ""
+"[Beta real-time kernel](https://ubuntu.com/blog/real-time-ubuntu-"
+"released) based on 5.15 and PREEMPT_RT patches"
+msgstr ""
+
+#: ../../22.04/index.md:494 87842bbd9f8a4edfacd9a4658b6d7c7e
+msgid ""
+"`ua security-status` provides a detailed view of available and applicable"
+" package updates provided by standard Ubuntu and Extended Security "
+"Maintenance channels"
+msgstr ""
+
+#: ../../22.04/index.md:495 df2901e48eb841018c56304ae457a4a5
+msgid "Enable Desktop installer to validate and attach Ubuntu Advantage tokens"
+msgstr ""
+
+#: ../../22.04/index.md:496 539d11aaf38f462385084b5d51f2777e
+msgid "Support machine-readable output JSON/YAML format for most commands"
+msgstr ""
+
+#: ../../22.04/index.md:497 fe2d40368e394179baee36610e8d954a
+msgid "Configurable auto attach behavior via `ua attach --attach-config`"
+msgstr ""
+
+#: ../../22.04/index.md:499 70401c0f18c74d42a60d633fa7d77890
+msgid "Ubuntu Server Main Promotions"
+msgstr ""
+
+#: ../../22.04/index.md:501 1313d591f7c04519ac305a59d13f8c23
+msgid ""
+"For Ubuntu Server 22.04 LTS, the following source packages were promoted "
+"to main:"
+msgstr ""
+
+#: ../../22.04/index.md:502 4fef3b3f82e94375a3df0d03d8c8404c
+msgid ""
+"[wireguard](https://www.wireguard.com): fast, modern, secure kernel VPN "
+"tunnel"
+msgstr ""
+
+#: ../../22.04/index.md:503 557821f82943447eb48c3831d367990d
+msgid ""
+"[glusterfs](https://www.gluster.org/): cluster file-system capable of "
+"scaling to several peta-bytes"
+msgstr ""
+
+#: ../../22.04/index.md:504 da3a825a51904cc483c11750cc74e3bc
+msgid ""
+"[frr](https://www.frrouting.org/): suite of internet routing protocols "
+"(BGP, OSPF, IS-IS, ...)"
+msgstr ""
+
+#: ../../22.04/index.md:506 f486318b6a0f4a09858193bb0870c7a8
+msgid "LXD was updated to the new 5.0 LTS version"
+msgstr ""
+
+#: ../../22.04/index.md:508 9b796f1d599644a2939f8bdf053db3ed
+msgid ""
+"5.0 LTS significantly steps up LXD’s abilities, especially when operating"
+" in clustered environments. In comparison to LXD 4.0, virtual machines "
+"are now effectively at feature parity with containers, and a lot of "
+"networking options, clustering, and project features were added."
+msgstr ""
+
+#: ../../22.04/index.md:510 db411f2c7813455090f617ddf35edac6
+msgid "Some of the key changes include:"
+msgstr ""
+
+#: ../../22.04/index.md:512 a25a3c20268d457fbc293c63bc485e32
+msgid ""
+"**LXD virtual machines** now come with vTPM support as well as arbitrary "
+"PCI passthrough support. VMs can now be live-migrated and support some "
+"device hotplug and additional storage options."
+msgstr ""
+
+#: ../../22.04/index.md:513 236a6f6fd86948dba9978c00929899db
+msgid ""
+"**Networking** now includes OVN support combined with BGP, DNS, floating "
+"IP and hardware acceleration support."
+msgstr ""
+
+#: ../../22.04/index.md:514 cb1e94720b2b4889a86b51399917d168
+msgid ""
+"**Projects** have grown a number of additional limits and restrictions, "
+"making it easy to safely grant access to various teams and limit their "
+"resource usage."
+msgstr ""
+
+#: ../../22.04/index.md:515 ba57e7e4d2424cb0aae9b850e1db1c7a
+msgid "**LXD-migrate** has been reworked with support for both containers and VMs"
+msgstr ""
+
+#: ../../22.04/index.md:516 66827af1cdff49248ab2a393418627e1
+msgid ""
+"**Cluster** users can now perform easy maintenance through cluster "
+"evacuation, group servers into target groups and get detailed instance "
+"metrics across entire clusters."
+msgstr ""
+
+#: ../../22.04/index.md:518 2e0a4cc4cf13492696a674b299f5b5a9
+msgid ""
+"Additional details and a complete changelog can be found "
+"[here](https://discuss.linuxcontainers.org/t/lxd-5-0-lts-has-been-"
+"released/13723)."
+msgstr ""
+
+#: ../../22.04/index.md:521 a76476ab496945089319cd3662d118b8
+msgid "Ceph"
+msgstr ""
+
+#: ../../22.04/index.md:523 b3b062dd94ca47ceaf1907b142418de0
+msgid ""
+"Ubuntu 22.04 LTS includes the latest release candidate of the Ceph Quincy"
+" release."
+msgstr ""
+
+#: ../../22.04/index.md:525 b32cf2f413c843be824a123d105f593e
+msgid ""
+"Ceph packages will be updated as a [stable release "
+"update](https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/1968318) once"
+" Quincy is released by the Ceph community."
+msgstr ""
+
+#: ../../22.04/index.md:527 5182a97597504de587915f4869f5d50f
+msgid "OpenStack"
+msgstr ""
+
+#: ../../22.04/index.md:529 0e4c20b8528a4999972dc681c74022bc
+msgid ""
+"Ubuntu 22.04 LTS includes the latest OpenStack release, Yoga, including "
+"the following components:"
+msgstr ""
+
+#: ../../22.04/index.md:531 47c096b55eec4cd5aa1ccf2122d859c6
+msgid "OpenStack Identity - Keystone"
+msgstr ""
+
+#: ../../22.04/index.md:532 dd840df5e25244b09cba8d5b1bad4415
+msgid "OpenStack Imaging - Glance"
+msgstr ""
+
+#: ../../22.04/index.md:533 b9b94d1f5af647c4be370537cf53e4f8
+msgid "OpenStack Block Storage - Cinder"
+msgstr ""
+
+#: ../../22.04/index.md:534 ba32f92c1f244be798d076a4f3f77d03
+msgid "OpenStack Compute - Nova"
+msgstr ""
+
+#: ../../22.04/index.md:535 e1f9b5d57a86453296fa6017f2547e8f
+msgid "OpenStack Networking - Neutron"
+msgstr ""
+
+#: ../../22.04/index.md:536 d9ca98749d3f4b6984897da993149ccd
+msgid "OpenStack Telemetry - Ceilometer, Aodh, Gnocchi"
+msgstr ""
+
+#: ../../22.04/index.md:537 4e74ccf4bdf84f47a994c16e100ec998
+msgid "OpenStack Orchestration - Heat"
+msgstr ""
+
+#: ../../22.04/index.md:538 fc91ec7351a746f390df4f49c35ce077
+msgid "OpenStack Dashboard - Horizon"
+msgstr ""
+
+#: ../../22.04/index.md:539 233800aaa2a34f8fb7f90d77dfb4a459
+msgid "OpenStack Object Storage - Swift"
+msgstr ""
+
+#: ../../22.04/index.md:540 33f7b59b224f42b68389d8f5238b03e1
+msgid "OpenStack DNS - Designate"
+msgstr ""
+
+#: ../../22.04/index.md:541 db1e1929f118426ab6c761b439e4d255
+msgid "OpenStack Bare-metal - Ironic"
+msgstr ""
+
+#: ../../22.04/index.md:542 a191067e550a4fd48a0dc73b34c69d07
+msgid "OpenStack Filesystem - Manila"
+msgstr ""
+
+#: ../../22.04/index.md:543 2fa11f81b292492cb96c497d9c29449a
+msgid "OpenStack Key Manager - Barbican"
+msgstr ""
+
+#: ../../22.04/index.md:544 4f5b2d73983c43b3a276acfeccb8d139
+msgid "OpenStack Load Balancer - Octavia"
+msgstr ""
+
+#: ../../22.04/index.md:545 b06f0fdb001546498adef385b53f112c
+msgid "OpenStack Instance HA - Masakari"
+msgstr ""
+
+#: ../../22.04/index.md:547 b5ab749989c84dba84ecb57d06b553d3
+msgid ""
+"Please refer to the [OpenStack Yoga release "
+"notes](https://releases.openstack.org/yoga/) for full details of this "
+"release of OpenStack."
+msgstr ""
+
+#: ../../22.04/index.md:549 9cd396d935054cc694567d370aa3b824
+msgid ""
+"OpenStack Yoga is also provided via the [Ubuntu Cloud "
+"Archive](https://wiki.ubuntu.com/OpenStack/CloudArchive) for OpenStack "
+"Yoga for Ubuntu 20.04 LTS users."
+msgstr ""
+
+#: ../../22.04/index.md:551 acfac46d59ce4e499d912b4e66032eee
+msgid ""
+"WARNING: Upgrading an OpenStack deployment is a non-trivial process and "
+"care should be taken to plan and test upgrade procedures which will be "
+"specific to each OpenStack deployment."
+msgstr ""
+
+#: ../../22.04/index.md:553 7006aa0800c1430eaf399c5f1f2eab41
+msgid ""
+"Make sure you read the [OpenStack Charm Release "
+"Notes](https://docs.openstack.org/charm-guide/latest) for more "
+"information about how to deploy and operate Ubuntu OpenStack using Juju."
+msgstr ""
+
+#: ../../22.04/index.md:555 a0a75cc3b7ba48699f6d028224573205
+msgid "needrestart and unattended operations"
+msgstr ""
+
+#: ../../22.04/index.md:557 d9847b17ab754797ae61d040ddc2c902
+msgid ""
+"[needrestart](https://discourse.ubuntu.com/t/needrestart-for-"
+"servers/21552) was first installed by default in Ubuntu 21.04 and "
+"continues to feature in Ubuntu 22.04 LTS. It helps ensure that services "
+"are correctly restarted when their dependencies receive security updates."
+msgstr ""
+
+#: ../../22.04/index.md:559 341af93e22e94941b97d14290678914a
+msgid ""
+"By default, needrestart will prompt after upgrading packages if restarts "
+"are determined to be required. To suppress this behaviour, you can set "
+"`DEBIAN_FRONTEND=noninteractive` as usual. needrestart will then fall "
+"back to \"list only mode\". It will be necessary to restart services "
+"afterwards, for example by rebooting or invoking `needrestart -ra`."
+msgstr ""
+
+#: ../../22.04/index.md:561 8cf50d4516594c2bbb33f563bd305cf9
+msgid "Phased updates in APT"
+msgstr ""
+
+#: ../../22.04/index.md:562 e3f9f14aeb5d49da8bdaa837b7692cbc
+msgid ""
+"Since 21.04 APT respects phased updates, see the [Phased updates in APT "
+"21.04](https://discourse.ubuntu.com/t/phased-updates-in-apt-"
+"in-21-04/20345) thread for more details."
+msgstr ""
+
+#: ../../22.04/index.md:564 ../../22.04/index.md:699
+#: 9bb45cde844b449cb9b4180cafde2ee0 de15d5188020435a8c94448cb0ebc2a3
+msgid "Platforms"
+msgstr ""
+
+#: ../../22.04/index.md:566 cb894a81bbc34ee0a3e7e53174543a7e
+msgid "Cloud Images ☁️"
+msgstr ""
+
+#: ../../22.04/index.md:568 45bdc860d3224f16bbd0c8c75d21927e
+msgid "AWS"
+msgstr ""
+
+#: ../../22.04/index.md:569 1985250a2d894f3abe298eab192c0c06
+msgid ""
+"AWS amd64 images use now a GPT partition table and setup a ESP partition "
+"to make it possible to use UEFI as boot mode."
+msgstr ""
+
+#: ../../22.04/index.md:571 2927c8b356a04214bcb2390bad0c71ef
+msgid "Oracle"
+msgstr ""
+
+#: ../../22.04/index.md:572 e15449be137d431ea584a7a418691e6d
+msgid ""
+"Jammy Minimal images are available for ARM64 servers on Oracle Cloud "
+"Infrastructure. Note that OCI releases images on a fixed cadence, and "
+"Jammy release to OCI will be slightly delayed."
+msgstr ""
+
+#: ../../22.04/index.md:574 50a67acb815b484dbba488297c8460b0
+msgid "Raspberry Pi 🍓"
+msgstr ""
+
+#: ../../22.04/index.md:576 c95c3b2c15fa4db4bdb5f8920a16351d
+msgid ""
+"The first long-term service (LTS) release of the Ubuntu Desktop for "
+"Raspberry Pi"
+msgstr ""
+
+#: ../../22.04/index.md:577 81e0b1e8f69d4db5b2104464d1b1a58a
+msgid ""
+"Support for several Pi-specific boards and tools have been added to the "
+"archive:"
+msgstr ""
+
+#: ../../22.04/index.md:578 8b352674815448ce92dd4fed58c2b7ae
+msgid ""
+"All variants of the popular Pimoroni [Unicorn "
+"HAT](https://shop.pimoroni.com/products/unicorn-hat?variant=932565325) "
+"are now supported with packaging"
+msgstr ""
+
+#: ../../22.04/index.md:579 4667f1e279204a73bcebe1593f470b2e
+msgid "The official DSI touchscreen is now supported"
+msgstr ""
+
+#: ../../22.04/index.md:580 0bbb9f2090a24cdb826f988589fa3e11
+msgid ""
+"The [rpiboot](https://launchpad.net/ubuntu/+source/rpiboot) package "
+"contains the [rpiboot](https://github.com/raspberrypi/usbboot) utility "
+"for working with Raspberry Pi Compute Modules (and other Pi boot "
+"facilities)"
+msgstr ""
+
+#: ../../22.04/index.md:581 73c04b212f1448668f7642ffacc5bc1a
+msgid ""
+"The [pyboard-rshell](https://launchpad.net/ubuntu/+source/pyboard-rshell)"
+" package contains the [rshell](https://pypi.org/project/rshell/) utility "
+"for working with micro-controller boards supporting MicroPython, "
+"including the Raspberry Pi Pico"
+msgstr ""
+
+#: ../../22.04/index.md:582 9519279541cd4699a5ada84362f089d5
+msgid ""
+"The [rpi-imager](https://launchpad.net/ubuntu/+source/rpi-imager) package"
+" contains the Raspberry Pi imager utility. The equivalent [snap "
+"package](https://snapcraft.io/rpi-imager) has also been updated to "
+"operate on all architectures (and bumped to the current version)"
+msgstr ""
+
+#: ../../22.04/index.md:584 3c145f0a77d2489886843a8b8452b2ae
+msgid "arm64"
+msgstr ""
+
+#: ../../22.04/index.md:586 28ad45bf01c24519b7d5a404042f438d
+msgid ""
+"Ubuntu 22.04 LTS is available on ARM in many public clouds - Azure, AWS, "
+"Oracle Cloud."
+msgstr ""
+
+#: ../../22.04/index.md:588 cf2320d9b9c04f95aad4ef8ebdd423a1
+msgid ""
+"Ubuntu 22.04 LTS adds linux-restricted-modules of NVIDIA drivers on "
+"ARM64. Users on ARM64 can now use `ubuntu-drivers` tool to install and "
+"configure NVIDIA drivers from the Ubuntu Archive."
+msgstr ""
+
+#: ../../22.04/index.md:590 b5c9bab6b8ef454b95e7c1bdbb65804d
+msgid ""
+"linux-generic-64k kernel flavor with 64K pages support is now available "
+"as a GA LTS kernel. It was first introduced in 20.10 release, and has "
+"been available as an HWE kernel since 20.04.2 LTS."
+msgstr ""
+
+#: ../../22.04/index.md:593 c7575469869843a9a11793dd85a1d4ec
+msgid "ppc64el"
+msgstr ""
+
+#: ../../22.04/index.md:595 fcaba0d86ec94988bb0310555ab06b76
+msgid ""
+"Starting with 22.04 LTS, Ubuntu Server for IBM POWER (little endian) is "
+"now compiled for POWER9 processors using '--with-cpu=power9' ([bug "
+"1930086](https://bugs.launchpad.net/bugs/1930086)). Thus Ubuntu Server "
+"22.04 LTS will not run, install or even boot on POWER8 systems anymore, "
+"due to the different instruction set requirements. But Ubuntu Server "
+"20.04 LTS can still be used for POWER8 systems for several years - at "
+"least until end of base support in April 2025. Users running Ubuntu "
+"Server on POWER8 today will be prevented from being upgraded to 22.04 LTS"
+" using ‘do-release-upgrade’, as this will obviously break such systems "
+"([bug 1960255](https://bugs.launchpad.net/bugs/1960255)). In addition, "
+"Ubuntu Server 22.04 LTS is the first Ubuntu release that comes with "
+"official support for POWER10."
+msgstr ""
+
+#: ../../22.04/index.md:601 ../../22.04/index.md:720
+#: 839ebac0abda4a9e8dc4e02e2fd7cff8 fd0188ad0c0547608a26ede49e1a338e
+msgid "s390x"
+msgstr ""
+
+#: ../../22.04/index.md:603 f634c71ec35540e1b0335b9d5762dae2
+msgid ""
+"Starting with Ubuntu Server 20.04 LTS (for IBM Z and LinuxONE), the "
+"minimal architectural level set was raised to z13 (and LinuxONE "
+"Rockhopper / Emperor) - this still applies to Ubuntu Server 22.04 LTS and"
+" support also includes all newer hardware that is in service as of today "
+"(22.04 release date). Support for additional future hardware might be "
+"added later. Ubuntu Server 22.04 LTS can be installed in an LPAR (classic"
+" or DPM mode), as IBM z/VM guest, as KVM virtual machine and in different"
+" container environments, such as LXD, docker or kubernetes."
+msgstr ""
+
+#: ../../22.04/index.md:606 73bc61818f304dc3b2e3d00d9deadabe
+msgid ""
+"IBM Z and LinuxONE / s390x-specific enhancements since 21.10 (partially "
+"not limited to s390x):"
+msgstr ""
+
+#: ../../22.04/index.md:608 a2a4500894114a19954f5dc8ab1dbc9e
+msgid ""
+"Like mentioned above, 22.04 LTS is the first release that picked up "
+"OpenSSL 3, to be precise v3.0.2 ([bug "
+"1905022](https://bugs.launchpad.net/bugs/1905022)), this transition "
+"triggered for compatibility reasons ([bug "
+"1959736](https://bugs.launchpad.net/bugs/1959736)) further updates, that "
+"largely ended up in the renewal of the entire s390x crypto stack, "
+"including:"
+msgstr ""
+
+#: ../../22.04/index.md:609 94a3930659084c71a0c2a8b58faaf665
+msgid ""
+"libica update to finally v4.0.1 ([bug "
+"1959421](https://bugs.launchpad.net/bugs/1959421)), including extend "
+"statistics to reflect security measures ([bug "
+"1959553](https://bugs.launchpad.net/bugs/1959553))"
+msgstr ""
+
+#: ../../22.04/index.md:610 b58f9c98957548d581699fb73ca4931e
+msgid ""
+"openssl-ibmca update ([bug "
+"1958419](https://bugs.launchpad.net/bugs/1958419)) to finally 2.2.2 to "
+"ensure compatibility with libica4 ([bug "
+"1960004](https://bugs.launchpad.net/bugs/1960004))."
+msgstr ""
+
+#: ../../22.04/index.md:611 e472283557a44ba5b18d1eab6210bca7
+msgid ""
+"opencryptoki update to v3.17.0+dfsg+20220202.b40982e (since the planned "
+"release date for 3.18 is post 22.04 GA) (Bug:1959419), including several "
+"(security) fixes and new features like in the key management tool (LP "
+"1959577)."
+msgstr ""
+
+#: ../../22.04/index.md:612 cbbdc69edd22479fa3b6647de82d5637
+msgid ""
+"with that cryptsetup was updated as well ([bug "
+"1959427](https://bugs.launchpad.net/bugs/1959427)) Further updates in the"
+" area of cryptography that are relevant for s390x are:"
+msgstr ""
+
+#: ../../22.04/index.md:614 b61dd8cb73bc482099dcf1ce7cf49c8c
+msgid "the upgrade of libgcrypt(20) to latest v1.9.4"
+msgstr ""
+
+#: ../../22.04/index.md:615 fdf3126c6dc644ceae3e92c0926a15ee
+msgid ""
+"in kernel crypto optimization of chacha20 now using a SIMD implementation"
+" ([bug 1853152](https://bugs.launchpad.net/bugs/1853152))"
+msgstr ""
+
+#: ../../22.04/index.md:616 310cad12072146b6b3c7a09519dd0fa1
+msgid ""
+"zcrypt device driver update for adding exploitation of new IBM Z crypto "
+"hardware ([bug 1959547](https://bugs.launchpad.net/bugs/1959547))"
+msgstr ""
+
+#: ../../22.04/index.md:617 9498348198014847b63d850234c0d09e
+msgid ""
+"and finally the newly packaged IBM Z protected-key crypto library that "
+"provides interfaces for cryptographic primitives ([bug "
+"1932522](https://bugs.launchpad.net/bugs/1932522))"
+msgstr ""
+
+#: ../../22.04/index.md:619 207d3e3ce46f4c0c8c83bfbde46c8e8a
+msgid ""
+"Furthermore new network features were added, like Enhanced HSCI "
+"(HiperSockets Converged Interface) Multi-MAC support for enhancing KVM "
+"setups and z/OS interoperability (kernel LP: 1932137 and s390-tools LP: "
+"1929721). And significant updates in the area of Shared Memory "
+"Communication (SMC), like EID (Enterprise ID) support (kernel LP: "
+"1929060, s390-tools LP: 1929056), SMC statistics support ([bug "
+"1959470](https://bugs.launchpad.net/bugs/1959470)) and SMC-R v2 support "
+"([bug 1929035](https://bugs.launchpad.net/bugs/1929035)) - and with all "
+"that the smc-tools have been upgraded to latest v1.7.0 ([bug "
+"1959428](https://bugs.launchpad.net/bugs/1959428))."
+msgstr ""
+
+#: ../../22.04/index.md:621 a961aa54dfb74407817027e226bfbbd0
+msgid "Several KVM and Secure Execution related new features landed too, like:"
+msgstr ""
+
+#: ../../22.04/index.md:622 63e65b1ae0904b9f87599166a878582a
+msgid ""
+"enablement of storage key checking for intercepted instructions handled "
+"by KVM ([bug 1933176](https://bugs.launchpad.net/bugs/1933176)) and by "
+"user-space ([bug 1933179](https://bugs.launchpad.net/bugs/1933179))"
+msgstr ""
+
+#: ../../22.04/index.md:623 3e4c5464e6d64d68a7fa85fb48627f7e
+msgid ""
+"the 'access register mode' got enabled ([bug "
+"1933178](https://bugs.launchpad.net/bugs/1933178))"
+msgstr ""
+
+#: ../../22.04/index.md:624 0fd4b56d60af4ed19b5d1d965afb596e
+msgid ""
+"allowing long kernel command lines for QEMU ([bug "
+"1959984](https://bugs.launchpad.net/bugs/1959984)) and for Secure "
+"Execution guests ([bug "
+"1959985](https://bugs.launchpad.net/bugs/1959985))."
+msgstr ""
+
+#: ../../22.04/index.md:625 8868927ff40a47beb2102546d88cfb62
+msgid ""
+"enable guest interrupt support via GISA for Secure Execution guests ([bug"
+" 1959977](https://bugs.launchpad.net/bugs/1959977))"
+msgstr ""
+
+#: ../../22.04/index.md:626 efea6a5595e64b1aab1b980b0cf7d1db
+msgid ""
+"support for Secure Execution guest dump encryption with customer keys "
+"([bug 1959965](https://bugs.launchpad.net/bugs/1959965))"
+msgstr ""
+
+#: ../../22.04/index.md:627 ec8f86e0e3c34c68a3f004bcda26a653
+msgid ""
+"and enablement of vfio-ccw and vfio-ap in virt-* tools, especially virt-"
+"manager ([bug 1959976](https://bugs.launchpad.net/bugs/1959976))"
+msgstr ""
+
+#: ../../22.04/index.md:628 a3a5140c21f04629973e614370004531
+msgid ""
+"In addition the KVM_CAP_S390_MEM_OP_EXTENSION capability was raised to "
+"211 ([bug 1963901](https://bugs.launchpad.net/bugs/1963901)) and KVM got "
+"improved SIGP architectural compliance ([bug "
+"1959735](https://bugs.launchpad.net/bugs/1959735))."
+msgstr ""
+
+#: ../../22.04/index.md:630 c5655fed14724fa1b5695c507757db35
+msgid ""
+"The modernized tool-chain was needed in order to add support for new IBM "
+"Z hardware ([bug 1959379](https://bugs.launchpad.net/bugs/1959379)), and "
+"the 22.04 default gcc became v11.2 (12, 10 and 9 are in universe). "
+"Binutils were aligned to gdb ([bug "
+"1959407](https://bugs.launchpad.net/bugs/1959407)) and updated to v2.38 "
+"([bug 1959463](https://bugs.launchpad.net/bugs/1959463)), again for "
+"adding support for new hardware ([bug "
+"1959408](https://bugs.launchpad.net/bugs/1959408)). And LLVM was updated "
+"as well for new hardware support ([bug "
+"1959378](https://bugs.launchpad.net/bugs/1959378)) and to include further"
+" optimizations ([bug 1959406](https://bugs.launchpad.net/bugs/1959406)), "
+"but not only v13 is available, even v14 is the default."
+msgstr ""
+
+#: ../../22.04/index.md:634 ffffc7f3daab459f9eaa6760ab7fc16f
+msgid ""
+"On top new hardware support was added to glibc ([bug "
+"1959385](https://bugs.launchpad.net/bugs/1959385) and LP: 1959383) while "
+"glibc was upgraded to latest v2.35 ([bug "
+"1959429](https://bugs.launchpad.net/bugs/1959429)), which contains "
+"HWCAP_S390_PCI_MIO and HWCAP_S390_SIE ([bug "
+"1959462](https://bugs.launchpad.net/bugs/1959462)). The Perl Compatible "
+"Regular Expression Library PCRE2 was updated to v10.39 and includes "
+"improvements for s390x and full JIT performance ([bug "
+"1959917](https://bugs.launchpad.net/bugs/1959917)). The 'Eigen3' algebra "
+"library contains further optimizations for s390x too ([bug "
+"1884725](https://bugs.launchpad.net/bugs/1884725)) and the query capacity"
+" library and utility for extracting system information 'qclib' was raised"
+" to v2.3.0 ([bug 1959464](https://bugs.launchpad.net/bugs/1959464)). "
+"Finally a brand new low-level IBM Z Deep Neural Network Library (zDNN) "
+"library, that provides an interface for applications making use of Neural"
+" Network Processing Assist Facility (NNPA), got packaged and is now "
+"available ([bug 1959396](https://bugs.launchpad.net/bugs/1959396))."
+msgstr ""
+
+#: ../../22.04/index.md:639 3f74c5e1fc064fb2970e86771ee49c72
+msgid ""
+"A core component of Ubuntu Server for IBM Z is the s390-tools package, "
+"which was upgraded to v2.2.0 ([bug "
+"1959420](https://bugs.launchpad.net/bugs/1959420)) in alignment to "
+"jammy's kernel 5.15, and includes among other features now an environment"
+" block implementation ([bug "
+"1959409](https://bugs.launchpad.net/bugs/1959409)), that is a persistent "
+"configuration information which is evaluated during boot without the need"
+" to rewrite IPL records, an option to auto-activate PCI devices for DPM "
+"system ([bug 1959537](https://bugs.launchpad.net/bugs/1959537)) and the "
+"new multipath re-IPL feature ([bug "
+"1959546](https://bugs.launchpad.net/bugs/1959546))."
+msgstr ""
+
+#: ../../22.04/index.md:641 3f6b5bf9d0bb423f947d738d4514ad77
+msgid ""
+"The kernel received several s390x improvements as well, like kernel based"
+" support for new IBM Z hardware ([bug "
+"1960187](https://bugs.launchpad.net/bugs/1960187)), new CPU-MF Counters "
+"for new hardware ([bug "
+"1960117](https://bugs.launchpad.net/bugs/1960117)), support for long "
+"kernel command lines on s390x ([bug "
+"1960580](https://bugs.launchpad.net/bugs/1960580)), transparent PCI "
+"device recovery support ([bug "
+"1959532](https://bugs.launchpad.net/bugs/1959532)), enhanced user "
+"information on HBA firmware ([bug "
+"1959545](https://bugs.launchpad.net/bugs/1959545)) and as clean-up the "
+"deactivation of the CONFIG_QETH_OSX kernel config option ([bug "
+"1959890](https://bugs.launchpad.net/bugs/1959890))."
+msgstr ""
+
+#: ../../22.04/index.md:643 50c15fe0b3f546fbb93409ca44b44572
+msgid ""
+"The service-call logical processor (SCLP) console interface driver (for "
+"'Operating Systems Messages' line-mode and 'Integrated ASCII console' "
+"VT220) got two new debug features for logging relevant data for all sclp "
+"requests or just for failing sclp requests, which requires kernel ([bug "
+"1960435](https://bugs.launchpad.net/bugs/1960435)) as well as s390-tools "
+"modifications ([bug 1960437](https://bugs.launchpad.net/bugs/1960437))."
+msgstr ""
+
+#: ../../22.04/index.md:645 e7c283837cc44647ad25ae3a81653c88
+msgid "RISC-V"
+msgstr ""
+
+#: ../../22.04/index.md:647 78ba195ea3a14f0292d9498a121f1700
+msgid ""
+"Starting with 22.04 LTS, besides the standard device-specific "
+"preinstalled image, we now also provide a live installer image for the "
+"RISC-V architecture. This can be helpful when wanting to install Ubuntu "
+"on an NVMe drive on an Unmatched board, for instance."
+msgstr ""
+
+#: ../../22.04/index.md:649 d7d69420e70844769155b55e15a47096
+msgid "UEFI and BIOS boot"
+msgstr ""
+
+#: ../../22.04/index.md:651 bd1b15bff5a14d5298a161a422e0aa36
+msgid ""
+"Other operating systems are not displayed in the boot menu anymore, "
+"unless Ubuntu has been installed alongside another operating system. Once"
+" all other operating systems are removed from the machine, detection of "
+"other operating systems is disabled, and to re-enable if after installing"
+" another OS, you will have to delete `/boot/grub/grub.cfg` and "
+"immediately run `update-grub` again."
+msgstr ""
+
+#: ../../22.04/index.md:655 ea8b35d4248e46519050da0e1e47a5d5
+msgid "Known Issues"
+msgstr ""
+
+#: ../../22.04/index.md:657 c814b89076954caeb4c0f241e8abc731
+msgid ""
+"As is to be expected, with any release, there are some significant known "
+"bugs that users may run into with this release of Ubuntu. The ones we "
+"know about at this point (and some of the workarounds), are documented "
+"here so you don’t need to spend time reporting these bugs again:"
+msgstr ""
+
+#: ../../22.04/index.md:659 b943219fa9db4e4a988cde3c43cefe07
+msgid "Linux kernel"
+msgstr ""
+
+#: ../../22.04/index.md:661 e465872b075d482b86d7359b0e05f0b5
+msgid ""
+"The kernel runtime parameter `kernel.task_delayacct` has been [switched "
+"off by "
+"default](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e4042ad492357fa995921376462b04a025dd53b6)"
+" in 5.14 and later. That saves a small amount of cpu cycles and memory "
+"for a rarely used feature. But if you use any monitoring that needs those"
+" you'd now need to enable this either at boot time via kernel parameter "
+"`delayacct` or at runtime via `sudo sysctl -w kernel.task_delayacct=1` "
+"(There might be a slight delay after activating until statistics are "
+"available)."
+msgstr ""
+
+#: ../../22.04/index.md:663 11aeefc6aa9542d5a4f1939f859dea72
+msgid "System"
+msgstr ""
+
+#: ../../22.04/index.md:664 7a36b5720cab4756a175b36a59b2cc78
+msgid ""
+"systemd / journald now defaults to `zstd` compression and uses the “keyed"
+" hash” feature (upstream default as of v246). Therefore, journal files "
+"written on Ubuntu 22.04 LTS cannot be opened using an older version of "
+"journal (i.e. from a 18.04/20.04/Core20 installation). This will fail "
+"with an error ([~~LP: "
+"#1953744~~](https://bugs.launchpad.net/subiquity/+bug/1953744), "
+"[~~Snapcraft forum~~](https://forum.snapcraft.io/t/accessing-journal-"
+"logs-from-22-04-hosts-when-using-older-base-snap/29627)):"
+msgstr ""
+
+#: ../../22.04/index.md:669 bbbd842e22e448d781c415d1d9456866
+msgid ""
+"Users of grub-customizer could hit [a bug](https://pad.lv/1969353) in the"
+" late stage of the upgrade process leading to the final stage of the "
+"upgrade to fail (autoremoval of packages). A workaround is available [in "
+"the bug's comments](https://bugs.launchpad.net/ubuntu/+source/ubuntu-"
+"release-upgrader/+bug/1969353/comments/6)."
+msgstr ""
+
+#: ../../22.04/index.md:673 2e5e0a11ea6b4ed3a9d4ca3e593608a2
+msgid ""
+"The Ubuntu Desktop images can be slow to boot (taking up to 10 minutes) "
+"when booted from a USB drive on a BIOS system. The issue is being "
+"[investigated](https://bugs.launchpad.net/ubuntu/+source/casper/+bug/1922342),"
+" however once the system is installed this is not an issue."
+msgstr ""
+
+#: ../../22.04/index.md:674 c42562cad7114910bfea46c67817e6d7
+msgid ""
+"The Ubuntu Desktop images can be very slow to boot (taking up to 30 "
+"minutes) when booted from optical media (DVD) on a a BIOS or UEFI system."
+" This is due to an integrity checker being run against the installation "
+"media. A workaround (setting \"fsck.mode=skip\") is documented in [the "
+"relevant "
+"bug](https://bugs.launchpad.net/ubuntu/+source/casper/+bug/1930880)."
+msgstr ""
+
+#: ../../22.04/index.md:675 9e60ec93e641424ea9feb54b799d6887
+msgid ""
+"The Firefox snap does not support the [NativeMessaging "
+"protocol](https://launchpad.net/bugs/1741074) yet but this feature is "
+"planned to be added soon. This means for instance that installing GNOME "
+"Shell extensions from Firefox won't work. As a workaround, you can try "
+"the `gnome-shell-extension-manager` app."
+msgstr ""
+
+#: ../../22.04/index.md:676 dc822261e1ff4c89894405796622be51
+msgid ""
+"Brazilians (and others that need PKCS#11 smartcard support in Firefox) "
+"**should not upgrade to Jammy** until [pkcs#11 support is added to the "
+"firefox "
+"snap](https://bugs.launchpad.net/ubuntu/+source/firefox/+bug/1967632)"
+msgstr ""
+
+#: ../../22.04/index.md:677 dc96f797e92c468db79a5ab4e42cb74f
+msgid ""
+"The GNOME Tweaks app no longer manages GNOME Shell extensions. You can "
+"install `gnome-shell-extension-manager` instead."
+msgstr ""
+
+#: ../../22.04/index.md:678 33c4627d35554e62bd65cb4f159d96cd
+msgid ""
+"To use AppImages, you'll first [need to "
+"run](https://launchpad.net/bugs/1965636) `sudo apt install libfuse2`"
+msgstr ""
+
+#: ../../22.04/index.md:679 302d097449074d64b19af67632f02024
+msgid ""
+"When doing an offline install of Ubuntu Desktop with NVidia hardware "
+"enabled, nvidia-settings [will not be "
+"installed](https://bugs.launchpad.net/ubuntu/+source/ubiquity/+bug/1990535)."
+" You will need to run `sudo apt install nvidia-settings` after enabling "
+"the network."
+msgstr ""
+
+#: ../../22.04/index.md:680 0feffae8c724420cbda71cce8c7ccbe2
+msgid ""
+"When performing an installation with a Broadcom wireless network adapter,"
+" which requires third party drivers, on a system with UEFI and Secure "
+"Boot enabled the driver will not be loaded due to a failure to sign the "
+"driver. A workaround exists in [the "
+"bug](https://bugs.launchpad.net/ubuntu/+source/ubiquity/+bug/2008120) "
+"tracking this particular issue."
+msgstr ""
+
+#: ../../22.04/index.md:681 1fda96daec4047e698abf265da0b1766
+msgid ""
+"A regression in the 22.04.5 images images prevents the Nvidia drivers to "
+"be correctly installed when the installation is done in offline mode ([LP"
+" "
+"#2080522](https://bugs.launchpad.net/ubuntu/+source/ubiquity/+bug/2080522))."
+" The drivers are installed correctly when the installer has access to the"
+" Internet."
+msgstr ""
+
+#: ../../22.04/index.md:682 7decdf0bd46245898d21cf080c9336d2
+msgid ""
+"Some Dell, HP, Lenovo systems might not be able finish the installation "
+"offline with Ubuntu Desktop 22.04.5 image due to a bug in the installer "
+"([LP: #2107458](https://bugs.launchpad.net/ubiquity/+bug/2107458)). This "
+"can be worked around by connecting to the internet during installation, "
+"or use [22.04.4 image](https://old-releases.ubuntu.com/releases/jammy/) "
+"to install instead."
+msgstr ""
+
+#: ../../22.04/index.md:686 fdb169a3ab80490ab96ddda17249d6be
+msgid ""
+"Starting with Subiquity 23.04.1 or Ubuntu Server 22.04.3: In some "
+"situations, it is acceptable to proceed with an offline install when the "
+"mirror is inaccessible. In this scenario, it is advised to use:"
+msgstr ""
+
+#: ../../22.04/index.md:693 054d2d0fb8d149f1bd42cd91af3130f0
+msgid ""
+"22.04.3 LTS live-server, which contains cloud-init version "
+"22.2.1-0ubuntu0~22.04.1, is affected by [~~this "
+"bug~~](https://github.com/canonical/cloud-init/issues/4271). The effect "
+"of this is that, when using cloud-init to provide autoinstall data, the "
+"`h` aka `local-hostname` or `i` aka `instance-id` nocloud datastore "
+"arguments should not be used.  For an example of a working configuration,"
+" please see the [autoinstall-"
+"quickstart](https://ubuntu.com/server/docs/install/autoinstall-"
+"quickstart) guide."
+msgstr ""
+
+#: ../../22.04/index.md:695 a9d91a41921a4c7d8b0884b8e2397226
+msgid "Active Directory Integration"
+msgstr ""
+
+#: ../../22.04/index.md:696 95fb5f4722e04753bd7ce10e27c534c1
+msgid ""
+"When logging in on a system joined with an Active Directory domain, "
+"`sssd` (the package responsible for this integration) will try to apply "
+"Group Policies by default. There are cases where if a specific policy is "
+"missing, the login will be denied. This is being tracked in [~~bug "
+"#1934997~~](https://bugs.launchpad.net/ubuntu/+source/sssd/+bug/1934997)."
+" The fix should now be available, otherwise please see [comment "
+"#5](https://bugs.launchpad.net/ubuntu/+source/sssd/+bug/1934997/comments/5)"
+" in that bug report for existing workarounds."
+msgstr ""
+
+#: ../../22.04/index.md:701 c36b71533fd2456bab454de4fbd5acf6
+msgid "Cloud Images"
+msgstr ""
+
+#: ../../22.04/index.md:703 6b420ba4a7fa4e80900f86ae18887148
+msgid "Vagrant"
+msgstr ""
+
+#: ../../22.04/index.md:704 4209a1034a0b4fd2a98e6b56abec9fc3
+msgid ""
+"Ubuntu 22.04 LTS images will fail to launch on Vagrant < 2.216 due to SSH"
+" connection issues. This includes `vagrant` running on older Ubuntu "
+"hosts, as 22.04 LTS is the first Ubuntu release to include vagrant >= "
+"2.2.16.  One workaround is to use an upstream version of `vagrant` on "
+"your system. [Upstream bug, already "
+"fixed.](https://github.com/hashicorp/vagrant/issues/11783).  The Cloud "
+"Team is also working on a more permanent solution: [Public cloud-images "
+"bug](https://bugs.launchpad.net/cloud-images/+bug/1969664)"
+msgstr ""
+
+#: ../../22.04/index.md:706 641d22f9cee94c0f8bf16c700f4774b6
+msgid "Raspberry Pi"
+msgstr ""
+
+#: ../../22.04/index.md:708 32e1f65820da4974b5e7e1bfe3a3b4a5
+msgid ""
+"The Raspberry Pi desktop images have switched to using the Full KMS "
+"graphics drivers. The official Raspberry Pi DSI display does not work "
+"with full KMS enabled. To enable the use of the Raspberry Pi DSI display,"
+" edit the `config.txt` file on your Raspberry Pi's hard drive and change "
+"the line `dtoverlay=vc4-kms-v3d` to `dtoverlay=vc4-fkms-v3d`"
+msgstr ""
+
+#: ../../22.04/index.md:709 18d157161c3143d89dd963daad0a08f5
+msgid ""
+"On the desktop image, the Firefox snap can take some time (several "
+"minutes has been noted) to complete initialization after first login "
+"([bug 1969529](https://launchpad.net/bugs/1969529))"
+msgstr ""
+
+#: ../../22.04/index.md:710 82d9db4b88154c2b940c8d517497c23d
+msgid ""
+"The legacy camera stack (MMAL based) is no longer supported on `arm64`; "
+"[libcamera](https://www.raspberrypi.com/documentation/accessories/camera.html"
+"#libcamera-and-libcamera-apps) is the supported method of using the Pi "
+"Camera Module on the `arm64` architecture (the boot-time configuration "
+"will automatically load overlays for detected modules)"
+msgstr ""
+
+#: ../../22.04/index.md:711 8a5a33fe230541e4b7d3fc16e72c5b0f
+msgid ""
+"After initial user setup on the desktop image, several packages can still"
+" be autoremoved ([~~bug 1925265~~](https://launchpad.net/bugs/1925265)); "
+"run `sudo apt autoremove --purge` to work around this"
+msgstr ""
+
+#: ../../22.04/index.md:712 74a5972e26de4054b144597073740caf
+msgid ""
+"On the desktop image, the wrong audio output device is selected on each "
+"boot. A workaround is available in the bug report ([bug "
+"1877194](https://launchpad.net/bugs/1877194))"
+msgstr ""
+
+#: ../../22.04/index.md:713 331276c4542b42f4bd5b8124194df856
+msgid ""
+"On upgrade from impish server (and possibly earlier releases) to jammy "
+"server, if a `match/driver` section is present in the netplan "
+"configuration, which matches a space-separated list of network drivers "
+"(as the default in impish does), netplan can fail to apply the ethernet "
+"configuration (potentially leading to no connectivity if no other "
+"interfaces are configured) ([~~bug "
+"1970761~~](https://bugs.launchpad.net/ubuntu/+source/ubuntu-release-"
+"upgrader/+bug/1970761))"
+msgstr ""
+
+#: ../../22.04/index.md:714 67ddb7993b304b219cb41dd25f93fc1f
+msgid ""
+"Various kernel modules have been moved from the `linux-modules-raspi` "
+"package in order to reduce the initramfs size. If you find an application"
+" failing due to missing kernel modules, please try the following:"
+msgstr ""
+
+#: ../../22.04/index.md:715 f236e2bbc49f4800a3c114b5d8f345b4
+msgid "`sudo apt install linux-modules-extra-raspi`"
+msgstr ""
+
+#: ../../22.04/index.md:716 d232f03d345a4f4d96912506c433139f
+msgid ""
+"This is currently relevant for users of VLANs where the lack of the "
+"`8021q` module can prevent the ethernet interface from configuring "
+"([~~bug 1973485~~](https://bugs.launchpad.net/ubuntu/+source/linux-"
+"raspi/+bug/1973485))"
+msgstr ""
+
+#: ../../22.04/index.md:717 91cd13660d934929bb0884f31a1c90e2
+msgid ""
+"With the removal of the `crda` package, the method of setting the wifi "
+"regulatory domain (editing `/etc/default/crda`) no longer operates. The "
+"only option to persist this information currently is to add "
+"`cfg80211.ieee80211_regdom=XX` (where `XX` is an [ISO3166-1 "
+"alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code, "
+"e.g. `GB` for the United Kingdom, `US` for the United States, etc.) to "
+"the `cmdline.txt` file on the boot partition ([bug "
+"1951586](https://bugs.launchpad.net/netplan/+bug/1951586))"
+msgstr ""
+
+#: ../../22.04/index.md:718 857c7367954f4e5596db7e927696329a
+msgid ""
+"The [Raspberry Pi Compute Module 3](https://www.raspberrypi.com/products"
+"/compute-module-3/) is no longer supported as of the prior release, due "
+"to a lack of storage capacity (the CM3 shipped with 4GB of on-board eMMC "
+"storage, and Ubuntu Server for Raspberry Pi images now exceed this size)."
+" The later [Compute Module 3+](https://www.raspberrypi.com/products"
+"/compute-module-3-plus/) models (for which the smallest storage capacity "
+"was 8GB of eMMC) are still supported."
+msgstr ""
+
+#: ../../22.04/index.md:722 bc2c783de9844c0aadc8e2037520444a
+msgid "No known issues yet."
+msgstr ""
+
+#: ../../22.04/index.md:725 74713b498c694ababe98584d873ded73
+msgid "Official flavors"
+msgstr ""
+
+#: ../../22.04/index.md:727 10074073703347fa86614b8796b2e32f
+msgid ""
+"The release notes for the official flavors can be found at the following "
+"links:"
+msgstr ""
+
+#: ../../22.04/index.md:729 961301f03cd442de830a262a4d07c372
+msgid ""
+"[Kubuntu Release "
+"Notes](https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/Kubuntu)"
+msgstr ""
+
+#: ../../22.04/index.md:730 ff35b9eace6f49acadf362ff6e5a7f04
+msgid ""
+"[Lubuntu Release Notes](https://discourse.lubuntu.me/t/lubuntu-22-04-lts-"
+"jammy-jellyfish-release-notes/3179)"
+msgstr ""
+
+#: ../../22.04/index.md:731 d47efaab32774b238e53a446c8276b01
+msgid ""
+"[Ubuntu Budgie Release Notes for 21.10 "
+"upgraders](https://ubuntubudgie.org/2022/03/ubuntu-budgie-22-04-lts-"
+"release-notes/) & [Ubuntu Budgie Release Notes for 20.04 "
+"upgraders](https://ubuntubudgie.org/2022/04/ubuntu-22-04-release-notes-"
+"for-20-04-upgraders/)"
+msgstr ""
+
+#: ../../22.04/index.md:732 0922145d18a54fa1b0987b597ba9889f
+msgid ""
+"[Ubuntu Kylin Release "
+"Notes](https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/UbuntuKylin)"
+msgstr ""
+
+#: ../../22.04/index.md:733 1c75c4b375074b029bb3f335641069d2
+msgid ""
+"[Ubuntu MATE Release Notes](https://ubuntu-mate.org/blog/ubuntu-mate-"
+"jammy-jellyfish-release-notes/)"
+msgstr ""
+
+#: ../../22.04/index.md:734 3bed3d6c98cd4efa9d575399b4688ed6
+msgid ""
+"[Ubuntu Studio Release Notes](https://ubuntustudio.org/ubuntu-"
+"studio-22-04-lts-release-notes/)"
+msgstr ""
+
+#: ../../22.04/index.md:735 4133fbd3ee204e048d47cf6ded09906b
+msgid ""
+"[Xubuntu Release Notes](https://wiki.xubuntu.org/releases/22.04/release-"
+"notes)"
+msgstr ""
+
+#: ../../22.04/index.md:738 c79ec18d10f84237879f165556902cc4
+msgid "More information"
+msgstr ""
+
+#: ../../22.04/index.md:740 11eee9e5192042079c8eb74500e4bedb
+#, python-brace-format
+msgid ""
+"Refer to {ref}`release-policy-and-schedule` and {ref}`project-and-"
+"community`."
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/22.04/schedule.po
+++ b/docs/locale/ja/LC_MESSAGES/22.04/schedule.po
@@ -1,0 +1,831 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../22.04/schedule.md:2 0f5c938f6d4744198097e9ffceff5480
+msgid "Ubuntu Jammy Jellyfish Release Schedule"
+msgstr ""
+
+#: ../../22.04/schedule.md 1765ccd5cbaa4e1b9ac7f10af9706084
+#: 9a5b2582e78548289d6dcb25936e51d1
+msgid "Week"
+msgstr ""
+
+#: ../../22.04/schedule.md 14bae94196e9464293b7b7ea3585b74c
+#: 45f69325a5d248d69b255f370dcf528c
+msgid "Date (Thursday)"
+msgstr ""
+
+#: ../../22.04/schedule.md f761bbdc765b4704a9a059349d0e970c
+msgid "22.04 events"
+msgstr ""
+
+#: ../../22.04/schedule.md a713510630a24477906ea2e1e452fc50
+#: daa5591c877c4c018f76efc15ee38902
+msgid "**October 2021**"
+msgstr ""
+
+#: ../../22.04/schedule.md 452c3e4ef6d64c5894ad528271815927
+#: 7d3c1a847fbe462694c76794a2423b48
+msgid "1"
+msgstr ""
+
+#: ../../22.04/schedule.md 840516d729f64289b357c867e2df9840
+#: 98520a043e094751bdb7fa4fbcdf7d0c
+msgid "October 21"
+msgstr ""
+
+#: ../../22.04/schedule.md 27a2d31796204138a0417039733333ca
+msgid "Toolchain Uploaded"
+msgstr ""
+
+#: ../../22.04/schedule.md 0cf02a69e6d54811b8f62d912123f469
+#: 6326087a5c124ce78d0d1665342cde86
+msgid "2"
+msgstr ""
+
+#: ../../22.04/schedule.md 50117b555995409489a2d5308ed371bb
+#: e0221f7702e540039d1813fa2d82deb6
+msgid "October 28"
+msgstr ""
+
+#: ../../22.04/schedule.md 87e45794a9544cd281efd76a72bbf8cf
+#: 9c98319796d74c2994a4bb976bf22724
+msgid "**November 2021**"
+msgstr ""
+
+#: ../../22.04/schedule.md 04df1d05a8f045988a33da15ae95dc95
+#: 153fe675c4024bd787d5b6f461fb1f0f
+msgid "3"
+msgstr ""
+
+#: ../../22.04/schedule.md 822f070ec16d49499a3ca49cab11b94e
+#: eebaca9937e84b7cb51190f174a42e31
+msgid "November 04"
+msgstr ""
+
+#: ../../22.04/schedule.md 31cf8a595c4b4683a51d0a9301dce5e6
+#: b57e0552e4474268abf8412e5bd4e88f
+msgid "4"
+msgstr ""
+
+#: ../../22.04/schedule.md 6c95549db32b472ebeafd5a0f19df314
+#: 80c285443fac4bfab286d25a8a5546a8
+msgid "November 11"
+msgstr ""
+
+#: ../../22.04/schedule.md 7250e6e6c24f4cca9d464cd88fc1bfb8
+#: ff992917b14244a68e73f02c6b0e056d
+msgid "5"
+msgstr ""
+
+#: ../../22.04/schedule.md 1055ca2a44884cbe9d3d7d5fa26688a5
+#: 2ef2b29dc90d47ee9fbc8ce59cf4805d
+msgid "November 18"
+msgstr ""
+
+#: ../../22.04/schedule.md 84efb50b307748859748cb37af51f42a
+#: c857af27e33f47ebb55ad4eac5aca92f
+msgid "6"
+msgstr ""
+
+#: ../../22.04/schedule.md 39887e165a1246759dd9bf6bacd68b15
+#: d8b76f5a3048486a9ad4307f170dc9b0
+msgid "November 25"
+msgstr ""
+
+#: ../../22.04/schedule.md 16d10071ea5f46e58e00cc92fae5de08
+#: 60c7b7eabf1c446cbcc06b8ad2f3fb75
+msgid "**December 2021**"
+msgstr ""
+
+#: ../../22.04/schedule.md a6da36869c0044bcb4895b7eff2aeeb1
+#: c1939b9971d94039a53c2f6ee3aade78
+msgid "7"
+msgstr ""
+
+#: ../../22.04/schedule.md 05d6eb6b77964d18b24949c56690cafc
+#: a38c26a0af5c4edab1177cd75e575d03
+msgid "December 02"
+msgstr ""
+
+#: ../../22.04/schedule.md 9a865dd837bd4bf59044d35bf06f86a4
+#: b8e4e541c3614aaeb66a70b6644ee4ce
+msgid "8"
+msgstr ""
+
+#: ../../22.04/schedule.md 56faf1704fc343718d36ce50912d0208
+#: dbefdd6252bb44f2bd2ede41572a1cce
+msgid "December 09"
+msgstr ""
+
+#: ../../22.04/schedule.md 0d5d1558132b45e7b3e96ce3af5da2cc
+#: 8b2a579b56044e1e8962adcaadd20cd3
+msgid "9"
+msgstr ""
+
+#: ../../22.04/schedule.md 190a6a4187ed4bbeb3a1b801249d7998
+#: 31e054e32aa045a9979c3f0e3c4bd09e
+msgid "December 16"
+msgstr ""
+
+#: ../../22.04/schedule.md 2de56f0811a243c688f478afcaf600e2
+#: 3bc63c8bb92e474eab282ea6b1b16d2a
+msgid "10"
+msgstr ""
+
+#: ../../22.04/schedule.md 16e0a10777e54b8ca819007c28aabbff
+#: 818f58933430410988786900d4402e44
+msgid "December 23"
+msgstr ""
+
+#: ../../22.04/schedule.md b9a664b341c24c7e8c5d56f4d466c25b
+#: f39eb50dd4254e30bcbeed0fbb8a7c97
+msgid "Ubuntu Testing Week (optional)"
+msgstr ""
+
+#: ../../22.04/schedule.md 0f0503fba1f84ee7af2d39ad69d9e466
+#: 4ca3a65ab2da406c907d1ecee49b7f2f
+msgid "11"
+msgstr ""
+
+#: ../../22.04/schedule.md 12970184048f4cc093b63f9486c556a8
+#: 3d535e02555e4f639f877fe7d45bdc18
+msgid "December 30"
+msgstr ""
+
+#: ../../22.04/schedule.md 4e5ca3155c8c43d6a8be342a95ee45e4
+#: dc5a705bca0646548f4b94049460820b
+msgid "**January 2022**"
+msgstr ""
+
+#: ../../22.04/schedule.md 25a09c584815443e8354638954296d51
+#: 376f0f21d503405384896236b3999608
+msgid "12"
+msgstr ""
+
+#: ../../22.04/schedule.md 8eff0e12e98b4c41982aeddd7aab2e46
+#: e118376eefc64772929c804dd7c91721
+msgid "January 06"
+msgstr ""
+
+#: ../../22.04/schedule.md 675b1ba1559e4bd6b2108b19d56dc2e8
+#: 7f00930b596c40a7aac64d45c69ddae6
+msgid "13"
+msgstr ""
+
+#: ../../22.04/schedule.md 5abf328010db45dba62f109e259b11f6
+#: df785b543d664a839ca3a2bbd1921e7c
+msgid "January 13"
+msgstr ""
+
+#: ../../22.04/schedule.md 5be5d440c31842e58f389fdf3a1aad63
+#: aa5ab92fac6c4074b4c275409a2f6dca
+msgid "14"
+msgstr ""
+
+#: ../../22.04/schedule.md 31df135fa09e4f718309b0ed08754920
+#: 53c5025c91ab41948348804d3a4da76f
+msgid "January 20"
+msgstr ""
+
+#: ../../22.04/schedule.md 775964c097da47c5a054919f6058dc16
+#: f8c84a6d122f49aca23514efb1b3d46a
+msgid "15"
+msgstr ""
+
+#: ../../22.04/schedule.md 3f302610926d47318b8620c54a701176
+#: ef7f2254c06d43fcba3d1e9459cc1a36
+msgid "January 27"
+msgstr ""
+
+#: ../../22.04/schedule.md af7a6b598e224e83a9eb408774be518a
+#: cc8f10873767424e858585ba8bd7656c
+msgid "**February 2022**"
+msgstr ""
+
+#: ../../22.04/schedule.md 376b33b86a5241c0be00437e0181b60f
+#: c2f8b6062481436ebcb9011cb8f0c05d
+msgid "16"
+msgstr ""
+
+#: ../../22.04/schedule.md 2addee6eb85b43a6a576ff7dabd7c497
+#: 5e797c51d4df48f297759d14d6238665
+msgid "February 03"
+msgstr ""
+
+#: ../../22.04/schedule.md ca2c9a240e0e4996ae72b102056f5792
+msgid "Chinese New Year week"
+msgstr ""
+
+#: ../../22.04/schedule.md bd9551138490401295fdd550a48b6de4
+#: ef3f076a05834edda451b46270d28d67
+msgid "17"
+msgstr ""
+
+#: ../../22.04/schedule.md 173d84f76a8d4b66acd94d0710869d00
+#: 64171808756545769e7f8c0428506729
+msgid "February 10"
+msgstr ""
+
+#: ../../22.04/schedule.md 0f920fc8b58b467e8a98441a4d9ca57d
+#: b2e911a2bc7945058b94a06419fa0fce
+msgid "18"
+msgstr ""
+
+#: ../../22.04/schedule.md c168bba5df1c4981978f7a89a779612e
+#: d197a98980ae41b7b78a27eeeb07e3e7
+msgid "February 17"
+msgstr ""
+
+#: ../../22.04/schedule.md 7d7f56cd631b4fcb853022967746f1ea
+#: d2d4e05af7a64175b5353dc269dda40c
+msgid "19"
+msgstr ""
+
+#: ../../22.04/schedule.md 001f9cc576c642a88b5bec9f2d7543da
+#: 120c4265bfd34089a32959222c370571
+msgid "February 24"
+msgstr ""
+
+#: ../../22.04/schedule.md 354831bbb3f74e639206b026e6b7231a
+msgid ""
+"[Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), Debian Import "
+"Freeze,  20.04.4 Point Release"
+msgstr ""
+
+#: ../../22.04/schedule.md 6aec0ec4652e4af2a2da3c8db493b4c2
+#: c4622bb776d7460eb48f6cb73c80f4a5
+msgid "**March 2022**"
+msgstr ""
+
+#: ../../22.04/schedule.md 188ccf9b53124acb801af4dc4492c68a
+#: c018282a638642cf8b6a9896382cb230
+msgid "20"
+msgstr ""
+
+#: ../../22.04/schedule.md 4be0b710e13f45cf9fb35ca0e1c7e623
+#: 7871c4e5979347a2a73f98b28cc4ad87
+msgid "March 03"
+msgstr ""
+
+#: ../../22.04/schedule.md 2858582366ee4a68b1c0bd4d0949e203
+#: 3a3753dcdeb24660b9279da28e7cd908
+msgid "21"
+msgstr ""
+
+#: ../../22.04/schedule.md 9e2c52eb7350477192717d35215ab3cb
+#: b8f59996c96d4437abf204294bedab10
+msgid "March 10"
+msgstr ""
+
+#: ../../22.04/schedule.md f93efb4c86184d64b11e92530e7acb7e
+#: fdd37542c31b426f8916950f5d4732cb
+msgid "22"
+msgstr ""
+
+#: ../../22.04/schedule.md cf98e51d05d84e4fae54a0d5cf871795
+#: fb93761d0dcb4850a14dc1f2754e9cf9
+msgid "March 17"
+msgstr ""
+
+#: ../../22.04/schedule.md a7a7a5d1a0dc47a398dd7e56476ed5ae
+msgid "[User Interface Freeze](https://wiki.ubuntu.com/UserInterfaceFreeze)"
+msgstr ""
+
+#: ../../22.04/schedule.md 3942027ad444425980d6d39f7bf47a55
+#: 4eff07e463984d268a99631e239ebc83
+msgid "23"
+msgstr ""
+
+#: ../../22.04/schedule.md 2afe4418baf34ca9882afafda3a73d5d
+#: d0c94d6a417e4144ab187ff527b102c4
+msgid "March 24"
+msgstr ""
+
+#: ../../22.04/schedule.md 7e986ff230e5469d90ba2aa23ff1f2fe
+msgid ""
+"[Documentation String "
+"Freeze](https://wiki.ubuntu.com/DocumentationStringFreeze), [Kernel "
+"Feature Freeze](https://wiki.ubuntu.com/KernelFeatureFreeze)"
+msgstr ""
+
+#: ../../22.04/schedule.md 06a878d4b7234cafbda77f16c3ff307c
+#: 71ef70800a414d95b7c19b1b9077b8fc
+msgid "24"
+msgstr ""
+
+#: ../../22.04/schedule.md 07462a5116764e56812941d6ebc01808
+msgid "March 28 (Monday)"
+msgstr ""
+
+#: ../../22.04/schedule.md 93aa9d0ed5b24761898d58991c9720dc
+msgid ""
+"Beta Freeze, [Hardware Enablement "
+"Freeze](https://wiki.ubuntu.com/HardwareEnablementFreeze)"
+msgstr ""
+
+#: ../../22.04/schedule.md cbbe3801f2764ea8b4a7d9dca428f5cd
+msgid "⠀"
+msgstr ""
+
+#: ../../22.04/schedule.md b03acdc3e4314d0a970ad1764622940e
+#: e0678332e70f4d4197e451322709e41b
+msgid "March 31"
+msgstr ""
+
+#: ../../22.04/schedule.md a233fac7c2b54879b8b49d77bcc0320d
+msgid "Beta (mandatory)"
+msgstr ""
+
+#: ../../22.04/schedule.md 3fd5802fc1d349a3a446edff49c6762b
+#: ece0c779b55c4383a519716be90a1012
+msgid "**April 2022**"
+msgstr ""
+
+#: ../../22.04/schedule.md 662fd9b358614f768d7c7f9a0da646b0
+#: cc31bfa83d604b6a972f31402882dae8
+msgid "25"
+msgstr ""
+
+#: ../../22.04/schedule.md 7a94cc9b595d48198ec90d6e43dec37e
+#: f75cf2016e6d4284bf49ca48d8a2b92d
+msgid "April 07"
+msgstr ""
+
+#: ../../22.04/schedule.md 2ae20557e7e94d6db5209ef390233cd7
+msgid ""
+"[Kernel Freeze](https://wiki.ubuntu.com/KernelFreeze), [Non Language Pack"
+" Translation "
+"Deadline](https://wiki.ubuntu.com/NonLanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../22.04/schedule.md 261123e3f63a47fda3910fb16236b65a
+#: c8847d3993344700ba4debe3c9517b12
+msgid "26"
+msgstr ""
+
+#: ../../22.04/schedule.md 4a86028564384d28a38c6f4e7512973b
+#: ab600168fe2347449a5988172fa30c30
+msgid "April 14"
+msgstr ""
+
+#: ../../22.04/schedule.md 3ffd1e6bd44b4fadb03f54f788a23e3e
+msgid ""
+"[Final Freeze](https://wiki.ubuntu.com/FinalFreeze), [Release "
+"Candidate](https://wiki.ubuntu.com/ReleaseCandidate), [Language Pack "
+"Translation "
+"Deadline](https://wiki.ubuntu.com/LanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../22.04/schedule.md 71525eae8beb4bf9a9bf62fe01299444
+#: c3d3c502419a4384b7218cf2c5de6e7f
+msgid "27"
+msgstr ""
+
+#: ../../22.04/schedule.md cc654ed23bf343308ce019b556c3d560
+#: ed32d02e1dd34e87b86cb5d2eb7947f2
+msgid "April 21"
+msgstr ""
+
+#: ../../22.04/schedule.md 95f2e663309c491187ac45f775f385a4
+msgid "[Final Release](https://wiki.ubuntu.com/FinalRelease)"
+msgstr ""
+
+#: ../../22.04/schedule.md 25333c6d0f55438e98176165f60fe806
+#: a65ca87080264ad0937060cc0b2eeee2 af3c7b2a81924818b4d83e76f2fba90b
+#: b32ccb49a4cc40fabd4aa1ae7a11a941 b8a8bdd3d2c149af8e6ee8684535a24d
+#: d7a812aa003b4297ba1659ee0b28034f d9bda453565b4c9cbd87ae5b7ea7c951
+#: dd37d414fab744daada57b6ef7a16a9f f26b7867aa574806872e9ca3e8610ee9
+#: f29d4eee8d3c459e80ce72ad86d34633
+msgid "..."
+msgstr ""
+
+#: ../../22.04/schedule.md e11a00d35b5948ea80d667bb18c58a85
+msgid "**August 2022**"
+msgstr ""
+
+#: ../../22.04/schedule.md b0d89bcbfa6546619274ebda46c94a3f
+msgid "42"
+msgstr ""
+
+#: ../../22.04/schedule.md fed2218d2dca4cbf8c24883da39f8f2e
+msgid "August 04"
+msgstr ""
+
+#: ../../22.04/schedule.md 14eeab27b7ca45fba6e870cb5b2bf9b1
+msgid "[22.04.1 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)"
+msgstr ""
+
+#: ../../22.04/schedule.md e93bd5b2955941b490e3751730296b62
+msgid "43"
+msgstr ""
+
+#: ../../22.04/schedule.md 57aeb5d33f8f4395931e006aadc2bfd3
+msgid "August 11"
+msgstr ""
+
+#: ../../22.04/schedule.md 3820fe86a5e74155b235616d6ed4b9da
+msgid "44"
+msgstr ""
+
+#: ../../22.04/schedule.md 87bbdc96298b469fabb7c9babde848f9
+msgid "August 18"
+msgstr ""
+
+#: ../../22.04/schedule.md d7064fb48a3d4213998b049fc0a9f96d
+msgid "45"
+msgstr ""
+
+#: ../../22.04/schedule.md 1a5657a96927460b9c39b027aa70bd1f
+msgid "August 21"
+msgstr ""
+
+#: ../../22.04/schedule.md b7926b9fe3dc4653a4d9663395d0e7e7
+msgid "**February 2023**"
+msgstr ""
+
+#: ../../22.04/schedule.md 806a6e8d37484c6484cef5b20d1d3459
+msgid "68"
+msgstr ""
+
+#: ../../22.04/schedule.md 84fa4cb8628f4873ac6b1bd0332f96ad
+msgid "February 02"
+msgstr ""
+
+#: ../../22.04/schedule.md 9a4e538d2e574c1a8eed890d8c80801b
+msgid "69"
+msgstr ""
+
+#: ../../22.04/schedule.md c53db5715e334f95ad5b277e58828ef5
+msgid "February 09"
+msgstr ""
+
+#: ../../22.04/schedule.md 3a96633578dc4a549e1f1a5b2d17b2cd
+msgid "70"
+msgstr ""
+
+#: ../../22.04/schedule.md f7719dba25204700a6fa39fa133d8ffb
+msgid "February 16"
+msgstr ""
+
+#: ../../22.04/schedule.md 3e3d6213a99a421e9be62a97c991b5ec
+msgid "71"
+msgstr ""
+
+#: ../../22.04/schedule.md 6bf7a21227f44d3bbd4dc1733baf6708
+msgid "February 23"
+msgstr ""
+
+#: ../../22.04/schedule.md 1c181fda2ca14b929b3acaba66d060f4
+msgid "[22.04.2 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)"
+msgstr ""
+
+#: ../../22.04/schedule.md 38e9fde26b8941aabb8aa7e473fb5f23
+msgid "**August 2023**"
+msgstr ""
+
+#: ../../22.04/schedule.md 7a1fd05e4d8d46849eec68dea9f18737
+msgid "94"
+msgstr ""
+
+#: ../../22.04/schedule.md 04f5ebde6daa4bd482012f58559a96ca
+msgid "August 03"
+msgstr ""
+
+#: ../../22.04/schedule.md 0edebcbab18b44e1b4777ec568278daa
+msgid "95"
+msgstr ""
+
+#: ../../22.04/schedule.md ba75af581456472b9f91e08e19f9f0db
+msgid "August 10"
+msgstr ""
+
+#: ../../22.04/schedule.md 0347be9132d1484189878c965dd835f7
+msgid "[22.04.3 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)"
+msgstr ""
+
+#: ../../22.04/schedule.md 80957d4a95ea48e5a9339ee023a72e98
+msgid "96"
+msgstr ""
+
+#: ../../22.04/schedule.md 0ee2121ca0fd4412899fcdbdf3a17a9c
+msgid "August 17"
+msgstr ""
+
+#: ../../22.04/schedule.md 14a4e2c97092477e934b8b7489999ea1
+msgid "97"
+msgstr ""
+
+#: ../../22.04/schedule.md e1e0923122914edfb353cbafaaca580e
+msgid "August 24"
+msgstr ""
+
+#: ../../22.04/schedule.md 1596367dc3884329a12dce9f3a29409b
+msgid "98"
+msgstr ""
+
+#: ../../22.04/schedule.md 9585e4d8f4dc45f9a3e4fd77e7bee401
+msgid "August 31"
+msgstr ""
+
+#: ../../22.04/schedule.md 2946d43aba6c419589650496e70268e9
+msgid "**February 2024**"
+msgstr ""
+
+#: ../../22.04/schedule.md 64ca8e9b4679419cbbdfdbdcda30c0d5
+msgid "120"
+msgstr ""
+
+#: ../../22.04/schedule.md 5c80b017f15d466f85de0da662de1f86
+msgid "February 1"
+msgstr ""
+
+#: ../../22.04/schedule.md 6fdef1bd14c14977957c4b3ec45ecbdb
+msgid "121"
+msgstr ""
+
+#: ../../22.04/schedule.md 292c8ae3594649af9ef9acb0747c1f7a
+msgid "February 8"
+msgstr ""
+
+#: ../../22.04/schedule.md 32c908596f2d4f4092a6ec1d9e7494f2
+msgid "122"
+msgstr ""
+
+#: ../../22.04/schedule.md 410c0c9c49bb458b93eb6764c0fb0438
+msgid "February 15"
+msgstr ""
+
+#: ../../22.04/schedule.md ae4361e9e77842969c3e7ab71bcf563b
+msgid "123"
+msgstr ""
+
+#: ../../22.04/schedule.md 8284ac02819e4b77a18e8bc6a08738fc
+msgid "February 22"
+msgstr ""
+
+#: ../../22.04/schedule.md 2853b42e8cc340c8b90cfe4c876c1b1b
+msgid "[22.04.4 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)"
+msgstr ""
+
+#: ../../22.04/schedule.md 5fef4a8e7c704812949a65761afa9565
+msgid "**August 2024**"
+msgstr ""
+
+#: ../../22.04/schedule.md a6820ddbc2914f0ba293d7b4de70f10a
+msgid "147"
+msgstr ""
+
+#: ../../22.04/schedule.md bcd974ee1bf04be49a1bac972323459f
+msgid "August 01"
+msgstr ""
+
+#: ../../22.04/schedule.md fbd9eff3d9174987ae0a1fff895a216b
+msgid "148"
+msgstr ""
+
+#: ../../22.04/schedule.md 050f994d2e3641cc9671b9d45c406365
+msgid "August 08"
+msgstr ""
+
+#: ../../22.04/schedule.md 051f860d39c24ba9a01fc4e462347e4f
+msgid "149"
+msgstr ""
+
+#: ../../22.04/schedule.md 996d68282adf402c99a72c6045857cdf
+msgid "August 15"
+msgstr ""
+
+#: ../../22.04/schedule.md f4dd26dc56ef43fca7fc434cf1120ee0
+msgid "150"
+msgstr ""
+
+#: ../../22.04/schedule.md 699fef02a93e482b980559f24281b882
+msgid "August 22"
+msgstr ""
+
+#: ../../22.04/schedule.md 39f603470def49919b398f87b74b7745
+msgid "151"
+msgstr ""
+
+#: ../../22.04/schedule.md a54ac18ed9064832a67065e16b9b95dd
+msgid "August 29"
+msgstr ""
+
+#: ../../22.04/schedule.md d75669bcf9704074ad3f0b7b87122ba8
+msgid "**September 2024**"
+msgstr ""
+
+#: ../../22.04/schedule.md c594d18563ba4ede8dcd22a86ace8a2b
+msgid "152"
+msgstr ""
+
+#: ../../22.04/schedule.md 4f681cf6fe0541659883471e8c1210f9
+msgid "September 05"
+msgstr ""
+
+#: ../../22.04/schedule.md 648b70e202584f2c8cafbf5012e99731
+msgid "153"
+msgstr ""
+
+#: ../../22.04/schedule.md a9c1bd16d34144c6b1e77f56ff3e3925
+msgid "September 12"
+msgstr ""
+
+#: ../../22.04/schedule.md f656daca7ac348658444a8d360a438ab
+msgid "[22.04.5 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)"
+msgstr ""
+
+#: ../../22.04/schedule.md:78 1982d7e4a7a440b1bf5dba36cc5f76c3
+msgid "Planned and potentially disruptive archive-wide activities"
+msgstr ""
+
+#: ../../22.04/schedule.md:80 c88e063a076a41f6b2d3a70eef5349bb
+msgid ""
+"If you're planning a change that might have a disruptive effect on the "
+"archive - e.g. transitions or switches of important defaults (such as "
+"compiler versions) - list it here."
+msgstr ""
+
+#: ../../22.04/schedule.md c6eb30ad000e47bb99341fb42eb8acf6
+msgid "Planned activity"
+msgstr ""
+
+#: ../../22.04/schedule.md 3e66a257aa9241aea21d28fa06a9ea2f
+msgid "php8.1"
+msgstr ""
+
+#: ../../22.04/schedule.md 1b2de1bbad394c09bdf6eeedbc56ec05
+msgid "OpenSSL3"
+msgstr ""
+
+#: ../../22.04/schedule.md 076760a15c5c47cc9bfda909e2adf583
+msgid "Ruby 3.0"
+msgstr ""
+
+#: ../../22.04/schedule.md f51d930d5fcf4a338c837dd1c5f0d64a
+msgid "systemd v249"
+msgstr ""
+
+#: ../../22.04/schedule.md 726e672a11504a8dad2e7225a94e4813
+msgid "DPDK 21.11"
+msgstr ""
+
+#: ../../22.04/schedule.md 9f30de8304a64e5d970cb19e07c52ae7
+msgid "binutils 2.38"
+msgstr ""
+
+#: ../../22.04/schedule.md e289aa2c594f4ceb8176de12a1fcb173
+msgid "Python 3.10"
+msgstr ""
+
+#: ../../22.04/schedule.md bb2981778c164c20af2e6dfdeb1ebd4c
+msgid ""
+"~~OpenLDAP 2.6 (tentative; depends on upstream release schedule)~~ -- "
+"Cancelled, see [this "
+"comment](https://bugs.launchpad.net/ubuntu/+source/openldap/+bug/1946883/comments/5)"
+msgstr ""
+
+#: ../../22.04/schedule.md 4621b91010fd4336bb789140eaa6f382
+msgid "Glibc 2.35"
+msgstr ""
+
+#: ../../22.04/schedule.md c0c71e9417a94327a080d3b8cf50e8c8
+msgid "[GNOME 42 Beta](https://wiki.gnome.org/FortyTwo), Golang 1.18"
+msgstr ""
+
+#: ../../22.04/schedule.md 948cca20228f4e788af6ee405508585a
+msgid "LLVM 14"
+msgstr ""
+
+#: ../../22.04/schedule.md 2964770d3eea4f42b7173b75f89a4311
+msgid "[GNOME 42.0](https://wiki.gnome.org/FortyTwo)"
+msgstr ""
+
+#: ../../22.04/schedule.md 4f73d00d4c4b4d1ab9d61e0b9770f8d9
+msgid "Openstack Yoga"
+msgstr ""
+
+#: ../../22.04/schedule.md:119 17038708919b4a40bfbeb93e76032092
+msgid "Ubuntu Jammy Jellyfish Release Task Signup Sheet"
+msgstr ""
+
+#: ../../22.04/schedule.md:121 79c1f814da084933bce89498a78a8235
+msgid "This signup sheet is to be used for planning release milestone tasks."
+msgstr ""
+
+#: ../../22.04/schedule.md:123 7cfb8cdee2b24732b41ad346a745bf89
+msgid ""
+"The Alpha and Beta 1 milestones have been replaced with [Testing "
+"Weeks](https://lists.ubuntu.com/archives/ubuntu-"
+"release/2018-April/004434.html), which are organized ad hoc at this "
+"point."
+msgstr ""
+
+#: ../../22.04/schedule.md 59075645d66a47ffa2dc51d424ab55bc
+msgid "Milestone"
+msgstr ""
+
+#: ../../22.04/schedule.md aa1353a9d00e4f5a88924a1d4dab3613
+msgid "Date"
+msgstr ""
+
+#: ../../22.04/schedule.md e5a8c60cbb16434787ff6f03974f09cf
+msgid "Image (Nusakan) Engineering"
+msgstr ""
+
+#: ../../22.04/schedule.md b4c33ce4d7d54456872b712a380fa4f8
+msgid "Checklist Tracking"
+msgstr ""
+
+#: ../../22.04/schedule.md c0885b826c3e4783893759f39e194ab4
+msgid "Announcement Email"
+msgstr ""
+
+#: ../../22.04/schedule.md 58f2c5c718bc4d7dabea2f601a2ef578
+msgid "Feature Freeze"
+msgstr ""
+
+#: ../../22.04/schedule.md 1e723565281d4a37b346268e07e7242a
+#: 3da84fb181414accbc184e2afd88e717 8c93fbc69913415ebedc54331fb83a26
+#: a9965237f9ef44db9a854cfc030c0dd8 f24a34e2a372417baaa8e0cd742a5f51
+#: fd8dc7f6cdf2464bb94d17afb464f088
+msgid "n/a"
+msgstr ""
+
+#: ../../22.04/schedule.md 63ef3a0f48664dd796c2e4f2d0053463
+msgid "UI Freeze"
+msgstr ""
+
+#: ../../22.04/schedule.md 9eed0a1f83ae416f9e5d45b14a9e7966
+msgid "Doc String Freeze"
+msgstr ""
+
+#: ../../22.04/schedule.md a331e1b7161b44beb75c85e06948a522
+msgid "22.04 Beta"
+msgstr ""
+
+#: ../../22.04/schedule.md fdb1b1cc6bac4f3d95ba4110bdf326c7
+msgid "March 31 2022"
+msgstr ""
+
+#: ../../22.04/schedule.md 36aa6a3dab7f4bedbeb169ea81d0a7bf
+#: 40901a5f6938417f820fcdae5cfa1aa0
+msgid "@sil2100"
+msgstr ""
+
+#: ../../22.04/schedule.md b79b9033f27646ff846e9f891d4752af
+msgid "Final Freeze"
+msgstr ""
+
+#: ../../22.04/schedule.md 3316aea2f5864d169b31d97a66c1ff2f
+msgid "April 14 2022"
+msgstr ""
+
+#: ../../22.04/schedule.md 3d27e0ff8e0140279a9ef04876b9fdd4
+msgid "22.04 Release"
+msgstr ""
+
+#: ../../22.04/schedule.md 643555e81a544f2f81f09e7c4ad0faf7
+msgid "April 21 2022"
+msgstr ""
+
+#: ../../22.04/schedule.md:134 e2b25509ffc94947bc37b4633d14cae8
+msgid ""
+"When the archive is frozen, all members of the release team are expected "
+"to participate in bug fix reviews."
+msgstr ""
+
+#: ../../22.04/schedule.md:136 932ccc8e32ce4ef2a0ae643e60eb6677
+msgid ""
+"After [Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), all "
+"members of the release team are expected to participate in Feature Freeze"
+" Exception reviews in their particular area of expertise."
+msgstr ""
+
+#: ../../22.04/schedule.md:138 031f83101b484157839d5b7d969970dc
+msgid ""
+"After [Final Beta](https://wiki.ubuntu.com/FinalBetaRelease), all members"
+" of the release team are expected to participate in Bug fix reviews in "
+"their particular area of expertise."
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/24.04/1.po
+++ b/docs/locale/ja/LC_MESSAGES/24.04/1.po
@@ -1,0 +1,3371 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../24.04/1.md:2 3dd81abe01bf4f4cb3ab32020a034991
+msgid "Changes in Ubuntu 24.04.1"
+msgstr ""
+
+#: ../../24.04/1.md:4 04356424b9eb48bdaa9203acf0edbcd2
+msgid ""
+"This is a brief summary of bugs fixed between Ubuntu 24.04 LTS and "
+"24.04.1. **This summary covers only changes to packages in *main* and "
+"*restricted*, which account for all packages in the officially-supported "
+"images; there are further changes to various packages in *universe* and "
+"*multiverse*.** Some of these fixes were by Ubuntu developers directly, "
+"while others were by upstream developers and backported to Ubuntu. For "
+"full details, see the individual package changelogs."
+msgstr ""
+
+#: ../../24.04/1.md:6 4b8fcf1a4f034c129a3fe6fe9c72fb83
+msgid "Installation bug fixes"
+msgstr ""
+
+#: ../../24.04/1.md:8 256157fa233e4b0790c02c4e014cceb0
+msgid ""
+"Updated CD images are provided with this release, including fixes for "
+"some installation bugs. (Many installation problems are hardware-"
+"specific; for those, see “Hardware support bugs” below.)"
+msgstr ""
+
+#: ../../24.04/1.md 1493359eb5574314b11ab8d6e9c699a1
+#: 1b677a8aca3b4b029cb8177a4fe11bc0 28157d1a3e8a4eb59d9a9c2640020ad1
+#: 41b1db42d6404076b3d631ed0f69c2f6 5c82dff54cb7452da40009d4c3dc67c8
+#: 8efa95707d1e488b9052ae1a7684d113 c5132bff00134a2ab507bdcc85a26d2f
+msgid "Source Package"
+msgstr ""
+
+#: ../../24.04/1.md 04cb7c70577344939b655355e0add261
+#: 139e5de55a984ffd9a3fc3177a6b83db 5ed157bc96994b609ed898f048a46ab8
+#: 7fe5cbdbaabc4a828dd1d6b7ef4c6c5b 94d44fb3c4174c32878c889c561d972a
+#: b27e4927d94547508da4a41992cfec69 e6dd70fb96a64c2197f13a5ba532fddf
+msgid "Bug  #"
+msgstr ""
+
+#: ../../24.04/1.md 32ecc535d6ca44e3a58bc69f6ac303a5
+#: 5b23df0a5983435f9152b7aa28cb4481 73277e38fcc54c6cb944c1b696607446
+#: 7bd0abe4f124418d8b315c5bf4cbdf36 89600133a36d4bbebcd74a9e757e63ba
+#: 897eaf33468d47a394c701e03b4d5a68 ae88745857de49398496575c13481b28
+msgid "Description"
+msgstr ""
+
+#: ../../24.04/1.md 2e70e3c9a441419ea2251561e837d3e8
+#: 4f1a0371ea3349df87e6febffb501156 8eef741e60b24cbbb2ed2d186fdf18b0
+#: 938430eeb9de47568f83032535493e6a adac0acf912d4e30bdba20fa5e2dc502
+#: b2d2d0ea96784a0bb4588c4cadc68862 d17367acec01448cb0023e41ffb2e56c
+#: d4346a09f0324948bddcb9d569d626a6 d552f745fd3e4ea5a632d5526bbd29ae
+#: e4d3d2fc3912431abaa644184b5fc32e e5a4b1959e0b4a0997850cae1830c02d
+msgid "livecd-rootfs"
+msgstr ""
+
+#: ../../24.04/1.md b3f232515503499aaed9b3f9de9ae70f
+msgid "[2068739](https://bugs.launchpad.net/bugs/2068739)"
+msgstr ""
+
+#: ../../24.04/1.md 8031263536874e90bf6e5c9d602cb8bc
+msgid "riscv64: use earlycon=sbi on command line"
+msgstr ""
+
+#: ../../24.04/1.md 9248a78a745c4bbfbaa5bc7c399060da
+msgid "[2069828](https://bugs.launchpad.net/bugs/2069828)"
+msgstr ""
+
+#: ../../24.04/1.md 9aa6423817c24517b65d520ec3dd9221
+msgid "Revert removal of unminimize call in server builds"
+msgstr ""
+
+#: ../../24.04/1.md 9af68dadfa354dbc8bf80ea6ac0e0b12
+msgid "[2064280](https://bugs.launchpad.net/bugs/2064280)"
+msgstr ""
+
+#: ../../24.04/1.md 1bf529848035443cbbffb6b376bafbc2
+msgid "Re-enable ability to build HyperV desktop images"
+msgstr ""
+
+#: ../../24.04/1.md 33113313c9984f5ba41362e28836eb71
+msgid "[2063203](https://bugs.launchpad.net/bugs/2063203)"
+msgstr ""
+
+#: ../../24.04/1.md 90ba1045b9ec45d8b8360e0328672777
+msgid "Add experimental support for building ubuntu-core-desktop installer images"
+msgstr ""
+
+#: ../../24.04/1.md 2eacbb3d8766467295165cff705008df
+msgid "[2066905](https://bugs.launchpad.net/bugs/2066905)"
+msgstr ""
+
+#: ../../24.04/1.md d91b9b6a5abe45f8b8256a4ebe0d06ea
+msgid "No longer install LXD snap in unminimize script"
+msgstr ""
+
+#: ../../24.04/1.md 6e272e3761994230a914296183e9ab8f
+msgid "[2072759](https://bugs.launchpad.net/bugs/2072759)"
+msgstr ""
+
+#: ../../24.04/1.md f5186eee670e4e19bf807d2d525895e6
+msgid "Build qcow2 images for ubuntu-core LXD support (LP: #2072759)."
+msgstr ""
+
+#: ../../24.04/1.md c9c5285f41f6436ebdec9aa57cbd2377
+msgid "[2072956](https://bugs.launchpad.net/bugs/2072956)"
+msgstr ""
+
+#: ../../24.04/1.md 3c1b9168e621413aa1f76ddea077d9d5
+msgid "riscv64: preinstalled server image for Microchip PIC64GX Curiosity Kit"
+msgstr ""
+
+#: ../../24.04/1.md 53d6e410ebfe40e891e3cd7344fe44be
+#: f9adc0b675b340779579e4253c43904f
+msgid "unminimize"
+msgstr ""
+
+#: ../../24.04/1.md 22afa80ec7374d29adcfa7eacce411db
+msgid "[2066903](https://bugs.launchpad.net/bugs/2066903)"
+msgstr ""
+
+#: ../../24.04/1.md ce9f1e9490a4416688aaef3c989c0289
+msgid "fix: No longer install LXD snap in unminimize script"
+msgstr ""
+
+#: ../../24.04/1.md 806da790ca964d7c9d0bbe1d222cdb4e
+#: dc9f7950a1344b7ba5c8f47853bb27af
+msgid "[2072699](https://bugs.launchpad.net/bugs/2072699)"
+msgstr ""
+
+#: ../../24.04/1.md 0da35b7f29f845669dddd5cfd8a54103
+msgid "Add a postinst script to rm livecd-rootfs' unminimize."
+msgstr ""
+
+#: ../../24.04/1.md ba3e085615b840e9b1d9045c30948361
+msgid "[2076307](https://bugs.launchpad.net/bugs/2076307)"
+msgstr ""
+
+#: ../../24.04/1.md 00d3f5756715467587caede46540f8ce
+msgid "Add 'ubuntu-core-installer' project."
+msgstr ""
+
+#: ../../24.04/1.md 76b9743d4a1a47e3b69fcce9b9748667
+msgid "[2077695](https://bugs.launchpad.net/bugs/2077695)"
+msgstr ""
+
+#: ../../24.04/1.md 79c523c6b9834c83b50b8b30ff6ee9fa
+msgid "Drop unminimize spit out by livecd-rootfs."
+msgstr ""
+
+#: ../../24.04/1.md 8564787515cb424ea8813d80f6bfc999
+msgid "[2077495](https://bugs.launchpad.net/bugs/2077495)"
+msgstr ""
+
+#: ../../24.04/1.md f983f3ccd67443988fa6912c31d87a2c
+msgid ""
+"Force latest/stable/ubuntu-24.10 subiquity onto the ubuntu-core-installer"
+" ISO for now."
+msgstr ""
+
+#: ../../24.04/1.md 98898e584de14c4698e6269af806eaae
+msgid "[2077899](https://bugs.launchpad.net/bugs/2077899)"
+msgstr ""
+
+#: ../../24.04/1.md cd852dea4b1244329c0b0fa03901d2e8
+msgid "Update ubuntu-classic-2404-amd64 model in ubuntu hooks."
+msgstr ""
+
+#: ../../24.04/1.md:27 0656a21df11e40e9bb63bebec006bd53
+msgid "Upgrade bug fixes"
+msgstr ""
+
+#: ../../24.04/1.md:29 663d2eb2145a47ae8aa6f0917f9e5d54
+msgid ""
+"These changes fix upgrade issues, smoothing the way for future upgrades "
+"to later releases of Ubuntu (and not only)."
+msgstr ""
+
+#: ../../24.04/1.md 08d4d2fbd86b4fd1bbfab7acecb4a233
+#: 0b079a49cb7244b6bee088af4c04e2e4 23d2ce7e5db343d691700b412b4d4078
+#: 2ed6e4508c9442ac80d6c0757ba1528a 33634571561f402898da740a61c7d955
+#: 3b29ecfcda1f415fb57cae7fa691e9e6 4db25055d5d148788a9e06e6eed74a72
+#: 615340a6382941dbb0786b5ba56b1af3 654761580fff48c68d6d9b9ee046a401
+#: 7b2e9863f6b24fd183a8fe0f61c92a05 7b52c9c4487e444bab9b806c875f725e
+#: 84a86f44b90e48d083efd73140fc8793 923831f605244990afb4aeb47aee6823
+#: 97091cdb80854717b8ebfb3a45625713 a7d77182325a4fe284cb24ae8569dd24
+#: b91ea99ba1ec4083a652a59736bad5a1 e0b4b22a81de4388aab5a686a5bfb9e5
+#: f68a49a0a7c54df4995262775707ff7a f99c58419f1843ae9bb9b67a48c9add8
+msgid "ubuntu-release-upgrader"
+msgstr ""
+
+#: ../../24.04/1.md f3c247dc5bdf49bdb3745ad12b61bbfb
+msgid "[2065229](https://bugs.launchpad.net/bugs/2065229)"
+msgstr ""
+
+#: ../../24.04/1.md 8d4b3cd1f0b5484aa23970cdb9a64be7
+msgid "DistUpgradeQuirks: prevent upgrades of TPM FDE desktops"
+msgstr ""
+
+#: ../../24.04/1.md 64bc5c6d42b9453eb066e4003ffee3fa
+msgid "[2065051](https://bugs.launchpad.net/bugs/2065051)"
+msgstr ""
+
+#: ../../24.04/1.md 5e87e1ffac134e7d8efafeeb3f69ab36
+msgid "New quirk to add KMS overlay on Pi Server images"
+msgstr ""
+
+#: ../../24.04/1.md 6e9256ea864e42819c490ecfb95bacee
+msgid "[2061891](https://bugs.launchpad.net/bugs/2061891)"
+msgstr ""
+
+#: ../../24.04/1.md b703e1efaebf46a6a7cecdd51f8f9dd4
+#, python-brace-format
+msgid "DistUpgradeQuirks: keep {netfilter,iptables}-persistent instead of ufw"
+msgstr ""
+
+#: ../../24.04/1.md 5ff6ddd5407443c68594bbf84738cdd6
+msgid "[2063464](https://bugs.launchpad.net/bugs/2063464)"
+msgstr ""
+
+#: ../../24.04/1.md e6d662f38ef64ea3b200ab0bb97ea7be
+msgid "DistUpgrade.cfg.jammy: Add systemd-resolved to PostUpgradeInstall"
+msgstr ""
+
+#: ../../24.04/1.md 2b3aa6d55d054d569a3f4d0cbcc30197
+msgid "[2064090](https://bugs.launchpad.net/bugs/2064090)"
+msgstr ""
+
+#: ../../24.04/1.md cb4842d269c24af583d62a2058fa9d0f
+msgid ""
+"Transition the automatically installed bit to t64 libraries, and do not "
+"write automatically installed bit in simulation"
+msgstr ""
+
+#: ../../24.04/1.md cb7edc0930154e889e08811e2fe2241e
+msgid "[2067886](https://bugs.launchpad.net/bugs/2067886)"
+msgstr ""
+
+#: ../../24.04/1.md 00d54911b80f445686316124c2d24524
+msgid "DistUpgrade: drop quirk for systems with BIOS and XFS /boot"
+msgstr ""
+
+#: ../../24.04/1.md 7f3d51abb6a5410ca5ca077cc9139803
+msgid "[2067071](https://bugs.launchpad.net/bugs/2067071)"
+msgstr ""
+
+#: ../../24.04/1.md 28dcd4f791b147bfbad4e44e1aa60ead
+msgid "DistUpgradeQuirks: make sure replacement.candidate is not None"
+msgstr ""
+
+#: ../../24.04/1.md 9b7127db7edd4f5591243b2f62ea33ec
+msgid "[2067585](https://bugs.launchpad.net/bugs/2067585)"
+msgstr ""
+
+#: ../../24.04/1.md 4bc1192fc8944575928c5ed86524cf08
+msgid "DistUpgrade: use tempfile for apt extended_states during simulation"
+msgstr ""
+
+#: ../../24.04/1.md c32d5daf892843c9b192f7ddfdfa6a3b
+msgid "[2076913](https://bugs.launchpad.net/bugs/2076913)"
+msgstr ""
+
+#: ../../24.04/1.md 9c3eb2b3ec6c4c6b9852ff0199a21456
+msgid "Fix typo in force_obsoletes."
+msgstr ""
+
+#: ../../24.04/1.md 761b25ad830e40b6b98d07b92239244d
+msgid "[2077358](https://bugs.launchpad.net/bugs/2077358)"
+msgstr ""
+
+#: ../../24.04/1.md b7414db66a0a4cb0b433bd02e918f8b9
+msgid "DistUpgrade: handle cache key error when removing obsolete packages"
+msgstr ""
+
+#: ../../24.04/1.md a176b74bb95b4a2fbc80826a8727571d
+msgid "[2077344](https://bugs.launchpad.net/bugs/2077344)"
+msgstr ""
+
+#: ../../24.04/1.md 1c4e8542f4ee42d3bc88fdb7a77f8a8f
+msgid "deb2snap: switch snap-store and firmware-updater tracks"
+msgstr ""
+
+#: ../../24.04/1.md 48b303d9b4794fcd94f739f82971034e
+msgid "[2043820](https://bugs.launchpad.net/bugs/2043820)"
+msgstr ""
+
+#: ../../24.04/1.md f7f9377eb4c744d289cd50554fd42d41
+msgid "DistUpgradeQuirks: disable stub resolver on upgrades from jammy"
+msgstr ""
+
+#: ../../24.04/1.md a4d0a18f8a984df49e8fc270d0ee6dbc
+msgid "[2073278](https://bugs.launchpad.net/bugs/2073278)"
+msgstr ""
+
+#: ../../24.04/1.md 544e7ce8f0d44034ace6857fb2e0635f
+msgid "DistUpgrade: show a message about denied package removals"
+msgstr ""
+
+#: ../../24.04/1.md 03a567caa7c54e6abd3c8cc177e609e2
+msgid "[2067622](https://bugs.launchpad.net/bugs/2067622)"
+msgstr ""
+
+#: ../../24.04/1.md c80bfdc56f9345a1a5255bd671cfab9e
+msgid "data: add cryptsetup-initramfs to removal_denylist.cfg"
+msgstr ""
+
+#: ../../24.04/1.md a9dd9503054b4fd9b1ddec4438f2fb4f
+msgid "[2058648](https://bugs.launchpad.net/bugs/2058648)"
+msgstr ""
+
+#: ../../24.04/1.md 4e3c746ba3104af49d248da97b4087a1
+msgid "DistUpgradeQuirks: abort if system is not /usr-merged"
+msgstr ""
+
+#: ../../24.04/1.md 074dcaec134b471b84b5461ab3c15373
+msgid "[2075968](https://bugs.launchpad.net/bugs/2075968)"
+msgstr ""
+
+#: ../../24.04/1.md 81188c8a9fbf41a9ae7c445797e19630
+msgid "DistUpgradeQuirks: disable cloud-init on upgrade"
+msgstr ""
+
+#: ../../24.04/1.md 1a77cc62093745618f8a8ec5296d5915
+msgid "[2074309](https://bugs.launchpad.net/bugs/2074309)"
+msgstr ""
+
+#: ../../24.04/1.md cbd83f89f9da49f8a61e743b5b6c2955
+msgid "DistUpgradeQuirks: abort if rabbitmq-server installed"
+msgstr ""
+
+#: ../../24.04/1.md 4704ca85f2a34e80a88bcf89ee7597b7
+msgid "[2054103](https://bugs.launchpad.net/bugs/2054103)"
+msgstr ""
+
+#: ../../24.04/1.md 3ff2658987434cb392afee2a6b674c1c
+msgid ""
+"DistUpgradeQuirks: make sure GRUB \"cloud_style_installation\" is set in "
+"cloud images"
+msgstr ""
+
+#: ../../24.04/1.md 9bf70600b9674243810532c912ddbbcc
+msgid "[1874272](https://bugs.launchpad.net/bugs/1874272)"
+msgstr ""
+
+#: ../../24.04/1.md 87599b584e584d26bde51ad96d3e5f85
+msgid "Reimplement obsolete removal with resolve_by_keep"
+msgstr ""
+
+#: ../../24.04/1.md:53 6b35ae88d2c84bbabf877168fc4c40d7
+msgid "Desktop fixes"
+msgstr ""
+
+#: ../../24.04/1.md:55 517a36b1435642f5b2e291d28eae1797
+msgid ""
+"These changes mainly affect desktop installations of Ubuntu and other "
+"Ubuntu-based desktop systems."
+msgstr ""
+
+#: ../../24.04/1.md 675d0ddd46ca4660a2f0aef4b4ba4e44
+msgid "remmina"
+msgstr ""
+
+#: ../../24.04/1.md fe911de537a248cc8535d1c131f593a5
+msgid "[2062177](https://bugs.launchpad.net/bugs/2062177)"
+msgstr ""
+
+#: ../../24.04/1.md 7bbba38a081843de860ac60d4f7a0f0e
+msgid ""
+"cherry pick a fix from upstream for RDP connections segfaulting with the "
+"newest freerdp3 version (lp: #2062177)"
+msgstr ""
+
+#: ../../24.04/1.md 174de0a78bfa46ae98751801b2cdf26c
+#: 2ab5fdc85eb446d3a2d6ebf239c096ca 8d33135d7b7246488af805171c97e179
+msgid "nautilus"
+msgstr ""
+
+#: ../../24.04/1.md 1bb3887b7f8847c4ad1b8427c969e30e
+msgid "[2064643](https://bugs.launchpad.net/bugs/2064643)"
+msgstr ""
+
+#: ../../24.04/1.md 3d742357d52d4043828ffb2255014484
+msgid "New upstream stable bugfix release (lp: #2064643)"
+msgstr ""
+
+#: ../../24.04/1.md 40e705053d654134bf1857dd88ba60e8
+#: 9eccfa576f1e42ee812be2c34e971322 f9a8f5be5c9a49a5b6f5ba1238cd0086
+msgid "gnome-shell-extension-appindicator"
+msgstr ""
+
+#: ../../24.04/1.md 2c6d8748e4f84cb5bbd9fe822269b86f
+#: 4bcbcab3ce3945759d03d5908ff95e93
+msgid "[2042844](https://bugs.launchpad.net/bugs/2042844)"
+msgstr ""
+
+#: ../../24.04/1.md c22db4b004864fe896a60193cacfc26b
+msgid ""
+"appIndicator: Try to introspect the application for Activate method "
+"support."
+msgstr ""
+
+#: ../../24.04/1.md 682f0dc3c122495181ebbda545d83c84
+msgid "dbusMenu: Handle missing AboutToShow gracefully (LP: #2042844)."
+msgstr ""
+
+#: ../../24.04/1.md 8e8a6faa20af4d78bd57b1d4fe888832
+msgid "[2059818](https://bugs.launchpad.net/bugs/2059818)"
+msgstr ""
+
+#: ../../24.04/1.md 4b2827a92bbe4b9ca73091c14c6b2155
+msgid "Replace add_actor and remove_actor (LP: #2059818)."
+msgstr ""
+
+#: ../../24.04/1.md 356c3dcd80104fcab8b3bb87b4a622e5
+msgid "pipewire"
+msgstr ""
+
+#: ../../24.04/1.md 48846d38051143cc89a2482b6c3ec84a
+msgid "[2067338](https://bugs.launchpad.net/bugs/2067338)"
+msgstr ""
+
+#: ../../24.04/1.md 1309eca0ef434ed0a62b6a0b65c5a67b
+msgid "Patch to handle long SysEx messages in MIDI bridge"
+msgstr ""
+
+#: ../../24.04/1.md 4bd0aced58314e0f8ca14e9df3180126
+msgid "[2067592](https://bugs.launchpad.net/bugs/2067592)"
+msgstr ""
+
+#: ../../24.04/1.md 5abc551b40934c2ea91f10364f70d44a
+msgid "New upstream release (lp: #2067592)"
+msgstr ""
+
+#: ../../24.04/1.md 06e707637200498794b8c232ab273ac6
+#: b1a018565d174bf39468ae738ca37d04
+msgid "webkit2gtk"
+msgstr ""
+
+#: ../../24.04/1.md e3838f7f06db4e5fac219067737d2bea
+msgid "[2037015](https://bugs.launchpad.net/bugs/2037015)"
+msgstr ""
+
+#: ../../24.04/1.md 7e44fdf231fa4ac798e1f22621682692
+#: e4ea65a0b40a447dac9eff7d5def5b9b
+msgid ""
+"Convert disable-dmabuf-nvidia.patch to disable-dmabuf.patch, adding "
+"detection for Broadcom to work around corruption and crashes occurring in"
+" Raspberry Pi X11 sessions. (LP: #2037015, LP: #2062146)"
+msgstr ""
+
+#: ../../24.04/1.md ca538ae6ab114e83830f3001230d4804
+msgid "[2062146](https://bugs.launchpad.net/bugs/2062146)"
+msgstr ""
+
+#: ../../24.04/1.md cda22681f99c45fa8fad383e41f3e97d
+msgid "file-roller"
+msgstr ""
+
+#: ../../24.04/1.md 49eb8778f0b64f2f9366e1f4540fa337
+msgid "[2067387](https://bugs.launchpad.net/bugs/2067387)"
+msgstr ""
+
+#: ../../24.04/1.md 239cc09fc237490ebe5707be1c1aa4e1
+msgid "New upstream release (lp: #2067387)"
+msgstr ""
+
+#: ../../24.04/1.md 5cbbb43fd8ee48e3a30e917cda907c46
+#: 655b24aba9074ebcbbeecf3dc3a905e1 b4fd66eed4a145fab13f1dac7fea1e77
+msgid "mesa"
+msgstr ""
+
+#: ../../24.04/1.md 780644fdf35d42deb5802d3f19b37e2f
+#: 8fad878f36ab4b6fb1c1383185c68228
+msgid "[2068918](https://bugs.launchpad.net/bugs/2068918)"
+msgstr ""
+
+#: ../../24.04/1.md 6521a8950857462abc5dae82ea3f8506
+msgid "Backport to noble."
+msgstr ""
+
+#: ../../24.04/1.md 3b03fdb9f27c4bb8b7aaceba4af75e18
+#: a779817bf2ce42329f4200e5eece1ad4
+msgid "New upstream release."
+msgstr ""
+
+#: ../../24.04/1.md 9ea44719aacb489ebf88511e62bbe8f5
+msgid "[2061955](https://bugs.launchpad.net/bugs/2061955)"
+msgstr ""
+
+#: ../../24.04/1.md 8b7ff1abb6f844d9be6f6b47b657a4a6
+msgid "patches: Add ARL support."
+msgstr ""
+
+#: ../../24.04/1.md 1872140ba895424ea8252fb7009e1450
+msgid "gnome-shell-extension-tiling-assistant"
+msgstr ""
+
+#: ../../24.04/1.md 6f5cf1fc083d47da96fceabc07cf857f
+msgid "[2064646](https://bugs.launchpad.net/bugs/2064646)"
+msgstr ""
+
+#: ../../24.04/1.md d1d7e721df73414d8238827790f1bdc8
+msgid ""
+"fix a bug where clicking on the top panel sometime triggers the tiling "
+"action (lp: #2064646)"
+msgstr ""
+
+#: ../../24.04/1.md 8d604c5b87a543389aabd3a2ffdc0aca
+msgid "[1996927](https://bugs.launchpad.net/bugs/1996927)"
+msgstr ""
+
+#: ../../24.04/1.md 401d217ee8624674b135f6740fad3357
+msgid ""
+"d/p/u/nautilus-sendto.patch: If nautilus-sendto is installed, then use it"
+" when clicking 'Email' in the file context menu, else do the default "
+"upstream action, namely to use the XDG portal (LP: #1996927)."
+msgstr ""
+
+#: ../../24.04/1.md 50ac18a86037453f8a2e784b4668c6e9
+msgid "gnome-calculator"
+msgstr ""
+
+#: ../../24.04/1.md b895d00460464343a6e670204700ac5f
+msgid "[2067420](https://bugs.launchpad.net/bugs/2067420)"
+msgstr ""
+
+#: ../../24.04/1.md 1eb5a970872d4c34adacb5f563ea50ec
+msgid "Merge with Debian (LP: #2067420), remaining change:"
+msgstr ""
+
+#: ../../24.04/1.md 129ccd901eca4786a7c71c957d6b33cc
+#: 41ec390f187646a6af0f9a8208595e36 6877a8a53bf141dab6c415fdb37cad94
+#: 89aea0e394c6488fa2dc118db1288fea 8c719b1fdf7d43acb62c0e815af8f2a2
+#: c615e88c4d0e4cdeb3fcc277f030c4cd ca96b14611814008811d9d36055f984f
+#: f16514c7fadf4e87baa587602b2429fe f401ef0bb6d644049399ad87f97397d0
+msgid "gnome-shell"
+msgstr ""
+
+#: ../../24.04/1.md c696e492680144a8a858baa5b667d288
+msgid "[2069381](https://bugs.launchpad.net/bugs/2069381)"
+msgstr ""
+
+#: ../../24.04/1.md b0c43fc1b8a14f2fbc320c0d623913c8
+msgid "d/p/ubuntu-authd: Revert unwanted change causing ibus not to launch"
+msgstr ""
+
+#: ../../24.04/1.md 2816d44ed5034825864fbad0b1745555
+msgid "[2067610](https://bugs.launchpad.net/bugs/2067610)"
+msgstr ""
+
+#: ../../24.04/1.md 0fec2248a7d54c1eada4d58646dad5b8
+msgid "d/p/ubuntu-authd: Properly draw qr-codes for longer URIs"
+msgstr ""
+
+#: ../../24.04/1.md 23de55e7d41a4feabb32d2177d3ef010
+#: d88acd1c03ee46b59353b037cc52b831
+msgid "[2067661](https://bugs.launchpad.net/bugs/2067661)"
+msgstr ""
+
+#: ../../24.04/1.md dd32e247fd0d41f98fc464a85d7399c4
+msgid "d/p/ubuntu-authd: Fix dialog text color when using light theme"
+msgstr ""
+
+#: ../../24.04/1.md 813120e8caa94877918602559f08de16
+msgid "d/p/ubuntu-authd: Use right colors to draw the qr code in light mode"
+msgstr ""
+
+#: ../../24.04/1.md e5ffb68ed2e44983996bf2ac79c7124a
+msgid "[2068080](https://bugs.launchpad.net/bugs/2068080)"
+msgstr ""
+
+#: ../../24.04/1.md 63d53ad4c79c42cab6f36ff80760a26a
+msgid "d/p/ubuntu-authd: Properly handle new-password messages requests"
+msgstr ""
+
+#: ../../24.04/1.md 02bfe6d758bb4939852fde1008de10c6
+msgid "[2068912](https://bugs.launchpad.net/bugs/2068912)"
+msgstr ""
+
+#: ../../24.04/1.md d524a7a926a0460eaa2a71eed02d5cd3
+msgid "d/p/ubuntu-authd: Add translatable js files to POTFILES.in"
+msgstr ""
+
+#: ../../24.04/1.md 7b99a21eb2bc4493ae5b5ccaff3ec1db
+#: 98af3c55fc08421d8a7678a0cfb4e979
+msgid "[2012388](https://bugs.launchpad.net/bugs/2012388)"
+msgstr ""
+
+#: ../../24.04/1.md 400cefc199164794929409015a6a8514
+msgid "d/p: Resize tray icon windows to respect their actor representation"
+msgstr ""
+
+#: ../../24.04/1.md 89a9a000fdd24b898a5d624fe6e10a3f
+msgid ""
+"d/p: Do not make tray icons to take any input event directly. This is all"
+" handled through their actor proxy representation"
+msgstr ""
+
+#: ../../24.04/1.md 0e559f8bf0444d1e8fe5ccdc951811d6
+msgid "xkeyboard-config"
+msgstr ""
+
+#: ../../24.04/1.md 37310b131d40484484f9d83ddc49c9aa
+msgid "[2069963](https://bugs.launchpad.net/bugs/2069963)"
+msgstr ""
+
+#: ../../24.04/1.md 7b7119a5b4564df5af85b2ad2271729c
+msgid "Added Ergo-L layout and variant"
+msgstr ""
+
+#: ../../24.04/1.md e2cbe7a0f9224a46b5b3923622190338
+msgid "xdg-desktop-portal-gnome"
+msgstr ""
+
+#: ../../24.04/1.md 8c9d6c1c69d644cf80dbc6abbb3c6e0c
+msgid "[2064732](https://bugs.launchpad.net/bugs/2064732)"
+msgstr ""
+
+#: ../../24.04/1.md 042c56cef487432791ca3253238dde54
+#: 0aceb13a024b4cbf9bf7b2ded69227ed 0f1ee40524404dedacf6fdc36ca04c9c
+#: 10301ad150b44215820b1c46597ee934 2d4a3048f8444b61a9b1993322bfb505
+#: 449ad472295544e89d42930b50220d28 51e44a5f678240ecbc62e42e2a8ba556
+#: a9d9b425efff40baa1fd0da57c7dec0f ade143d37bfa4988b34f5a6830575698
+#: c31491a45bd24d079024858028ee0b93 f70f9a6c3b12448fa4ca29c2cc60fea2
+msgid "New upstream release"
+msgstr ""
+
+#: ../../24.04/1.md 01be126449a548d094dbfff358839d50
+#: 041df89b0fbf4b939c73a7f54521a2fe 0b0ba5254ae740a4a2f6def17218756e
+#: 143b67df18b744bc8c46f7e6c22a96f8 207053917f3d47c0a24e3059cd3720a2
+#: 24bd8db5dac841979c627dfa7419a8d2 2a753cf805fc4cb5bb2f378647714d63
+#: 2b3334af3c0640368c3c4b2a29056db5 2b62d52bf87d407e8c27c2192bd9bf6c
+#: 342b22f8efc34d3a9dacfe6f1b917f3c 356f629b2ab548058bd81b0d7a523024
+#: 35e0986480e14040881720383e31a5f2 44bfbf0e4dbd4d6e897acb306ed13959
+#: 4cf6f31145d844619c51d66a8758fd8b 4ea3402cc1794c978883269990305b08
+#: 4edc3ebad97c4eddb7d1338569f64ecc 50d4cf6ecc0d4e8db17975d410f16e63
+#: 53dbfe9b432c4b21838696cb1255ebc1 55ddf4b8991c4da68068e7b46aeb97e8
+#: 57f1a29b2f7a415f837070044f26da54 58c3fcdcb0ef4a6d95ac29effaf21180
+#: 6e13d8235e06481188f7db8a1f5ee388 8278a4859b554463a205c6584d30aea0
+#: 8403293fd62740edb6cfc979c0b279d4 84a7cc3e2f8d41d899eb8ca4cc52fca5
+#: 950cd2035cca47659b6f665ef7f27239 972d864a37be4673aac3247253c19113
+#: 99de4cc52f174b0caeee28cb6965987e 9d170832f6d04a11ae0694f39f0d6970
+#: a2bf60e2a8bf4c0e936ecc831d6f4125 a316b80a944e41868b3348b5144bfe0f
+#: a4e2519242aa49a2878d034221bc7530 a4e7f0c9ff27479b977a327ed50a3fe8
+#: afee5b5c7aa740ef931657524178fe52 b07ecebda2b14b7fa938cf07579587fd
+#: b19a359a5b524e81a5985ccc68e5e01e b6d197b3bf9e48bb99f6610602654586
+#: b70c21eb7a3e454cba01b7f0ab67ca6c b7f90dd5ca5743559c329270e2219c7c
+#: be172ed40f614ba7a0af8d61cd8c2797 be2a18bcb98f402caf9a8cbf6094882a
+#: c1260ef29f194324813925fe3afd4d6b d59161e3f3884855ac1a7771a2bfb44e
+#: d82577c9dedd4fcbaf0b18cb8d709879 d9e5b9f45d864233a8e67c2a3fdba4ce
+#: dc06eea3a5f54fa584d116749b0d5df5 dc8a4bdc48c84b59a05cdf2364709337
+#: ea8c5692332a483680ec2b537ce10884 ecb685805da842faa17a7fa144fe5ed6
+#: f0a3a57077e846e782585e5c16af7f88 f75fe176c58d4b1c8532a1d2e07df5c9
+msgid "linux-aws"
+msgstr ""
+
+#: ../../24.04/1.md b44f2bd5447545e1a1e2d557cab7db64
+msgid "[2070059](https://bugs.launchpad.net/bugs/2070059)"
+msgstr ""
+
+#: ../../24.04/1.md 5ab55ea6acf642d2ba21148b9d61d467
+msgid "noble/linux-aws: 6.8.0-1011.12 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 492bc19e1c1b4a54ad1cb53582ffffb1
+#: e16e787c35084c3aa40ffdfa82a01a25
+msgid "gnome-text-editor"
+msgstr ""
+
+#: ../../24.04/1.md bc67104e376044f184fb3a68b98590e8
+msgid "[2070283](https://bugs.launchpad.net/bugs/2070283)"
+msgstr ""
+
+#: ../../24.04/1.md 4192dacdb7dc4800a790c681bcd7eaea
+msgid "evolution-data-server"
+msgstr ""
+
+#: ../../24.04/1.md 775af12239d44f88a37034a200f5936d
+msgid "[2070386](https://bugs.launchpad.net/bugs/2070386)"
+msgstr ""
+
+#: ../../24.04/1.md 0121cea5ffcb430bb40cffa7c510ec55
+#: 0d062b45a2db4c939f0a334ced556e1c 158df6a84f4c4117a156fc1c05362fba
+#: 2e04158a73174d68872edfff93b79753 3c2b180b233a4a0bab483b147186089f
+#: 691a53b3f3014f22b66cf28b0018d9be 6b1d11a075ef4106a03a2b7d692074d3
+#: 6fd20e26e3c444c0a131ebb109799d3b 80cb5d69eadd40ca96eb4bb74151f3c7
+#: adf294bc88bc480fac78d38d3ba7d0c1 cc0d0dc1c5cc46f4839f5158d0c794ce
+#: dc07710ba0df46acb9c5c79cb23f8eac ebfc32a8d72b4a7fa7033b86be37cd4c
+#: f6ccfa0e742c40a6b8a64a371a484f23
+msgid "mutter"
+msgstr ""
+
+#: ../../24.04/1.md c2bb4ac2acbf4944ab386cecc006147b
+msgid "[2068598](https://bugs.launchpad.net/bugs/2068598)"
+msgstr ""
+
+#: ../../24.04/1.md 3fd3f29858aa4a73a915d1bddef5535c
+msgid "New upstream release 46.2"
+msgstr ""
+
+#: ../../24.04/1.md a68487f156d84f25966da370474309d5
+msgid "[2026194](https://bugs.launchpad.net/bugs/2026194)"
+msgstr ""
+
+#: ../../24.04/1.md 481aecd298db41baba21cccaed779be1
+msgid "Fixed mouse clicks falling through to the window behind"
+msgstr ""
+
+#: ../../24.04/1.md ea1b65a558d540de945b23dc7944022e
+msgid "[2061739](https://bugs.launchpad.net/bugs/2061739)"
+msgstr ""
+
+#: ../../24.04/1.md e5308419ac974f4d93657578aae3d391
+msgid "Fixed a crash in meta_wayland_transaction_commit"
+msgstr ""
+
+#: ../../24.04/1.md 4db1fece145a4b2f8d235de65e54bead
+msgid "[2066902](https://bugs.launchpad.net/bugs/2066902)"
+msgstr ""
+
+#: ../../24.04/1.md 64b676d6797a4814af28f37810c111ed
+msgid "Fixed night light getting stuck on"
+msgstr ""
+
+#: ../../24.04/1.md 7790bea491e0451ea0fe6e3989f2d52e
+msgid "[2064735](https://bugs.launchpad.net/bugs/2064735)"
+msgstr ""
+
+#: ../../24.04/1.md 7db30bd510bc442783e321fa2b771155
+msgid "New upstream release 46.1 (LP: #2064735):"
+msgstr ""
+
+#: ../../24.04/1.md 37fb36e0e1c54368ae52cf6200436bfc
+msgid "[2066931](https://bugs.launchpad.net/bugs/2066931)"
+msgstr ""
+
+#: ../../24.04/1.md a3586a4a0b4d491796f61c518cac786e
+msgid "Fixed blank screen on hybrid GPU machines using nouveau"
+msgstr ""
+
+#: ../../24.04/1.md 31becb6d3ebb49069d22437537c1a036
+msgid "[2050865](https://bugs.launchpad.net/bugs/2050865)"
+msgstr ""
+
+#: ../../24.04/1.md f274ea98d54a499bbe1f841f117a8b02
+msgid "Fixed a monitor hotplug crash"
+msgstr ""
+
+#: ../../24.04/1.md 2db55204ecdd43378d72915c776088dc
+msgid "[2038801](https://bugs.launchpad.net/bugs/2038801)"
+msgstr ""
+
+#: ../../24.04/1.md ac59a8aa952741369c9ee7b4c85ea15e
+msgid "Improved performance on secondary GPU monitors"
+msgstr ""
+
+#: ../../24.04/1.md c8786a3bd76e419aa94b67231ae993f0
+msgid "[2070437](https://bugs.launchpad.net/bugs/2070437)"
+msgstr ""
+
+#: ../../24.04/1.md 149ff421a23c4336a1fad2aebbc83f07
+#: 4d4a54b348c44437a70b84303028036c
+msgid "Support-Dynamic-triple-double-buffering.patch (LP: #2070437, LP: #2070438)"
+msgstr ""
+
+#: ../../24.04/1.md 8e060b5a164f43dcbb60263b5b4bb41a
+msgid "[2070438](https://bugs.launchpad.net/bugs/2070438)"
+msgstr ""
+
+#: ../../24.04/1.md 5f1ce089880646df837d692d351a92a7
+msgid "[1967707](https://bugs.launchpad.net/bugs/1967707)"
+msgstr ""
+
+#: ../../24.04/1.md 29e72b356daa497e95593a25bf3f2d04
+msgid ""
+"Add `backends-Handle-null-views-instead-of-creating-dummy-view.patch` to "
+"prevent \"clutter_frame_clock_notify_presented: code should not be "
+"reached\" log spam in some Nvidia Wayland sessions"
+msgstr ""
+
+#: ../../24.04/1.md 99b17880baee447285c86a8004c92284
+msgid "[2062377](https://bugs.launchpad.net/bugs/2062377)"
+msgstr ""
+
+#: ../../24.04/1.md b36cefaf77a74a099339ff4e8e684566
+#: b3d8942dbbe942259d7bf7bac0e496f2
+msgid ""
+"Add backends-Restore-support-for-X11-cursor-themes.patch to restore "
+"support for X11 cursor themes, which was lost in Mutter 46.0 (LP: "
+"#2062377, LP: #2063869)"
+msgstr ""
+
+#: ../../24.04/1.md d4a04682f6bb4f96b14f8de78d0e095a
+msgid "[2063869](https://bugs.launchpad.net/bugs/2063869)"
+msgstr ""
+
+#: ../../24.04/1.md 2af8dc1d20d84afaa54840efe753359a
+msgid "[2016013](https://bugs.launchpad.net/bugs/2016013)"
+msgstr ""
+
+#: ../../24.04/1.md f46b7bf0a697420091a12bc10c3b1ef2
+msgid "Add place-Always-center-initial-setup.patch"
+msgstr ""
+
+#: ../../24.04/1.md 646856e65d9e463db97639f8a64ed81a
+#: 676507069a4046c0ac7f94667f10cea6 f7e612e834094e3e8eb2d2e0bd84242c
+msgid "gnome-initial-setup"
+msgstr ""
+
+#: ../../24.04/1.md a02fb3bf661f40c3936e8a3e7f197df5
+msgid "[2071447](https://bugs.launchpad.net/bugs/2071447)"
+msgstr ""
+
+#: ../../24.04/1.md 06ca6aecb1aa48cb8ee97e1a3b7b4f93
+msgid "New upstream version (lp: #2071447)"
+msgstr ""
+
+#: ../../24.04/1.md 6f64d31519944e049626666b60569328
+msgid "[2069375](https://bugs.launchpad.net/bugs/2069375)"
+msgstr ""
+
+#: ../../24.04/1.md c926f43fbd9749a48123162af48ddc2b
+msgid "improve the keyboard navigation on the pro page (lp: #2069375)"
+msgstr ""
+
+#: ../../24.04/1.md 4f7186a7ddbb493b998f3bbafe5704a7
+msgid "[2071449](https://bugs.launchpad.net/bugs/2071449)"
+msgstr ""
+
+#: ../../24.04/1.md 637657790a5c447d9726d836007f99bb
+msgid ""
+"Fixes and improvements to the 'create initial user' mode. We aren't using"
+" gnome-initial-setup to create users in Ubuntu today, since our desktop "
+"installer is handling the user creation, but that's wanted feature for "
+"oem installation to replace oem-setup which doesn't exist in the new "
+"installer (lp: #2071449)."
+msgstr ""
+
+#: ../../24.04/1.md 59bc0def8e1044569e6e5f126d3c22dd
+#: 6f8af4e4e47f4e0db38ad44a4e3decc5
+msgid "gnome-remote-desktop"
+msgstr ""
+
+#: ../../24.04/1.md d9cd96f23e87420ab68de1471b17aba9
+msgid "[2072771](https://bugs.launchpad.net/bugs/2072771)"
+msgstr ""
+
+#: ../../24.04/1.md 7bbab8b36e484ed7a4528facfba89601
+msgid "[2072596](https://bugs.launchpad.net/bugs/2072596)"
+msgstr ""
+
+#: ../../24.04/1.md 73a20caf06704fffa2c2c7ae2ed4e90e
+msgid ""
+"Use custom postinst to fix long delay when first installing 46 (Closes: "
+"#1070119)"
+msgstr ""
+
+#: ../../24.04/1.md 50db08d6fb32481e95f8c2f8cbda0ca6
+msgid "ubuntu-settings"
+msgstr ""
+
+#: ../../24.04/1.md 60eb82dc83364922ba8fd5f18ca8e742
+msgid "[2072574](https://bugs.launchpad.net/bugs/2072574)"
+msgstr ""
+
+#: ../../24.04/1.md bef2701f47ce4087ad3cd4a20f14c213
+msgid "Drop obsolete evolution-data-server notify-with-tray override"
+msgstr ""
+
+#: ../../24.04/1.md d3db10e34b7f4f7381046d9e841b1606
+#: ddd85ed3441343e5924ebcb1e6e19dce
+msgid "gnome-online-accounts"
+msgstr ""
+
+#: ../../24.04/1.md 9f727082242d49ea86f012a97f9bcddf
+msgid "[2072782](https://bugs.launchpad.net/bugs/2072782)"
+msgstr ""
+
+#: ../../24.04/1.md 8eff5dc160a3404a9a1a3b6515982716
+msgid "[2072775](https://bugs.launchpad.net/bugs/2072775)"
+msgstr ""
+
+#: ../../24.04/1.md 04e50d65bd9b4380bad98428b0aecb6c
+msgid "Update WebDAV/CardDAV/CalDAV support for Fastmail and mailbox.org"
+msgstr ""
+
+#: ../../24.04/1.md 4aad2d908fd54e7c8cc7b1094cda8779
+msgid "gsettings-desktop-schemas"
+msgstr ""
+
+#: ../../24.04/1.md c804ea64abd64fa2ac33c63e882092c0
+msgid "[2064656](https://bugs.launchpad.net/bugs/2064656)"
+msgstr ""
+
+#: ../../24.04/1.md 1f78a297a49c4770ae44f515568c7db5
+msgid ""
+"Fixes systemd journal log spam in some languages once the language packs "
+"are updated"
+msgstr ""
+
+#: ../../24.04/1.md 4c1e7132e3e94cffbff6378945609941
+msgid "gnome-calendar"
+msgstr ""
+
+#: ../../24.04/1.md 6a5b534101a64b13ad0260f7345db32e
+msgid "[2072742](https://bugs.launchpad.net/bugs/2072742)"
+msgstr ""
+
+#: ../../24.04/1.md acb2c568226e48f8a20b2c6427ddd482
+msgid "New upstream release (lp: #2072742)"
+msgstr ""
+
+#: ../../24.04/1.md 7c90f802bbe3497a99339dfcf4f92b8e
+msgid "[2069559](https://bugs.launchpad.net/bugs/2069559)"
+msgstr ""
+
+#: ../../24.04/1.md 8ec958912a7a420ea75ecd44f8f11bfc
+msgid ""
+"Add st-theme-node-Forget-properties-cache-on-stylesheet-chang.patch to "
+"fix crashes that occur when locking the screen from within the overview. "
+"But more generally can occur whenever any extension that modifies "
+"stylesheets (like ubuntu-dock or dash-to-dock) is unloaded (LP: "
+"#2069559)."
+msgstr ""
+
+#: ../../24.04/1.md 2ccf01810ae5407795ebdc536a089e32
+msgid "[2075553](https://bugs.launchpad.net/bugs/2075553)"
+msgstr ""
+
+#: ../../24.04/1.md 1d87c932c9d04a6d9f87f6a4ca168e44
+msgid "debian: Backport patches to fix crash on launch (lp: #2075553)"
+msgstr ""
+
+#: ../../24.04/1.md:115 e471b964a3ac4d479088818d58d2e2ae
+msgid "Server and Cloud related fixes"
+msgstr ""
+
+#: ../../24.04/1.md:117 c5687883b6594d98be66a0500d5b10dd
+msgid ""
+"These changes mainly affect installations of Ubuntu on server systems and"
+" clouds."
+msgstr ""
+
+#: ../../24.04/1.md 14ac5c8e2cf14e59b81fb6eb8cde4465
+#: 18753f5985c046d09594fdcae6fbaa64 4742ed9c9dee43d0a643c4fbb2558efa
+msgid "google-osconfig-agent"
+msgstr ""
+
+#: ../../24.04/1.md 5dc32f3b64944305965e26035c6dae99
+#: c72802b32e934d2491ac43ba0ddf17f3
+msgid "[2064580](https://bugs.launchpad.net/bugs/2064580)"
+msgstr ""
+
+#: ../../24.04/1.md 114840c9a2a64e869b3bc009a354e3f0
+#: 398f0c295fd94316a44007f174471dc8
+msgid "Rebuild for Noble."
+msgstr ""
+
+#: ../../24.04/1.md 3fe6b4aa48e847bba1a3a3672c8bf4c3
+#: a5c128afe0224c13bb306037eb43c597
+msgid "New upstream version for upstream tag 20240320.00."
+msgstr ""
+
+#: ../../24.04/1.md e8bd782ba974437db7787268c7223e64
+msgid "nbd"
+msgstr ""
+
+#: ../../24.04/1.md a738f338aee94a9e8f0375d6cbb6ebd9
+msgid "[2060745](https://bugs.launchpad.net/bugs/2060745)"
+msgstr ""
+
+#: ../../24.04/1.md 4afaf9539b2f406d9039565d64e4ac65
+msgid ""
+"d/p/0002-Set-sensible-default-for-port.patch:  When no port is specified "
+"in nbdtab, set default to NBD_DEFAULT_PORT (i.e. \"10809\") to fix issue "
+"where \"0\" is assumed."
+msgstr ""
+
+#: ../../24.04/1.md 9b12cd33e6bc4ba9a72dd9cf16a4cb85
+msgid "dhcpcd"
+msgstr ""
+
+#: ../../24.04/1.md 7909a80f11ce46fcb2a60f650b78d273
+msgid "[2064926](https://bugs.launchpad.net/bugs/2064926)"
+msgstr ""
+
+#: ../../24.04/1.md 752038704df64658904feef8badfb543
+msgid ""
+"hooks/30-hostname: Exit with 0 if setting hostname is not needed This "
+"prevents retrying dhcpcd for 5 minutes during boot."
+msgstr ""
+
+#: ../../24.04/1.md 8f1e21c10b984e2390c85e9938862184
+#: ad57c2f6d5584a06873e2f185a64daac baa50512acaa476192259c8c1d04a7cd
+#: ff133bc609cd48c5b116c7cefcf2554d
+msgid "cloud-init"
+msgstr ""
+
+#: ../../24.04/1.md 1ce4d5a7343645df96619b42ade555de
+#: 458cfb8509894a5db67c5f6404198488
+msgid "[2064132](https://bugs.launchpad.net/bugs/2064132)"
+msgstr ""
+
+#: ../../24.04/1.md fa913846b8294c5ba45da6bae9d2bea2
+msgid ""
+"cherry-pick 51c6569f: fix(snapd): ubuntu do not snap refresh when snap "
+"absent"
+msgstr ""
+
+#: ../../24.04/1.md 1f35017a7522467d84f33d2b2a7f852a
+msgid ""
+"cherry-pick a6f7577d: bug(package_update): avoid snap refresh in images "
+"without"
+msgstr ""
+
+#: ../../24.04/1.md 12685da4ef564a89ba60b72da4b412a4
+#: 930b8c63a24e49d6bb49bcd799d33959 ae3e35dbc0824be3a6f030bcebc11a4e
+msgid "openvswitch"
+msgstr ""
+
+#: ../../24.04/1.md a8b1bcd1dcbb4faaa1d59e22e0c215e1
+msgid "[2066906](https://bugs.launchpad.net/bugs/2066906)"
+msgstr ""
+
+#: ../../24.04/1.md f124013fda504a6fb90155657a72c788
+msgid ""
+"d/p/ofproto-dpif-xlate-Fix-continuations-with-associated- metering.patch:"
+" Cherry-pick fix required for OVN 24.03.2 (LP: #2066906)."
+msgstr ""
+
+#: ../../24.04/1.md 88aa825c0abb45b88aae2bf1c253a63b
+msgid "[2063112](https://bugs.launchpad.net/bugs/2063112)"
+msgstr ""
+
+#: ../../24.04/1.md d6b8af5585b4430e88f4fea830c363a5
+msgid "d/tests: Bump number of 1G hugepages to 3 for arm64 (LP: #2063112)."
+msgstr ""
+
+#: ../../24.04/1.md f599bc35b98c42699a4ed58a63d34c37
+msgid "[2063152](https://bugs.launchpad.net/bugs/2063152)"
+msgstr ""
+
+#: ../../24.04/1.md a5bf7d0dccde46a68d8082f9f587ed73
+msgid ""
+"d/tests: Skip tests not fitting memory constraints in arm64 CI (LP: "
+"#2063152)."
+msgstr ""
+
+#: ../../24.04/1.md 6311febd8fd3438c8a83a407429ea505
+msgid "[2066979](https://bugs.launchpad.net/bugs/2066979)"
+msgstr ""
+
+#: ../../24.04/1.md 03c707fbecbd44abadb9ba4d6fb0c8e9
+msgid "cpick-417ee551: fix(ec2): Ensure metadata exists before configuring PBR."
+msgstr ""
+
+#: ../../24.04/1.md 7252a6e557c449979ebf87d529f579de
+msgid "[2066985](https://bugs.launchpad.net/bugs/2066985)"
+msgstr ""
+
+#: ../../24.04/1.md c9d3213bce7140fb9b895caa0c4dae7b
+msgid "cpick d771d1f4: fix(ec2): Correctly identify netplan renderer (#5361)"
+msgstr ""
+
+#: ../../24.04/1.md 8bd96dcb4aa34e66a9d42111187d9161
+msgid "ec2-hibinit-agent"
+msgstr ""
+
+#: ../../24.04/1.md c961d075911e4a3e8e5e3ea25d2a06eb
+msgid "[2066999](https://bugs.launchpad.net/bugs/2066999)"
+msgstr ""
+
+#: ../../24.04/1.md 2c4911f049e343deb7e759fa5bfa7feb
+msgid ""
+"d/p/0015-ignore-setting-resume-offset-again-if-dev-snapshot-d.patch: do "
+"not set the snapshot swap area if /dev/snapshot does not exist. This is "
+"necessary to enable ARM hibernation."
+msgstr ""
+
+#: ../../24.04/1.md 468fd3bba8f8410eac955f046c01af52
+#: 77a5017f51104e15980975c002124484
+msgid "netplan.io"
+msgstr ""
+
+#: ../../24.04/1.md 9da14d934ace4b3f86135d51851f80d4
+msgid "[2066258](https://bugs.launchpad.net/bugs/2066258)"
+msgstr ""
+
+#: ../../24.04/1.md eb8bdde7c23149c8b9aa3ad2c0e55d08
+msgid ""
+"d/p/lp2066258/0017-backends-escape-semicolons-in-service-units.patch: "
+"Escape isolated semicolons in systemd service units."
+msgstr ""
+
+#: ../../24.04/1.md 52db9db0dd244bc5ba426e8d3af6ee2e
+#: 5a1a7bfcca864010a93adfbd943a9015 5f09d6e9468c410c9bac9096ce587976
+msgid "horizon"
+msgstr ""
+
+#: ../../24.04/1.md a7fc7edb218640fe895d28a20b1b7cc7
+msgid "[1728031](https://bugs.launchpad.net/bugs/1728031)"
+msgstr ""
+
+#: ../../24.04/1.md d81871683cc549529e123dfcc1dbc970
+msgid "d/p/lp1728031.patch: Fix admin unable to reset user's password."
+msgstr ""
+
+#: ../../24.04/1.md bdf9767e66254e15aaeeda9c07b74fa0
+msgid "[2054799](https://bugs.launchpad.net/bugs/2054799)"
+msgstr ""
+
+#: ../../24.04/1.md 50d701024f174520a5b02ddb073b913c
+msgid ""
+"d/p/lp2054799.patch: Fix Users/Groups tab list when a domain context is "
+"set."
+msgstr ""
+
+#: ../../24.04/1.md 864508b45f904eeaafd9d6e233e2684e
+msgid "[2071333](https://bugs.launchpad.net/bugs/2071333)"
+msgstr ""
+
+#: ../../24.04/1.md 5b5dce0b55ad48e6b4943cf571d76d9c
+msgid ""
+"debian/netplan-generator.postinst: Don't call the generator if no "
+"networkd configuration file exists."
+msgstr ""
+
+#: ../../24.04/1.md 1985fbe882884cac9405a38280bfaeaf
+msgid "ovn"
+msgstr ""
+
+#: ../../24.04/1.md d69725d8321a4f3b8fd6fc084a7da32d
+msgid "[2066908](https://bugs.launchpad.net/bugs/2066908)"
+msgstr ""
+
+#: ../../24.04/1.md 5dc2a67ffdea45b6a73b793f97dcd9be
+msgid "New upstream point release 24.03.2 (LP: #2066908)."
+msgstr ""
+
+#: ../../24.04/1.md 3a99ca3868dc4accb05e6b12dc32bc96
+msgid "landscape-client"
+msgstr ""
+
+#: ../../24.04/1.md 000de179e3de446fa438bf5c6593122b
+msgid "[2066983](https://bugs.launchpad.net/bugs/2066983)"
+msgstr ""
+
+#: ../../24.04/1.md 96c90e71d0f64ba28e24828aff6aba19
+msgid ""
+"d/landscape-sysinfo.wrapper: fix 'cores' variable to CORES in message- "
+"of-the-day load threshold calculation"
+msgstr ""
+
+#: ../../24.04/1.md 7b02cd3a59f24cdbbec4d69af38b823f
+msgid "libvirt"
+msgstr ""
+
+#: ../../24.04/1.md bbf06f8f141e427c9694a6fd6367f299
+msgid "[2071848](https://bugs.launchpad.net/bugs/2071848)"
+msgstr ""
+
+#: ../../24.04/1.md 526d123bf1704022b2c11eca8602afc8
+msgid ""
+"d/p/u/lp-2071848-fix-migration-with-disabled-vmx-features.patch: Fix "
+"migration issues with disabled vmx-* CPU features."
+msgstr ""
+
+#: ../../24.04/1.md eb9be634d6aa454ca7c7ffdf388fffb0
+msgid "[2067632](https://bugs.launchpad.net/bugs/2067632)"
+msgstr ""
+
+#: ../../24.04/1.md e6682fe4f2d74901b8fc4a8f9371ef84
+msgid ""
+"d/u/_styles.scss: use static_url variable instead of absolute path (LP: "
+"#2067632)."
+msgstr ""
+
+#: ../../24.04/1.md 61635cb91da34f0fae2ef8a830c9401b
+msgid "ceilometer"
+msgstr ""
+
+#: ../../24.04/1.md af331a8f93b642af8cac0a0132520538
+msgid "[2071939](https://bugs.launchpad.net/bugs/2071939)"
+msgstr ""
+
+#: ../../24.04/1.md 438691ce63f94c36b84478b88ea114a9
+msgid ""
+"d/patches/install-missing-files.patch: Ensure that all data files in the "
+"Python module directories are included in the binary package (LP: "
+"#2071939)."
+msgstr ""
+
+#: ../../24.04/1.md 092136b970ea4a72a22abd355bb439dc
+#: bce619a662b646c5ad96cb12c243af8a
+msgid "gce-compute-image-packages"
+msgstr ""
+
+#: ../../24.04/1.md 159c23c6c6534b1eac6325e978010222
+msgid "[2066314](https://bugs.launchpad.net/bugs/2066314)"
+msgstr ""
+
+#: ../../24.04/1.md 7f06c96f996e48be950837dd29db6e9d
+msgid "open-iscsi"
+msgstr ""
+
+#: ../../24.04/1.md 0affc75804ec4d6890510017134cc120
+#: 4d27aaa481dc42c29df1b195d68c2f55 a64ce084eaa643859d583bd92140eda0
+#: d6789c8ba05142faa1dfab9293d3c3c8
+msgid "[2065180](https://bugs.launchpad.net/bugs/2065180)"
+msgstr ""
+
+#: ../../24.04/1.md 5d30622617bc415fb9a0a1fb98e11f4a
+#: a9a9b6a262c34d8ca808e8076cfbc8c3
+msgid "initramfs-hook: Combine calls to manual_add_modules"
+msgstr ""
+
+#: ../../24.04/1.md 81904f50ddfc4610a9e48e337bcf4108
+msgid "thin-provisioning-tools"
+msgstr ""
+
+#: ../../24.04/1.md 7d00c0e558df44c5976fff3844e3c187
+#: d6b5775a22964c1e88bc7d98f9a9ef40 f08da7c0e8384fed9f950f24a95aba55
+msgid "ceph"
+msgstr ""
+
+#: ../../24.04/1.md bedb76846b554732aceabda9eab2f1b7
+msgid "[2064717](https://bugs.launchpad.net/bugs/2064717)"
+msgstr ""
+
+#: ../../24.04/1.md 4f5bb61061e14ffabe746dd221d1b9cf
+#, python-brace-format
+msgid ""
+"d/control: Add python3-{packaging,ceph-common} to (Build-)Depends as "
+"these are undocumented/detected runtime dependencies in ceph-volume (LP: "
+"#2064717)."
+msgstr ""
+
+#: ../../24.04/1.md fc6865c70a574660aef8aadc54637ed2
+msgid "[2063456](https://bugs.launchpad.net/bugs/2063456)"
+msgstr ""
+
+#: ../../24.04/1.md 25ded6ee79644511bc0c02b6f34ff881
+msgid ""
+"d/cephadm.install: Install cephadmlib Python module which the cephadm "
+"script uses (LP: #2063456)."
+msgstr ""
+
+#: ../../24.04/1.md 6d49e110910745d18ce7c58120ec39ee
+msgid "[2065867](https://bugs.launchpad.net/bugs/2065867)"
+msgstr ""
+
+#: ../../24.04/1.md 795935a646864c0c85538043f7e3f5f9
+msgid ""
+"d/p/mgr-distutils.patch: Directly use vendored distutils from setuptools "
+"for Python that runs in the mgr daemon (LP: #2065867)."
+msgstr ""
+
+#: ../../24.04/1.md be1ac7ac7c0e4c51a7357ebf7ac43355
+msgid "google-compute-engine-oslogin"
+msgstr ""
+
+#: ../../24.04/1.md a2d3626321ad46d092a0dbc4cd889275
+msgid "[2073166](https://bugs.launchpad.net/bugs/2073166)"
+msgstr ""
+
+#: ../../24.04/1.md d98e235907ab48b19780ed97314aa79b
+msgid "[2073161](https://bugs.launchpad.net/bugs/2073161)"
+msgstr ""
+
+#: ../../24.04/1.md 03d80faafe974f368ddc9752dd412b7f
+msgid "New upstream version for upstream tag 20240524.03."
+msgstr ""
+
+#: ../../24.04/1.md 0490b0b0757044cd8c2de180c9e62095
+msgid "[2073164](https://bugs.launchpad.net/bugs/2073164)"
+msgstr ""
+
+#: ../../24.04/1.md 160fbc9540b945c7bbfcf406407050c9
+msgid "New upstream version 20240607.00."
+msgstr ""
+
+#: ../../24.04/1.md 24a2e88d0ee84c2d99067f02faa63b1a
+#: ef24a21db4614fc8a47fa9ba3d1a787e
+msgid "google-guest-agent"
+msgstr ""
+
+#: ../../24.04/1.md 275e4bb1298b49afa38d31001bdb07ba
+msgid "[2073163](https://bugs.launchpad.net/bugs/2073163)"
+msgstr ""
+
+#: ../../24.04/1.md f17cff05855942ebb344a42fbf8b3625
+msgid "New upstream version 20240716.00."
+msgstr ""
+
+#: ../../24.04/1.md 607753b75eb24484acc94e02c030fd4f
+msgid "[2057965](https://bugs.launchpad.net/bugs/2057965)"
+msgstr ""
+
+#: ../../24.04/1.md cd31f12f0565499d98582c76a09cbfef
+msgid ""
+"d/p/0006-add-after-cloud-config-service.patch: add patch to force "
+"ordering between cloud-init and the guest agent."
+msgstr ""
+
+#: ../../24.04/1.md:154 04abac0c9b154cbfac10650f27932982
+msgid "Base platform fixes"
+msgstr ""
+
+#: ../../24.04/1.md:156 c392308400844ce79fc02e1269e60573
+msgid ""
+"These changes affect the core fundamental components of all the Ubuntu "
+"flavors."
+msgstr ""
+
+#: ../../24.04/1.md 414ef111a89b42b49cbc0900756e2fe0
+#: 5bb443c51af046d0956b5b502daf5cf5 797544e8737a4b9da8ff93f36b22bd8b
+#: 7dba089a89fd481884ac7dc9694423f0 995ecdeb3a9e416bad145dd989b034f3
+#: c056013d9bd8442c9619587dd00a843e e8a81737725c4bafa48b0004681da106
+msgid "apport"
+msgstr ""
+
+#: ../../24.04/1.md 9726647ba7ad4de18062f2e3154a8ab1
+msgid "[2056758](https://bugs.launchpad.net/bugs/2056758)"
+msgstr ""
+
+#: ../../24.04/1.md b017979995c54605a7cff7102edd5fe9
+msgid "report: fix determining bug report URL for Thunderbird"
+msgstr ""
+
+#: ../../24.04/1.md a5e4a78a8e4740d5af8840dfcc0ca829
+msgid "openssl"
+msgstr ""
+
+#: ../../24.04/1.md f9d23b1879c24d8399a05efdcebf2a8a
+msgid "[2054090](https://bugs.launchpad.net/bugs/2054090)"
+msgstr ""
+
+#: ../../24.04/1.md 14563121384f402a90d50c2a915f037f
+msgid "SECURITY UPDATE: Implicit rejection for RSA PKCS#1"
+msgstr ""
+
+#: ../../24.04/1.md 082b20e545e8474daa41730d868657da
+msgid "wsl-setup"
+msgstr ""
+
+#: ../../24.04/1.md 0fd098ad591c48518c8a4607617de7d6
+msgid "[2065349](https://bugs.launchpad.net/bugs/2065349)"
+msgstr ""
+
+#: ../../24.04/1.md deaf895d199342eda594b44865b47bd6
+msgid ""
+"Override cloud-init default_user configuration for Ubuntu distros to "
+"prevent creation of a default user which confused WSLg (LP: #2065349)."
+msgstr ""
+
+#: ../../24.04/1.md 9fe1b91ef5f3450bb68dbfd3edcbea9b
+msgid "initramfs-tools"
+msgstr ""
+
+#: ../../24.04/1.md da74195a26f7400087165d5d0787acf5
+msgid "[2065037](https://bugs.launchpad.net/bugs/2065037)"
+msgstr ""
+
+#: ../../24.04/1.md efe43b12a1864d85a5b544a4190f599a
+msgid ""
+"configure_network: Call dhcpcd with --nolink --noipv4ll to succeed "
+"getting a DHCP lease on the first try and avoid a 30 seconds delay"
+msgstr ""
+
+#: ../../24.04/1.md 2520760b47654823a212551b37118b9d
+#: 3e89a69e2f3745218536e81f101ee018 5b1dd5dbef6b4cf19827d606b4e5ead8
+#: 6642f923573e4cc6be9e58b6fa292a0f 6fa68312eb464dcba2c8d0b46e79db27
+#: 7865c8429cab41b0a31c2e9bca11331e 84318b5bca3d412e8ba91a5a944cfb0c
+#: 8ceb30ee73cd4111a8ae26a77e693ee0 dc8899636b8047739ab4bebbe6041200
+msgid "ubuntu-advantage-tools"
+msgstr ""
+
+#: ../../24.04/1.md 4d94c9a60b06477c867914cf7f0b155f
+#: 5a124b8bf0514ea8864e942eaade4ea0
+msgid "[2060732](https://bugs.launchpad.net/bugs/2060732)"
+msgstr ""
+
+#: ../../24.04/1.md 664bde444aaa4bebb4b3272d351c9168
+msgid "Backport 32.3 to noble"
+msgstr ""
+
+#: ../../24.04/1.md 08822ad4a1d849ad8700c48bf7a33d5b
+msgid "[2067319](https://bugs.launchpad.net/bugs/2067319)"
+msgstr ""
+
+#: ../../24.04/1.md 0b52a552a57440049e12ca2a8023a8dc
+msgid "d/apparmor: adjust the profiles to account for usr-merge consequences"
+msgstr ""
+
+#: ../../24.04/1.md 2055c4b2b9684b2e8f5bdf70945f7678
+msgid "[2066929](https://bugs.launchpad.net/bugs/2066929)"
+msgstr ""
+
+#: ../../24.04/1.md 15f9ce3870224251baa1dc3fedcfcb24
+msgid "d/apparmor: adjust rules for violations found during testing"
+msgstr ""
+
+#: ../../24.04/1.md f82cf468ab18471d9f23891acda967f7
+msgid "[2065573](https://bugs.launchpad.net/bugs/2065573)"
+msgstr ""
+
+#: ../../24.04/1.md 7a0dbd2a3f3c4311b02624d1daab1c62
+msgid "d/apparmor: allow access for /etc/os-release on all supported profiles"
+msgstr ""
+
+#: ../../24.04/1.md e4b930658223450b97f0b4a88ce17b12
+msgid "[2065616](https://bugs.launchpad.net/bugs/2065616)"
+msgstr ""
+
+#: ../../24.04/1.md c86793f5ea224587944e633658590d92
+msgid "apport: get path for timer job status from the correct place"
+msgstr ""
+
+#: ../../24.04/1.md eb69e749ef2f463e80f21145adb3ae53
+msgid "New upstream release 32"
+msgstr ""
+
+#: ../../24.04/1.md 22f279994760484dafc98c9f6318d14f
+msgid "[2033313](https://bugs.launchpad.net/bugs/2033313)"
+msgstr ""
+
+#: ../../24.04/1.md bae77e388a054e89ab53a6754781894b
+msgid "collect-logs: update default output file to pro_logs.tar.gz"
+msgstr ""
+
+#: ../../24.04/1.md e0f207aae9d943ffa4cb23ab2bcfa508
+msgid "[2031192](https://bugs.launchpad.net/bugs/2031192)"
+msgstr ""
+
+#: ../../24.04/1.md a0238dbe08594aaca03c7899e9c23a6a
+msgid "update logic that checks if a service is enabled"
+msgstr ""
+
+#: ../../24.04/1.md 1fca29432d3247c08170ff3b63a0cc80
+#: 21eee9e2b1b3433fb22bdf09b3850932 277d320f07cc4cd9b216d91bb61fc6c2
+#: 420ef98d23714d8e84935cefda85e3bf a1186e1a9a074a87945f73d5d3e1fccc
+#: d0cb57e10f624aaaa7a8c41c05b0a93c d3d2082312f7405487ab1db2344a8441
+#: f99166e23fa645abb7c468d7307fdeae
+msgid "systemd"
+msgstr ""
+
+#: ../../24.04/1.md fe65b79256d7425dbbd67ae66a07af33
+msgid "[2047975](https://bugs.launchpad.net/bugs/2047975)"
+msgstr ""
+
+#: ../../24.04/1.md 9afc7274c09e4d10ac358f042479ffab
+msgid "debian/systemd-resolved.postinst: ignore cp failure"
+msgstr ""
+
+#: ../../24.04/1.md 6190db4ed18b41d18d505230a8a14a27
+msgid "[2054761](https://bugs.launchpad.net/bugs/2054761)"
+msgstr ""
+
+#: ../../24.04/1.md 3dc401bebb4f4538bca45f2ae1144686
+msgid "debian/systemd.postinst: don't restart user managers if too old"
+msgstr ""
+
+#: ../../24.04/1.md 7df509e3577c4454aa54a9265600b5bd
+msgid "[2064096](https://bugs.launchpad.net/bugs/2064096)"
+msgstr ""
+
+#: ../../24.04/1.md 55978807f7cc4ae6a5294ae9f84faa8e
+msgid "switch-root: use MS_MOVE for /run when switchig from initrd"
+msgstr ""
+
+#: ../../24.04/1.md 0ed254131e784d3389b1168f89845dee
+msgid "[2065964](https://bugs.launchpad.net/bugs/2065964)"
+msgstr ""
+
+#: ../../24.04/1.md 89fac4ff0af340b9bf228e92771c20db
+msgid "test: check for kernel.apparmor_restrict_unprivileged_userns"
+msgstr ""
+
+#: ../../24.04/1.md 92320556cd95478a847044030988a3a8
+#: d5486710549d403eb3d15fe5c66ffc32
+msgid "tzdata"
+msgstr ""
+
+#: ../../24.04/1.md 256e8f7af1554308ae3858dcc020385a
+#: 426400e191024871b1bd3ea922762aeb
+msgid "[2062522](https://bugs.launchpad.net/bugs/2062522)"
+msgstr ""
+
+#: ../../24.04/1.md 28400e9ec2a744a1a4b11d3e854f5f38
+msgid "Fixup for avoid timezones being symlinks to symlinks"
+msgstr ""
+
+#: ../../24.04/1.md 1f9f2d073f9144d58eb2f8547c44c7ce
+msgid ""
+"Avoid timezones being symlinks to symlinks to avoid breaking C++20 "
+"standard expectation"
+msgstr ""
+
+#: ../../24.04/1.md 7d6cae340bde41e293282221ff4d2574
+#: e0e387b12ca64b0b9db62621276d4a4d
+msgid "pam"
+msgstr ""
+
+#: ../../24.04/1.md 5e696e2e4e3b4d189498bd47a60da61c
+msgid "[2064360](https://bugs.launchpad.net/bugs/2064360)"
+msgstr ""
+
+#: ../../24.04/1.md f10850c08a1b440eaab5ddbe1b09611e
+msgid "Correct Build depends for docbook5"
+msgstr ""
+
+#: ../../24.04/1.md b455d75149924642beaef742dae1d20d
+msgid "[2064350](https://bugs.launchpad.net/bugs/2064350)"
+msgstr ""
+
+#: ../../24.04/1.md 50e3015b9bfa4442b21e528aac9418cb
+msgid "Depend on libdb-dev again, bringing back pam_userdb"
+msgstr ""
+
+#: ../../24.04/1.md 819a007d82e341feb789d5fbe1399b5b
+#: 9a263e3a6f63419c9b18b70e711288ba
+msgid "snapd"
+msgstr ""
+
+#: ../../24.04/1.md b9c9eb44a96b4317b3c52ddb9e65e10e
+#: fdb6c0bbe5da441398cd8cbd73c1f0c3
+msgid "[2061179](https://bugs.launchpad.net/bugs/2061179)"
+msgstr ""
+
+#: ../../24.04/1.md 2dd08ed43641480d84e262ffde556ccb
+#: a591daab5d4e4dc9b629003b07363e39
+msgid "New upstream release, LP: #2061179"
+msgstr ""
+
+#: ../../24.04/1.md 988aaf2b5b1d4c55bd000fd0fb290122
+#: b067fbebb70241d2946e7f09372946b6
+msgid "dracut"
+msgstr ""
+
+#: ../../24.04/1.md 3321d706fd924013bdd39b5667a250d3
+msgid "perf(dracut-install): preload kmod resources for quicker module lookup"
+msgstr ""
+
+#: ../../24.04/1.md a73f56d2068f4de7a53f63f593ab5b69
+msgid "llvm-toolchain-18"
+msgstr ""
+
+#: ../../24.04/1.md 7a1deecc20234c448547d48ccd39631b
+msgid "[2064187](https://bugs.launchpad.net/bugs/2064187)"
+msgstr ""
+
+#: ../../24.04/1.md 04fc76634c454c67ba07e47a2ddf913e
+msgid "Disable mold for all to make sure it builds gold"
+msgstr ""
+
+#: ../../24.04/1.md 9e03cb3a7a414c4296d12f5629756ce8
+msgid "[2067810](https://bugs.launchpad.net/bugs/2067810)"
+msgstr ""
+
+#: ../../24.04/1.md 744f1fd6820e4f63ae1c598f2c005125
+msgid ""
+"Adjust the esm_cache apparmor profile to allow reading of dpkg data "
+"directory (LP: #2067810):"
+msgstr ""
+
+#: ../../24.04/1.md 0036ecadc3a24914a99d905151a84d6e
+#: 037262dd26b9439694f3376960249d67 10329999c94041949ffe7a580f300d26
+#: 2e883231c44741e0a900988f7008bc05 7028b129882a4807bca56caa3522eade
+#: 9a2d9f63818b47e7b923af6c6aafe2ad a0d98256d2a04662800a4bc3a163c465
+#: d9ed1d6a34f24bec8decadeca12a310d
+msgid "apparmor"
+msgstr ""
+
+#: ../../24.04/1.md 89a6f0fc679e4f4e85b07394dc01e4d0
+msgid "[2064672](https://bugs.launchpad.net/bugs/2064672)"
+msgstr ""
+
+#: ../../24.04/1.md 1a790b43c9fb421c93a9720282d783c5
+#: 80870363cfe3483d98a1604e29ad304e bcde244316de404397a6e09d66b6a795
+msgid "[2046844](https://bugs.launchpad.net/bugs/2046844)"
+msgstr ""
+
+#: ../../24.04/1.md ab3d0582882f4c548a4653ed59898a0f
+msgid "Add patch to add balena-etcher profile"
+msgstr ""
+
+#: ../../24.04/1.md 833c35d3f6164c38b67a89817a9be436
+#: b578cbc5d0174fbf84661168b1660cb7 d07b81500dba402e8e8dfd7e4185460c
+msgid "New upstream release. (LP: #2046844, LP: #2060100, LP: #2056297)"
+msgstr ""
+
+#: ../../24.04/1.md ac29dcfff8a042b98ce6f8d8cc70ca15
+msgid "[2060100](https://bugs.launchpad.net/bugs/2060100)"
+msgstr ""
+
+#: ../../24.04/1.md c9a3b3c139ba45e3bfab0bd2880982a5
+msgid "[2056297](https://bugs.launchpad.net/bugs/2056297)"
+msgstr ""
+
+#: ../../24.04/1.md 13557fe2ccd841968f63b38c6f2e48a3
+#: 7b61f104a71d4243a61e80838246aa86
+msgid "d/p/u/enable-bwrap-profile.patch (LP: #2046844, LP: #2065708)"
+msgstr ""
+
+#: ../../24.04/1.md 9d49dfa3db2d4e2d8014871dce5ba097
+msgid "[2065708](https://bugs.launchpad.net/bugs/2065708)"
+msgstr ""
+
+#: ../../24.04/1.md 7413d75135364f05aecb6b0c3c0fbb1d
+msgid "[2067907](https://bugs.launchpad.net/bugs/2067907)"
+msgstr ""
+
+#: ../../24.04/1.md 657aa0295d434192818f7b46bba81d8e
+msgid ""
+"mountpoint-util: Deal with kernel API breakage in \"norecovery\" mount "
+"option. Also include fixup commit 055b465a3f (\"shared/mountpoint-util: "
+"for old kernels, assume \"norecovery\" is supported by btrfs\")."
+msgstr ""
+
+#: ../../24.04/1.md dfcc6ea33bbc4cb0b0e286760c1610be
+msgid "[2067922](https://bugs.launchpad.net/bugs/2067922)"
+msgstr ""
+
+#: ../../24.04/1.md a89d4db9da9446a5b16fb631cc299e10
+msgid "cgroup-util: allow cg_read_pid() to skip unmapped (zero) pids"
+msgstr ""
+
+#: ../../24.04/1.md d93ea01a738444869bd00d8e83807d41
+msgid "[2067927](https://bugs.launchpad.net/bugs/2067927)"
+msgstr ""
+
+#: ../../24.04/1.md 7eb158d48f5845ddada196e5d0ed48e6
+msgid "debian/extra: ship nice.conf for journald, not logind"
+msgstr ""
+
+#: ../../24.04/1.md e49aa7bf2c004571b7e7f3a6b773bc7d
+msgid "[2072811](https://bugs.launchpad.net/bugs/2072811)"
+msgstr ""
+
+#: ../../24.04/1.md 611d35fe5ffa423eaa9640c247826b3d
+msgid ""
+"Due to regression, revert changes in previous update back to a source "
+"tree equivalent to 4.0.0-beta3-0ubuntu3 (LP: #2072811)."
+msgstr ""
+
+#: ../../24.04/1.md 210ea1459b3348a3a0a3e9743631d53d
+#: 70b9e62d663f413b93680fab3eb9ec18 a47140c4f7ea430999ad49572019342d
+#: d0a9305ffde14118a6076405776a518e da215c5c72cc44c7b24422d5ff5d950b
+msgid "needrestart"
+msgstr ""
+
+#: ../../24.04/1.md 7735b8e50d3d47d6b828a44eda5a23e9
+msgid "[2067482](https://bugs.launchpad.net/bugs/2067482)"
+msgstr ""
+
+#: ../../24.04/1.md c823b22c5f7e48ddb1260c1fe6159b2d
+msgid "Prevent needrestart restarting itself"
+msgstr ""
+
+#: ../../24.04/1.md 8f5163af34e04ef3891b3143add73a23
+msgid "[2065863](https://bugs.launchpad.net/bugs/2065863)"
+msgstr ""
+
+#: ../../24.04/1.md 1ab746fcd2e44198804df01306575f39
+msgid "d/p/ubuntu-mode.patch: Don't touch /run/reboot-required on kernel updates"
+msgstr ""
+
+#: ../../24.04/1.md 49b288951b184378bfa15fb4e83e348a
+msgid "[2068543](https://bugs.launchpad.net/bugs/2068543)"
+msgstr ""
+
+#: ../../24.04/1.md 43146d06578540b78175177807cb9e63
+msgid "Ubuntu mode: disable it if restart mode has been explicitly set"
+msgstr ""
+
+#: ../../24.04/1.md 01c9b3900c2e44a69ef9a948c93ce203
+msgid "[2068573](https://bugs.launchpad.net/bugs/2068573)"
+msgstr ""
+
+#: ../../24.04/1.md 6a8d28a566664ff4a21dc167dcd9958a
+msgid "Add some inline documentation for the Ubuntu mode"
+msgstr ""
+
+#: ../../24.04/1.md 8ada1adaae104f1281418648d975d069
+msgid "[2063442](https://bugs.launchpad.net/bugs/2063442)"
+msgstr ""
+
+#: ../../24.04/1.md 1bc9d72ce24c4dd0ba4c00e2c8d58436
+msgid "Don't restart the google-guest-agent service"
+msgstr ""
+
+#: ../../24.04/1.md 8fafd8bd6d1f4f748f9d8c82dd73a024
+msgid "Cherry-pick upstream performance fixes (LP: #2065180):"
+msgstr ""
+
+#: ../../24.04/1.md 4a19640d5be045f1b1528e56e2c99f42
+msgid "[2067775](https://bugs.launchpad.net/bugs/2067775)"
+msgstr ""
+
+#: ../../24.04/1.md 09b6808300e64b7895770063f502e8ae
+msgid "d/package-hooks/subiquity.py: update information collection"
+msgstr ""
+
+#: ../../24.04/1.md 19c26d44122e4231a76bde88b08c006d
+#: a71a96473bdb46fc8cd4d00118e29b7c
+msgid "[2066995](https://bugs.launchpad.net/bugs/2066995)"
+msgstr ""
+
+#: ../../24.04/1.md a2d95e1c937848beaeef8a00cfbdb281
+msgid ""
+"apport: do not modify permission of existing /var/crash or create "
+"/var/crash with setgid permission (mode 3777)"
+msgstr ""
+
+#: ../../24.04/1.md 2cd1d8b546c8411bb9527b6b758396f3
+msgid "apport.postinst: Create /var/crash with mode 3777"
+msgstr ""
+
+#: ../../24.04/1.md efb00985496d47bba103298476b45e1f
+msgid "[2069360](https://bugs.launchpad.net/bugs/2069360)"
+msgstr ""
+
+#: ../../24.04/1.md 313a42849e4646e88743e6da141f5023
+msgid "whoopsie-upload-all: exit with 0 if whoopsie is disabled"
+msgstr ""
+
+#: ../../24.04/1.md 03bd6e3ac8354c95afd73ed09c6a55e5
+msgid "[2067120](https://bugs.launchpad.net/bugs/2067120)"
+msgstr ""
+
+#: ../../24.04/1.md 60a63358d7dc44ba9430dbb6c16089d7
+msgid ""
+"Fix retracing crashes on Ubuntu 24.04 LTS (noble) and add chaos-marmosets"
+" as dependency for the newly added system-tests"
+msgstr ""
+
+#: ../../24.04/1.md f30c157579c242e29b6e9f74cbee13f6
+msgid "[2072751](https://bugs.launchpad.net/bugs/2072751)"
+msgstr ""
+
+#: ../../24.04/1.md c8e9d86d9857479c976fef969a872078
+msgid "Fix some issues in the hook for ubuntu-desktop-bootstrap"
+msgstr ""
+
+#: ../../24.04/1.md 39af2aa05f1c43709211fb7c055ea58d
+#: e9594c54e41e423db98a65da6dfdad29
+msgid "dpkg"
+msgstr ""
+
+#: ../../24.04/1.md 45fceb66ee3449d0bf4b103fac503ce4
+#: 4668accd5f4a491e8aea6845b536fb2b
+msgid "[2064539](https://bugs.launchpad.net/bugs/2064539)"
+msgstr ""
+
+#: ../../24.04/1.md d8f721999c464e739c8e90251c76bbc5
+msgid "Disable framepointer on ppc64el. LP: #2064539."
+msgstr ""
+
+#: ../../24.04/1.md 95474b7855604f1a9028b573b7763a31
+#: d22a4382c642450bab0af1d39081c219
+msgid "[2064538](https://bugs.launchpad.net/bugs/2064538)"
+msgstr ""
+
+#: ../../24.04/1.md 71e2882d555d490f8003235c57dda1cf
+msgid "Disable framepointer on s390x, leaving only -mbackchain. LP: #2064538."
+msgstr ""
+
+#: ../../24.04/1.md a1e1550b38544801a07541fb8586568a
+msgid "ubuntu-meta"
+msgstr ""
+
+#: ../../24.04/1.md 577c8d6a6d94428596e32bf4045a6443
+msgid "Added unminimize to cloud-minimal, server-minimal."
+msgstr ""
+
+#: ../../24.04/1.md bb7e29942649477bb9f65e55062c1408
+#: f65eb35be2244b1faa64f5cacc9c7ad4
+msgid "glibc"
+msgstr ""
+
+#: ../../24.04/1.md 98895a8099f542959d434c82feb7cb8d
+#: fe96765304cc413e8147293da3a37473
+msgid "Fix framepointer flags for s390x and ppc64el (LP: #2064538, LP: #2064539)"
+msgstr ""
+
+#: ../../24.04/1.md e3a94eb360dd4602b4756bf19c8977dc
+msgid "[2055239](https://bugs.launchpad.net/bugs/2055239)"
+msgstr ""
+
+#: ../../24.04/1.md f430a84890c64651b5226849101c86ed
+msgid ""
+"core/dbus-manager: mark unit file state as outdated only if some changes "
+"succeeded"
+msgstr ""
+
+#: ../../24.04/1.md e6f89ec8bff346289dc203dd33d37405
+msgid "e2fsprogs"
+msgstr ""
+
+#: ../../24.04/1.md 49ee91a1376f42a5a8da8926fc5c9c6f
+msgid "[2036467](https://bugs.launchpad.net/bugs/2036467)"
+msgstr ""
+
+#: ../../24.04/1.md c511c01a2b9b4e3c9ffea0e59451dec0
+msgid ""
+"Fix superblock checksum mismatch during resize2fs operations, most "
+"notably during online resize of cloud images during boot. Read the "
+"superblock with Direct I/O to ensure we get the correct view of the disk."
+msgstr ""
+
+#: ../../24.04/1.md ed4d24339f7447aa8eb40fe968f88db8
+msgid "python3-defaults"
+msgstr ""
+
+#: ../../24.04/1.md aa8f3dbb7a154e8e934338966e8d140e
+msgid "[2075337](https://bugs.launchpad.net/bugs/2075337)"
+msgstr ""
+
+#: ../../24.04/1.md e53691f8d0ab49d99b3bf15784be5cef
+msgid ""
+"debpython/files.py: Use LC_ALL=C.UTF-8 when calling dpkg -L to avoid "
+"localization issues"
+msgstr ""
+
+#: ../../24.04/1.md:217 47bdb7081ca8455bbdf56b0fca3bbcd3
+msgid "Kernel and Hardware support updates"
+msgstr ""
+
+#: ../../24.04/1.md:219 befe6d9dd56740f99b4f3943a96ce898
+msgid ""
+"Considerable work has been done on improving support for many specific "
+"items of hardware."
+msgstr ""
+
+#: ../../24.04/1.md 0d3d8bf6ce5b4f6ba87a73bf2ff2cd8b
+#: 516f313188ff4dd3bcf022f9856c78e6 5631cb94e06040c6b515c50d98da4d95
+#: 6719b4d2ab55408fbdbe149c41037404
+msgid "linux"
+msgstr ""
+
+#: ../../24.04/1.md 0493a2c208d041678bb8fc39029c4f4b
+#: 0d714556710d4968955d9ae93a367074 502390a25650400b80384c5f49b031c3
+#: 53edb53ba9b44d04be76eae7a8db3b4d 5753c2f240764b6a9059d6e12dc47cab
+#: 57ed654e1d9f44ed880334ad025bdc96 5dc2b65e05a74b8c99cc5937afb94d79
+#: 6605e9af36424d5398908f530ad65dd0 791ce47f95794c4f8032799772dcc81e
+#: 7964a86e33b04b269fcc93aceb6d7791 851fb978a0f642b79bf85082ed57bb27
+#: 879e887958544595a2e3d8411c73adfd a84b8c0c9d1d434a81ba905c1ba2585a
+#: a9a90e291c344ebc97637017795b603c b27eb95fdd8e4943b81bc5b38f983362
+#: bc357dfe4d5e4d4fb3939fe4542cce40 ddefe0c6fcb7460997b6a845f7e580e3
+#: e330567543944e40a0bcceab1f434f25 e7b66c79ced540b4b7820b7a98cc468c
+#: ec6cf385d1524f66943f8f306c3a53b6 ed3c821b05f44b1e8ade0280acca505d
+#: ef004053ae314e358ea8b491045f2d5a f179c4c660444efda44526aa872cb1c9
+#: f58b807582834ca3ab209983410b22b8 fb8ff029ec12434bb226d54d958b5e4c
+#: fbe6624310174f15b55e639ad1a15a7e
+msgid "[1975592](https://bugs.launchpad.net/bugs/1975592)"
+msgstr ""
+
+#: ../../24.04/1.md 37a8726b3ae74f62bd95f4bd9d628b38
+#: 37b028cf6ee8488289e6d7b96829c5bd 3a8bee6c483c4f838797b2c2be9f895a
+#: 4c7d4adc652e42a2976871d7ae74dd71 72052de67d7a45bca75003a74ed698ec
+#: 880d9249a04f45679374f8de1004abf0 99b414be59344559ab008debc45e82a1
+#: a64855edd3d94bacacc243ccd966bb35 b8211623e2d44bdb8f086976ce4a0494
+#: e067db8e4c274f0eaf25b78872fbe965 e3805fa1acf5431bb44a58ed25da14bd
+#: e8336245a7f34dfc8f24106630a72a3e f1ac5e074bda4e73a24ba651c42b265a
+msgid "Enable Nezha board"
+msgstr ""
+
+#: ../../24.04/1.md 04cd27d1c0ae439da4126644b09332e5
+#: 0b83d012ac274eb48fd4837a1afc5269 1f97a67367a84e5eb6655c79b365fdbb
+#: 2086616d0f6f4c2a9cd5917325228584 273a8cd44a4f44c58c6b30ede7ae0a2b
+#: 2acea4555d034b5dba94fc0c22984781 2bda59fbe59542ac855db426a75f6098
+#: 31597b25e23a449dbc2e1df4a11e1cca 3938f78ef9e24b1a8c77cd3d7151fd40
+#: 3972d0371d044fe9aff5b525c7800d6a 3b6f76469b604787a125d94e5e3fd0aa
+#: 4fba8dc99ce84357802348e65e2846c3 59f566744ae94331a8a4165651649016
+#: 65e7d5410233425f8cee479c121e4194 913782042e1d4954b8c9df1f46d12f65
+#: a1063220e676473fad336054661b5bd4 a49029e8126c4b718e53588215d86f34
+#: af7c1d1729844037b0766cb08a370e49 c171db2bddbb4c18ace39fb242edaf44
+#: c689ca6f3bc4417e9d18fa49dc62a6ca d3f2f1f4d79946a2bef6b932ef151ec1
+#: dd2a2b49bcfc442c91aa360125348fea e3f3f210aacb40eb9c87ccaf06cc9584
+#: ec0f4287e6e942f8b4b443a57d21d5ba f15cf5b93f1048be988e14b9c5f3018f
+#: f4b136be561e4b0a9f5dc29ab32a3b3d
+msgid "Enable Nezha board (LP: #1975592) // Enable StarFive VisionFive 2 board"
+msgstr ""
+
+#: ../../24.04/1.md 07b1b74b9f3a433bb95548a5d959e6be
+#: 2d6aa0afcc43428686aaff417856500a 3ef3502381184910ada398e37f599ca4
+#: 49732807520b45079643a8551d76d8b5 71cf6ce492e740f483fefc3cd3c24682
+#: a6ba456f65954f82bdc5ddc345f54401 ad8757d41c714f4ea6a0111d18965399
+#: b0e696e39e304330abb53508403a1af8 b580347702b946609b2159d3aafb13ce
+#: bad34a82b9ed44e1b34ecd896f2e8df1 c0ffa1dc9aa947b18d8b1ec5a6c8aeda
+#: ddd403e0fb65408bb25589111b92cc87 ec333bb835f54312989ddd81d3ad91ae
+#: ff921df17eae46e3a5d476fce8fcef3d
+msgid "[2013232](https://bugs.launchpad.net/bugs/2013232)"
+msgstr ""
+
+#: ../../24.04/1.md 15c75be1a3124add8fef25d209079afe
+#: 1c66812d53e74547ac3007997947336b 71c96c0c4f2c4b22af79859e8b9b4055
+#: 744b5bfc514542ed8b7b058b53741be2 78c3936f17e449728c840cd8c3a5afab
+#: b9d456d6924f428e9da8b483264b7807 bd5376e60a2e42a3a20c3b445fcba47e
+#: c12fc0f5901e43a183af33cca4642bc5 c6785358d1734834871b9faeff9fa5fd
+#: c7bbd11980394e7ead708d176a5ecbcb cab3bc3280c24840baf000a28f3a5c94
+#: dde68593a8294779847e241afc72422f dec68702c7714033a2b5b71a5f8ea5a0
+msgid "[1981437](https://bugs.launchpad.net/bugs/1981437)"
+msgstr ""
+
+#: ../../24.04/1.md 5cecbe1f536f4cc18ae30c1e8c462820
+#: 5d7672ba11d14a47bcefb0e94f9d0682 613e0f2764454511af31b2765aec35ef
+#: 65731b21a3de47fb95f5b18c67729d4f 65cf46b12c5e4011a1ba352ddaa6871c
+#: 6fd54945ade44d0ebb382fed66c8c840 84f4e4648b664dc5b5a5533d329098ba
+#: a77d92f50a094e68874dce78084acbd9 bbbe5e9a72c24ae8a3b885d6d258a214
+#: d1613d6b23ba40bda445f06f4e4782ee e8fc4ec1b933441f90e38160851d94b5
+#: ef21248298ce4deea535b56cedd956a5 fb651aa59e3440758df98859c58c4e87
+msgid "RISC-V kernel config is out of sync with other archs"
+msgstr ""
+
+#: ../../24.04/1.md 8f3b66abfab24856baa43a7bfcf87373
+msgid "linux-meta"
+msgstr ""
+
+#: ../../24.04/1.md c75c1c9ac3164535a1fabd775f9fee11
+msgid "[2064266](https://bugs.launchpad.net/bugs/2064266)"
+msgstr ""
+
+#: ../../24.04/1.md ea82a08229794d3f8255d6f345fd9d38
+msgid "linux-virtual: recommends linux-tools and ubuntu-kernel-accessories"
+msgstr ""
+
+#: ../../24.04/1.md 100c739f34df4665bf15afa592d762bf
+#: 15b3da0839994e19a8c5b098ffaa44b3 16a4afaf36314ceeab9b45684ec6e934
+#: 1c8a83b0c013487197481d37a9a77913 38a7386a4eaf444e97b8478111c5c5ca
+#: 3a5d43551b0344e6bd602b2e5681b43a 830b78ffaca24966980a32454b55c7e0
+#: 8ad0227733784e03847905ec9fe49ea7 c33d53a987ac4655a64e63453f0b605d
+#: f289cd6aeefb421290bb0370e887637c
+msgid "linux-raspi"
+msgstr ""
+
+#: ../../24.04/1.md 15df8a7c03e3471190a448195f24d6f1
+#: 331fb76d3efe4dbfb87aa926ba6aff0e 39dea029254f4561bd55cd3c79031ec1
+#: 5702e1cd1c404b5997d5e51cf42402d1 574e936687214ed6b96f5edef7a3c9aa
+#: 6e5870f8f48f4ff0b62381b7548b0b62 91195ab7a7ec41d0ac34d4c343349631
+#: 98d57c0a51c544238b98cf2fb8297f7d b7cb2587c8fc456ba8a510c6be8f0df3
+#: d3cbdaa4a17644c8a0201eb535a842a7 d4bfac0f75284b8a9a7db101c2c8764e
+msgid "[2062933](https://bugs.launchpad.net/bugs/2062933)"
+msgstr ""
+
+#: ../../24.04/1.md 03d3de7af1e84130976214c853c270a8
+#: 12063f7bf2db4f8f9f4e18065d0b730f 164b6d20c4f04f8eb3d4a34d23ca04c3
+#: 36b80686b75240cd9d40f164a7577c44 5fa41874a9494f31aac63896f5138712
+#: 720d7487460a4cb1ae0e05cf6650e3eb bf855940960d4069bd474e69aeeb0dec
+#: c9387cef502d45d6b602c7755eee6595 e6e34af5f4614487b4177c17c61a2ab5
+#: e87db87d325a4835a39879f0a56964f9 fea62521261c44e9811178605af1722f
+msgid "noble/linux: 6.8.0-31.31 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 22781dd3bb9f46aca58a342d836eaa58
+#: 31828f2e538541f6a1f837904e574799 38c80478220643cb80146241046012c1
+#: 396f90ec186143949afc4a142852edc3 3a9ff6ef35ad45279a87a2d0e79f57bb
+#: 624dc61d6cb74169897323eafe3c5b8f 8459b8f2ccc04c098f04cc6c6044386b
+#: af3643cf8b8743fa9154b65932ca71d3 dcf0dfd55ffb4902bc783c4ff9985d59
+#: fcadd360324a45a980e717da1e599013
+msgid "[2061893](https://bugs.launchpad.net/bugs/2061893)"
+msgstr ""
+
+#: ../../24.04/1.md 38f27eee9e9546d4a84def5b7e482654
+#: 410340618635475a9c1af44340c8ecee 4c56b44f84be4afc98ac7e67953c3981
+#: 4ed78e49505b42da800e8f409d1b0944 6150bded8de0409a93f20b48f83f8fab
+#: 65aa7e6e0f5c478da237d2a7fc236d57 9fea4ec49b7a4c61a5d86a24e7ba08cf
+#: e4788ed68a944a3688acefb3afaa988c f043587d56d84954bf14ff98c4e46ba3
+#: f35483ee8b38422f9b30e429c06e0e55
+msgid "noble/linux: 6.8.0-30.30 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 000b440acf2d4ce986dde7d677b4cf6e
+#: 01ef323bc66641deac43775d9808c2ea 177277f395bb431db3451c840f46b4b5
+#: 32e18d30655d4100a50577bb2e8970b4 38c7704efd3843ccbf53a6507df86cc6
+#: 816772b5c7ef46d791529348623e8d71 a2b63150f1c0440795698270e8c512d9
+#: b30bc2f162f34883804ea3cb3864777c f703b3fbf83d4bf6b2bacc63269ceb36
+#: feeb90cae63f4404b25374cd898f3d14
+msgid "[2056706](https://bugs.launchpad.net/bugs/2056706)"
+msgstr ""
+
+#: ../../24.04/1.md 0a6bb8ba554b4055bed2befcf9f06346
+#: 43df8b2499254121a02139753de0fc20 58adc94f092d4c0f9d939d0f5e3061d5
+#: 6823bd99896745cea155f61e8f94002a 8356e7eef97e4be4943baee4535bd504
+#: 8411740166bf45d492d35b971c35d8bc aa5d29d18d8f4abf828c12c9aeb20c08
+#: b4414d85d1284326a968472e4932463c bf3f23ee9dcc4d47b6ea77f41f26032d
+#: e92b89eb16fb4d868f350c4c98351bef
+msgid ""
+"System unstable, kernel ring buffer flooded with \"BUG: Bad page state in"
+" process swapper/0\""
+msgstr ""
+
+#: ../../24.04/1.md 09d30a252a1b474c80743f9a2cc57498
+#: 60de930db0b44cca9aea755368f3fe8f 6571c02f7d864132ab7258ae235aadbc
+#: 767a9eaf9be649b1af856fc871588823 a092bc4f02c64e22a7d297b87bd4adce
+#: afd3a342d74e4ac489b149f39e005a3f b75cc282b0e7470588171c7cdcded956
+#: c6fe9838fd854e9f9ff248943ec602dc c8bb7d9917664fe39ecd8d4cbfd228cf
+#: ede95ef63cd742babd7726a106718c28
+msgid "[2061888](https://bugs.launchpad.net/bugs/2061888)"
+msgstr ""
+
+#: ../../24.04/1.md 111e4d66e4584a7b8b897c7425d520fa
+#: 1ced31cc19af42a2bb989b64bd7538de 505adf105604482ca484781f8c698185
+#: 53fe72da438d42de92e33bc799f21fc4 68516532426741569661ef59da5aa35b
+#: 88a347ad6dcf4292a1b6226d5a857e3f 9ffd899ba8004140b8574361c278d273
+#: a931c19c5a874a8cb87a621265a1a6cd b408ea7d8970407397c301e682a24e4f
+#: cafadd642b5b47f8bf17142ada33f4a7
+msgid "noble/linux: 6.8.0-29.29 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 2af92f48932e4d8dbd59ed94eab80bae
+#: 34e652f9f5dd46cab7023a4dc1cf1f45 480620edb8eb411a89666c9acda3ee1e
+#: 5b2e9ab846144d61a79c4318cec49130 6360b081dc0540479a054e0ecec9b918
+#: 6858d888f3cd4b4bbde8883c4ee0d91b 800d803a4352446b842f0f546469b978
+#: b4804ea040364b0aaa8bb9bc6efe826c b5d342bd21bd4fa0807597b60386e112
+#: b6c5b467cdce49afac44e37a5464ad1f
+msgid "[2050019](https://bugs.launchpad.net/bugs/2050019)"
+msgstr ""
+
+#: ../../24.04/1.md 0c981c27769e4c28973d0cbb917250fd
+#: 313f1702de35426b8cc57df1fcdeacd4 6c04a92e71494797ba721c1ab2803e22
+#: 7298ab8a18d5465b90603fdbd5336b38 9d268d3ee7eb44cea63a808da2c752da
+#: a00f6454e8344933851e5989ec257223 a81f30cc6e0f438a90362f0f5ac085aa
+#: d0ac9974c8e3498b9923fe0c1f394b08 f1a045bc09bf4c658d1a2e4b2a3a67da
+#: f6685f1c962d4435818dd2b86c5f9e6f
+msgid ""
+"24.04 FEAT] [SEC2353] zcrypt: extend error recovery to deal with device "
+"scans"
+msgstr ""
+
+#: ../../24.04/1.md 0a5c6c1dd605425ea53f81861fc6a90c
+#: 0b1dc73f06db40dca48456c226ceaefa 160187f8e80d4585bacbc4fde098731d
+#: 401f234921074063a8972662efed5e20 45f66e19d3294937b39152736f446baa
+#: 8ee643d81d9f454d875aa4320563c02c a9f9190f0bfa4ed7a73631bc37553d41
+#: ab5fd60d51964fc294f40c9d5d0a5632 d7d572cf74c54300944ad7577992e2e0
+#: ea621d591478404db640e7dde8ef5020
+msgid "[2051835](https://bugs.launchpad.net/bugs/2051835)"
+msgstr ""
+
+#: ../../24.04/1.md 0ea728a898534f638203973beb39d7c7
+#: 2a0b74a2111742978cea7d1aa7cb97bd 45732faddfd14f9bad2247802e7fba6a
+#: 45b79897e2234c1fbe7c028e806ea525 70edbcf73d124355b0f3c57ab0ae1026
+#: b0282eb82cb34aa79d3a58fd0343fdda c05bebe64b5440cfa3c579542fa90617
+#: e0a2af82e7264d7aafd7fada81f564e1 ea254ce39247429bad12be1eb2fe245c
+#: ff46876185c5405f8dbe20e1311bc765
+msgid "24.04 FEAT] Memory hotplug vmem pages (s390x)"
+msgstr ""
+
+#: ../../24.04/1.md f280b787b1724a148290767f97d09b91
+msgid "[2064325](https://bugs.launchpad.net/bugs/2064325)"
+msgstr ""
+
+#: ../../24.04/1.md f9a16c757cf2471eaf86358ccb4e4b00
+msgid "noble/linux-aws: 6.8.0-1009.9 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 1f49ffc4e08f428ab15cb085df93f0e3
+#: 3b91fe34eab54fcf87e971252cc70305 415a3cc5891641e09d040164512f3801
+#: 68854ff8c8634d4d909596687a5b1988 76ac602cb995426ca3e378e273d7417d
+#: 7e9b57b6117b4ab289553f216d8b35f2 8c7bf6bb09f541d0842d423c0e4c75ad
+#: b6e8dc2cf7fb4d0db56b36d89d952869
+msgid "[2061867](https://bugs.launchpad.net/bugs/2061867)"
+msgstr ""
+
+#: ../../24.04/1.md 0a17564480b545f4b705df62cce9f6d1
+#: 4ef521590a5f4b31b6d6efbc183260b7 627e3c5175d0485ea5f3f75c985d44c8
+#: 74237110dd074ea78cc5159dd62a71a1 7c5d8fc4571e40c28f674b9714af8494
+#: 868e0c5529de4e75b62fc99a9e99f5b4 a1bb9023cf684a7ea037cddbc06a0349
+#: e080cc3e259b463d86eeeacdeb62d691
+msgid "noble/linux: 6.8.0-28.28 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 1180c85d47384f47a7a116b414758fcf
+#: 25768e3cc93545658609e84ceb3dfa97 41a5ce94af7443199d26315f3fa7017a
+#: 820abb823a7c48fa8f5208ea97b8bd46 a7760533b14441a995c6207e4ea68f23
+#: e6aff3446dd94cc6851a7eb0ca7dde04 ef0ca1b5fe1e41d49bc34a23b6ba92e9
+#: f46b70b201b745d3875898ffacbd7925
+msgid "[2061851](https://bugs.launchpad.net/bugs/2061851)"
+msgstr ""
+
+#: ../../24.04/1.md 075ac5ef3b0147e28883dffbf77ea608
+#: 215b96c3b140402e9be2361a084f5d00 3c7fb784af4b493f829fbb0a4fb1ee01
+#: 6ac4a4760acb449daf71c015861a748c 7493247925814278a3dcd77907a684ca
+#: cf94387da21a45c2a16d93a1256b5dd5 dc757adaaf7e45499ffa1381aa6ea182
+#: ee08b235ffd24080837d2f6c5325baec
+msgid ""
+"linux-gcp 6.8.0-1005.5 (+ others) Noble kernel regression with new "
+"apparmor profiles/features"
+msgstr ""
+
+#: ../../24.04/1.md 10a00396acf143d99c49c31878002b71
+#: 66a1dbba3b4f4754bb4b46bd855382e5 741c8cbfa0704a458dbdf867d07e7cc3
+#: 7873cad71d75421fbef8a546e37d514f 7dcaa3af214846aea877a3983428e6c0
+#: c970191d716d4affbc440b342abd8a2e ef95860f19dd47258bb05542133833e5
+#: eff1651cbda4414cb0e1741fd31e8110
+msgid "[2061083](https://bugs.launchpad.net/bugs/2061083)"
+msgstr ""
+
+#: ../../24.04/1.md 289616a6475c4f9ca5b7a61ff29218b0
+#: 4d98097d687243768bad59cb1c5efb30 51af2a2280e54f3891e6a9ea551d58b8
+#: 644d8749b7e342988664b1faf3952580 740c2141f9cb4126b64c1af4532f1dcc
+#: b9e02cc35df840509a84da0ab5f1854d c63fd06af1dd4b82af36ba0e9dab530d
+#: d93a72d609384c4eaf3b3a52f2f43189
+msgid "noble/linux: 6.8.0-25.25 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 0280acb2ef1142c08c443d378a1cc809
+#: 051382d298da43a6a431eab852eea1e6 4cee49013134433596d74fa24d54efa0
+#: 64c443ce0fe144b0bd23655d8f7e61df 6bc5648460ed47b0b38ee527c85101d4
+#: 8389fd5577b8463d9901f349f4e504df ddbf5eb369cb44a6836bef7cf65ed10d
+#: f87a76cfc16c4aba906188281d05bfd4
+msgid "[2060909](https://bugs.launchpad.net/bugs/2060909)"
+msgstr ""
+
+#: ../../24.04/1.md 2fcce40675334064b67eb9953671f052
+#: 56e2560e0b934bceb8890de08a76a08c 5915bc5d09ea4f7991cbc1bea028d1c1
+#: 66dce9dcd5774d4793012054b15086bb a05df6eb66aa4b7cb5617e557741e6c3
+#: ce4c9c84547c498896975ecbf42ec186 ecd755a5e1ee4b29a3bc0d57fd89388e
+#: ee58d747fe004611a8f30172fa5a64b1
+msgid "Apply mitigations for the native BHI hardware vulnerability"
+msgstr ""
+
+#: ../../24.04/1.md 00e800162ab2416fa93046591650f08e
+#: 039aaff138724b76ba68606536fc5c7d 0b9c8f756cf94eeba08be0a5a48856c3
+#: 1097622702b542759d76b3084abce9d5 1f8ccc102635458cb1cd943a54c30a81
+#: 2efe1cc7b6ea4eac8afaf9c22411e761 2feb355920ad4f94b6d1fa4d034639bf
+#: 3148350328d644fcb1dba1169b586cdc 322eec3ce9ac4575a2db44ab00eecad8
+#: 3430d78e72594dd6987668fd83e412dc 41c933e3d85f40ff9fd13e8e4428e205
+#: 429200e767cd402986b4f2bdadae49cc 55de18edb366414b9c59b3e355e4b5b9
+#: 5d700b3800b5465899ff496f9991b84e 67e3c1993c0143cab65700f004d795ec
+#: 6933d0866d554eff9f5416cdaddbdcc8 6a927cf1630640f7843860c0d82d2ad5
+#: 7fb8f9f42cf349b180be9cd41ef986bc 8358e566576a4af59ba765474a098252
+#: 83ad1ceb1db44c7e8c018a3f0606a892 95e6e414f74947e5acbed0b40c6ed5d0
+#: 973bbca310fb44bca1accbcf5e12ab86 9fa71a1ed5fd42ab95e9d9a98df13ed5
+#: ad8f5c05f7394589a7b45cf29b96a7e1 ae0c2f4c6bfc46c1ae4de571c647bf87
+#: b7a4317058624cbc99dd2ddaa346910e b7e4ec25537d4cfeb4c509a8afc1cc79
+#: b80943a0379f4ea38eb605fc5b19bc12 be0d7a0ab15045dd841023e6eec19ea2
+#: d0b14af97f0a4de5a3d41678eb58548e d122a741014042bbb7e03f8badd5b6a8
+#: d72b347d0839416390dedc81e77f2835 daf8d0e86d614732b08ccb3ca6f01e9b
+#: dba7ff583be0472187d6ff99a8663a67 dc1e2718a9aa42c2b082895e6f2903ce
+#: de036b0379a6428c9dfb40f68dc62d17 e678beb94e49468cb03f036ca2310aa9
+#: eb722a9c69b2466583f0c99f700c9027 ee1e082f152d46b993e87d1f84a9fdbf
+#: f0d7e3597d2347d883b41a8a64391cbd
+msgid "[2028253](https://bugs.launchpad.net/bugs/2028253)"
+msgstr ""
+
+#: ../../24.04/1.md 0f0c3d3acd1a46cfae9ec429efc3e525
+#: 182b575c458140b4b439077b9d1900b7 5987f750dff14d2494908a41047cad6b
+#: 5a0df464d4af433f93bda934d57d02f3 5a849a83c2284de1807250526477d173
+#: 7a119fefbe24409e94683b2929d8a3ec 8b2ea72ad0c54155a8e28278cab2e714
+#: a2033f3e78e44b91b9effed00ab7b04c a2db5b0b619c44e29e1d90d545b31416
+#: b547c1b5f9324bb0822be1164106e1a6 b54a98be562d4148bdde16e8a78bcc30
+#: be1e5dd5e7e44dd0889dd6abefc0206a c2d37df7f7a14f398a3936805c190f26
+#: d54e0f4feaa941009f3e4c5739b20cdc ddac3d13dc88408f9561d19556c5a8c5
+#: e3892f1a7ee7430c8a64100259823cca e62ab8eec40941a999b2e654d7817f43
+#: e9068d2f410a41b88bdf6a0e5999d163 fa702c05edab44a7a73af7989417c867
+#: fcbda7582ceb458b9bf44259b519c14e
+msgid "update apparmor and LSM stacking patch set"
+msgstr ""
+
+#: ../../24.04/1.md 007824c39ce44242aae0a4aed83fe035
+#: 048d83c284e14fda95cc29ef24c914b9 0e15856e37be44e08fa44f61a03806b2
+#: 0ef76c02632a4d0d8e87ede0db4d0dfd 10b067cd7199466aa289ecb250d09b78
+#: 17351186349f475faa0705c2a0975f10 1a919ecc60014e84add925c753fb3ce3
+#: 25f873e0f3244d23b6221583155b828f 291a1f0b8fe64877bc71784ffcc64579
+#: 30aa2a5b20574ad1934c78a63002af5c 33e53f1002a646afa8ee19c824021e13
+#: 40f051a9ad1f4f2fa0588c18a6780023 4233dfbf14904bc7b2a3a038a804f31b
+#: 49417812b5cd4a0aa2bb08e4c815547d 5472cc6a0c364a148fa204ddf07d0cab
+#: 5a22bbecd65d43b7ad8de570afc9c2f8 5db825d52f7b44e29d32c2e0e0ccf00f
+#: 5f3810008be04b4e8199db39ad4870ea 61625444ddbe4738a71acdb58c113bfe
+#: 63ac2f6032a2481d80634f67bb94520c 65b5ac6df13a4711980bab293b2dca9d
+#: 6e122df72aa14e09b7d6c6a754293f65 6e480d97c1054d47a55b45616c7cef18
+#: 8cd4bf06eb1a4daeaef0aa67489e18bc 8e74d2e6576b418db10b5c94ed04f886
+#: 8f2fc323a98d47e8bbbddc46cc5fe449 a7d4c87b90ec4a16aa2caa27d7299ac5
+#: a8cf863db95a48488389ddc66e0ced69 bd98b56dd4f54ef383d883df93c084fb
+#: cc65ddc063d748e5bf80d99f444b85d4 cefe97150c89418eb946f49935006426
+#: dde68e263ae343e3b25fb729023f94fd e19d295cfe614318ae970b817d6b925d
+#: e1fab131795b43669929ee93d0f9453e e60d832f024743df9d591a675e4c241b
+#: f39e922274ab47ebbc967aaf7fc6b1f0 f62c160ce8764ebfbdfc73fbdac9f4a6
+#: f70618adef834e36bcab22590e1b89ee f7ec301809c84e7db919276d8c9f383f
+#: f91cf784a5a246248204fe4e734dbbec
+msgid ""
+"update apparmor and LSM stacking patch set (LP: #2028253) // [FFe] "
+"apparmor-4.0.0-alpha2 for unprivileged user namespace restrictions in "
+"mantic"
+msgstr ""
+
+#: ../../24.04/1.md 0a1167fb7a5a426c9b34a94b78e042f0
+#: 0f5e9f3569b54655bf0249137a927496 37e63f55990c4ed2846acd059d11bb57
+#: 5a62955c397847318414fc770901d8be 63cce7a1f30b4376a6900fab7f173086
+#: 646123fbcfba4433b49163dfac87ca23 6600ae93ce044e2e973d59c60340d379
+#: 724154149e62406f8110f4d75bb543f1 8ca84b14aa684540b80014d1afd7d7d5
+#: 91377e0caf30419986a34b39679c5cd2 9435f5b5faae49e2bc6bef7af6a6c831
+#: 9c5ff2cbe1b84256b27fadaeb7f32d85 a09a0c92f47249dfa8d5d59509c7bee9
+#: a88f7865565344758ac46f7ea999da03 abd8f6efad714b86a962d7c7387d9220
+#: bcabfd8b3efa4d73a7051db861ff54e7 d6de6f93604d486488f51b29859181e3
+#: e1bce6faebb14fa0a7efe705d9039482 f10a32b730ff4fcdbf1d148c8d9a138f
+#: fd5d8616335d4b82a978b56872b0e53f
+msgid "[2032602](https://bugs.launchpad.net/bugs/2032602)"
+msgstr ""
+
+#: ../../24.04/1.md 2a37b1c7a7134b27a05488a2ea737c6d
+#: 40e4feb69c504853b60b8a9d7168a064 a660558c20fd4bb68fd5e74377b64ac8
+#: a7f9e595b0fd4d129edcb834c4ca0662 ad3561ec52dd4d7cbe34e47edb80bc98
+#: c6c73add30c04e25ab69fa792b14f03a fba5121771814d6984eec86a3329e0d1
+#: ff77f43005c1436a9c120456717f9937
+msgid "[2049793](https://bugs.launchpad.net/bugs/2049793)"
+msgstr ""
+
+#: ../../24.04/1.md 31af98a7f2f347c7ad791b12e3b21ce8
+#: 5f11b05c679642d0a233196640978ec4 75f3bc170ea5423080364ce131c5076c
+#: a46b7173211045d1aa46779268eac556 d607f3f52d8043ea9bc0677f4321a5c1
+#: d74b7fdb7e15457ab9d3921e5321cb8d dd7657d5bd7d4aa3a61a93392d17cac6
+#: fa814bc3529942df84e8e5d204f70529
+msgid "MTL] x86: Fix Cache info sysfs is not populated"
+msgstr ""
+
+#: ../../24.04/1.md 1f19a62a858d4d69a71618be38dfad7c
+#: 2c4c21ddb50245b78cafb781f3e47d9b 48fc8cabee004c7c9530d5f07f2fd127
+#: 4dc6365617ac4f36b11e6adb6490527e 7c3db18991c64539965bb8770bcc88dd
+#: 821df343b930423898525494f2cae8c3 f5d5f0d4b17447189d7a05f1105fdb0b
+#: fc8c70656533449398790bcd9f22f68b
+msgid "[2060238](https://bugs.launchpad.net/bugs/2060238)"
+msgstr ""
+
+#: ../../24.04/1.md 3fcae31141cb42cab06e28d12c31ada8
+#: 40c45cf13afe4fe7aa886d569d0b816e 680bc6a4dab54fe6826b84088ff307b2
+#: 8cc065f081b14b779c370a99580eca50 c127d58dfb9a4efb97d71f0fd2e2bda8
+#: c4320968f93f45a0af6b47a2ddc0e6ae cc59f4e2a27240be95ec8ccd44e4c472
+#: eee20ab0a1114929906cea30d895fa5e
+msgid "noble/linux: 6.8.0-22.22 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 19851bb802b34437b8b65947f6d0e872
+#: 1cba8bc1db924a55b35a18b48e811bab 55cf923debf0442ea6c7a63e4801b6ff
+#: 73e4b476b1864121a6ccee1e06a946d2 972dcc1bb11e494ba1261b0cdf915293
+#: c3cdcefb667e47aeb74a121a6ab711df e9777434963e45a9b9501f7cdb569915
+#: f7e630d512d549e08c29a28dcd772caf
+msgid "[2060225](https://bugs.launchpad.net/bugs/2060225)"
+msgstr ""
+
+#: ../../24.04/1.md 28606e0449144b1c9cc00dea4531aeb7
+#: 409c0a490c96459dad837e862963b32b 6d3951138976436598d21456fec20fd5
+#: 73832c6533564bae81f422f44b611e41 8facec67a5eb4048ba5dd96d2f9355ca
+#: a44ec2763b284ff28ede6e268d7a12f6 af2a7684aecc48728693ecd1a11d3216
+#: f80cea4ab8a04bbfba691b533a354cad
+msgid "noble/linux: 6.8.0-21.21 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 0c9e64a9ca0249beb45a08550f439075
+#: 7014c05e32284425b9713846a7e27d7a 98879168c25442489fe51ba4cecce48c
+#: a632cd7e22ee4ce582ec045b02454495 a6bfa3fed1bd4b73a08713a6b5af6827
+#: cb699d638b8045ca908983f2c3f2a60d e3d7ae2eb72542a0bb95f29d06b89d3c
+#: f29b3e46f6eb4a0ea7959ce8cec0fbcc
+msgid "[2058221](https://bugs.launchpad.net/bugs/2058221)"
+msgstr ""
+
+#: ../../24.04/1.md 191c5d014f0145fdbbd6774284cb31dd
+#: 21e0dc124e1348dda1356cffcb9845f4 46b7ce4ae73049eab8ef63fdbdd34bde
+#: 66ff9c8517ad422fb8e6a1a235ecd7de 6dded3a2255f410fbcd38fda4cd968da
+#: 74452c08b9e64ea8975ee80cb4c356cd cade73c93d6d41be8737490203d74cda
+#: da7b9474f3954bbc827b3957ef68c651
+msgid "noble/linux: 6.8.0-20.20 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 0fb93d47deec4d8b9d2ea1ebd0043c32
+#: 4b58a1fae47947c48f8a7e7059948a94 5d1d29e323804e8984fc150943547f48
+#: 6117440caad54d36b49bdb7851547ee6 72391a3fb7b24b098ae1e23f4586a40f
+#: 85a23024dc5044eeb4d44311fa99126c 8eb30d7025eb4f23a3ad73627ce89978
+#: f966ac8987c54ac892bba5baccbb358b
+msgid "[2058224](https://bugs.launchpad.net/bugs/2058224)"
+msgstr ""
+
+#: ../../24.04/1.md 0ea7e5a00202496fbba5bcb2ebda972b
+#: 2111da8b97aa4790b03f8753c577d74f 2a6abd726bfa40979e99a0010c136269
+#: 4bd5e2a4dfb94a5f99b96b63fab8a823 4fe1d758bc6e498f91b465b5d70c4470
+#: 563da2752e164ecab0f682e74f7bed82 6b28fe01b88b40b4afd5904966132143
+#: b85ad8bf8179487e8fd1e9ac57f11746
+msgid "Noble update: v6.8.1 upstream stable release"
+msgstr ""
+
+#: ../../24.04/1.md 106818cb45024362afec133b7a7a04a6
+#: 6e924b3b99b7433e8ec74ea4c5c3d729 7c4f9098321a44f2962cb8087a358012
+#: 853574aae0ec47ceb88e12c186e6d2a0 8d9c521fb0bb4f648a114276147f712e
+#: 920c52ab12a942c3a650f119eaf0216d bcd2bb9d2c054890ad947f606c04fa78
+#: c95e0dd470054bb291b693b0c4541eb5 f0fd1476384e4c28a9f7cb74b89b8a67
+msgid "[2048768](https://bugs.launchpad.net/bugs/2048768)"
+msgstr ""
+
+#: ../../24.04/1.md 08fadd3a94584a8db485b7d6ef0f723a
+#: 2c9c3fe5db4a4466897d1574aa1c052e 8db04833808842ae958d0679e85cd01d
+#: a07db8688dba46859e04c544e5a2937e c59db272817041918db2c57077061e90
+#: d4f859f29e5e4d8e997c4c4820cedf18 f19171cb3868435a8b1510bf9c0f4f45
+#: f34dfff3bfeb4948925e78ee1c517f13 f530b2e6b3fc4188868f0552ce80e85f
+msgid "Autopkgtest failures on amd64"
+msgstr ""
+
+#: ../../24.04/1.md 025504ae72b142bb97ddf7f20edc3426
+#: 0daa1db5da0c4eb7b3c48715383a649c 4711c29ab8554a1e994a1fd0a39b02c9
+#: 8574961aae8d48a19fbd6de5cccd6d90 940320f65800462e909942decf4f2d49
+#: 9dbbd373b968468db16641912f10dec0 b2fe026fc62f4a2dad04d5e9a38ab3b9
+#: b5384cba24614c87a40af566ab51829a
+msgid "[2057910](https://bugs.launchpad.net/bugs/2057910)"
+msgstr ""
+
+#: ../../24.04/1.md 02787ef8f0914cc197b2466ae4f66336
+#: 238bd7e44aa74299a3a48857e9a3936b 5a235f8efd61493bb6a9de662ac9dbc0
+#: 5ca3063b4dde43f8aed5f8cf2511c3f3 88682a98a03744388fb56d55f700aec1
+#: d3733fa121ee4e148cb7a3478772dab4 d60eed5683fe47afb8f0cee85575391e
+#: d76417f1ab3c408cab1661d79f118aa3
+msgid "noble/linux: 6.8.0-19.19 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 59637bb6ff29482fbb82679bd9d27775
+#: 67bc39c803404f4d85afad8951b5d142 8bb270ef051a458fa89c8410dc58cc11
+#: 961ac010ba7c4509bf6ec45ca39b1553 a3403a080685449492af9658e274d809
+#: cc51cff5cab44cc48d4e604285267347 dd186ceebe0e494083c5b0f52677a3e2
+#: ec844c5df23b4a4695243a4f49aa892c
+msgid "[2057456](https://bugs.launchpad.net/bugs/2057456)"
+msgstr ""
+
+#: ../../24.04/1.md 70d36a08426b433fa8b1c89d4ddda597
+#: 89a8c9b7d5734ae6a66f4c70bb524478 8c854905ca834d9ca3a9c094f35658b5
+#: aca8f97d21d64376a65c3d5b41b750bc adb5f244f2ef4862bc96755bec5621f7
+#: bd6ccc68dfce4b39a217c56bd2e724e0 cfc71b52151d4d469ec614c5f3e66a6d
+#: d3c65138d0e540bdb76d86e6084ba2ee
+msgid "noble/linux: 6.8.0-18.18 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 30eec796657149dbaa6d5f245ead2ef1
+#: 38303bb25bc64939a04cfdca66d372ee 3f99c62aeed245908a64a457781815a2
+#: 3fa63f15e9ed405fba630cc0d3aa3c3a 7f1474655f4047f287eb9e0e6cd6ca98
+#: 9c2958451537488da4da0353e1be42f2 da1f520659cd4f2a9ee7d19da65175d8
+#: feb6477fe9aa40b4b6022bbd1cc143a5
+msgid "[2056745](https://bugs.launchpad.net/bugs/2056745)"
+msgstr ""
+
+#: ../../24.04/1.md 15153507a2d24736ab9934b3b78abe20
+#: 1d4a66575cd14f23b4d51e84e6a34b35 4a1c876cc6964bb9ba9edb143975a3b4
+#: 5d97c6677fa7456aa02d3f3f47d179ee 648429b9c3c447eaba4d3c82137a196f
+#: a544e2e3fb1e4aabb2f79c398894f081 d94611932e884f5eb236ad977756a014
+#: d9fcf305e6754570a1780e986468430a
+msgid "noble/linux: 6.8.0-17.17 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 167eab0d5c41408b93db8ce7d6cf39f5
+#: 3bbb0592e1a44a1dabc60af6214deb39 3c1b4a9a884c4ba4b57d17fd9cecd0f5
+#: 4229aef56e4b46c4bf4f68ca9fc435f6 a74fb72d536e4f8796261459333e546b
+#: a960cea5b5fa4302a4e237061aab304a e5071f1edd824387b52eea5bb69fec8f
+#: e96347b6dffb4a868fcff4ef3c2e2b7f
+msgid "[2056738](https://bugs.launchpad.net/bugs/2056738)"
+msgstr ""
+
+#: ../../24.04/1.md 30acd86986d74993b567be48315897f0
+#: 38e5938bf47747dd9d343e29cdcb3cf9 7a66f7b080ca48a0858fb43d085865d0
+#: 8cd24eb4c9fe463995b994fdf33e611e b68122b760bc4ba9a4c83019519bbf69
+#: bbc215cec1db4e3abc2ddfebf3a1c6cb fb1cf172309b49089564fe28827a3d62
+#: fc9f908651ec47d7ae704cce39a112ef
+msgid "noble/linux: 6.8.0-16.16 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 25428d0c93014399b892b6ad1c2fb235
+#: 354b3547f7f4459f8a01926974671f3c 4f005a212be6490899ba0d0d380575ad
+#: 579ecd72ec9146f3b531b5798936419b 5bb6c2ac1fd145ea8ce25dd27f8655f4
+#: 5e2572a4be254d46bb91431dd8e88145 74862b660e844408831fdca0910d7b30
+#: a17e9d6c6ddc4e6ebc226b3e49a0c3b8
+msgid "[2056616](https://bugs.launchpad.net/bugs/2056616)"
+msgstr ""
+
+#: ../../24.04/1.md 0b3807fe29754f4e844bcbc9648e262a
+#: 1a0a5c6e57084bb6903e7611a7393e71 52f856d3d9224ba4a1c088616d4654ed
+#: 85adeb69ff4d43f8aabd288cd41e1308 a3401f9b745a44b4ae9ee35cba01ac95
+#: ba22a7a3be6e494ab9ffba01cafcdeac dce67082b2b043b580ce1cf2bfa9253c
+#: e6193a96f1bd4940ac3b65183e85cf5c
+msgid "left-over ceph debugging printks"
+msgstr ""
+
+#: ../../24.04/1.md 3c5362dd76a943008aeeb42dd4865e02
+#: 4f666250e0ca44b480115fcb6b977170 65a7fd36d7ad4cd98e294bacbfe9069b
+#: 7a81faeb05734b6ebbfb7c030bf08aa5 7e64b426a46b48e6868798a348b4a73e
+#: 9a322ee8e4fb4e54b90ffcab04729905 9bdc48be9e134a4ba8ed499c726c91c3
+#: d255371d202b469b8a30c78de979dbab
+msgid "[2056354](https://bugs.launchpad.net/bugs/2056354)"
+msgstr ""
+
+#: ../../24.04/1.md 29ac8acfccc24cb4856a3616a6bf0f77
+#: 38d2c6773484415e8c4cde3e5324646a b41ee93749ea49bdbc2ec3eb8befd802
+#: bafc4cc0dc014835b20ce0b19836844f cb6e1b2985a54d199621ecad9e000810
+#: ea6821c8f14841fd83f0a1fc1b4ae139 ef55e4eda3434fc99bca5aa548375586
+#: f8e14114dfcb442a980213237dc92107
+msgid "qat: Improve error recovery flows"
+msgstr ""
+
+#: ../../24.04/1.md 08d4fdab1ea84d129a54bf7f50a17eae
+#: 16989c08d7f54d4bb2b1c4baef4bb983 74df803dd19c4ac0b30bb1d7d539e8d0
+#: 9336e814b2eb4f24b96f7d5c9a16995a a0552f4272b1416da9e1a1f3a5621ec0
+#: b1ff7429af4d4b5b99f887bff7ee8f0b c02f4292f742445eb7490123c723b54e
+#: cc4712979f164b7da3dc159c0837eb26
+msgid "[2051342](https://bugs.launchpad.net/bugs/2051342)"
+msgstr ""
+
+#: ../../24.04/1.md 283d8c178b704e52a8ff2eec15fdeae0
+#: 3569544fb7af477f8baebc398a057035 4ad74ffe7f5148e8a338ca4c84bd5f64
+#: 5f4221aa42b54f90b4f5104f3d49cd6e 7999ae2c55d54e85a591d60c99e19df3
+#: ca65f8fb8ff840c3b7d49c8c1f2b9058 cd715628611e4cb7b9559e4e745c60a7
+#: e6bf21ef693345f29d82d4ebd6f1d359
+msgid "Enable lowlatency settings in the generic kernel"
+msgstr ""
+
+#: ../../24.04/1.md 23127909821549ce9cc56e58540da961
+#: 4586f03bacfe4a32a122440e32042120 487f219376284b9696860bbf3e7748d6
+#: 57eda35efd22490c843454a868919cdb 61b12b3eb7654c4d9f881dd4ae8b00f5
+#: 772070a629b84513a11e6d0750f7d4ee dee853a770eb4c84b0b595d8e198b1b9
+#: f768a340132547829ed26732da31a8ed
+msgid "[2056126](https://bugs.launchpad.net/bugs/2056126)"
+msgstr ""
+
+#: ../../24.04/1.md 16bec05e4867460daa264803de598163
+#: 3f1f6dbfe5844f29858fe878a2328c41 5891f7f011594e57b7277df22e7c65fc
+#: 78d66a7bc7e143848476238d088b615d ae9c5cbe4423413fb91d0d54fd1fdcf2
+#: b4c9c88e98204d308ceab38c2c5b61b5 d07a76dd872145bfbd624b52e8c25cf4
+#: ed075f146b3c4c998a831f2a45a2e37c
+msgid "hwmon: (coretemp) Fix core count limitation"
+msgstr ""
+
+#: ../../24.04/1.md 08fcad505f8140d78d55bf0a815aa714
+#: 82d97c9874e444e6b7a918f78d1b5236 902e6eb843824cc8bb267656153c4edd
+#: a33bb80203334808ace64886eb2d9e81 a594b98193f3424d9820298b37c4d949
+#: a8e48440ffb142a5be228d705b417c39 aabd5e1c995f4fed9fb05ddc59245187
+#: fa0aaf789fa547e4be46be09ce745980
+msgid "[2055871](https://bugs.launchpad.net/bugs/2055871)"
+msgstr ""
+
+#: ../../24.04/1.md 34b5e4e6a3234e7ead8840ddc2cfe0ff
+#: 5ff70579002840d8beadfb3b5c262c90 60f3fc2db155443a94dfae66f2f6e438
+#: 74a1b6b97a234d439f5e3a5bb7ef01de 7b182f40e18b44a8a3174b782e057a1c
+#: 81001e53183a4b5c96ce9e0efe8bff07 b3562ad6313d40b1b369c81c68a73652
+#: e213f20bc4bb46cabe942044438a5ab8
+msgid "noble/linux: 6.8.0-15.15 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 38991d8830c6446ca8580fa7530e56a0
+#: 3d92093d883249c2b7b33157cd7cf962 8c62110a8c464ff99891740e63152720
+#: 9819955cc4284d63af6e514cd56f71b5 a19486ef1e094f01a375cc46c1c74c89
+#: ac6e2d1f0a264ba683081d889b6c9550 d97342d32d30439baa60aa4a67c9d3cf
+#: df657ea3e6844af8983d159786e9b36e
+msgid "[2055551](https://bugs.launchpad.net/bugs/2055551)"
+msgstr ""
+
+#: ../../24.04/1.md 01ebb547f6554fa69ccef5a543897e67
+#: 35bfc1b30edb4037b2fb43260998490e 93386257d6144c7b9ed689ae6079073f
+#: a41271994753495696981298e1f0d0c6 a89008bdd8e24a1c94be27a1e2326175
+#: d2d3bd1f58cd40589037c0e140c24ff9 db2db403df7f4e4ba16db19763bd6d4e
+#: e1cd40f751d444c486156e49ddc1b32a
+msgid "noble/linux: 6.8.0-14.14 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 10345028ec0145a185219786a8fae507
+#: 127afb5bd31547faa0f9e642f2e37422 287ebafcf3224fa8b975df3b35478237
+#: 767f33f432cf4d678e8f65febc3a42c1 9c3bd32d610e47c2bfb31e86c447d41e
+#: b9fb7517b428486a8d1ec2bd4fc16b1c f606e3f157224449b02273dd365df7b0
+#: f93550e4c8294cb18db3cb55499ccd51
+msgid "[2049390](https://bugs.launchpad.net/bugs/2049390)"
+msgstr ""
+
+#: ../../24.04/1.md 1fb87ad24c364a96819760c5c4a99b57
+#: 21af76adff664591ac4b658a91a3e20b 37ef3928684d49ef979553601337febc
+#: 5641dd437e5d424fabee284fdc2a5860 7a4ad14c08004023946d0449dcb1993e
+#: 9805d982f8194e049154f838f606b6d7 d8f14e2161114d99b74fc83a2d0be0df
+#: f2c04beb40b346888d8a007080b4fbab
+msgid "Please change CONFIG_CONSOLE_LOGLEVEL_QUIET to 3"
+msgstr ""
+
+#: ../../24.04/1.md 10d88f3b849141fb9cd87b8a0c52c7c3
+#: 1581f3e0d78146adba09e36af29de544 21000a3e23e24315b8f4f55718503eff
+#: 37a3239030de40f4bd1d11ae553616da 43c7725a0325412598176180e5959ef1
+#: 440ff5c298ef46169e1ea79eea8d3bfa 5d5e9ebcd7f143489e1f6cf13001f0c3
+#: 5e2b7618266149908037a7bcd24940c0 80493b545d8543f6af7a47734ddca714
+#: 8fe0b196e62b4cb4afae19bd55f39f46 91fdd6e1a9474d24b5d41780f22328b0
+#: abfcde9ba0ad46aa91bd7a14209a6160 ac69f086ee4b4364b48daf35c1681338
+#: b7227d3a62e74e20a50dd6638d1490a6 d2e4cd61ee3c4fcd87af219559bb7d5c
+#: dd3d059ba5ef4f4ba601592128b8ec82
+msgid "[1951440](https://bugs.launchpad.net/bugs/1951440)"
+msgstr ""
+
+#: ../../24.04/1.md 0757d393800f4ecfb74d81c604eae09d
+#: 3186bd0f9c9a4a42b5bf9848ad63701c 3951d39d2fd04a549bc03716cb29cc37
+#: 397cb190ea134437bbcebad8469728c4 43f5b82408bc469ea5b94197ad144c37
+#: 44403bf88489436cb6c7c70352990134 4faecf8e5c8a417f839e81f2035c772a
+#: 62bfc8bb9d954056814f8b34aa939529 6590ab76348942b9b49f71f324e50c27
+#: 65f3eb4f81ba4a93b717be05a6cce903 68dc731a5a6d422390534f0a8b8f7973
+#: 887db8e752924e60aeef5559db505f16 8a800170562f4579be91b7a7d90de549
+#: e2cae9c57a4c4b31acded080039917db e6b86345418a4300996ecedc7b6afe33
+#: ef3d06e98eed495b9ee2e10917143ebd
+msgid ""
+"Enable CONFIG_INTEL_IOMMU_DEFAULT_ON and "
+"CONFIG_INTEL_IOMMU_SCALABLE_MODE_DEFAULT_ON"
+msgstr ""
+
+#: ../../24.04/1.md 040253453a0645c69383662070006641
+#: 124d0414069a4cf5a63ce3d1ad842a65 1c11523fe6c34269b00ab04ed92b8fae
+#: 3c35b745998247899d0ba3db79c4a47b 4294ed982a8b490aa8fb21ab18807f7a
+#: 4b29477c13304b3b96efa8f908594b78 50da16392897481a864f01b0c21bb2a6
+#: 54f905771b6d451b88a66469d01f845e 612fa877aabf44d0822bdb829199280a
+#: 8276fcbc315d4808b97a1b3be4d6f3eb 9ad59ab549704e839466d0a5a5f0ae42
+#: ca38b20d289b44c68da54437f57208b1 cef8945880d441debfd1fd1f89f5c74a
+#: dcac64a6849a4cb3b4dde276283747dc ed9efc0c09d54aa3a736f9a9fae293f5
+#: f17d1cbca6ee49baa5ddd3193c5bb7d8
+msgid "[1971699](https://bugs.launchpad.net/bugs/1971699)"
+msgstr ""
+
+#: ../../24.04/1.md 09e17248e8a34e3894c295aa2ceef962
+#: 0da5fa215b1441a7be35a70e55b30a4f 19eb194d2a6c46439ffc5ef29ba21e7a
+#: 36939dfdab9e40c4a4e2b6026ddf4f28 3bc46e049288408d8fe040ff29ed1dd7
+#: 4242025816bf447a8e44303f140ae788 50363bf9fad24feb8aba398a938eb9f8
+#: 583e45e7b3bb4f2baa681a8d077e7042 5b7decef6fa64c67b31bf85cda4c1c12
+#: 5e45f5e39a084a1695565c6474258092 86b073f033fb48c0952cd7998421e032
+#: 98172dceb4304565b12da53863a56e6a a96d97ca0bfa4e3fa18c2ed6e65f0dd0
+#: adaf5136aae04d4b975de114c4a0e3ab d252d4208a374a12af7fd3409e58b8a2
+#: f5a3043ac3b14d428482ec86b85b210d
+msgid "disable Intel DMA remapping by default"
+msgstr ""
+
+#: ../../24.04/1.md 0fbbe304edf14893bc487e598c5f96ba
+#: 1f29dff6afad4b4c858ba137ed84f090 2aaf110188c54b36bc033905b5698f7f
+#: 3116e3b948634cf3acadc7a31c01602b 475ad166621d40e99f90a18d311258e4
+#: 4aed80b6f37645a990178c566f1065aa 4c2da711e8b848a291eff488c134519c
+#: 51eb630fa94243e7b26804ca38a13b5a
+msgid "[2055421](https://bugs.launchpad.net/bugs/2055421)"
+msgstr ""
+
+#: ../../24.04/1.md 3f21eedf9611473a82149a35f1355e2c
+#: 67e291e2f9e2454bba0afc8ecb459832 8d18bb8fd3f34a97b49649bcf699b158
+#: 98abf5e8619b420f9aecb8f979f9f2c9 a27188de38d64ba181b87c7ec87c6556
+#: ab4f98125d184a2a9a6abb4b63ce39f1 cca9b03e76a44f28b4d4bc9a3eafec71
+#: e04443c66d624d3581ca221059c8416c
+msgid "noble/linux: 6.8.0-13.13 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 11817d0599d14d1a8632a7174c0d33dc
+#: 17998201f2d6478aaea015788c510c25 485764eb2ae24cae82cdb8554e55b92a
+#: 8c4bff1d302f4053b60ab5c3f90e0601 9eb406fe09494d9298c334b66281da98
+#: a86d764354604063956f935de5a6f5c2 b2683759d16e4fa0af31258f94fff7f9
+#: c680e02ac65a4c4a9e6cb0f450d87d0c
+msgid "[2038583](https://bugs.launchpad.net/bugs/2038583)"
+msgstr ""
+
+#: ../../24.04/1.md 1453cadb564e4c77b195341c4d6633b8
+#: 1455eb18b22a424495b0e3a4bce9e54d 6cce2e821cf9445f99091bc45cc9557a
+#: 9e5d3e79b7ef4843875ca1edf903d55c b2daf2e990854ffe913f514c27436c89
+#: b67953546f5041f8bb8ec46640bbca46 d9c1dc4ec9764af383969cc8173bac38
+#: e1f26bb01228443e8f037f76115396fc
+msgid "Turning COMPAT_32BIT_TIME off on s390x"
+msgstr ""
+
+#: ../../24.04/1.md 07e30499cd734ed68275e14bb7afa23f
+#: 1f7772a1425c450893aacd6b7878a967 21a13472e4644664a89f55c7fc101e37
+#: 3d15541e439d4cceaedbc7e616708706 5c21f461cbd24310a30002de4db04653
+#: 851a39548d9e4405a5d28c9f4f736c82 e35f5e1b80aa42119165ee5fe877624c
+#: ed17d9b3c2f8449a9b6f8af7bd2f209b
+msgid "[2052439](https://bugs.launchpad.net/bugs/2052439)"
+msgstr ""
+
+#: ../../24.04/1.md 0be3ce74f08d4a2cad07ad49afe2b3bb
+#: 2893ffc4ddac40dfa76c1fb83ff3235e 337cfcd4a2914cf5a98da67df925ec7e
+#: 5f9a9cb604b2411ca662407c3d84867d 7731aee4521f4e66b907c34a210c34f0
+#: e2f5dcb31dd048efbe14f5432502bd80 e5563a0aac4249a1935d03cdb404d6e3
+#: ea16bb68d71f44629385d6d90b753701
+msgid "Don't produce `linux-*-source-<version>` package"
+msgstr ""
+
+#: ../../24.04/1.md 2d0006b67ba84a54aba73464fdb7290a
+#: 35f34aa6672a489984c850f58c78c916 3e50120d2e914bd29939166efa0b5722
+#: 52456f6f84184ecf8d9c22687ea1b602 6c4d12cec6a748d4978104844d46eca9
+#: 82eaf1e7b0744eb1bdfa6c6c8f4816fe ca9596f4d24d4dfcb682820bcbf10bde
+#: e35609802d3c42309888cbd5e06ea7cb f7a1d3e7fa484305b6fe38e791143bb1
+msgid "[2048183](https://bugs.launchpad.net/bugs/2048183)"
+msgstr ""
+
+#: ../../24.04/1.md 01a02cb726374bc2a8ae2b872376a566
+#: 1c2739006df4417f82b292bd64659a05 36f8c947a4ce456884d8bf47e4a7ca6f
+#: 41cf1c358e0f426ca066d1b7bb3bd431 6d64591eaaae4b5bbdc618da886a949b
+#: 7af0ce9f5b0b47ababa7532fb251e65a a2ccbb5df97f4111b0faa6cc40c5b88f
+#: bba6c38f19c24b40a92c343d35b1fff9
+msgid ""
+"Don't produce `linux-*-cloud-tools-common`, `linux-*-tools-common` and "
+"`linux-*-tools-host` binary packages"
+msgstr ""
+
+#: ../../24.04/1.md 2dd032e9b04b42279ce7afdb196b42fc
+#: 492045e660014ae4a9bc7e103ba107fb 50a126182eee4474801d05e55455f5b9
+#: 6912e8b292cb414a8ae7b5b3d131dd48 7a58f18ac23a45bf80886d7ec77863ff
+#: 7e16c8eb821d4ad79a54b26b0d3ead40 8e6eda0ce5064d58b829af2e107e3b12
+#: f4831dbc02df45d5a19429d05b401ba8
+msgid "[2053094](https://bugs.launchpad.net/bugs/2053094)"
+msgstr ""
+
+#: ../../24.04/1.md 053f7bd7573e4bea84fd4f91f54b9751
+#: 10ed8b66527f4aa9a25c5cc7ffbfcaa1 2d14be60e08d4cfa8f382a54d5f16946
+#: 426b4d9742604fd69f7271a218bd8bc0 68411096782a4ded94763d8526189864
+#: 92ceff910d674dfd822eed25b3e43303 9c9dd411586542bfbb1bbb414b187f5b
+#: e01e3f2bb99b411ba6fb518b93f73d6f
+msgid "noble/linux: 6.8.0-11.11 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 0f82ac2ca4064d3b924690853788e511
+#: 17c900b865594b09a8df77af106170a0 8952dfbc5a3d4833bdf23ff231c4033e
+#: bb15ab8604514c3b9c13ac4498ea5444 c341e1cbe665439282baf297a255a823
+#: d1bd1a70d79345db91c64b4c55953c1b e9dd4941475c451a9f44ee48a8ef8b4b
+#: f6df6a094d604a01949ad0b74ab02db9
+msgid "[2053015](https://bugs.launchpad.net/bugs/2053015)"
+msgstr ""
+
+#: ../../24.04/1.md 1046b9478ace4d1094fa0f5c83196629
+#: 12e8d050378c4e8088f9f381ef1d4ed2 2478bbd60ed140aaa8e5e0d376de41ce
+#: 516f41c32bf54435bb74bffed9dfe45c 51db956ff9ae437a887c507b42ec7799
+#: 630e5213d02f460c8247c7e38119b209 a6cd1065aac84c5c8886462708324223
+#: db05f287d75242e6bfc2b4975eba26bc
+msgid "noble/linux: 6.8.0-10.10 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 02281d491d18479997c795e1db2c8593
+#: 044241786f5d4c54bbb962dc86d0d8c8 0af323cd2bbc41d29b26dadb0a51cf6b
+#: 7fb20a2b53d64a2ab8407b9179058052 95f716a49b0840db9def1af99bb653b0
+#: a7906d22dffc4867bd9a84f88a06e9b9
+msgid "[2052945](https://bugs.launchpad.net/bugs/2052945)"
+msgstr ""
+
+#: ../../24.04/1.md 0cbee2420980432a9eaad9c6261c6a53
+#: 51f1ecd1077e44bdae6d50ff7e682946 7dc7f61d565b45e2acf6d216b1d47d99
+#: b1b331669a5647e2971da17a301f2514 c5ea3518c62d4393b707e9bff6605388
+#: e81484636ab946dea5438222d4e446d7
+msgid "noble/linux: 6.8.0-9.9 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 32e3996211d14ac8a6bd821128669745
+#: 3f2e45fbf165475bb70cfabc35212fbc 3f9b61b113714c70997ebed5ba564847
+#: b86135d47bed4f7083b9fad4ffcd1ae8 c213804331e94a3fa7db8de5b6dfc641
+#: c895df91ffc54698a2548ade3253ab71
+msgid "[2052918](https://bugs.launchpad.net/bugs/2052918)"
+msgstr ""
+
+#: ../../24.04/1.md 14eba553f3fd4e3c86ebc5c11cdc28bf
+#: 2e130ba6ecde440f97df57fd095c020f 492348a0948b45a08408a5fa8a5940c9
+#: addb719aa1c54a259b4105fed7eb7868 d5f3c094d8da4d20a12a32903e70e209
+#: e19527b95b664f59a361f55f9fe8ac33
+msgid "noble/linux: 6.8.0-8.8 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 11a4ac12df324821bfc5ec5422a558f0
+#: 14e12a3f0c60430895a32fb334bc3af9 185f3f7b23324c798245db6b2d74c22c
+#: 18c22ea3ad9341baa7c95250811239ca 1a4f5aeaefbf4fe1998efe3a49ddca3d
+#: 1b9cdfa2440e4502a9522891e57d4c35 2f31dfbbef5348d8ad192abb839d4fc0
+#: 3060843b6d2f4d62830cf25c618fab38 3062861a467b47b1a72fdcb30ad32363
+#: 327cb60d35404189b4bb45b2dfccebd3 3b0a515a3f56479fb5f515b9b1a1138b
+#: 3d5bd28fef874dec9ae602b796d4d2db 40aba30fc16b414283e999b661309920
+#: 467e5a77b159490abadc23c87ad49a41 499ad7bcc86847c1acb4d14a58aa1f2e
+#: 4a76bd4e6914432cace3d600513862cd 4be3a438711743bfb63bf2dc0163fe3f
+#: 5be3d712f5564ebc8cd9eeccc52abac5 714e74db743648e69738810449b6d16f
+#: 7ffe0ba153204289b815bc020b7fbf22 85e53dcdb1f44b0a9e82edcf98e4d52e
+#: 882fe2d579394f64829c8c560e1a10c2 8d9287574ade4da29672aaa3d9069075
+#: 8fac21afce254a2dad84fea931347912 9405d43bd7e14e52982b9c1a4cf8cc76
+#: 9498de74e4bb4c76bc0f04c7162becd9 94a44bebb90a4cc1a8fba32e7d94af0f
+#: 94aed8b155ec4adab6038f2d3b45a427 9acd53e1dc224079be4bd60594e63f11
+#: a6b94f82265c44a49b018a62d27bdc6e b39e7b46f9954950ae30da955df20144
+#: b3c960dc32ef4ee49c62ae36b48e42af b482b51986f944b89b64db4574140433
+#: b8cc0f2c6f8a47109f0ce3e117a43f54 bd0387a12a4a4ba99b23894d8a3fc93b
+#: c0d6ffa28e7f4e678c5ce4b7264edc2f c4a02315472a48e5814e7855b1427069
+#: c4ba953afd5541fd9e0ac4784e399e03 c4e697c1ded9475db53c574ca21def1d
+#: c99eaabc908f4f7983d72c3ea15ff76f dd4416fe7942423a9fadbdcf9e74ce4d
+#: e42db01dabff402ca0e9c243540acdb8 e6518a903ce546b8aab8a30997d4ccd4
+#: ee65b88b98c54220bc98da748ff3b691 f863d6bb986f449fa00901626df55cfc
+#: f93727ff15864390ac80e59a4ead8fd9 f9ca0f5b55d645bbb80106d7aeda0a78
+#: fb2769dea58245f48faf114b85a34f24
+msgid "linux-gcp"
+msgstr ""
+
+#: ../../24.04/1.md ac22250e4d39438194cf7af7e653e667
+msgid "[2064328](https://bugs.launchpad.net/bugs/2064328)"
+msgstr ""
+
+#: ../../24.04/1.md cdb0e74e1a7244278c6d2fac99e5f522
+msgid "noble/linux-gcp: 6.8.0-1008.9 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 01c65201fa16456d9f4d9f280c080854
+#: 0b2716a621074c40812d401de60cfff4 10dbe54036be477ebe4687b23af58168
+#: 11305fc35238414dbe461ac10d568d94 141c2b3e5903446fb3e9142f66eeaaa1
+#: 1d9134a2928b42878781b9a021f71b27 201a47ad805f4c7f94c19655cc03743b
+#: 2bb9c6e6ee5d4fd4964f699b242a10ad 2df89edb1b9b4d8183ee4e2de6c5875b
+#: 382150c2bf7947849d59c30ac62da594 3f3c49285bae4505a1a9c587c02b495d
+#: 4758da1a2cfd4ab3a1963d2d4909cdb3 4b3c26f8d4d3471d90395b22b09d650b
+#: 50dc7d2eb71f4bdbb73f9146f742614b 51ffa1ec487e4eb4bcbf65490009b689
+#: 540253a28f9a4480a38637c4721aedc0 5a9d4925990a4aeaa80005fea53f488b
+#: 648e382890034708a05d94f36fb0ce98 656c0dc80502462e93a52783ebac204c
+#: 6ae0d6acb5c34784a586d73849defb07 712e62a4017349e3b95b2439a047781f
+#: 72aad7e1853043529e5ac0bdeb0591e6 7314edbae1ae489790bcf9616815488f
+#: 73f8181406224235b00685c232af8f96 7bda951ede98469cb14346c2f0205fa3
+#: 83b8d095fc0044669cb95f36235340c5 8bbc5fc62a77423caac387a6b4656a55
+#: 8d12b5729c3f45c39a5f85cd69f8350e 8f1afb2b040f47b693fb4c773f69e318
+#: 903df74d3e7b4008be4c12114d3b7f2b 97e867443eea41d58f9866b3cded73dd
+#: 9a379244821a489c85d2845bcbad2de4 acf5236d81774d0fb396d4ea0b49d7c2
+#: b66d477a88454520a116c0425ec5e69c bbe8982a43d141e290beb96c4f51f9d7
+#: bf6c708eb12c4033899cbeb8d0d0ef54 cdbb6b43cce94a2fb730a665e12bd275
+#: d1d1bb2ce42a413ca66a80d9333a1af2 d59798ec1da54c6abfea43d8c6372082
+#: d7ca72a36e96467bba4c66d151ee882b e2bdd15cc0d04d389fb360445b7b52db
+#: ea611696a3e141e0b15551faf2221278 eab94b35987d41a6aea96685dce0cad4
+#: eda8f9a3ebcd4f089bffe18dbeca3077 ee4bdf80944e4c53ba7f32f3bd2efec3
+#: ee9d33de140f4305b24109ae2d1c33be f4ca8b97b6324b76802e343a06c59cd3
+#: f6cfe7a57b0d4841acba0376f84e9f0c fa26470bfeaa4ce4bd4cb9afd9ecac4f
+#: faa28b222252472a95bbb27e574557b6
+msgid "linux-ibm"
+msgstr ""
+
+#: ../../24.04/1.md ea05f6a00fb94572988dc9cf5a0f9791
+msgid ""
+"Don't produce linux-*-cloud-tools-common, linux-*-tools-common and linux"
+"-*-tools-host binary packages"
+msgstr ""
+
+#: ../../24.04/1.md 00e6c32f7e114a9aa94da459dcf3476d
+#: 02aaef558ac645f885640af258597f7f 035b6a7d14234ca2ad09acc96ef7280f
+#: 0c73e4b3fe11447cbf7639fa71f77aac 0e3801cf2a6345d69eee1fc6db991067
+#: 11b704e8e96a4188b47b628b48455c54 1235a1e74f984b81a51d4db528a49c02
+#: 14871ea27d884c76a6812f3608abec89 1577f49023764e3591919d2cbd3a7f2d
+#: 251aeb4c03c14d56a675b09c104bab23 26c3981c1d5742ca90435923e5f6d179
+#: 26ce46bb444d4813b455188e7bdb87a1 2cd6010a06d745f5bd6dee902fbd824f
+#: 2d6cf07d373a4d53bd96ab7bfc3fa79f 35843cdb40c248fd9ef002c1686cb884
+#: 35b55c1a78644f6bb829d4ebd499e46b 36dfe9f607494abdb3efa6b86759bd51
+#: 438ebe29a0db4e3fb6198755ea68b066 43aa53d2a9474518bbb4729eca180594
+#: 51df62b003fa4e169637e42ebe74487e 5451cb369cd149ae9694d0b96d79f5df
+#: 5ef6ba32f69d4f5298be4ae93b784e08 68f4bd41599d4bbbb42304daa2b07b69
+#: 6ef31f3d26b74bd197fe8b5efc820af1 71e253f80911465392111ad29db4a700
+#: 80406cce93714a298c505e1c5d6cbecc 8d020f9d9b30469b80fb902941825de2
+#: 935e36aad69946c2bc54f941276e0f3c 9b1d0898a1fb49cdb3b453cdf6d41e42
+#: 9d43e08608584f4db0d0c78fb19c8439 a305646e71d9409aa21d4b5cad91e13d
+#: af03092b444f4f82a5333b5e6852f86e b6c545b7a64146cf9bd97461c22edd8f
+#: b834d465d20b4babafcdf58029cca8b0 b87988ac7fc449c5915f03fac099bb6a
+#: bf07358f01b0452dab1affc0a353752d c217d8e98b1d40ae981dcc3aacfa6bbf
+#: c5a6bef62dac4e21b9109e334339d44c c89f08c435e84580ad635476965b0860
+#: d5a9b5992a2e41c69791b282c144007c d860f8ffe4574643966efe0aca4503bb
+#: da19a2ae17df49e6a47ba97bdb2b0354 debf5fe34482439291d0076fe5703848
+#: e1f2b878f3694b4185ee19ea0a06d66d ea45e09933264b8da176f0bafea97b06
+#: ebf8fb6f200d472eb9fff6ecb8c08b5e f6415dac318342738dd93a30b55646e7
+#: fb60d39abd754d4eb04319766d4cea02 fe07fa1c3e384c65ac2055612813a883
+msgid "linux-lowlatency"
+msgstr ""
+
+#: ../../24.04/1.md 049c31828f4643fdb004da4aeefbd3ea
+#: 4617f21e644244ba8138c6f4db78062d 8e69e026eaf64288b17a1a710cad49ac
+#: b652a910dc494902a4f5159ef074c77b bebb1e0fced74495b5773cb65bbba66d
+#: c515e0be78694d9fb945470a2e8d13c1 f362502c3c354b56a66a61541f8bb49c
+msgid "linux-riscv"
+msgstr ""
+
+#: ../../24.04/1.md 0d7d2caa7d3445288b0c6d263a4981c8
+#: 0e33f2918d7147249c5a069b10845704 0edce69289bf41289d140bad8d2d181b
+#: 1191f570dc784609ad3317f5f8a7388c 3eddb426655341208013e1d8cb6791a8
+#: 3f9e6641f7d548519aaa9832399289e1 40112e1e8e4b46a1a2f7badc85b0f14d
+#: 4b4c5ee3ba4b46698766d40ed24e9a7e 588339db99784fe1bb77bcb671eef676
+#: 6132ad15e65e4369a44ad96730f07962 92500cf7dac24186a187d9f1f42394ce
+#: bf9fcd62c8ef4d13a9edaf8faf94644b c1d0abcaa84b47ff8f55ac3387c66ce4
+#: ea8c6766138c47889dad9354fb6597c6
+msgid "linux-oem-6.8"
+msgstr ""
+
+#: ../../24.04/1.md 0ef271c3f2e5445aaf7e9ab244ce164e
+msgid "[2064336](https://bugs.launchpad.net/bugs/2064336)"
+msgstr ""
+
+#: ../../24.04/1.md 1eca1cb9c78f4974b6e246abe58630ee
+msgid "noble/linux-oem-6.8: 6.8.0-1006.6 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md b937830a7e1c4fcca12256b1d782c758
+msgid "[2024199](https://bugs.launchpad.net/bugs/2024199)"
+msgstr ""
+
+#: ../../24.04/1.md ff2c3c6ee21d443fb931bc4851c2cca7
+msgid "Resync CI Runner Configuration"
+msgstr ""
+
+#: ../../24.04/1.md 69db0fb4c9f54211887a2bdec9dbbaec
+msgid "[2065365](https://bugs.launchpad.net/bugs/2065365)"
+msgstr ""
+
+#: ../../24.04/1.md 8fc7f89657f14abf96fdfc420220381b
+msgid "AMD Strix s2idle failure due to AMD VPE driver init"
+msgstr ""
+
+#: ../../24.04/1.md f89e813eec3145ae984d178d82dec032
+msgid "[2058333](https://bugs.launchpad.net/bugs/2058333)"
+msgstr ""
+
+#: ../../24.04/1.md 335128d633c54327a9b8d66a78a75aea
+msgid ""
+"daisy chained thunderbolt devices not working at reboot on AMD strix "
+"platforms"
+msgstr ""
+
+#: ../../24.04/1.md 2785cf65a5fe4b3b817f3b35db3703f7
+#: 3889ee83e2ef4d3b803318620d27c673 b9abcbd0692046dfae2e034ac03f1c5e
+#: def8ea60bfde410c9609041023c51afb f4be996f3ac94cb98831bf233e0088ba
+msgid "linux-nvidia"
+msgstr ""
+
+#: ../../24.04/1.md 893c1765c7ac4dbdb36460ed193bb1ea
+msgid "[2061930](https://bugs.launchpad.net/bugs/2061930)"
+msgstr ""
+
+#: ../../24.04/1.md 4ed11c5eebc646708553054a0af4f7ba
+msgid ""
+"linux-nvidia-6.5_6.5.0-1014.14 breaks with earlier BIOS release, and "
+"modeset/resolutions are wrong (LP: #2061930) // Blocklist coresight_etm4x"
+msgstr ""
+
+#: ../../24.04/1.md 05136cdc809c48208ed7d358660e2c3c
+#: 06558a05fa1340aea5f6f8477c6adfb4 08e9acb1aaf142109d8a22604eb895fc
+#: 1a78a268ad6640c7a991e9320b75a414 1b2199ee7645433689044c96eeb99b2a
+#: 22bf16c4c3dc4b19a149003b34499205 241b36e7487643ed8928520831b74574
+#: 26d809d332bd4e129b1d85c6efa2d125 30928e332f25413d9ac3c4b4ae3f4914
+#: 43eb337df9524db0aea68e8631b35abf 5547d09a10594fb3890f9967d58e15ef
+#: 5ad8f4f2c9414c99b2b69b9d8d12aad0 5d96eec8469248d9a2d211e5d3ae54f1
+#: 5de71fe5d9044b9cb7c67356629afa26 6a9b36e1ba864373a7a8d36dcd83be71
+#: 72108873f09943598389daef7e8c6035 77cd4e58eea34a758f6c3c8a6e81bf9c
+#: 7842a4f810394d149add8ec93ab29b1f 7cf489253c7a49ddafcfa016b640017c
+#: 7f067b2d76454a67beb56eb425e48e01 841a133551b7402c8bfba4cb03c5a0db
+#: 84a178314b99408fbd3215347b10fb1d 88a34843f10349e2a2d847df582751b2
+#: 8b44f9eb58694864be0455856ec353fd 8cc645425a1e43f08bd1bb7f982cf2b3
+#: 95193be5da91418791216ab4ee330395 9550d2bf1c7b4845a7c3a814aba7ed4e
+#: 95e6a45f5583458fa2cf12da51f4d469 9b9f99197ab3416999e81d09aa8aba85
+#: 9f4c8b97efa24e88be93f69c7a2cbed1 acdd77971cac4620ba0f692f20dd31c5
+#: b2d4a508606f4be58b35e265b5c4e573 b509c68e8ed44f5e98d6b34fbc60f219
+#: b9ffae80a2de412eb878160e2cca54f6 bb43a4a7ff914bcfab48d97fd240ec66
+#: bdee8460a97d45728840309cf7c8803f c050c44ba85f4b7784dee46d1f52e196
+#: c6e509a4de444f5db3a3597c2a8f4c44 c7c135cdd0d1476f83e45258f335fcab
+#: ca4eb751cf9e4f4999816a12948e73b4 e0dfa17f115d4280a718dc512bf254f3
+#: e133609e3a5c4eba95b1a9857b02006b e1e5fd2aede74fecb1657695a8af2661
+#: ea6b40fcec3a442baecb008fdc150269 f33d3ed95cc0441490d42b5fdaee4bd2
+#: f46451405a994c2d98b29c7475a50f97 fccce711189446e39791841c047b7c06
+#: fd21d7727d1942909c484b93bbae9655
+msgid "linux-azure"
+msgstr ""
+
+#: ../../24.04/1.md 636eb8c3c0d3453d8cc6b0e49f421ad1
+msgid "[2064327](https://bugs.launchpad.net/bugs/2064327)"
+msgstr ""
+
+#: ../../24.04/1.md 8574bcd519a94abe8e9d48c2dc0ca61f
+msgid "noble/linux-azure: 6.8.0-1008.8 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 102ca5f87c4449a49f4275b9fcd65fe3
+#: 1607b3a47cad440f9f8aa6c234dd846a 1bd2fd86468a447e84a6958c2a9b253e
+#: 3a5bf17343344cff9969ccdff45adf7e 90cb2b8e0b1c446c8e4774828d3a691d
+#: cef6a5ca7f1e4e4b9be0b2c079a5a1ef
+msgid "linux-firmware"
+msgstr ""
+
+#: ../../24.04/1.md fef43aa261c54d44b7a957ccde75cacd
+msgid "[2063002](https://bugs.launchpad.net/bugs/2063002)"
+msgstr ""
+
+#: ../../24.04/1.md f49288c388b7472abe7bfbb52fd2a27b
+msgid "Add support for DCN 3.5"
+msgstr ""
+
+#: ../../24.04/1.md 004d10adc81b44bcbab9863bbc85db63
+#: 01abc945fccd4b7b947a3e53fc4bfbda 04387b9a75da464ea9f82fe4812da98f
+#: 06f4b3b675bd4348be91dd63051c5ac6 080504f08b16408189298c086143aa6c
+#: 08a32a47f0224ff78f61873837e93c97 09798515ba98476c9d9126d8d71ee454
+#: 0a1a228f8a8b40468fc513686628d1bf 0d979a32ee484146a7ffb91633e82f6c
+#: 0ee185ded62a4249a52948ca6e94027b 10e589faca05434b8064af07578257bb
+#: 11a4e4ebad5c4a1db0a0e116bfb1224f 11d4114ca97841909e5999d7b745d9db
+#: 13b1a030d43e485789b9321a985cdac5 174c6d18f234466785fc906ec60c7da5
+#: 17fabb2adc274756b58f3f6ef9853aef 186d119cb7cc4e6e9e60c92eda1d91ff
+#: 18de0ab8589d45cca2d9f7b1b25765a9 1a45f6812bfc4259834db15c10b12d28
+#: 1bbb24a9d65543d68c057801bd9f385a 1d58c02136704e52a7e19c2e714e9a2c
+#: 1df77351f36f4b27a58e0bac636d29a2 216d55dbc3c241ebbb4b17b6f327c6a8
+#: 24c95517773c46eea938dea97c2da1c1 25fe6d794cf748258f18e8346ff2c2ff
+#: 29d653d5b23747d182302663cf1a0c6e 2b795521b9a24efeb2a31d29ca8f7416
+#: 2d5094642dd04821af401aa5cc8ac00a 2e2f689f9f204ab48bb788ccd1966485
+#: 2fb6a72e04454ecf88afc4a55a978dc2 30c6d57424284934b984bf7ab8a5b10b
+#: 36ab9c16c1d04d929f857ade80ca07dd 383a0c1ab2b642a78357d30aa3ced42c
+#: 38c3a0dd081e44c1983e6ab369757d69 3b0bfa60c9fe43f2b94de130e1aa9e8a
+#: 3b41de51877c4e6686557c059658bacd 3ca18119195146c8a7584b133e452aa9
+#: 3fdb849238ab4194b9c6137e09490e69 4296766479c3475ba492e47d48666cdf
+#: 432c58412d294ba982fb753a83dea379 445496b0f39144138a4a565398b7bd9e
+#: 46a66899bb8549e6b23480f00c4ed502 46be667f04fe4d6ebbfd43cc9d2c419f
+#: 46e37f4a8cae4c31aed1a0ebb0b6c48f 4760eef5274c40c59eef9c0320576e65
+#: 4a29f94ccc37443cb262b1252eedb825 4b79ee5106b9400e987c18835315c145
+#: 4d8b1a71a8494b58addb528346ea4cd2 525282c85f2548c08e67d56a66a3e044
+#: 549565bb8b0848c6899dd5fee33b0d13 5ae5eebfa2e347d38940a0c3fbdd52a6
+#: 5c94e7188e38485cbca7b1a3908e8be4 5debc6c26b8546e5a14e319dd9dff962
+#: 63106b1df5e24b78b0de3bdbb80ed660 64304bfc4cf7403c8856b2d13ebfec57
+#: 65dab7f0ff1148bab96dbe57093072d9 65e3af28def24f6caa12427a846b5b64
+#: 663dcad6e61540078ee27eaa011d36fa 6dfbb1baf80e4818aa934357dd3c55f3
+#: 6ea36184b77945768db9ac4e772e3640 7047c51fe767436ab7e84e6200bed890
+#: 72149a348aac414e96a8d8c1a2150688 729bb569058b43f0ae46edff26623722
+#: 738a4aee1bf246ada9b3cb0cc1175d55 75937be8d3dd48abb62d7ccfa063dde6
+#: 77e6e0b6b5fb45ffb0e77e0a64b96d7f 7bedb9741dba4d2a83ad8283a938b7aa
+#: 7bf975cd2dab4b96b6ad6a83bdb12123 7cddc33db7d74e1cbe295fb7dfcffdaf
+#: 7d3fff08839d4679ba85989991896bb8 7f83619f14374c24b7e164bd86f92bc3
+#: 8456ce976a0c49038fce40f1f673e4ab 84afcff77e33440283a34e9f1a67e0e3
+#: 8697e0a105b84dc195d0b665b8ccdc09 886b8096bd814f69b9dcf2f359839a79
+#: 8997b44a07ec474ebf079f681230822d 8a075ea3e1854dd88b58bd51cbf41ade
+#: 8be3ec23881043419a4025c7b75bf46d 8c98a4d946144694800a1b23672b0bdd
+#: 8d6ea7f9127c4eb6a68745e1e982912b 908771beacef4ad193b47fc08ae1a033
+#: 91263ccbef5b49999b597f964479c5cb 934635a520ea45ec92777cd1adc1b6f5
+#: 9465def88ed34c8a80f0c6c23fa783a2 96bb4c7fe2114cc18a0a473f9cbd7c89
+#: 977dc9ee12d24325810fc149fcc865a0 97fad0692cdd4b40b7a4df6734f5a528
+#: 983ed79c0ca14bb6b460bf76ba6bddb9 98cc1bfecc03408da7fa0a077ed51512
+#: 99a5c0007a374b07a204cbc020d41064 9bbf5f7dd7454890a3e968c2a9215215
+#: 9bed233476c04840abad80623decd046 9de79e6a13714625b48400683a7eacc0
+#: a69d5a4e03b74266af12ae677fde7e7b a907bdf4d66e4102ac9f79408b096c29
+#: aa6a76f9512c4855a980a3adcfea33c4 abd66b7fb14a4f9197f53ec6a05b4e61
+#: acceed3bf10d45e58d04033c2895a692 ae9738e31ce24e8dad17b86b8caeeea1
+#: b357b92755e04443ac1b118cf0945467 b4ab029ba0f7494682b470a242f58d43
+#: b62387ca9fe34c65b105bb519519fb7d b70a98669da84476ade45cac1034bd98
+#: b7e1e4cb21904ae297ba45c7f0244bea ba6b368f260a410f822874f2cd7cf311
+#: bc1e63710a1c44e79cb34605cef01cc1 bc63259f4c6247eca607bf551b113e13
+#: bca0c93e68ce4da7959385e7ae9e878c bd72134f0e784edc81cb422944f87a1f
+#: cbaed2cf3ac148c7adf60a77feb0e25a cc901397a5ec4b32914664ca1b5c041e
+#: d1d05554ae424f49a8d4ee94aedac52e d6d349c04acd46b48589c4a707125825
+#: d6e6f1a2ba384ad2a3f24764d89480d8 d74871239e7144fd8425ca8be7e138fc
+#: d7d11bb06c96483daccc1a8c1df04101 d8bcc65a7ca645d5b63a5c9268aefc32
+#: d96fd6c5c3694e20905a9fcb240884c4 ddb9d1aea56f45fc9221a1a5510b08fd
+#: e29138907c6b450f936a19179c8fd295 e2ab3d5a3007485486d52f0714a61a68
+#: e616c11e4f9246de8bb6300e64654989 e9657862a9f34d4cb486d0703b6f1e36
+#: eacf2f0ed86842728777cb6efd555fc9 eaec759d1fa74b949e7e9e3d4907f7b5
+#: ebca1d5f6ab64c7da7ae020b818f3707 ec314fc60d3843d09edad1acc571de2e
+#: eea347585ae44b2eab961cb8a999320a efcca41f60eb4fd4b8b28f29a9c8d36c
+#: efdf4db02dd1424eb780138ad50c12cd f05ddfd57a1b4aec84024e43575e90d5
+#: f361de4fe26846e9a48a39e2a50afcfe f883bde2dff5455980caf83cb320c82e
+#: fb4805f4ecf947e8ac8fa7977996fca3 fdf5c1319782407a802ee3c792eac1d3
+msgid "linux-gke"
+msgstr ""
+
+#: ../../24.04/1.md cc1f01b719884901b72e4c7297c1bfde
+msgid "[2064329](https://bugs.launchpad.net/bugs/2064329)"
+msgstr ""
+
+#: ../../24.04/1.md ca1a5ed3ff7a48b487db542778baba64
+msgid "noble/linux-gke: 6.8.0-1004.7 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 6deed7b34a294691b0b0148ef1d1615f
+#: eedbd202794c47a7a9238fc548217d58
+msgid "[2052691](https://bugs.launchpad.net/bugs/2052691)"
+msgstr ""
+
+#: ../../24.04/1.md 961888f9d0f5467d842b873356840a97
+#: bed255e363f04031a7dde49b5b363823
+msgid "noble/linux: 6.8.0-7.7 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 43ba7c17b978445bb51a5298ac9017bf
+#: a64eee90e1c74593b8064a2c8246124c
+msgid "[2052592](https://bugs.launchpad.net/bugs/2052592)"
+msgstr ""
+
+#: ../../24.04/1.md 6b6ab962da514c87a4bd5e60cc475343
+#: a7ad07ef698b448ea03595dda934f02c
+msgid "noble/linux: 6.8.0-6.6 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md b89caff805db40caadefd68526c6201e
+#: f6903a6f9f9142eeb696c999438fd274
+msgid "[2049082](https://bugs.launchpad.net/bugs/2049082)"
+msgstr ""
+
+#: ../../24.04/1.md 242a79b837a5400e904215123c796c9a
+#: acd7871f9dce4d70af0b09a4223f7518
+msgid "FIPS kernels should default to fips mode"
+msgstr ""
+
+#: ../../24.04/1.md 2b9eb51823b64a169c1822c08bd4a7be
+#: bec9121c25b94a468468aebf0cb5090f
+msgid "[2052136](https://bugs.launchpad.net/bugs/2052136)"
+msgstr ""
+
+#: ../../24.04/1.md 6f0e49833a4a448fbdb5a048d7ed003f
+#: ee97f5baba19434a8174b398d0ef555d
+msgid "noble/linux-unstable: 6.8.0-5.5 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 236654d696e84201b2b56ce81696ffff
+#: 5f09f6c05e1b4f3d9e4726fbff0cd6c5
+msgid "[2051502](https://bugs.launchpad.net/bugs/2051502)"
+msgstr ""
+
+#: ../../24.04/1.md 234bdf2c03bb460f96be206400e20d01
+#: ec387078611a46739b1954a55422bd91
+msgid "noble/linux-unstable: 6.8.0-4.4 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 513f7419e2c84e2698147dbb551577af
+#: 6dd1106c2361488b8ac7ab3ed224385c
+msgid "[1965303](https://bugs.launchpad.net/bugs/1965303)"
+msgstr ""
+
+#: ../../24.04/1.md 6255a766d653495ebb5af6a8f5e47ffa
+#: a9d7c46e3511433eb802605edf8d9b76
+msgid "Migrate from fbdev drivers to simpledrm and DRM fbdev emulation layer"
+msgstr ""
+
+#: ../../24.04/1.md 14b11164d41845588aee66eb0b7ba8a4
+#: 2cb1fc714c214c7db53cda894f6d3564
+msgid "[2051488](https://bugs.launchpad.net/bugs/2051488)"
+msgstr ""
+
+#: ../../24.04/1.md d4437ac5a927463aa9719bd278bd90f7
+#: e2cc4dca28474393b8148de2789bdb02
+msgid "noble/linux-unstable: 6.8.0-3.3 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 4062f999260c45be877cfc958b126773
+#: 4674426f0eac4e10b446576f21415102
+msgid "[2040194](https://bugs.launchpad.net/bugs/2040194)"
+msgstr ""
+
+#: ../../24.04/1.md 2dd3fbf40e8140c5a9f2756ff55a0a9f
+#: fb198d4aefc640a596172843475867f6
+msgid "apparmor restricts read access of user namespace mediation sysctls to root"
+msgstr ""
+
+#: ../../24.04/1.md 5497bf347563495da754ab93c41f463e
+#: a1a28a9c56874834a28b439ead4ffccf
+msgid "[2040192](https://bugs.launchpad.net/bugs/2040192)"
+msgstr ""
+
+#: ../../24.04/1.md b119ff9fb8dc4d5da856b84550caa492
+#: fc5af4110c8f442594db67862165c109
+msgid "AppArmor spams kernel log with assert when auditing"
+msgstr ""
+
+#: ../../24.04/1.md 1d55c5bba1a74d988acafd7a0c16082c
+#: 4bbc2b3aa30d4100996dd1fa46cb6401
+msgid "[2040250](https://bugs.launchpad.net/bugs/2040250)"
+msgstr ""
+
+#: ../../24.04/1.md 001b070bf9624d69bb15c7bf884d55e2
+#: f771b3e1920647c5a09b672cba09e189
+msgid "apparmor notification files verification"
+msgstr ""
+
+#: ../../24.04/1.md 12fd1ffd0474486186405724f659afe8
+#: 8eebf872d1544f90a24481bebbf4d7d4
+msgid "[2040245](https://bugs.launchpad.net/bugs/2040245)"
+msgstr ""
+
+#: ../../24.04/1.md 4e86751430c84ff781e7b0991444f358
+#: a51e5297ef6740ccbe28a74932b2262a
+msgid "apparmor oops when racing to retrieve a notification"
+msgstr ""
+
+#: ../../24.04/1.md 318cc316ff6c4e69b4ade34a3af1ecc1
+#: ef34e8967c61431397379012a4e7abc8
+msgid "[2051110](https://bugs.launchpad.net/bugs/2051110)"
+msgstr ""
+
+#: ../../24.04/1.md eedbade728344862a25237222ed74cfb
+#: f0cf1e5c517c41d28f1eac3e460b39a0
+msgid "noble/linux-unstable: 6.8.0-2.2 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md 77ce54a65d804dfa93013840e4a410d4
+msgid "nvidia-graphics-drivers-470"
+msgstr ""
+
+#: ../../24.04/1.md b667189ecd294f9ba0b5a6d070d90d62
+msgid "[2067598](https://bugs.launchpad.net/bugs/2067598)"
+msgstr ""
+
+#: ../../24.04/1.md 60a555ad05844b029553fddf148b2f42
+msgid "nvidia-graphics-drivers-535"
+msgstr ""
+
+#: ../../24.04/1.md 32c5adad47e541f0ae0ccb94632ed8dc
+msgid "[2067597](https://bugs.launchpad.net/bugs/2067597)"
+msgstr ""
+
+#: ../../24.04/1.md 6ee8721e0af9474590e581c2249bba6d
+msgid "nvidia-graphics-drivers-550"
+msgstr ""
+
+#: ../../24.04/1.md fefe73e632d84b6ebc23204bc25bd6be
+msgid "[2067881](https://bugs.launchpad.net/bugs/2067881)"
+msgstr ""
+
+#: ../../24.04/1.md 54bd13ff5ec04c51b26aeacf906d09b5
+msgid "nvidia-graphics-drivers-470-server"
+msgstr ""
+
+#: ../../24.04/1.md 529ac19de009477e89920ec47f66db1a
+msgid "[2066904](https://bugs.launchpad.net/bugs/2066904)"
+msgstr ""
+
+#: ../../24.04/1.md d76b9c703e8b4f9596f7bbd0a633f339
+msgid "nvidia-graphics-drivers-535-server"
+msgstr ""
+
+#: ../../24.04/1.md f8d6b4a5067744058f89b5dcc18f1cfe
+msgid "[2066367](https://bugs.launchpad.net/bugs/2066367)"
+msgstr ""
+
+#: ../../24.04/1.md dfc2e1864e204fb4ab08f35bbc8ecd2d
+msgid "nvidia-graphics-drivers-550-server"
+msgstr ""
+
+#: ../../24.04/1.md f99f26c514e14981bd1c07339e5d1775
+msgid "[2067041](https://bugs.launchpad.net/bugs/2067041)"
+msgstr ""
+
+#: ../../24.04/1.md 023ac2ed8018442e9880c3d57dca13bb
+#: 13a9a56796464e8994cc822645f16e2e 158d9074d7e646debf76aa3c20fc07b1
+#: 191d5471ef4e4c93b3e436cc940681c6 1d71e7bca71b4b708c25f6a33b3456b0
+#: 22417326400141618cdbafc309ab1e88 232a4a37a443426281e1b261d72e0769
+#: 2ae8cd5c4351451fadd024be82c0bbd9 36c8a0064faf4db18decf55baa81e285
+#: 39f6fab4db9f4ba488c5efd4c918b505 42e4fa7f6cb040eea812126952d339b2
+#: 4bbb1540f43540f4ae9274e56cc96498 4c02c549a58c4433ae184b0f7eac7980
+#: 4e19e1acf5394bbeb4a691d354241a42 53ad44714683439fb5d7e5f3b92a8bb1
+#: 57bd9642eb214cbe99173e6150edd4bb 632a49f1513b4e59b4c34cbbbeab8fe8
+#: 647cb9da300949688215a097b2657d4b 65b4df7bc1c34eb989a64eabeab3b8d6
+#: 6a38609fbe9a447d95519f082d024755 6a981be70eea433c8e492d9de77320f3
+#: 6b004038fe0c474baabf746f7646c0b5 71440e858be841269b81b87f6b52d44a
+#: 71f6b4633a7a43ab934e81692bdc582b 8d8850a4c4254680a9b19a0679485ac7
+#: 9026b7f11e15463ab34ad2f92517e141 94edf2702c5043fc9c33423e082f583e
+#: 9514149f73524861910a74daa84ae95b a1e27030d7d743bd9ff2a15c90e5756f
+#: a45c358877cb420b83992fd6e5db090b a865e59cabfe4ed885876b3dca1ab09f
+#: a8c3bbe695af49ceb2b7b93a2d415346 a93034e51be4417ca5ab09cf87e956a3
+#: be26f55e9d274dd887cf650faa7ee7d8 cc28675928f54f5ea9dd5ea9dd4c6796
+#: cc42673783f747e4a57785577da74e09 d0ea43c66e234fddbfd32bb760684eeb
+#: d7a64002158f4312a322bfb9950bef72 df7dad3a12214c90b6bbd1dcdc237c3d
+#: e4b99c189b4e40d08000246dfd067a54 e4dd871855b9433d910db030e2f23587
+#: e613c902c42742e7b4301eb54c3a0908 e6a858dc19ce45b9be38e42d4d3893ab
+#: e768c481a0ad4b088dab193d8e43cc18 e7dec9d887b94f54a83483920014d51a
+#: e90a1a035a8a45148b41128547a60dab eaf0db2652dc4f5197e2512473335c2c
+#: f69a5689d1554f629ca70293e475e7fb fd984eb94c2d4f299931f93e6f9ff147
+msgid "linux-oracle"
+msgstr ""
+
+#: ../../24.04/1.md 4dc3402945b44cbda673e4126db12cfd
+msgid "linux-nvidia-lowlatency"
+msgstr ""
+
+#: ../../24.04/1.md 99e50464087d46dda9fe400936165d45
+msgid "[2069770](https://bugs.launchpad.net/bugs/2069770)"
+msgstr ""
+
+#: ../../24.04/1.md a71f745bd824489fae74067b261e9801
+msgid "noble/linux-nvidia-lowlatency: 6.8.0-1009.9.1 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/1.md d39b7283c87f47719e441f1810336e13
+msgid "flash-kernel"
+msgstr ""
+
+#: ../../24.04/1.md e5f0e51fd7874286a8db3d08d6b3d85a
+msgid "[2072500](https://bugs.launchpad.net/bugs/2072500)"
+msgstr ""
+
+#: ../../24.04/1.md e11a8a724c20450fb41225ed871e8a46
+msgid "db/all.db: Add Microchip PIC64GX Curiosity Kit"
+msgstr ""
+
+#: ../../24.04/1.md fa9a0b9e2e6649228d52f660078dd221
+msgid "Enable StarFive VisionFive 2 board"
+msgstr ""
+
+#: ../../24.04/1.md af5f53a1c64e4be683806848d467a2dc
+msgid "ubuntu-raspi-settings"
+msgstr ""
+
+#: ../../24.04/1.md 338116c0089a40ce91ac3c90ffd573e5
+msgid "[2069827](https://bugs.launchpad.net/bugs/2069827)"
+msgstr ""
+
+#: ../../24.04/1.md 2bf33d5b5699403f97dc05d94bd4525c
+msgid ""
+"etc/cloud/cloud.cfg.d/99-fake-cloud.cfg moved from ubuntu-raspi-settings-"
+"server to ubuntu-raspi-settings as it now applies to both server *and* "
+"desktop images"
+msgstr ""
+
+#: ../../24.04/1.md dfb1d98911e94d3cb8ec99b2c9729320
+msgid "[2069412](https://bugs.launchpad.net/bugs/2069412)"
+msgstr ""
+
+#: ../../24.04/1.md d98b391335b84cf0a10311b0ce357c6e
+msgid "CS42L43 and CS35L56 for soundwire on Intel LNL/ARL"
+msgstr ""
+
+#: ../../24.04/1.md a571d8e4bd674ce0a7bf6160f1161d43
+msgid "[2071771](https://bugs.launchpad.net/bugs/2071771)"
+msgstr ""
+
+#: ../../24.04/1.md d11ba8d702234a7f9c93f7df697c2d03
+msgid ""
+"Missing firmware for Intel NPU driver on Intel Lunar Lake platform: "
+"Failed to request firmware: -2"
+msgstr ""
+
+#: ../../24.04/1.md 2fa5b0d5b3a64c95a399ae615a123eda
+msgid "[2068001](https://bugs.launchpad.net/bugs/2068001)"
+msgstr ""
+
+#: ../../24.04/1.md adc0962485834d77a87f42da1ca27c5e
+msgid "Add support for DCN 3.5.1"
+msgstr ""
+
+#: ../../24.04/1.md 6cc680dbb5074e2d864594f901e9ddc7
+msgid "[2071812](https://bugs.launchpad.net/bugs/2071812)"
+msgstr ""
+
+#: ../../24.04/1.md e87454f5d22c47b18ff8c607714c97d9
+msgid "Add support for AMD ISP 4.1.1"
+msgstr ""
+
+#: ../../24.04/1.md 24cf4de736ae462f8effbdd81f1a1192
+msgid "[2073047](https://bugs.launchpad.net/bugs/2073047)"
+msgstr ""
+
+#: ../../24.04/1.md 7c2c32b8709f41b18c61abfaefb87035
+msgid ""
+"Regression on Linux 6.8.0-38: Bluetooth adapter (Intel AX200) stops "
+"working after a few suspend/resume cycles"
+msgstr ""
+
+#: ../../24.04/1.md:709 f0d1b2dc69014ff3b6ef4f8a604b0ecf
+msgid "Unsorted changes"
+msgstr ""
+
+#: ../../24.04/1.md e21da1bd36de4f68b1955882dea7a3c2
+msgid "distro-info-data"
+msgstr ""
+
+#: ../../24.04/1.md 490334b07f14448e91c076b832b26a1e
+msgid "[2064136](https://bugs.launchpad.net/bugs/2064136)"
+msgstr ""
+
+#: ../../24.04/1.md 3fc336895b5240eeb2118462b5508f33
+msgid "Add Ubuntu 24.10 \"Oracular Oriole\""
+msgstr ""
+
+#: ../../24.04/1.md 2044b2aadad2410d8009c9632519d263
+msgid "lintian"
+msgstr ""
+
+#: ../../24.04/1.md 8580cb5dca2c4d6bbc3562c8e98d7762
+msgid "[2064686](https://bugs.launchpad.net/bugs/2064686)"
+msgstr ""
+
+#: ../../24.04/1.md 59c2daeca8814792b2d5153287457b24
+msgid "Add \"oracular\" as a known Ubuntu distribution (LP: #2064686)."
+msgstr ""
+
+#: ../../24.04/1.md 7ab43185f6c94875ae1f9160735d94c8
+msgid "vim"
+msgstr ""
+
+#: ../../24.04/1.md 5f0989dec3a04b5aa0b6c65b319117ea
+msgid "[2064687](https://bugs.launchpad.net/bugs/2064687)"
+msgstr ""
+
+#: ../../24.04/1.md b512b7f52a5543959ffa0acc51103687
+msgid "Ensure Ubuntu codenames are current (LP: #2064687)."
+msgstr ""
+
+#: ../../24.04/1.md 61a665391ce34df499680eda105b579b
+msgid "libfprint"
+msgstr ""
+
+#: ../../24.04/1.md 3262de805302464f9143e21da07eb488
+msgid "[2067785](https://bugs.launchpad.net/bugs/2067785)"
+msgstr ""
+
+#: ../../24.04/1.md 5f7d60a0a5cd4534891bfe7061b0eb5e
+msgid "d/p: Add new Broadcom device IDs to reduce the power consumption"
+msgstr ""
+
+#: ../../24.04/1.md 84f5ab32811742a3b0c287c0f0dc7600
+msgid "cups"
+msgstr ""
+
+#: ../../24.04/1.md a6636a899814475d8a12e7fa2372831b
+msgid "[2070315](https://bugs.launchpad.net/bugs/2070315)"
+msgstr ""
+
+#: ../../24.04/1.md bfe512c51c144dfdadffeb9009dd66ff
+msgid ""
+"d/p/fix-scheduler-start-if-only-domain-socket-to-listen.patch: don't exit"
+" if no valid Listen or Port found"
+msgstr ""
+
+#: ../../24.04/1.md 755f4bf6921f4796a5f888239132b86a
+msgid "`lxd-installer`"
+msgstr ""
+
+#: ../../24.04/1.md a4a957222e234087921389069ab3a5a7
+msgid "[2061017](https://bugs.launchpad.net/bugs/2061017)"
+msgstr ""
+
+#: ../../24.04/1.md f4b9ba341c2e44639f12d1f77c1f1315
+msgid "scripts/lxc: check if socket is writeable"
+msgstr ""
+
+#: ../../24.04/1.md fb093e4478f746f6b7c5f15ed432fadf
+msgid "chrony"
+msgstr ""
+
+#: ../../24.04/1.md d394d7e6d7cd4545ad559b0a526eda72
+msgid "[2068526](https://bugs.launchpad.net/bugs/2068526)"
+msgstr ""
+
+#: ../../24.04/1.md fde3d56efa4241b99ac55d9790ea0596
+msgid ""
+"d/usr.sbin.chronyd: fix the apparmor profile to allow multiple PTP "
+"clocks/interfaces"
+msgstr ""
+
+#: ../../24.04/1.md b3c9e56d5dc64e22940221e2b9b33d80
+msgid "swtpm"
+msgstr ""
+
+#: ../../24.04/1.md 17b948cba4854c59a6a514d72d04aa95
+msgid "[2071478](https://bugs.launchpad.net/bugs/2071478)"
+msgstr ""
+
+#: ../../24.04/1.md 2ccfa1c81a644d3189fc4e612bb66d57
+msgid ""
+"Add sys_admin capability to apparmor profile to allow access to kernel "
+"modules such as tpm_vtpm_proxy"
+msgstr ""
+
+#: ../../24.04/1.md dbc0a492af4849d79e8bc93a62470bd1
+msgid "wtpm"
+msgstr ""
+
+#: ../../24.04/1.md 35a76506138642389208c44489ada051
+msgid "[2072524](https://bugs.launchpad.net/bugs/2072524)"
+msgstr ""
+
+#: ../../24.04/1.md b19a9b90abc444d788abd7976aa6600e
+msgid ""
+"Allow non-owned lockfile write access in /var/lib/libvirt/swtpm/ to fix "
+"apparmor denials when working with TPM2 locks"
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/24.04/2.po
+++ b/docs/locale/ja/LC_MESSAGES/24.04/2.po
@@ -1,0 +1,4397 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../24.04/2.md:2 07ee1551a69b4fc094ab5f78ef4166e6
+msgid "Changes in Ubuntu 24.04.2"
+msgstr ""
+
+#: ../../24.04/2.md:4 ad20b25f793f413e9301a1ee9cecd3b1
+msgid ""
+"This is a brief summary of bugs fixed between Ubuntu 24.04.1 and 24.04.2."
+" **This summary covers only changes to packages in *main* and "
+"*restricted*, which account for all packages in the officially-supported "
+"images; there are further changes to various packages in *universe* and "
+"*multiverse*.** Some of these fixes were by Ubuntu developers directly, "
+"while others were by upstream developers and backported to Ubuntu. For "
+"full details, see the individual package changelogs."
+msgstr ""
+
+#: ../../24.04/2.md:12 c09761eb44bb4bb3ade6fecbd244c573
+msgid ""
+"In addition to the bugs listed below, this update includes all security "
+"updates from the [Ubuntu Security "
+"Notice](https://ubuntu.com/security/notices?order=newest&release=noble&details=)"
+" affecting Ubuntu 24.04.2 LTS that were released up to and including "
+"February 20, 2025."
+msgstr ""
+
+#: ../../24.04/2.md:17 e075d664ac984e4bb11123459014f2fb
+msgid "Installation bug fixes"
+msgstr ""
+
+#: ../../24.04/2.md:19 892ca97b170340b8a0efbbe5ff60abcd
+msgid ""
+"Updated CD images are provided with this release, including fixes for "
+"some installation bugs. (Many installation problems are hardware-"
+"specific; for those, see “Hardware support bugs” below.)"
+msgstr ""
+
+#: ../../24.04/2.md 428cbcda485a40d584db58b954c10da7
+#: 621c811e456143539b3d5dd31c8ec8fd 62d02748432044ce98a82162c6a0e84a
+#: 92a28ea50f334248a6096cc62182d6f7 a6bc724ee9544d179d49f47a892e12e9
+#: bc8d75eeacab4c509b5a19de0f2bb1c8 de3734024c904f54a732b39aabc17b7b
+msgid "Source Package"
+msgstr ""
+
+#: ../../24.04/2.md 866c6a08fc9b479f911e814eafd1304f
+#: a0935f33a0254d769c3b3489ae735ef7 ae2c62198f734a9ead255d67f3356349
+#: d20a484ceca04d55aefe61c5b84a18a9 d3265b4b3b4a4e87b6bc54b90575c6cb
+#: e06e2cee5abe44fbaeabc62029c5f7ca ebb26849a93c4921a4a98063b58e7b38
+msgid "Bug  #"
+msgstr ""
+
+#: ../../24.04/2.md 15a0035b16eb4097a0089a7284d0667c
+#: 264df378f4f74653a25404cad820a96e 283663d6305346b6890076870453032f
+#: 8516e1b4273d47af9e1a15f74f9c079a 96db2707d0c14d2b94374aa1dd7494ab
+#: e0037a1b1e5f4e928b3ef172a9ce0c35 f9c2b34fa684473bb7137a0cfa563f21
+msgid "Description"
+msgstr ""
+
+#: ../../24.04/2.md 03ee952c3819405299bf32529fbf231f
+#: 03f4d19f38df4576a38a5092d260a673 4fb200648330418f90d3deb64c7bce27
+#: 8bbb013054e449d29cc959377c7e6960 91b7f03501054f2ca9540e047104fe44
+#: b17c35a24b694315ad3f95c03a6d8bac d6df1b1497fd44f78f82d81222038327
+#: dacdb084f9224f80a760a769cb90eb1f f58b7df730c24528af88383b8a5fc4bc
+msgid "livecd-rootfs"
+msgstr ""
+
+#: ../../24.04/2.md bb9f234bd9fa46548cd8dd7e8756e293
+msgid "[2077899](https://bugs.launchpad.net/bugs/2077899)"
+msgstr ""
+
+#: ../../24.04/2.md ca44fafb344c417da345a2108277a675
+msgid "Update ubuntu-classic-2404-amd64 model in ubuntu hooks."
+msgstr ""
+
+#: ../../24.04/2.md 234d06fc9b1e49caab6b56714a52343d
+msgid "[2077105](https://bugs.launchpad.net/bugs/2077105)"
+msgstr ""
+
+#: ../../24.04/2.md 2e060c6d36c04743874f365859d5ea47
+msgid "add cpc-sbom to create_manifest calls to generate sboms"
+msgstr ""
+
+#: ../../24.04/2.md b8cfcbb6ec6c407a8b6e9f969ca3e79a
+msgid "[2084698](https://bugs.launchpad.net/bugs/2084698)"
+msgstr ""
+
+#: ../../24.04/2.md 860584014fa34a4a883be9b6bc18b218
+msgid "Add apparmor policy permstable32 missing component"
+msgstr ""
+
+#: ../../24.04/2.md 5858fc03925c4a8ca367f9eeb21b6a88
+msgid "[2078583](https://bugs.launchpad.net/bugs/2078583)"
+msgstr ""
+
+#: ../../24.04/2.md 0ec3d614994a4b10928a8da44aeb35ac
+msgid "Introduce unminimize as a package in OCI images."
+msgstr ""
+
+#: ../../24.04/2.md e090f7e69e4e4a83ac5083b9fb4818d5
+msgid "[2083240](https://bugs.launchpad.net/bugs/2083240)"
+msgstr ""
+
+#: ../../24.04/2.md cb7cee66fa374f27b0ebbc42acc9221b
+msgid ""
+"Explicitly create home directory for buildd system user to avoid issues "
+"with installing and running snaps."
+msgstr ""
+
+#: ../../24.04/2.md 338fc417a0724449b47368f9c873b63c
+msgid "[2091392](https://bugs.launchpad.net/bugs/2091392)"
+msgstr ""
+
+#: ../../24.04/2.md f496da630c8d47bb94a1cea1be3603d8
+msgid "Add support for arm64+tegra-jetson flavor."
+msgstr ""
+
+#: ../../24.04/2.md 558f891642b64b939d5886a83ea63ed5
+#: ae414ee5b3c5431ea9a65b500c0197be
+msgid "[2091293](https://bugs.launchpad.net/bugs/2091293)"
+msgstr ""
+
+#: ../../24.04/2.md f3c9e539282f4878b1a2128a5815ec16
+msgid "Adapt to new Microsoft package format:"
+msgstr ""
+
+#: ../../24.04/2.md e3043d93026c4f79baa7276b027d3598
+#: eab37f9c73d84802ba80926b639db9cc
+msgid "[2098105](https://bugs.launchpad.net/bugs/2098105)"
+msgstr ""
+
+#: ../../24.04/2.md 7486bfa0bee548199df5758352c5150e
+msgid "Fix build failure when using lowlatency-hwe-24.04, as ubuntustudio does."
+msgstr ""
+
+#: ../../24.04/2.md f86dd7537b5442ddbbd25dd34a46c601
+msgid "Enable the HWE stack for 24.04.2."
+msgstr ""
+
+#: ../../24.04/2.md 2643efada9ed4e65bac339f2f8572389
+msgid "live-build"
+msgstr ""
+
+#: ../../24.04/2.md fbf848f62fc84027943da9b540558e1f
+msgid "[2077603](https://bugs.launchpad.net/bugs/2077603)"
+msgstr ""
+
+#: ../../24.04/2.md fc95c1a28add4b93b8f135097867b669
+msgid "Fix usr-is-merged causes dpkg-divert of some files ineffective."
+msgstr ""
+
+#: ../../24.04/2.md:35 da648e24d9514522b5f6da9aa1ce8537
+msgid "Upgrade bug fixes"
+msgstr ""
+
+#: ../../24.04/2.md:37 0d2d96f42ca649d5a7d296447285f075
+msgid ""
+"These changes fix upgrade issues, smoothing the way for future upgrades "
+"to later releases of Ubuntu (and not only)."
+msgstr ""
+
+#: ../../24.04/2.md 159ae7f7327543b99ae5acaf5af354fa
+#: 23e0225517054561b94bd547cc8c7099 2dd64aba8c244523acf50b81ae3b38d0
+#: 2e3b7465f954457da1f5216d8a2c6486 3a89d1ebb83d454a993a08fe70b3164f
+#: 493dc685042645938d4a88e864345eda 4a46faca1c63492482918d2c04875f0d
+#: 73622f17f734409a8de7aa58f8ff3d64 7e1461b884844e74a9126fcf2b09042d
+#: 80a1871402094a83ba56cef82e20d0b4 885811fc6a1c40c8888a328ab40f685f
+#: b80b30b048ce48dba86b6f02ff68f49a da3d138c96d1468fa69922808e361629
+#: dce475096dc5429dabafd8fb53f96f2f f295ef2d9aa54dcbb16549e4b449df8f
+#: f6cb3095ba0e4738b466ad73d0b022df
+msgid "ubuntu-release-upgrader"
+msgstr ""
+
+#: ../../24.04/2.md 62a43554a8554ff09a570a224a739b61
+msgid "[2076913](https://bugs.launchpad.net/bugs/2076913)"
+msgstr ""
+
+#: ../../24.04/2.md f472507851204e8299e972e6cb612826
+msgid "Fix typo in force_obsoletes."
+msgstr ""
+
+#: ../../24.04/2.md d2c0666e34fa4c0a8f3efd2b8836a184
+msgid "[2077358](https://bugs.launchpad.net/bugs/2077358)"
+msgstr ""
+
+#: ../../24.04/2.md 1d9f7ca8222e4c0480bf581eae8bb191
+msgid "DistUpgrade: handle cache key error when removing obsolete packages"
+msgstr ""
+
+#: ../../24.04/2.md 2ace416d66d04051943da5c954b3bc18
+msgid "[2077344](https://bugs.launchpad.net/bugs/2077344)"
+msgstr ""
+
+#: ../../24.04/2.md 69e427be5d164bf5b699c2ed58ed3109
+msgid "deb2snap: switch snap-store and firmware-updater tracks"
+msgstr ""
+
+#: ../../24.04/2.md dad71e5221b84910ac357c226b43fd72
+msgid "[2043820](https://bugs.launchpad.net/bugs/2043820)"
+msgstr ""
+
+#: ../../24.04/2.md 4cb5fabe37f6444e831866a29bc3aa9b
+msgid "DistUpgradeQuirks: disable stub resolver on upgrades from jammy"
+msgstr ""
+
+#: ../../24.04/2.md f75a5a2fc58c4f97a81a59b7d8d767bf
+msgid "[2073278](https://bugs.launchpad.net/bugs/2073278)"
+msgstr ""
+
+#: ../../24.04/2.md c02e5c4c126c4a658fbeae78017ef6e3
+msgid "DistUpgrade: show a message about denied package removals"
+msgstr ""
+
+#: ../../24.04/2.md b1b5bd2b8319464a9cc471a33aac22c1
+msgid "[2067622](https://bugs.launchpad.net/bugs/2067622)"
+msgstr ""
+
+#: ../../24.04/2.md 2abd49ad2ecb499b825e62554d2fd1a5
+msgid "data: add cryptsetup-initramfs to removal_denylist.cfg"
+msgstr ""
+
+#: ../../24.04/2.md 7f6855c3a5654dd491276f5b523ffde6
+msgid "[2058648](https://bugs.launchpad.net/bugs/2058648)"
+msgstr ""
+
+#: ../../24.04/2.md 0a4565653a74469ea0995121dfd5b5cf
+msgid "DistUpgradeQuirks: abort if system is not /usr-merged"
+msgstr ""
+
+#: ../../24.04/2.md 33786865334c4cd7aef052ff101dfda7
+msgid "[2075968](https://bugs.launchpad.net/bugs/2075968)"
+msgstr ""
+
+#: ../../24.04/2.md 7463e2b4c60344eea15d45141a26cc25
+msgid "DistUpgradeQuirks: disable cloud-init on upgrade"
+msgstr ""
+
+#: ../../24.04/2.md ad95abfa97524e5092dbf34bec4e0f7f
+msgid "[2074309](https://bugs.launchpad.net/bugs/2074309)"
+msgstr ""
+
+#: ../../24.04/2.md dac0495c21214bde98282db16ce3705e
+msgid "DistUpgradeQuirks: abort if rabbitmq-server installed"
+msgstr ""
+
+#: ../../24.04/2.md 2f97b1eb6e984ec7912675e813441983
+msgid "[2054103](https://bugs.launchpad.net/bugs/2054103)"
+msgstr ""
+
+#: ../../24.04/2.md e326eee04db74569abfa7450b3b8e7d8
+msgid ""
+"DistUpgradeQuirks: make sure GRUB \"cloud_style_installation\" is set in "
+"cloud images"
+msgstr ""
+
+#: ../../24.04/2.md 9e261d332bd24e769fd4b03894b3de18
+msgid "[1874272](https://bugs.launchpad.net/bugs/1874272)"
+msgstr ""
+
+#: ../../24.04/2.md 283a2bea003d417b901d2080dc17be92
+msgid "Reimplement obsolete removal with resolve_by_keep"
+msgstr ""
+
+#: ../../24.04/2.md 10851f9878cd4282bd8215842de07094
+msgid "[2078720](https://bugs.launchpad.net/bugs/2078720)"
+msgstr ""
+
+#: ../../24.04/2.md 8b30545b4b764f01a4842a3953a2db17
+msgid ""
+"Ensure that we remove only the right obsolete packages, specifically not "
+"kernel packages :"
+msgstr ""
+
+#: ../../24.04/2.md 5b4e94c5d5424d589006b2a6705c405c
+#: e1a2b1d36aa045fca988be1759d88f7d
+msgid "[2078639](https://bugs.launchpad.net/bugs/2078639)"
+msgstr ""
+
+#: ../../24.04/2.md f751602c98c54f89b3321cc3a2dd99a4
+msgid ""
+"DistUpgradeQuirks: install pipewire-audio on ubuntu studio upgrades, "
+"uninstalling pulseaudio and preventing install of pulseaudio:i386"
+msgstr ""
+
+#: ../../24.04/2.md ad39d630fe98474eb6a71d9e5dbe2522
+msgid "[2078555](https://bugs.launchpad.net/bugs/2078555)"
+msgstr ""
+
+#: ../../24.04/2.md f33bcc3f03524db2bcea379af6db723f
+msgid "DistUpgradeQuirks: skip sd-resolved quirk if it's not running"
+msgstr ""
+
+#: ../../24.04/2.md 3d383a3f95004c7fbc0abeda0b559e0e
+msgid "[2081864](https://bugs.launchpad.net/bugs/2081864)"
+msgstr ""
+
+#: ../../24.04/2.md 78f13d40fc3a42c6b85eafe628a3744a
+msgid "Avoid breaking upgrade by treating cross-grades as replacements"
+msgstr ""
+
+#: ../../24.04/2.md c4f304d21aba458ca92b3a77a3da7612
+msgid "DistUpgradeQuirks: install pipewire-audio on ubuntu studio upgrades"
+msgstr ""
+
+#: ../../24.04/2.md b0962be0325a49079d3f59b6ef5f5ae9
+#: cbee5e107f20410b867e39ba44f82c40 fef474b1e0f84658839f4ec31c2ee104
+msgid "update-manager"
+msgstr ""
+
+#: ../../24.04/2.md 918f17a5f8a546f29914e47df1887051
+msgid "[2068809](https://bugs.launchpad.net/bugs/2068809)"
+msgstr ""
+
+#: ../../24.04/2.md 1bb2700c532e4220a7e40edf9e971612
+msgid "Display changelogs also for PPA packages on `ppa.launchpadcontent.net`"
+msgstr ""
+
+#: ../../24.04/2.md 4378793b6a5644e1ad0d710fa5ef3c68
+msgid "[2064211](https://bugs.launchpad.net/bugs/2064211)"
+msgstr ""
+
+#: ../../24.04/2.md 92c00ceb4b3042d58e8e604b5e3f6082
+msgid "Don't crash if the end-points of the Pro API fail."
+msgstr ""
+
+#: ../../24.04/2.md 672bc69ddf1b4abdb806f2358f2fdbbd
+msgid "[2041831](https://bugs.launchpad.net/bugs/2041831)"
+msgstr ""
+
+#: ../../24.04/2.md 79b8b15f55414d95a0ca53bcf3542592
+msgid "Fix crash when packages get un-selected."
+msgstr ""
+
+#: ../../24.04/2.md:62 9fc9c694a2f0421da0b8849ce650f2c0
+msgid "Desktop fixes"
+msgstr ""
+
+#: ../../24.04/2.md:64 467a956e72374445b82ccbae24d87f84
+msgid ""
+"These changes mainly affect desktop installations of Ubuntu and other "
+"Ubuntu-based desktop systems."
+msgstr ""
+
+#: ../../24.04/2.md 09fc6cd71c19498ab03e51bf17643df2
+#: 0ddf69d5e5a54c5183778b1e2f90339a 1ffb08b6808a4af5ae564ff4335eb412
+#: 214581abc2fe4b9fb41e7989482ea4c9 28aaadbedebc4e7ab731c4e15ce26278
+#: 44cac9e8d19941df98b313870312baca 45a34873a5bb461daa7c7d7e81a8e83a
+#: 47f6cc0e856345278be955017e19bc1d 7fd05730f31a4d38abb4b11079f65dbe
+#: 85cce8e43e254f319a24748fd82832b8 8bc3c99dfc9a44c98fff9661e485ed4f
+#: 8e94c826bbd14d2c8648f9ea3dfaf3ea 96011bec7ebd4afb99f4cc24a3586c42
+#: 9712ff14422e4a548ff7fd1a57c58b6e 989c134f566540b3b7e5b263f884276a
+#: 98f84c8749ac44dca3ae589e804aeec7 ece43d79908e4c659b8fe0d705e60416
+#: f968166d9e3742bdb8936e1e4689120c
+msgid "gnome-shell"
+msgstr ""
+
+#: ../../24.04/2.md 5292505a233248f4becd6eaa9dfe8955
+msgid "[2069559](https://bugs.launchpad.net/bugs/2069559)"
+msgstr ""
+
+#: ../../24.04/2.md 6fa6e2ff3fa24021a1965f1f6b67c2c3
+msgid ""
+"Fix crashes that occur when locking the screen from within the overview. "
+"But more generally can occur whenever any extension that modifies "
+"stylesheets (like ubuntu-dock or dash-to-dock) is unloaded."
+msgstr ""
+
+#: ../../24.04/2.md d5cb528f805046409f45d280c4e90eff
+msgid "gnome-text-editor"
+msgstr ""
+
+#: ../../24.04/2.md 59763236e2904fe4b907e5f6cabd9e87
+msgid "[2075553](https://bugs.launchpad.net/bugs/2075553)"
+msgstr ""
+
+#: ../../24.04/2.md 8e5698d584dd486e88c2d9a4fee6939a
+msgid "debian: Backport patches to fix crash on launch"
+msgstr ""
+
+#: ../../24.04/2.md 6765851e85e14e1b94111660f66630d5
+msgid "ubuntu-settings"
+msgstr ""
+
+#: ../../24.04/2.md db982395d61147adb2e8be809f6a0da6
+msgid "[2077741](https://bugs.launchpad.net/bugs/2077741)"
+msgstr ""
+
+#: ../../24.04/2.md 4504285dcf154f1dbadf0d9362c40327
+msgid ""
+"Set default background in GDM gnome-initial-setup session. Use ubuntu "
+"default background when using the GNOME greeter session that is default "
+"when using gnome-initial-setup from GDM"
+msgstr ""
+
+#: ../../24.04/2.md 0b34facd012a4a8086b5f726b3aae5ea
+#: 77589f9b70e94938b1fb84136a4b9463 84f7b9fc79a84f578fd5bd1913e8bd96
+#: b4ea55f404d34d59bfb442254bcec27b e0d3cd9b0224447191ce622237105e77
+#: e648afc1962e41a2bb151e190d546b24
+msgid "mutter"
+msgstr ""
+
+#: ../../24.04/2.md 10a1d1dedef3456d94216487749c2038
+msgid "[2077746](https://bugs.launchpad.net/bugs/2077746)"
+msgstr ""
+
+#: ../../24.04/2.md e5ac47adad124528bd96e4b63e34e69e
+msgid ""
+"debian/patches: Fix screen recording crash with scaling and a custom "
+"cursor"
+msgstr ""
+
+#: ../../24.04/2.md e6d448c4b6db424c8a62dd7a55c09144
+msgid "[2025006](https://bugs.launchpad.net/bugs/2025006)"
+msgstr ""
+
+#: ../../24.04/2.md e7e8c298c8834b0ebdaf9d98b4b5a560
+msgid ""
+"Avoid duplicating or losing colour profile, night light, HDR, or privacy "
+"screen updates"
+msgstr ""
+
+#: ../../24.04/2.md 011d0db3b11045e98cdd01053c75b118
+msgid "[2076318](https://bugs.launchpad.net/bugs/2076318)"
+msgstr ""
+
+#: ../../24.04/2.md 894a3aacf9744d3082d5ca4f88d9c5b5
+msgid ""
+"Update the KMS deadline evasion patch to 2000us instead of 1000us. Some "
+"laptops need higher numbers than 1000us to avoid cursor stutter"
+msgstr ""
+
+#: ../../24.04/2.md a62fd104f95c44fc8e9b813a0d689b97
+msgid "xdg-desktop-portal"
+msgstr ""
+
+#: ../../24.04/2.md 2e6c4a8ff5d448b88c073b7f9a93343a
+msgid "[2077587](https://bugs.launchpad.net/bugs/2077587)"
+msgstr ""
+
+#: ../../24.04/2.md f6989f0150184ffa896dbab68bf41aa3
+msgid "Refresh webextensions portal patch to latest version proposed upstream"
+msgstr ""
+
+#: ../../24.04/2.md 17ea41672af841dabc01fc033866e6aa
+#: 304cb1044fd845f2b1bc0b5b00a60743 367dec29f9374177a6c74b360037f0fd
+#: 59bcc41e9b22479a8c04f164fa0c919b 7b8ab9390fff49708ae57b7b033bf1a4
+#: 7c28fc6a462847758f52da9201348d71 ed13addfd90d4fb78d52805f4b8bfd97
+msgid "adsys"
+msgstr ""
+
+#: ../../24.04/2.md 6f6a50559c3d4ee18bf1498d9172b7a1
+msgid "[2078245](https://bugs.launchpad.net/bugs/2078245)"
+msgstr ""
+
+#: ../../24.04/2.md 32dfc35905a54717a1c1cd5ca7e8be40
+msgid "Fix DCONF policy manager removing user DB on empty policy"
+msgstr ""
+
+#: ../../24.04/2.md 64660a1f36a14c419af83863b1064f2a
+msgid "[2078246](https://bugs.launchpad.net/bugs/2078246)"
+msgstr ""
+
+#: ../../24.04/2.md 73483c05109343c5a8f4ea159bd918e3
+msgid "Ignore casing in domain/ section of sssd.conf"
+msgstr ""
+
+#: ../../24.04/2.md 1dca72400a214e249b5a31bd11149281
+msgid "[2078247](https://bugs.launchpad.net/bugs/2078247)"
+msgstr ""
+
+#: ../../24.04/2.md 5cf0981a688c4c54805d7881062252fc
+msgid "Fix parsing of slash usernames (i.e. domain\\user)"
+msgstr ""
+
+#: ../../24.04/2.md dbc405d49957459bb8cc2c7d17d04a12
+msgid "[2078473](https://bugs.launchpad.net/bugs/2078473)"
+msgstr ""
+
+#: ../../24.04/2.md f040d133cb5140e087af41dc39bc462a
+msgid "Fix errno in get_ticket_path()"
+msgstr ""
+
+#: ../../24.04/2.md 1a51032cf68e4a77aaae108c4403f16b
+msgid "gnome-shell-extension-appindicator"
+msgstr ""
+
+#: ../../24.04/2.md 7dcbfe76faaf425496d919f6e16e178d
+msgid "[2064698](https://bugs.launchpad.net/bugs/2064698)"
+msgstr ""
+
+#: ../../24.04/2.md f3f8974febd1419baa59f242c44885d8
+msgid "debian: Backport patch to silence logspam"
+msgstr ""
+
+#: ../../24.04/2.md 1a7f0f408f3b4660862cf97c25133301
+#: 70e57f9f16db4eaba1c64cfde37ebab7 7d98784ca6c54fa3ac33057e2462a555
+msgid "libreoffice"
+msgstr ""
+
+#: ../../24.04/2.md 15a78031aa24456895eae38f36666797
+msgid "[2079005](https://bugs.launchpad.net/bugs/2079005)"
+msgstr ""
+
+#: ../../24.04/2.md 194e7eec5794457684b7090d5ff1632f
+#: 451b68b31ed14a16840afa47d16d03a4 54532546a77840f49bd1d30ff6bf75a0
+#: 5721186c9bbd4f78bcc42c8c3a08aaa8 625b67676c8643319364a2a03e16d144
+#: 62882da9f66846b688cd472000484b9e 7fc10d6070f34838919952aa35c0d868
+#: d685ab6f41dc407983f8485aa48dcbae ed1322eee1444a7ba3b9799ba728a916
+msgid "New upstream release"
+msgstr ""
+
+#: ../../24.04/2.md ebf9cdf3726c4ef488b0376d4ce6df75
+msgid "gnome-shell-extension-ubuntu-dock"
+msgstr ""
+
+#: ../../24.04/2.md 5fe0787917f04a1b8f5d7a3f6f06e51c
+msgid "[1993054](https://bugs.launchpad.net/bugs/1993054)"
+msgstr ""
+
+#: ../../24.04/2.md 367e13f3de2b4e4691ce34c4fea68cce
+msgid ""
+"locations: Do not cancel operations after a volume has been umounted / "
+"removed"
+msgstr ""
+
+#: ../../24.04/2.md 00788d33b7f84da282f015b0504109bd
+#: 8b5de2f29a4c4b32bbb93696f5c9989f
+msgid "shotwell"
+msgstr ""
+
+#: ../../24.04/2.md 98ff579a10ba453ebc70cb38361f35c1
+msgid "[2080004](https://bugs.launchpad.net/bugs/2080004)"
+msgstr ""
+
+#: ../../24.04/2.md cfa89b69a14b4303b75fb10d141ba0c8
+msgid "d/p/memory-leak: Fix memory leak in slideshow."
+msgstr ""
+
+#: ../../24.04/2.md af6d2234e218427e90a6ce7cfce92520
+#: def2c76356d046389d51c5f20d059fbb ea725103dd41473aa923b573b67a8a98
+msgid "mesa"
+msgstr ""
+
+#: ../../24.04/2.md 8b40447f33304dbaaac352eb1a84c7d4
+msgid "[2082072](https://bugs.launchpad.net/bugs/2082072)"
+msgstr ""
+
+#: ../../24.04/2.md 5e8a25d0c73a445c957c833ad7a0f302
+msgid "Add support for Pi 2712D0 stepping"
+msgstr ""
+
+#: ../../24.04/2.md 9a308b48f580400496d98bb8d92fcd1f
+msgid "gtk+3.0"
+msgstr ""
+
+#: ../../24.04/2.md 0373f99823684343866c2a256ed4bba5
+msgid "[2077290](https://bugs.launchpad.net/bugs/2077290)"
+msgstr ""
+
+#: ../../24.04/2.md 2070c40df5734cf38c9d0ee32d16fd68
+msgid "d/p/glarea-transparency: Fix GLArea transparency regression."
+msgstr ""
+
+#: ../../24.04/2.md 005d2d0e5069496593c26bee1fa52128
+#: 0757cde5b9414371842813d5973a05b9 087b571f92cc4ceaa5c493ff5a76f180
+#: 15bdfca266464a13a33ad036b4b3a96e 182044a5b8eb42488347ef906e6e4d0c
+#: 1b22d0d4e0cf4bcfaf93d4f5dced9745 1d9e8aca14f640479e0f191263c1e51c
+#: 210e0b0408e8429ba81500cadb002472 34dcc5cb13d6453088e11b588e3e0288
+#: 4847480f54214da98b2e7a8c361bd7b4 4f1eacc54fa14442b746e7a62b383dea
+#: 548be2afb1e74e48bcc8f81bcbe5d52b 62e6ed61e573495482e097a3f79384fe
+#: 63bb3577edb943eb9d21edb9ed599142 6a1009a10197447799cd2756c66b4907
+#: 6fafc44b1928449792e825fe2521a370 aaaf490a1a1941fea8c3f45284599bbd
+#: b650a7c1145e4ac08936642c937185cc c45b272c02cb45fab88afafe629af932
+#: d96a0880081940fd99d30e27292bc9cd f3f0105e9c064bd9b90433dde2aea001
+#: f4c9639870ba45aeaf05d058b9a149bb
+msgid "gnome-initial-setup"
+msgstr ""
+
+#: ../../24.04/2.md 873ee6deaa8646a9b8bff52ece09b3ff
+#: d257ff4b722941daa108a65c9358941d
+msgid "[2076662](https://bugs.launchpad.net/bugs/2076662)"
+msgstr ""
+
+#: ../../24.04/2.md 7869de9005e24b08ad921e0a87d27f57
+msgid "No-contents-change backport from oracular"
+msgstr ""
+
+#: ../../24.04/2.md 6617791f674042d296e8d9cf721e5d9e
+msgid "New upstream stable release"
+msgstr ""
+
+#: ../../24.04/2.md 1daa02741d2f42c498dabeffc9b829b9
+#: 1f95ca4671ae4b0a97d16b959a4abe04 4248982ad59e49be818a318b6b51fa0b
+#: 454ced7c296447f8b0d9b28c3ba01f70 c3981be1273a4278a6a77c8c791a2db7
+#: e153f85ab14a4b2b9094c911c78db8d6
+msgid "[2062971](https://bugs.launchpad.net/bugs/2062971)"
+msgstr ""
+
+#: ../../24.04/2.md 2e73bdb7c3c14ad8b941a6703c3acc86
+msgid "Fix alignment in bullet points in first Pro page."
+msgstr ""
+
+#: ../../24.04/2.md cc667608bfbf41a485dd362fcd894338
+msgid "Align radio button text and its hint below in first Pro page."
+msgstr ""
+
+#: ../../24.04/2.md 31e6430ecba44654aa8093112758c9a8
+#: a2fddea47d3e40eca68da73e0d6af11c
+msgid "[2068614](https://bugs.launchpad.net/bugs/2068614)"
+msgstr ""
+
+#: ../../24.04/2.md fbfefb7c34ea4a749121e409d5ca2e3f
+msgid ""
+"d/p: Ubuntu pages, bind functions to template. C Functions referenced by "
+"the template must be bound to the template or they won't be properly "
+"connected."
+msgstr ""
+
+#: ../../24.04/2.md 36305e9960c44a1b8e117c5021141f9e
+msgid "[2068862](https://bugs.launchpad.net/bugs/2068862)"
+msgstr ""
+
+#: ../../24.04/2.md c6a99daeea9443d494da9ce1fdb10e93
+msgid "d/p: Ubuntu pages, ensure welcome screen is loaded"
+msgstr ""
+
+#: ../../24.04/2.md 6cd9156eda9a481d8270aa133b0883c8
+msgid ""
+"d/p: Ubuntu pages, reference private widgets only after construction. "
+"They're just not created earlier, so we ended up referring to NULL "
+"pointers instead of the actual widgets"
+msgstr ""
+
+#: ../../24.04/2.md 05675ac4ed284d9a8a635f1b84d868d1
+msgid "d/p: Ubuntu pages, use filling alignment for the Ubuntu Pro offer message"
+msgstr ""
+
+#: ../../24.04/2.md a79c07e67a424da4aa33ced92766774d
+msgid "[2068632](https://bugs.launchpad.net/bugs/2068632)"
+msgstr ""
+
+#: ../../24.04/2.md c64df685183549cca4a5fe9e47f4f929
+msgid ""
+"d/p: Ubuntu mode, always set the missing connection warning icon. Then "
+"it's visibility is controlled as before, but at least now we will show it"
+" even if there's no connection setup on startup"
+msgstr ""
+
+#: ../../24.04/2.md a1bef71b218d45a799418a38e5c7e503
+#: d98bbaefe3044ea5810dcf35d52abae2
+msgid "[2068639](https://bugs.launchpad.net/bugs/2068639)"
+msgstr ""
+
+#: ../../24.04/2.md f07cc2f20a57400c80633be2b08d464a
+msgid ""
+"d/p: Ubuntu mode, add pro pages to POTFILE and improve strings to be "
+"translated. UI or C files of the Ubuntu Pro pages were not translatable, "
+"so add the files to the POTFILES and fix the strings that contained "
+"elements that should not be exposed to translators"
+msgstr ""
+
+#: ../../24.04/2.md cc6da1b49f1c445eb627d7b2f9f7907e
+msgid "d/p: Ubuntu Pro, add translatable pro services descriptions."
+msgstr ""
+
+#: ../../24.04/2.md 058dd0609dc34d8883f6cb80bf880ed8
+msgid "d/p: Ubuntu Pro, fix alignment of widgets to match design"
+msgstr ""
+
+#: ../../24.04/2.md 02e48cee9fde4b16ac1d95e8afef8b0c
+msgid ""
+"d/p: Ubuntu Pro, Use a grid to properly align dotted list elements. We "
+"were listing the elements using manual formatting and this was broken for"
+" lower resolutions or in general for longer texts, making a dotted list "
+"not properly padded. So use a grid to manage this, this indeed changes "
+"the text used by translations but because of lp:2068639 it's not a "
+"problem because no translations are available so far. Also in this way "
+"RTL languages are properly handled"
+msgstr ""
+
+#: ../../24.04/2.md 38091cbf5b6049d08c035644be6dfa89
+#: b4853a31c5c444d4bd8fb66395c24735
+msgid "[2068856](https://bugs.launchpad.net/bugs/2068856)"
+msgstr ""
+
+#: ../../24.04/2.md 299628bad5d0418da24a04973a7df620
+msgid ""
+"d/p: Ubuntu Pro, limit the wrapped label widths not to increase window "
+"size."
+msgstr ""
+
+#: ../../24.04/2.md acdb6e1aff5146b9a198dda3ffdd678c
+msgid "d/p: Ubuntu Pro, animate stack on pro page changes"
+msgstr ""
+
+#: ../../24.04/2.md 9da6a637d1814778b31338d6239a4b1e
+msgid "d/p: Ubuntu Pro, improve readability of long labels"
+msgstr ""
+
+#: ../../24.04/2.md 3651d78fc8fd4c11ae8d87df2dc8a8b0
+#: b05d46de3da2470596f68a9036442b91
+msgid "[2068675](https://bugs.launchpad.net/bugs/2068675)"
+msgstr ""
+
+#: ../../24.04/2.md ad14b71a8b3b428e8b1b024ecd2c7154
+msgid "d/p: Ubuntu Pro, scale icons and images to follow widget scaling"
+msgstr ""
+
+#: ../../24.04/2.md 8b0bff660b4c41d08e6221444c8ec773
+msgid "[2068859](https://bugs.launchpad.net/bugs/2068859)"
+msgstr ""
+
+#: ../../24.04/2.md 8d2044eb50764d7785ddb7ad3b0fc50d
+msgid ""
+"d/p: Ubuntu Pro, use async spawn of pro client process. The pro client "
+"process may slow in responding to us the tokens, so use asynchronous "
+"spawn to ensure we don't freeze the UI while calling it."
+msgstr ""
+
+#: ../../24.04/2.md 88393874daa945859c07a390d2e492d9
+msgid "[2069346](https://bugs.launchpad.net/bugs/2069346)"
+msgstr ""
+
+#: ../../24.04/2.md d36626f9075e4080b857abfd24e8189a
+msgid "d/p/Ubuntu mode: Do not override links color in the welcome page"
+msgstr ""
+
+#: ../../24.04/2.md 0db4dc1147724d2b99d25d7d5acec6de
+msgid "[2076189](https://bugs.launchpad.net/bugs/2076189)"
+msgstr ""
+
+#: ../../24.04/2.md 9001828671514bd68fb5b82119f77c1e
+msgid ""
+"d/p: Ubuntu Pro, use style that is more consistent with the app: this is "
+"not changing anything at functional level."
+msgstr ""
+
+#: ../../24.04/2.md 94ca7bc200174b82bb7a4789b1eb77d8
+msgid "d/p: Ubuntu Pro, scale icons automatically"
+msgstr ""
+
+#: ../../24.04/2.md 5568aef8c38342ddaad2dc6ab9f50389
+msgid "[2061317](https://bugs.launchpad.net/bugs/2061317)"
+msgstr ""
+
+#: ../../24.04/2.md b473363fa34647c98a7b4233a82e5eec
+msgid ""
+"Don't call the release notes a changelog and mark the corresponding "
+"string as translatable"
+msgstr ""
+
+#: ../../24.04/2.md 6394e339b47f4ad69c3f77e3cfb43134
+msgid "pipewire"
+msgstr ""
+
+#: ../../24.04/2.md 9c2c7d02ef7c42f6811a46e471de3b16
+msgid "[2061687](https://bugs.launchpad.net/bugs/2061687)"
+msgstr ""
+
+#: ../../24.04/2.md 05a319655198487f9471f4d5caf961eb
+msgid ""
+"d/p/snapshot: Fix missing V4L2 sources that manifest in Snapshot failing "
+"to find a camera."
+msgstr ""
+
+#: ../../24.04/2.md 8ef02e7702ff46f5be7948aab356a294
+#: 9d87f5f47bc241349db44d965ffe48ed bc709b5fc6394a889a6e1a0a415663e0
+#: f2326d64f33d4b98ad2fafa2caf1bb89
+msgid "malcontent"
+msgstr ""
+
+#: ../../24.04/2.md 24266b71722b46ca811d4bd311439989
+#: 97aa92ba05e54d3bac328ce4343736e5 9f769f8c2e894898b74e0ec8fdc95b9d
+#: fe7695df67ef4edc9a81d66af7996145
+msgid "[2077641](https://bugs.launchpad.net/bugs/2077641)"
+msgstr ""
+
+#: ../../24.04/2.md 89624598ae4046698b085048d58b4cee
+msgid "Allow all apps to be filtered"
+msgstr ""
+
+#: ../../24.04/2.md b31ba2588b4e4156a69e48f0d5abaaf4
+msgid "Hide UI elements for features not supported in Ubuntu"
+msgstr ""
+
+#: ../../24.04/2.md c7e953e8e69442a3953259f90534474f
+msgid "Don't reference unsupported features in the help files"
+msgstr ""
+
+#: ../../24.04/2.md 6902f906334f46088e93657880720471
+msgid "Only include help files for supported features"
+msgstr ""
+
+#: ../../24.04/2.md 0b22ad095f66432cb70ba85d7b11be7b
+#: 18e32b5aeb024e9fb3f9d37ed1b45640 747c3e80f2b04122a48c1a57b7f69287
+#: 906a54176dbb46f7887f6b3da16a5792 cb5a1e331fa3411891c98926d91f827b
+#: e5b06111b31d4c908f45abd04e8c298d fabea1a4e89142e991a7ba0e3a7367fc
+msgid "gnome-control-center"
+msgstr ""
+
+#: ../../24.04/2.md 0d8cb5e70fbe47a1a50b0e9d293f07df
+msgid "[2080611](https://bugs.launchpad.net/bugs/2080611)"
+msgstr ""
+
+#: ../../24.04/2.md d87d9fd179894a6c85c55e1b1d00dbdc
+msgid "New upstream version."
+msgstr ""
+
+#: ../../24.04/2.md b7031cdcc91d4328b352a8e6bbec0c8d
+msgid "[2065294](https://bugs.launchpad.net/bugs/2065294)"
+msgstr ""
+
+#: ../../24.04/2.md d85d17ac93d74222b9715affa6a6c089
+msgid "debian/patches: Better handle dbus callback from WhoopsiePreferences"
+msgstr ""
+
+#: ../../24.04/2.md 8f42fa702e354b37a93ac888f60f4f2c
+msgid "[2073430](https://bugs.launchpad.net/bugs/2073430)"
+msgstr ""
+
+#: ../../24.04/2.md 9c57feb9198749109babe4a17b900d6a
+msgid "fix disabling of auto timezone during panel load"
+msgstr ""
+
+#: ../../24.04/2.md f334757ab48b4cd38996a04603c12930
+msgid "[2080602](https://bugs.launchpad.net/bugs/2080602)"
+msgstr ""
+
+#: ../../24.04/2.md 743c8383f0b24777bd19272cd4cf61e3
+msgid ""
+"Regenerate the patches for Xilinx (Mali) support using gbp pq syntax and "
+"fixing an unused uninitialized variable."
+msgstr ""
+
+#: ../../24.04/2.md 52dcdb3ed93740a99adf476d348be06a
+msgid "gnome-bluetooth3"
+msgstr ""
+
+#: ../../24.04/2.md 980dee0fe41d48d585a433c34ce47d8c
+msgid "[2081672](https://bugs.launchpad.net/bugs/2081672)"
+msgstr ""
+
+#: ../../24.04/2.md 0ac8c0131624482eb3581f663563e11d
+msgid "Enable bluetooth toggle has no scan result"
+msgstr ""
+
+#: ../../24.04/2.md 698ae855242f42afbd4ff3768ba79e61
+#: 7b233a685903481bbca2ee7559ffb217 7b7dd0afffc2480c84294e8204e7a9de
+#: 9a023f76afbf4d99a2996537794d3259
+msgid "alsa-ucm-conf"
+msgstr ""
+
+#: ../../24.04/2.md 1b9acdba4e674e23b73c4d7e6aa95fb1
+#: 8b5f70b4d64a4c61b000c92bd9e6ee6e
+msgid "[2069760](https://bugs.launchpad.net/bugs/2069760)"
+msgstr ""
+
+#: ../../24.04/2.md ac0060706ee24fafb813d0ea73c52e4a
+msgid "Added patches for CS42L43+CS35L56 soundwire support"
+msgstr ""
+
+#: ../../24.04/2.md 94769e1950f047fbb44e4e0fe6031441
+msgid "[2085067](https://bugs.launchpad.net/bugs/2085067)"
+msgstr ""
+
+#: ../../24.04/2.md 795b7d92b1f84ffcba41669081d725a8
+msgid "Added patches for AMD micmute LED"
+msgstr ""
+
+#: ../../24.04/2.md 7fb8958adfff4aafa45c54f8b1c9495b
+msgid "[2086214](https://bugs.launchpad.net/bugs/2086214)"
+msgstr ""
+
+#: ../../24.04/2.md 27a52dd39e1e4d2a90243e93750404d0
+msgid "[2073128](https://bugs.launchpad.net/bugs/2073128)"
+msgstr ""
+
+#: ../../24.04/2.md 0827056cf98749dcbba8ba1bf5bc804c
+msgid "Pass CFLAGS, CXXFLAGS, CPPFLAGS, and LDFLAGS to external projects"
+msgstr ""
+
+#: ../../24.04/2.md f3ff265492d344df8eedb81767d8cbf0
+msgid "[2088403](https://bugs.launchpad.net/bugs/2088403)"
+msgstr ""
+
+#: ../../24.04/2.md e9de11ce6ed445309dfcf998bd06fb11
+msgid "Added patch to fix missing digital speaker on Dell Tarako"
+msgstr ""
+
+#: ../../24.04/2.md c4640b1f66074735a0c810adcf480143
+msgid "speex"
+msgstr ""
+
+#: ../../24.04/2.md 72e03a22b9bf4d97a93858e1bbddb296
+msgid "[2085896](https://bugs.launchpad.net/bugs/2085896)"
+msgstr ""
+
+#: ../../24.04/2.md a0bf8029067849b5995e542b4a2d1283
+msgid ""
+"Fix issue in merge where the floating point on armhf was accidentally "
+"disabled."
+msgstr ""
+
+#: ../../24.04/2.md c476180734ae46af9f3f789ee77b421d
+msgid "[2083538](https://bugs.launchpad.net/bugs/2083538)"
+msgstr ""
+
+#: ../../24.04/2.md 1e82121a1ad24be4a72dd0f221b257a8
+msgid ""
+"patches: Backport patch for green artifacting and GPU crash on radeonsi "
+"with kernel >= 6.10"
+msgstr ""
+
+#: ../../24.04/2.md 57454bc579aa452ea62bb66d8731019a
+msgid "udisks2"
+msgstr ""
+
+#: ../../24.04/2.md f0e67543dbd14db4957ead0d235e4370
+msgid "[2038761](https://bugs.launchpad.net/bugs/2038761)"
+msgstr ""
+
+#: ../../24.04/2.md d9606c6d663b4bd29eb1458b7e267881
+msgid "Fix missing size for NVME disk."
+msgstr ""
+
+#: ../../24.04/2.md 8a0afebe88e247e6b9997a79f8b3da9b
+#: cb4ef77c93be4b8d9d1110329c225823
+msgid "packagekit"
+msgstr ""
+
+#: ../../24.04/2.md 4e8d73ace16f4e79b55d4f139db72f44
+msgid "[2086773](https://bugs.launchpad.net/bugs/2086773)"
+msgstr ""
+
+#: ../../24.04/2.md c66df9b1916944d79b1e627ea06a4e1a
+msgid "Backport patch to fix showing the GTK debconf helper on Wayland"
+msgstr ""
+
+#: ../../24.04/2.md 57f69e89fc0044ac983e365fa162e8ac
+msgid "evince"
+msgstr ""
+
+#: ../../24.04/2.md 172b3308b3b24a84b50e4d604cbace20
+msgid "[2070353](https://bugs.launchpad.net/bugs/2070353)"
+msgstr ""
+
+#: ../../24.04/2.md 21601079085a476ab5dd6393c4bbd9bf
+msgid "[2080390](https://bugs.launchpad.net/bugs/2080390)"
+msgstr ""
+
+#: ../../24.04/2.md 7db2a815683642949d639d49294f2c39
+msgid "Ignore casing when fetching Registry.pol"
+msgstr ""
+
+#: ../../24.04/2.md 308574579ec0475a85f4d859d2a0a24d
+msgid "[2081966](https://bugs.launchpad.net/bugs/2081966)"
+msgstr ""
+
+#: ../../24.04/2.md 181716948fd74ad18cbebd5781370a89
+msgid "Add configurable timeout for listing GPOs"
+msgstr ""
+
+#: ../../24.04/2.md bd1087c68de24de49163412b7714f1ec
+msgid "[2081968](https://bugs.launchpad.net/bugs/2081968)"
+msgstr ""
+
+#: ../../24.04/2.md 171f17c079d049f0b65d45688649cfc3
+msgid "Add support for DCONF usb settings"
+msgstr ""
+
+#: ../../24.04/2.md 7515e1676246464ab381a453f245ff83
+msgid "lp-solve"
+msgstr ""
+
+#: ../../24.04/2.md 3163fbe3de6341f4a814bf173997845b
+msgid "[2084527](https://bugs.launchpad.net/bugs/2084527)"
+msgstr ""
+
+#: ../../24.04/2.md e6d234ea94c14ba1a5d2c907fc7b8c51
+msgid "fno-omit-frame-pointer flag"
+msgstr ""
+
+#: ../../24.04/2.md 5adafb147ba44e34bdb67e85be7e7a7a
+#: 78978637a5504c6dab0181bf9a512708
+msgid "network-manager"
+msgstr ""
+
+#: ../../24.04/2.md d95ebcc4595b41a38013cb429e0cf68a
+msgid "[2033259](https://bugs.launchpad.net/bugs/2033259)"
+msgstr ""
+
+#: ../../24.04/2.md b54ef945e9204be6981931becc479eca
+msgid ""
+"d/control: Avoid calling into half-upgraded Netplan NM calls 'netplan "
+"generate', which will crash if new libnetplan1 is already installed, but "
+"we're calling the old netplan.io Python code expecting the old "
+"libnetplan0 API."
+msgstr ""
+
+#: ../../24.04/2.md 6b708af359574bcb98ad8e04bc1ddd80
+msgid "[2084731](https://bugs.launchpad.net/bugs/2084731)"
+msgstr ""
+
+#: ../../24.04/2.md 467426720e7744fdafb83ffea331f82d
+msgid "Fix detection of 6 GHz band capability for WiFi devices"
+msgstr ""
+
+#: ../../24.04/2.md a1f6f7887285493b9e4f17cdebd599b6
+msgid "[2084777](https://bugs.launchpad.net/bugs/2084777)"
+msgstr ""
+
+#: ../../24.04/2.md 96cacbc5b68d4f1884e85cee35cbad1f
+msgid "d/p/memory-leak: Fix crash when cropping and resizing window"
+msgstr ""
+
+#: ../../24.04/2.md 5eaac96f36ad469e9a06bf564116c4db
+msgid "[2091714](https://bugs.launchpad.net/bugs/2091714)"
+msgstr ""
+
+#: ../../24.04/2.md 288ef712e22345939cb6d3346c7b18a5
+msgid ""
+"No-change rebuild to fix unintended dependency on apt which was in noble-"
+"proposed back then, and caused packagekit to become uninstallable on "
+"armhf"
+msgstr ""
+
+#: ../../24.04/2.md 60f8eca0d91240179aa19dc2321a979e
+msgid "pulseaudio"
+msgstr ""
+
+#: ../../24.04/2.md fd06ac3c600d4d7ebb054cecf892e99b
+msgid "[2055842](https://bugs.launchpad.net/bugs/2055842)"
+msgstr ""
+
+#: ../../24.04/2.md 1a496a17a87a41949ac9bd02781d6665
+msgid "Backport patches to fix seeking in gstreamer"
+msgstr ""
+
+#: ../../24.04/2.md 07219c485f524d3fb0e7782806f999f1
+#: 8ac19cb86bfc4cf396cac252490fcd43 9a69fda4fc92401da94bf7de62941824
+#: f62facd392b04f629bf522b623dd1562
+msgid "gdm3"
+msgstr ""
+
+#: ../../24.04/2.md 9c93ffbf826b408d96dbb46876c571f6
+msgid "[2090876](https://bugs.launchpad.net/bugs/2090876)"
+msgstr ""
+
+#: ../../24.04/2.md d0c63c40a02245869ce84306dbd53ff7
+msgid "No-change backport of stable release 46.2"
+msgstr ""
+
+#: ../../24.04/2.md 2e5ccfd73c3a40449edd92b8183a5585
+#: a08994e43b6e450380dc4e0042c98588
+msgid "[2080498](https://bugs.launchpad.net/bugs/2080498)"
+msgstr ""
+
+#: ../../24.04/2.md d432fc97f27248c096c0074049a61d27
+msgid "Default nvidia hybrid laptops to Xorg:"
+msgstr ""
+
+#: ../../24.04/2.md 03e7a64fb31c4fd397b590f748b94a46
+msgid "[1955850](https://bugs.launchpad.net/bugs/1955850)"
+msgstr ""
+
+#: ../../24.04/2.md bbc6d0067b5c456b89748b9c072603e9
+msgid ""
+"Rewrite xresources_is_a_dir.patch. To fix failure to load files in "
+"/etc/X11/Xresources (in case the latter is a directory instead of a "
+"regular file)."
+msgstr ""
+
+#: ../../24.04/2.md 3fc19eab6d3c458d8ba03b42c48b99a2
+msgid ""
+"Remove the Ubuntu-specific rules that made Xorg the default for Nvidia. "
+"Updated Revert-data-Disable-GDM-on-hybrid-graphics-laptops-with-v.patch "
+"to ensure Nvidia 5xx drivers always get Wayland as the default unless "
+"there's a stronger reason why it won't work (like modeset has been "
+"disabled on the kernel command line). Also refresh the patch description "
+"with a more recent justification."
+msgstr ""
+
+#: ../../24.04/2.md 5808a6353d4c44a1bf366a0c23fcb39c
+#: 83005774a733411eb6d594e072f428ce
+msgid "policykit-1"
+msgstr ""
+
+#: ../../24.04/2.md 15aedfba487441d696d7afd5753de83b
+#: e130084e45614cb99c72cd079cb1d59f
+msgid "[2089145](https://bugs.launchpad.net/bugs/2089145)"
+msgstr ""
+
+#: ../../24.04/2.md c01640f495664629b8d8c3d98c20865a
+msgid "fix incorrect call to get instance's priv."
+msgstr ""
+
+#: ../../24.04/2.md 1e7538f45a69430b9a311a5730046a4d
+msgid ""
+"cherry pick an upstream change to allow alternative directories for the "
+"actions files"
+msgstr ""
+
+#: ../../24.04/2.md 78215bf7729449029598972e8437a5cd
+msgid "xwayland"
+msgstr ""
+
+#: ../../24.04/2.md 774f280b9e184ee9a18d0455ae79c315
+msgid "[2043517](https://bugs.launchpad.net/bugs/2043517)"
+msgstr ""
+
+#: ../../24.04/2.md d1663a313012403bb93d05b279093eb7
+msgid "Backport patch to fix busy-loop on inactive VT"
+msgstr ""
+
+#: ../../24.04/2.md 78d377da9e024b86b5f0f11786128c03
+#: ca74e3bd6b564e0faed22148d95a42c9
+msgid "[2089273](https://bugs.launchpad.net/bugs/2089273)"
+msgstr ""
+
+#: ../../24.04/2.md 5b44db3c0b7840be84505547f5cd6164
+#: 7871d5a6cb58491990912cad590643e4
+msgid "Add soundwire support for AMD platforms"
+msgstr ""
+
+#: ../../24.04/2.md 35e55f18244c4a13ab3d2dbe768c949e
+#: f39bd6379d754e6baad763a78fa09283
+msgid "nautilus"
+msgstr ""
+
+#: ../../24.04/2.md a836f9feb64f480794b9a1f667050df9
+msgid "[2072569](https://bugs.launchpad.net/bugs/2072569)"
+msgstr ""
+
+#: ../../24.04/2.md c0441e81b74b4a83a492fbe1150a2174
+#, python-brace-format
+msgid ""
+"d/p/u/nautilus-sendto.patch extended: If {nautilus_sendto installed && "
+"mailer is a snap && folder in selection}, do not present 'Email' option, "
+"as Nautilus then compresses the selected files to a zip, which it creates"
+" in /tmp, to which a snap doesn't have access."
+msgstr ""
+
+#: ../../24.04/2.md c9c14068c2c84a85a6bcaefcd1d500c4
+msgid "[2084554](https://bugs.launchpad.net/bugs/2084554)"
+msgstr ""
+
+#: ../../24.04/2.md 7ee8fd5bf6fc419a90f5e3547b272201
+msgid "Backport patch to fix touchscreen selection by dragging"
+msgstr ""
+
+#: ../../24.04/2.md 68e823eb42d545bcb632f685302ab5be
+msgid "gnome-calendar"
+msgstr ""
+
+#: ../../24.04/2.md 21883d1614a142afa0a60486b54b85e7
+msgid "[2082879](https://bugs.launchpad.net/bugs/2082879)"
+msgstr ""
+
+#: ../../24.04/2.md 9f3c91f3e1a14f94afa2fa77c001912d
+msgid "Backport patches to fix adding event reminders"
+msgstr ""
+
+#: ../../24.04/2.md c8f0a64c676842beb09f4368238eae7b
+msgid "libfprint"
+msgstr ""
+
+#: ../../24.04/2.md 8741afa317874299b7c1987c623321ff
+msgid "[2089367](https://bugs.launchpad.net/bugs/2089367)"
+msgstr ""
+
+#: ../../24.04/2.md 613a6e4531a6459e81eb2684d8daa122
+msgid "debian/patches: Add new Elan device 04f3:0c9f"
+msgstr ""
+
+#: ../../24.04/2.md 9f387cd181d040b6bc0e9062386c7cb1
+msgid "[2087565](https://bugs.launchpad.net/bugs/2087565)"
+msgstr ""
+
+#: ../../24.04/2.md 5e26f16917b84f0fa24a0fade3445e0b
+#: 61a88e1d00bc4bafb64081743585f136 9a588452f93748dcb7b219a5c0223a69
+#: b24cddda65e9400abad7317fd447d521 ba70de0544c5493ebf9e08609f75df71
+msgid "New upstream release."
+msgstr ""
+
+#: ../../24.04/2.md 943e6434cb2f4bfeaf23dc73b90afec0
+msgid "[2084232](https://bugs.launchpad.net/bugs/2084232)"
+msgstr ""
+
+#: ../../24.04/2.md f3dc155ace1a44e4ae0bc9212cbe0bfe
+msgid "Fix showing custom idle-delay values in the Power panel."
+msgstr ""
+
+#: ../../24.04/2.md 4a6b4ac76a5345c88d19fb2d42d323f8
+msgid "[2083869](https://bugs.launchpad.net/bugs/2083869)"
+msgstr ""
+
+#: ../../24.04/2.md 98ea7ab6d9174807b3fb259b92e17b46
+msgid "Avoid the Privacy panel resetting idle-delay to zero."
+msgstr ""
+
+#: ../../24.04/2.md d05c23dc6aef440698029700bc43ed2b
+msgid "[2084405](https://bugs.launchpad.net/bugs/2084405)"
+msgstr ""
+
+#: ../../24.04/2.md ccdf692418f1442eb7c3a396295a16cb
+msgid "Add 6GHz to \"Supported Frequencies\" in wireless connection detail"
+msgstr ""
+
+#: ../../24.04/2.md 45738766ad6c49a0b87c5b5e331a4181
+#: 50ff9c8ed3c04918818762c6febbff0f
+msgid "[2083020](https://bugs.launchpad.net/bugs/2083020)"
+msgstr ""
+
+#: ../../24.04/2.md 89ef9137f02b4683a740347f518d9112
+#: f0f3aaf40f3c491392e2797f44f2beba
+msgid "Backport to noble."
+msgstr ""
+
+#: ../../24.04/2.md 560e5bcc4fa64a35ba4f6ab38ed77783
+#: 74c04c99d2ed41dba3dc2288b2f7dc80
+msgid "wsl-setup"
+msgstr ""
+
+#: ../../24.04/2.md 154184c0748e49ca8c0959906fbdceb2
+msgid "Adapt to new Microsoft package format::"
+msgstr ""
+
+#: ../../24.04/2.md 5d40713796fc497bae78d6659cec688c
+msgid "libdrm"
+msgstr ""
+
+#: ../../24.04/2.md 01c61f0615b74392a918ef27f37758e9
+msgid "[2007652](https://bugs.launchpad.net/bugs/2007652)"
+msgstr ""
+
+#: ../../24.04/2.md 6aefe2db779d4b71aeedadebb40e73f2
+msgid ""
+"d/p/chromium-snap-pwa.patch: Fixes tab and dock grouping of progressive "
+"web applications for the Chromium snap."
+msgstr ""
+
+#: ../../24.04/2.md 20da2d9b55954fb6a11be0c3affbe6e3
+#: dda49e0b646c47f995940915c978d240
+msgid "[2065432](https://bugs.launchpad.net/bugs/2065432)"
+msgstr ""
+
+#: ../../24.04/2.md cda3b45b11ee4b3fbf23eeca51e70f3e
+msgid ""
+"d/p: Fix default service discovery. Fix an issue where authentication "
+"service was not properly picked due to incorrect checks in "
+"_isDiscreteServiceEnabled"
+msgstr ""
+
+#: ../../24.04/2.md 61a52c8e637c42c6a56b4a9dd1dd3053
+msgid ""
+"Cherry-pick for e5d9a0fe Fixes null dereference during login with smart "
+"cards."
+msgstr ""
+
+#: ../../24.04/2.md 35183382539e4c9c90f2a9769f5a4157
+msgid "[2084276](https://bugs.launchpad.net/bugs/2084276)"
+msgstr ""
+
+#: ../../24.04/2.md ff9f29e804a5481c9cbd5687c73dfaa3
+msgid "d/p: unlockDialog: Also center the time in 12h format"
+msgstr ""
+
+#: ../../24.04/2.md 4940b627973448ff89cbc3797f0f9c5b
+msgid "[2039543](https://bugs.launchpad.net/bugs/2039543)"
+msgstr ""
+
+#: ../../24.04/2.md 50c76111c081412582974cc0fc231153
+msgid "d/p: Exclude override-redirect windows from workspace animation"
+msgstr ""
+
+#: ../../24.04/2.md 551d21fe29534ca4a6a339c1cffc5f8d
+msgid "[2084281](https://bugs.launchpad.net/bugs/2084281)"
+msgstr ""
+
+#: ../../24.04/2.md 01c40e59514a4d4c8f59091a2fbe6050
+msgid "d/p: Fix password not re-asked for TCRYPT devices"
+msgstr ""
+
+#: ../../24.04/2.md b5d5b47ab0ae46f4abe0d89e9b8dffd0
+msgid "[2039801](https://bugs.launchpad.net/bugs/2039801)"
+msgstr ""
+
+#: ../../24.04/2.md 7de7578eb6f24412adf85037f1ade959
+msgid "d/p: Keep locate pointer animation when animations are disabled"
+msgstr ""
+
+#: ../../24.04/2.md 8665ad2776004d7e819701231c53e903
+msgid "[2042763](https://bugs.launchpad.net/bugs/2042763)"
+msgstr ""
+
+#: ../../24.04/2.md 150ff057c9f84f48bbc541c8832b39d9
+msgid "d/p: Fix keyboard navigation in AppFolderDialog"
+msgstr ""
+
+#: ../../24.04/2.md 4267bd257b79435ea1d8ee0284ad4303
+msgid "[2084286](https://bugs.launchpad.net/bugs/2084286)"
+msgstr ""
+
+#: ../../24.04/2.md f85e78b4974c4e22a706a441a62f6742
+msgid "d/p: Fix connection to WPA Enterprise networks from quick settings"
+msgstr ""
+
+#: ../../24.04/2.md a958fd84073942ae9c024cda9f75eae4
+msgid "[2084287](https://bugs.launchpad.net/bugs/2084287)"
+msgstr ""
+
+#: ../../24.04/2.md d0e7c9cefbf9490ab1098f7d477e94bd
+msgid "d/p: Add user permissions to new wifi connections if has no system ones"
+msgstr ""
+
+#: ../../24.04/2.md f4e4dc492898430b89b4ab1ec7f9e3d4
+msgid "[2084289](https://bugs.launchpad.net/bugs/2084289)"
+msgstr ""
+
+#: ../../24.04/2.md bde5ec50305341ea891a9752db2d2def
+msgid "d/p: gdm: Actually wait for pending messages being notified on failures"
+msgstr ""
+
+#: ../../24.04/2.md b1691e417eba42a7bc9941dfd6067aa6
+msgid "[2084301](https://bugs.launchpad.net/bugs/2084301)"
+msgstr ""
+
+#: ../../24.04/2.md 8408e9ebadcd469fa7b9b97c13aded05
+msgid "d/p: Fix themed icons rendering in notifications"
+msgstr ""
+
+#: ../../24.04/2.md 9a4f52b0aaf1474197a72ad66e9f80b3
+msgid "[2084302](https://bugs.launchpad.net/bugs/2084302)"
+msgstr ""
+
+#: ../../24.04/2.md 972073dc01e746d6be6df944799a632d
+msgid "d/p: Fix notifications not showing in the lockscreen"
+msgstr ""
+
+#: ../../24.04/2.md c6d531e6c09e4588b6273fd2393406e1
+msgid "[2084306](https://bugs.launchpad.net/bugs/2084306)"
+msgstr ""
+
+#: ../../24.04/2.md e1ae512e541740099970f53aa291892b
+msgid "d/p: Allow to set a custom ShellUserVerifier"
+msgstr ""
+
+#: ../../24.04/2.md ce9f726f438c47b398b68549de56ba23
+msgid ""
+"[2084308](https://bugs.launchpad.net/bugs/2084308) "
+"[2072716](https://bugs.launchpad.net/bugs/2072716)"
+msgstr ""
+
+#: ../../24.04/2.md fcab6247bebe4c17b9897cf177701879
+msgid "d/p: Fix toggling lockscreen view using Escape"
+msgstr ""
+
+#: ../../24.04/2.md 752e85fa1dfa47f69d87d43d7e4ef7b1
+msgid "[2084310](https://bugs.launchpad.net/bugs/2084310)"
+msgstr ""
+
+#: ../../24.04/2.md a2afc63261734a049efee703d6c9c0d2
+msgid "d/p: Make active workspace above siblings"
+msgstr ""
+
+#: ../../24.04/2.md 95be2cece1ba46ad9105ff42882b7a69
+msgid "[2084293](https://bugs.launchpad.net/bugs/2084293)"
+msgstr ""
+
+#: ../../24.04/2.md 3c63f8a309144ca08690d1d428c2fbb0
+msgid "d/p: notificationDaemon: Use correct property name to enable markup"
+msgstr ""
+
+#: ../../24.04/2.md 6623accb28924478a2d333043e308434
+msgid "[2076869](https://bugs.launchpad.net/bugs/2076869)"
+msgstr ""
+
+#: ../../24.04/2.md 29eb266ca2374995bfc9a263d09aa721
+msgid ""
+"Fix Intelligent Input Bus (IBus) not activatable during filename editing "
+"operations."
+msgstr ""
+
+#: ../../24.04/2.md f3c17f32251543ac940e77691010d7c3
+msgid "[2040453](https://bugs.launchpad.net/bugs/2040453)"
+msgstr ""
+
+#: ../../24.04/2.md 06e2834ad3f64ad8810f173fe9005586
+msgid "Backport patches to fix restarting the x11 compositor"
+msgstr ""
+
+#: ../../24.04/2.md:176 1189f64ca6ae4ad3bda90d0b74cf38b2
+msgid "Server and Cloud related fixes"
+msgstr ""
+
+#: ../../24.04/2.md:178 4813e0bd98e44c78b73b087dba918b72
+msgid ""
+"These changes mainly affect installations of Ubuntu on server systems and"
+" clouds."
+msgstr ""
+
+#: ../../24.04/2.md 053071242ad745f8bdf38e63511000a1
+msgid "google-compute-engine-oslogin"
+msgstr ""
+
+#: ../../24.04/2.md 1199c6edece446518b9d9af60c3b983b
+msgid "[2073166](https://bugs.launchpad.net/bugs/2073166)"
+msgstr ""
+
+#: ../../24.04/2.md 28107d620ce247f6883d45e267885b49
+msgid "New upstream version for upstream tag 20240320.00."
+msgstr ""
+
+#: ../../24.04/2.md 1c58b1f9bd6643cfb0a56797e7957400
+msgid "google-osconfig-agent"
+msgstr ""
+
+#: ../../24.04/2.md ec905c4dd7854a68ae5177c6c32aa855
+msgid "[2073161](https://bugs.launchpad.net/bugs/2073161)"
+msgstr ""
+
+#: ../../24.04/2.md 0822c5177c654548a83f9be713f000d1
+msgid "New upstream version for upstream tag 20240524.03."
+msgstr ""
+
+#: ../../24.04/2.md d44f239f5b644c7bbc9bdd43273ca5c1
+#: efc3c98be3084a46935f2b236ac80236
+msgid "gce-compute-image-packages"
+msgstr ""
+
+#: ../../24.04/2.md d54cd46c181c41fe96d1e9c4e6f3367f
+msgid "[2073164](https://bugs.launchpad.net/bugs/2073164)"
+msgstr ""
+
+#: ../../24.04/2.md 8642c5157bb5460d92893de32c9964da
+msgid "New upstream version 20240607.00."
+msgstr ""
+
+#: ../../24.04/2.md 1dab526195244cdd8c3d261d44e8a4d8
+#: 44c5b080d1a742d6b1f73bd4e6d7ee46 96ef0a85c78940328ddf4d1f9dbe1b55
+msgid "google-guest-agent"
+msgstr ""
+
+#: ../../24.04/2.md f312fbf9aca147378b01a03bf88b116d
+msgid "[2073163](https://bugs.launchpad.net/bugs/2073163)"
+msgstr ""
+
+#: ../../24.04/2.md e7c9dbcf9fc846af912f48e12e66849f
+msgid "New upstream version 20240716.00."
+msgstr ""
+
+#: ../../24.04/2.md e25edf23451f4046ab0c73f68d89e57f
+msgid "[2057965](https://bugs.launchpad.net/bugs/2057965)"
+msgstr ""
+
+#: ../../24.04/2.md aecebf6136354d2f974e3cb799cec4ac
+msgid "add patch to force ordering between cloud-init and the guest agent."
+msgstr ""
+
+#: ../../24.04/2.md 1900b44295f648e4a2cd6dda07f9732b
+#: 22eb5d2558034e01a95146dc680be070 55edd90303b046f894d50ca5a4459de9
+#: 7adcf9189e484aebbf3fbf3b3e384101 93db1352abc7454b97bbc3cc4d79a230
+msgid "cloud-init"
+msgstr ""
+
+#: ../../24.04/2.md 3066f968cbab474dba08738c0ce1aec3
+#: 31be04b8baf84cbab4eb40bdca61eec4
+msgid "[2075337](https://bugs.launchpad.net/bugs/2075337)"
+msgstr ""
+
+#: ../../24.04/2.md ab2d6f6b47a64ec38a694d08c0508b29
+#: c11780a031b6439c8d19910d0d9141e1
+msgid ""
+"Declare breaks on the python3-minimal version that is affected by the "
+"py3clean failure when using alternate character set"
+msgstr ""
+
+#: ../../24.04/2.md 4c0ae7fb470b4dbc864f7fb99664b50b
+msgid "[2071762](https://bugs.launchpad.net/bugs/2071762)"
+msgstr ""
+
+#: ../../24.04/2.md 137c824ca5f74f2ebf73599134e79456
+msgid ""
+"Upstream snapshot based on 24.2.. List of changes from upstream can be "
+"found at https://raw.githubusercontent.com/canonical/cloud-"
+"init/24.2/ChangeLog"
+msgstr ""
+
+#: ../../24.04/2.md ce6e5ab17a24494f9a7c9d47cfaef0fc
+msgid "cloud-initramfs-tools"
+msgstr ""
+
+#: ../../24.04/2.md 38cd4d2af73648a790ea51df4cac31bf
+#: a4d1eeb007334a36969b2d2a0b6fd770 f516f2ae2d9b48fa9101250fdc8a4d28
+#: f810fc47d3234b4898b8e3827946d095
+msgid "[2065180](https://bugs.launchpad.net/bugs/2065180)"
+msgstr ""
+
+#: ../../24.04/2.md 758ef041478e41af838951143ad96011
+msgid "overlayroot: Combine calls to manual_add_modules"
+msgstr ""
+
+#: ../../24.04/2.md 853c6e84f4c3439481288af0903a76ab
+msgid "ipvsadm"
+msgstr ""
+
+#: ../../24.04/2.md 52a706023f084f84b21fdbb21b1e272f
+msgid "[2071949](https://bugs.launchpad.net/bugs/2071949)"
+msgstr ""
+
+#: ../../24.04/2.md 17262998aea444be858494c82059ec97
+msgid ""
+"Don't overwrite compiler/linker flags inherited from the environment. "
+"It's preventing the package to be built with hardening and frame-pointer "
+"flags."
+msgstr ""
+
+#: ../../24.04/2.md b7d546ea000348e3902b1cfefa3bbccc
+msgid "open-vm-tools"
+msgstr ""
+
+#: ../../24.04/2.md b9ad3fb16a714f8da92b79edfb3ee779
+msgid "[2073317](https://bugs.launchpad.net/bugs/2073317)"
+msgstr ""
+
+#: ../../24.04/2.md b6a4278d680547fcb98cb583170d2e99
+msgid "Backport recent open-vm-tools release v12.4.5"
+msgstr ""
+
+#: ../../24.04/2.md d1c9b134f4cd40f49ed58ac22f258bb7
+msgid "`lxd-agent-loader`"
+msgstr ""
+
+#: ../../24.04/2.md 122efd29f64f43e7b3efdfd610b87725
+msgid "[2078936](https://bugs.launchpad.net/bugs/2078936)"
+msgstr ""
+
+#: ../../24.04/2.md 21b013c480aa42ebb28bb1a9d0bebfac
+msgid "d/rules: don't stop `lxd-agent` on upgrade"
+msgstr ""
+
+#: ../../24.04/2.md 3baf54e321ee49b599c140b21e9115f5
+msgid "[2079224](https://bugs.launchpad.net/bugs/2079224)"
+msgstr ""
+
+#: ../../24.04/2.md 2623ca59f6c44caeb62042bff2a86c39
+msgid ""
+"Upstream snapshot based on 24.3.1.. List of changes from upstream can be "
+"found at https://raw.githubusercontent.com/canonical/cloud-"
+"init/24.3.1/ChangeLog"
+msgstr ""
+
+#: ../../24.04/2.md bea334c13b734445a29942e508a8f62d
+msgid "[2081124](https://bugs.launchpad.net/bugs/2081124)"
+msgstr ""
+
+#: ../../24.04/2.md 7c557337d09343a4837d7697877263a9
+msgid ""
+"fix systemd ordering cycle issues with network cloud-init-"
+"hotplugd.socket, NetworkManager and dbus.socket by adding "
+"DefaultDependencies=no to cloud-init-hotplugd.socket."
+msgstr ""
+
+#: ../../24.04/2.md 2c5eb02cd6814ac3be4dc27ce725c76e
+#: 3e07dea416814c5db1658efa509e0968
+msgid "libvirt"
+msgstr ""
+
+#: ../../24.04/2.md 9b4fa3b3eed043b1980abf3e090e267c
+msgid "[2072647](https://bugs.launchpad.net/bugs/2072647)"
+msgstr ""
+
+#: ../../24.04/2.md 26c13e0c57084f7b89ed5ab42a482a5e
+msgid ""
+"d/p/u/lp-2072647-log_cleaner-Detect-rotated-filenames-properly.patch: Fix"
+" virtlogd bug \"internal error: Failed to parse rotated index\", this "
+"happens when max_age_days parameter is enabled."
+msgstr ""
+
+#: ../../24.04/2.md 039c210e6a3242a786aee8eb386e85eb
+#: 4008b4c3ca864e808de623175582e608 5eed725dd235486596ce06fcec8c99c4
+msgid "ceph"
+msgstr ""
+
+#: ../../24.04/2.md 3aeaf356d265488f8a8bf855d6f443de
+msgid "[2080208](https://bugs.launchpad.net/bugs/2080208)"
+msgstr ""
+
+#: ../../24.04/2.md 6406b5e64f84467487d9fb3da15641d3
+msgid ""
+"d/p/lp2080208.patch: Cherry pick proposed fix for compatibility with "
+"newer versions of importlib-metadata."
+msgstr ""
+
+#: ../../24.04/2.md 86803f3f41b84c198d94f9d03dedae0a
+msgid "[2081781](https://bugs.launchpad.net/bugs/2081781)"
+msgstr ""
+
+#: ../../24.04/2.md ad386afc471f454cb37d08452207213e
+msgid "New upstream stable release."
+msgstr ""
+
+#: ../../24.04/2.md 9752bed935e849f6a158a7bb3c237568
+msgid "[2065515](https://bugs.launchpad.net/bugs/2065515)"
+msgstr ""
+
+#: ../../24.04/2.md a99714fe36364ebbb64d0f2d115286d1
+msgid "New upstream release candidate:"
+msgstr ""
+
+#: ../../24.04/2.md 04fd0cf71ff7407cb1cf30bcb3499d52
+#: 1fe294817226440fa93b0f32ac96fd9f
+msgid "sosreport"
+msgstr ""
+
+#: ../../24.04/2.md 4ed5fb95c48a4ca8abae99b11e17097c
+msgid "[2054395](https://bugs.launchpad.net/bugs/2054395)"
+msgstr ""
+
+#: ../../24.04/2.md 42d6583680e04a5f8bffd714f42217fd
+msgid "New 4.7.2 upstream release."
+msgstr ""
+
+#: ../../24.04/2.md 3239de8cf0094941b19e1f3966b7aac9
+#: 4a12aea4c451440bbb22401bad2ad302 a327271df5984272a355034aa4a14298
+#: a4252ec9c31a40e4b248d981556c4ae8 e2657204ed4c4e8a8a0a82307bb56e50
+msgid "openssh"
+msgstr ""
+
+#: ../../24.04/2.md 8db43daf563642ea82b8cb667261215b
+msgid "[2080216](https://bugs.launchpad.net/bugs/2080216)"
+msgstr ""
+
+#: ../../24.04/2.md d224f135f0df4dba8e8b7e48d01a1ec2
+msgid "Explicitly listen on IPv4 by default, with socket-activated sshd"
+msgstr ""
+
+#: ../../24.04/2.md a5202b64a7344223a409b0725dd9fa73
+msgid "[2076023](https://bugs.launchpad.net/bugs/2076023)"
+msgstr ""
+
+#: ../../24.04/2.md 04dfad3afaf24617b8210d427d6ee0d0
+msgid "sshd-socket-generator: do not parse server match config"
+msgstr ""
+
+#: ../../24.04/2.md 73866840e7e54433acb0b2e481383d4d
+msgid "[2071815](https://bugs.launchpad.net/bugs/2071815)"
+msgstr ""
+
+#: ../../24.04/2.md 574fc7e7137048faa750240d0c170699
+msgid "d/p/systemd-socket-activation.patch: don't clear rexec_flag"
+msgstr ""
+
+#: ../../24.04/2.md 8cd40e94d5544ef68db707f21f727bc5
+msgid "[2069041](https://bugs.launchpad.net/bugs/2069041)"
+msgstr ""
+
+#: ../../24.04/2.md b38dbbfb04094b24941e9f9c62eb37b3
+msgid ""
+"d/p/sshd-socket-generator.patch: add note to sshd_config Explain that a "
+"systemctl daemon-reload is needed for changes to Port et al to take "
+"effect."
+msgstr ""
+
+#: ../../24.04/2.md 20bfa73869b742b8a3734263d88c67f0
+#: e0c0b88b36fa485d992aaa692d06bc8c
+msgid "[2076340](https://bugs.launchpad.net/bugs/2076340)"
+msgstr ""
+
+#: ../../24.04/2.md 20e536a2b9bd48ad868568d3fc0f8b96
+#: 67062fcab89143b88e81abebc882e3f8
+msgid "No-change rebuild to pick up changed build flags on ppc64 and s390x."
+msgstr ""
+
+#: ../../24.04/2.md 186a9078daf84e299adf2cc43e13c48e
+#: 7050ca914c3746d5940b914dab73bf8d be05950f40a3450bbabbeb7a8f20d079
+#: da5e1fd829d74910a87286ff2c96b3b0 facd3d2b17784972b892bba9f0ac3305
+msgid "containerd-app"
+msgstr ""
+
+#: ../../24.04/2.md 1dbbad28d79b40919790d106509b77f8
+#: 39fdcdf7203f40b9861b6df8f6fa77a1 538618363e83468e95a0a760f2afcc8f
+msgid "[2065423](https://bugs.launchpad.net/bugs/2065423)"
+msgstr ""
+
+#: ../../24.04/2.md 6fc9943c48a94f48826a8f62745ee932
+msgid ""
+"d/containerd.postinst: notify that a reboot is required to reload the "
+"AppArmor profile."
+msgstr ""
+
+#: ../../24.04/2.md d055ef8779c949b984b573d08fc3b360
+msgid "Update AppArmor template to allow confined runc to kill containers."
+msgstr ""
+
+#: ../../24.04/2.md 49ab0911993147cbaa05793ec621c80c
+msgid "paramiko"
+msgstr ""
+
+#: ../../24.04/2.md d087db07cfd343008805c0f7e5acf911
+msgid "[2072974](https://bugs.launchpad.net/bugs/2072974)"
+msgstr ""
+
+#: ../../24.04/2.md e88a0b841381427a8ab1de9c2266e3d6
+msgid "Fix error in FIPS mode with X25519 isSupported check"
+msgstr ""
+
+#: ../../24.04/2.md a79571a49817482cb49e3aa2819897e3
+msgid "sssd"
+msgstr ""
+
+#: ../../24.04/2.md f940eb16623d4f3d8297ca8c641b72df
+msgid "[2085389](https://bugs.launchpad.net/bugs/2085389)"
+msgstr ""
+
+#: ../../24.04/2.md 5006545a7e974382a5ace27f692626de
+msgid ""
+"Close file descriptors to the /var/lib/sss/pipes/nss socket when threads "
+"are destroyed to avoid file descriptor leak."
+msgstr ""
+
+#: ../../24.04/2.md 29729413ce50489099ab0657dd13f949
+msgid "[2085607](https://bugs.launchpad.net/bugs/2085607)"
+msgstr ""
+
+#: ../../24.04/2.md 230a4c6adae64bab8c927e700a2550b6
+msgid "Resolve obfuscation issues"
+msgstr ""
+
+#: ../../24.04/2.md 9b6b8beb91fa45ed8a06680782b8930a
+msgid "neutron"
+msgstr ""
+
+#: ../../24.04/2.md 4e2bb47338874941a4b5db94b1915df0
+msgid "[2072154](https://bugs.launchpad.net/bugs/2072154)"
+msgstr ""
+
+#: ../../24.04/2.md 9f2224d8bc3743db99c95c5819cd8952
+msgid "Checking pci_slot to avoid changing status to BUILD forever."
+msgstr ""
+
+#: ../../24.04/2.md 5ed4ebc055fc47ecbdf0438c4fc1a327
+msgid "Allow confined runc to kill containers."
+msgstr ""
+
+#: ../../24.04/2.md 22928bf7add14a62b0ab1d201835ef2d
+msgid "[2089704](https://bugs.launchpad.net/bugs/2089704)"
+msgstr ""
+
+#: ../../24.04/2.md d977a97edabe47b4b3ccf72423c0d3a6
+msgid ""
+"d/rules: hardcode upstream version to reflect the \"really\" version in "
+"the debian revision string."
+msgstr ""
+
+#: ../../24.04/2.md 0abef7d3a0aa4db891cc9ca8a6a202b8
+#: f39f79b1ae7742a4b4e35b876308d403
+msgid "exim4"
+msgstr ""
+
+#: ../../24.04/2.md b06f133d5072447bba4a08ade3e77e2a
+msgid "[2077893](https://bugs.launchpad.net/bugs/2077893)"
+msgstr ""
+
+#: ../../24.04/2.md 777d16884e994fd6b3421f04fba84663
+msgid "Fix crashes due to memory allocation when using PCRE2."
+msgstr ""
+
+#: ../../24.04/2.md 4903e7b0ef4c4f86832099b65e750009
+msgid "[2084391](https://bugs.launchpad.net/bugs/2084391)"
+msgstr ""
+
+#: ../../24.04/2.md ee56be48d97943509b2cd77ec63f4dc7
+msgid "d/control: Add libnsl-dev dependency for exim4-daemon-heavy."
+msgstr ""
+
+#: ../../24.04/2.md fef52b7680044da08d055cd35ff4f6cb
+msgid "[2083986](https://bugs.launchpad.net/bugs/2083986)"
+msgstr ""
+
+#: ../../24.04/2.md 66c0154e584e44d69ea6d7e159f2183f
+msgid ""
+"Backport upstream patches to fix issues with domain migrations between "
+"two nested VMs due to mismatched check of CPU features."
+msgstr ""
+
+#: ../../24.04/2.md 46da1ccd1b26457f85ef67646edd697b
+msgid "[2089577](https://bugs.launchpad.net/bugs/2089577)"
+msgstr ""
+
+#: ../../24.04/2.md 4bd52d36c7cb4be2b834b3743aab83ef
+msgid ""
+"Upstream snapshot based on 24.4.. List of changes from upstream can be "
+"found at https://raw.githubusercontent.com/canonical/cloud-"
+"init/24.4/ChangeLog"
+msgstr ""
+
+#: ../../24.04/2.md 9afed864652442a7b604d4b787a80539
+msgid "ssh-import-id"
+msgstr ""
+
+#: ../../24.04/2.md d8d650e9b1c348a8b1100015b241e0d0
+msgid "[2085898](https://bugs.launchpad.net/bugs/2085898)"
+msgstr ""
+
+#: ../../24.04/2.md 4a2ea8f73768414a8cc78f0d839bbdc8
+msgid ""
+"Ensure ssh-import-id (the binary package) depends on "
+"`python3-launchpadlib`."
+msgstr ""
+
+#: ../../24.04/2.md 766fb1c48042439695138de71a132f18
+msgid "bind9"
+msgstr ""
+
+#: ../../24.04/2.md 12d43e1e30ed4196a831459265418ab1
+msgid "[2073310](https://bugs.launchpad.net/bugs/2073310)"
+msgstr ""
+
+#: ../../24.04/2.md f7291eca8620472b9b3a47312eeb101a
+msgid "New upstream release 9.18.30"
+msgstr ""
+
+#: ../../24.04/2.md 19c6296daf244f8ca13a6cd73549bebd
+msgid "gpsd"
+msgstr ""
+
+#: ../../24.04/2.md 2ecbd8b7d839460596566db8b6867f64
+msgid "[2076191](https://bugs.launchpad.net/bugs/2076191)"
+msgstr ""
+
+#: ../../24.04/2.md e832e3cf9d0640f689e7c2a20be207c1
+msgid "Fix gpsmon crash in NMEA"
+msgstr ""
+
+#: ../../24.04/2.md 14396c2b9165412aaf2717f052148f6e
+msgid "[2084498](https://bugs.launchpad.net/bugs/2084498)"
+msgstr ""
+
+#: ../../24.04/2.md 5c1b884446954d508fa8002e3ceebb6e
+msgid "New version for upstream tag 20241011.01."
+msgstr ""
+
+#: ../../24.04/2.md 9cafa4819bd544fba076351ebbc9a2ee
+msgid "[2084486](https://bugs.launchpad.net/bugs/2084486)"
+msgstr ""
+
+#: ../../24.04/2.md 928bbefa4cac4133843aa5bbe89c9e40
+msgid "New version for upstream tag 20241010.00."
+msgstr ""
+
+#: ../../24.04/2.md 05abb8d0a0da4644b3ef8df747d8f88e
+msgid "rsync"
+msgstr ""
+
+#: ../../24.04/2.md 65f0eb552cc240d793707e102e1fb92a
+msgid "[2095004](https://bugs.launchpad.net/bugs/2095004)"
+msgstr ""
+
+#: ../../24.04/2.md 2981ea8e036b4b35973e51ed17c3e84a
+msgid "SECURITY REGRESSION: flag collision"
+msgstr ""
+
+#: ../../24.04/2.md 2d92d1b9ee3b4d27b66ea6c6e1b523da
+msgid "heat"
+msgstr ""
+
+#: ../../24.04/2.md f3c9bbb00b244c8a9a1b13fbffab9618
+msgid "[2085409](https://bugs.launchpad.net/bugs/2085409)"
+msgstr ""
+
+#: ../../24.04/2.md 8c1d925d338b489cba0eb0093eb28c7c
+msgid "Fix wrongly passing \"no_fixed_ips\" to Neutron."
+msgstr ""
+
+#: ../../24.04/2.md cd4ca8e3179247538657ff823b5435ef
+msgid "python-keystoneauth1"
+msgstr ""
+
+#: ../../24.04/2.md ea4a769fe08a450f85f58098e65ba82f
+msgid "[2088451](https://bugs.launchpad.net/bugs/2088451)"
+msgstr ""
+
+#: ../../24.04/2.md 523fb3c82b504e25a02701eff5434d69
+msgid ""
+"Refresh to use upstream accepted patch which avoids a runtime dependency "
+"on python3-oslo.utils."
+msgstr ""
+
+#: ../../24.04/2.md:228 ff17ad8f7b674ddca601f93a11198fce
+msgid "Base platform fixes"
+msgstr ""
+
+#: ../../24.04/2.md:230 adf2c84e1a704a31b9ef0a616dfb1285
+msgid ""
+"These changes affect the core fundamental components of all the Ubuntu "
+"flavors."
+msgstr ""
+
+#: ../../24.04/2.md 022e32e8098b45b5af1b27cf8a50101b
+#: 0be3e22c95c0480697eaba6d2aca5505 538dbde5dab54acfbb6b6c71882ceab5
+#: 7f09716dbf28480cabb2897810056bb6 821516ee4bfc43f8b777aea6977158c6
+#: 989a3d7b4a8f40249eaa8e1bfceebe44 a392c665da0749508b69a146bdbee2b0
+#: a3fac5784ffc4407bc348a1c3e547cfc c4e63c3bc5c44f9792869049810a4ac2
+#: c52967f273c4411e8c09be761324dbb5 d0bed58e0f124277b6e131f17d175957
+#: eb48c114cf564114bbdd4701c118d425 ed11cc77ae7a4667be183ba9ac3a6b42
+msgid "ubuntu-advantage-tools"
+msgstr ""
+
+#: ../../24.04/2.md 27351c9dd67a49509e8f4b486f72f600
+#: de42f9ab9217431382ee49b7a4d62b88
+msgid "[2069237](https://bugs.launchpad.net/bugs/2069237)"
+msgstr ""
+
+#: ../../24.04/2.md 4174bf9b1ad2459cae9a8ea45631eb0d
+msgid "Backport 33.2 to noble"
+msgstr ""
+
+#: ../../24.04/2.md 4e7570d71f224daab1a2f3a99a0deafe
+msgid "[2072489](https://bugs.launchpad.net/bugs/2072489)"
+msgstr ""
+
+#: ../../24.04/2.md 4ebd084300844747b0bf003ae8c287eb
+msgid ""
+"d/apparmor: add apt-news access to package information on the system (GH:"
+" #3193)"
+msgstr ""
+
+#: ../../24.04/2.md 5d86b26e4d854e049567c248b05e5cf5
+#: e2abfad7b79c48bd8ddf6b998afc97f8
+msgid "[2060769](https://bugs.launchpad.net/bugs/2060769)"
+msgstr ""
+
+#: ../../24.04/2.md 800b87e3c4ed4796bd51e76f9a701fcb
+msgid "New upstream release 33.1:"
+msgstr ""
+
+#: ../../24.04/2.md 32f93347ff984eb2a67463f16027f6fe
+msgid "[2067810](https://bugs.launchpad.net/bugs/2067810)"
+msgstr ""
+
+#: ../../24.04/2.md d82ed8124ec841e9a19ad152edd52c6b
+msgid ""
+"d/apparmor: adjust the esm_cache apparmor profile to allow reading of "
+"dpkg data directory (GH: #3137)"
+msgstr ""
+
+#: ../../24.04/2.md 450ad618760a4e99bc673de6eee7d71e
+msgid "New upstream release 33"
+msgstr ""
+
+#: ../../24.04/2.md 0f72ae7a541144d78ebd8a3e505d42c6
+#: cb93355a0a1648e78e87fc8dd4c3317a
+msgid ""
+"apt: use Python bindings instead of apt CLI to query for installed "
+"packages"
+msgstr ""
+
+#: ../../24.04/2.md 2c17082eab324e47a790a807b59dccae
+msgid "[2068744](https://bugs.launchpad.net/bugs/2068744)"
+msgstr ""
+
+#: ../../24.04/2.md a621501149194fc2909bbba5dbb8bf90
+msgid "cryptsetup"
+msgstr ""
+
+#: ../../24.04/2.md b47b9ac4ba4f449c92ed1f7409fb762f
+msgid "initramfs hook: Combine calls to manual_add_modules"
+msgstr ""
+
+#: ../../24.04/2.md 10eba93b3a044fd7bba6802071cbd06c
+#: 626a8dea6c114cbea46aea1b40a606ad a6a46ef5d57447df8ef44c9897ac7af1
+#: ae509566aef64d71abaae195f863ce02 f9dbed252f2f43c8bfc37f94c931bfba
+#: fdfe4839dde64aab923b8a164351d8af
+msgid "initramfs-tools"
+msgstr ""
+
+#: ../../24.04/2.md 110daaf569bd4f83931e82e60f06b045
+#: b7ca366c4d3449ccb159a14a6338a52a
+msgid "[1769297](https://bugs.launchpad.net/bugs/1769297)"
+msgstr ""
+
+#: ../../24.04/2.md b6b2212726004a4691008290d4a15e5b
+msgid "Fix resume failure due to resume=UUID=... in certain cases"
+msgstr ""
+
+#: ../../24.04/2.md f573f2de8e8e46c79db81151bd2366cb
+msgid "resume: always write valid resume device to /sys/power/resume"
+msgstr ""
+
+#: ../../24.04/2.md 7fba4ff514944614bb5f6f7c0ac0e9ae
+msgid ""
+"reduce number of dracut-install calls: group dracut-install calls for "
+"block modules in auto_add_modules and use copy_modules_dir code instead "
+"of dracut-install calls"
+msgstr ""
+
+#: ../../24.04/2.md b2823515f4024a4caff701f6fcad6f4a
+msgid "lvm2"
+msgstr ""
+
+#: ../../24.04/2.md d73bed9299fc4f4db948ee031988658d
+msgid "initramfs-tools hook: Combine calls to manual_add_modules"
+msgstr ""
+
+#: ../../24.04/2.md 45670b5a32da48b5a70a9de22207c813
+#: c91000cc62374d4cad7b7dbf548ccbc8
+msgid "nvme-cli"
+msgstr ""
+
+#: ../../24.04/2.md 283d1517f1034169935b7b13eb6bcbd3
+msgid "[2072381](https://bugs.launchpad.net/bugs/2072381)"
+msgstr ""
+
+#: ../../24.04/2.md 569a338bc0884c16b110550c1447ff38
+msgid "NVMe show-regs command forcibly reboots ARM-based VM"
+msgstr ""
+
+#: ../../24.04/2.md 33aa57fc99df43c398cfc427e48a29f2
+msgid "[2076668](https://bugs.launchpad.net/bugs/2076668)"
+msgstr ""
+
+#: ../../24.04/2.md 91d844e154eb4eab9bdebd1311a92e2a
+msgid "Fix FTBFS due to 64-bit time_t on 32-bit architectures"
+msgstr ""
+
+#: ../../24.04/2.md 51b5e53fa04e4a618114b336d6a6d9b3
+#: 76295f56baec4401a4e819c059143f06
+msgid "dotnet8"
+msgstr ""
+
+#: ../../24.04/2.md f48c295e5c2e43e89497c1c80af35f96
+msgid "[2075185](https://bugs.launchpad.net/bugs/2075185)"
+msgstr ""
+
+#: ../../24.04/2.md 6fd2ea756bb040cdb3aff6a217e2c8e4
+msgid "Add ppc64el as a supported architecture."
+msgstr ""
+
+#: ../../24.04/2.md 176d4497d06e4c869c67a172ca891407
+#: 66f2482980604e4ebe3132fb8171d27a
+msgid "systemd-hwe"
+msgstr ""
+
+#: ../../24.04/2.md 1726dd1b2d4e4b8a857e372bb15692aa
+msgid "[2073717](https://bugs.launchpad.net/bugs/2073717)"
+msgstr ""
+
+#: ../../24.04/2.md 1deca7eee6b341e48e00958be1b4dab9
+msgid "Add micmute key mapping for Dell Pro Rugged series"
+msgstr ""
+
+#: ../../24.04/2.md 9778a48ebbc24abd955d2ed97854a56a
+msgid "[2069383](https://bugs.launchpad.net/bugs/2069383)"
+msgstr ""
+
+#: ../../24.04/2.md 5cf809be8e184a41a72f91712219723a
+msgid "hwdb.d/90-sensor-ubuntu.hwdb: drop duplicate rules"
+msgstr ""
+
+#: ../../24.04/2.md 1f82562aeb4a4a588faa5fa4fbeddaf7
+#: 27a1e471895b41869bdedd7f9b08b44c 3769396fe5484d249daeea7c692e48a3
+#: 4bdc38d788aa4a8b946e1f4610b3c480 d80b42c3d5fa4daebc4b0e540efd4fcc
+#: da25cf259bf145f0904fd1bf81e883dd
+msgid "apparmor"
+msgstr ""
+
+#: ../../24.04/2.md de97125edf214adcb71ec5a5ea845d5c
+msgid "[2072811](https://bugs.launchpad.net/bugs/2072811)"
+msgstr ""
+
+#: ../../24.04/2.md cf1393a5ff3a4315b5e6e830273f46d9
+msgid ""
+"Revert to version 4.0.1-0ubuntu0.24.04.2 except for the patch that "
+"enables the bwrap-userns-restrict profile."
+msgstr ""
+
+#: ../../24.04/2.md f2a85242adca47b3a8f28206a6e56d5e
+msgid "[2064672](https://bugs.launchpad.net/bugs/2064672)"
+msgstr ""
+
+#: ../../24.04/2.md 14ead5c6fdec4c4cba0148ea6ef9df1a
+#: c42d81bfc5184b4d97e961c17bb700e7
+msgid "[2046844](https://bugs.launchpad.net/bugs/2046844)"
+msgstr ""
+
+#: ../../24.04/2.md 49651f0cac5e4720acac881b0c37e8b2
+msgid "[2060100](https://bugs.launchpad.net/bugs/2060100)"
+msgstr ""
+
+#: ../../24.04/2.md dcc7d16356db429abb67c5d31b056307
+msgid "[2056297](https://bugs.launchpad.net/bugs/2056297)"
+msgstr ""
+
+#: ../../24.04/2.md d28d92004f81452cadfa06967924a49a
+msgid "Add patch to add balena-etcher profile"
+msgstr ""
+
+#: ../../24.04/2.md 756b1f465040431bb3440bec66c508c2
+#: 99182fafad6f4eeea3751232385d0530
+msgid "procps"
+msgstr ""
+
+#: ../../24.04/2.md 5c88cd48a7404012b50423c9da4223f8
+msgid "[2003027](https://bugs.launchpad.net/bugs/2003027)"
+msgstr ""
+
+#: ../../24.04/2.md de18885231334f439180511d4e403a97
+msgid "d/sysctl.d/10-bufferbloat.conf: set default qdisc to fq_codel"
+msgstr ""
+
+#: ../../24.04/2.md 0a43739555e74681ab91aa78fab83d93
+#: b602b2ce4e5045eb855d9cf509eb0917
+msgid "[2075543](https://bugs.launchpad.net/bugs/2075543)"
+msgstr ""
+
+#: ../../24.04/2.md bdc5dec4d6394f74b5f2813066ba5f14
+msgid "Backport 34 to noble"
+msgstr ""
+
+#: ../../24.04/2.md 3bd028b0f3d24282a12a8b5a898ebbef
+msgid "New upstream release 34:"
+msgstr ""
+
+#: ../../24.04/2.md aa17ad04826849fb88391505fbf619bf
+msgid "[2074211](https://bugs.launchpad.net/bugs/2074211)"
+msgstr ""
+
+#: ../../24.04/2.md 5fe504ef42764b7b813421e18f5230f5
+#: ea9d330617604e5aa4e0d7caab122c9a
+msgid "apt-hook: redirect errors away from users"
+msgstr ""
+
+#: ../../24.04/2.md 319856637b9841ecb80afc12ead56e37
+msgid "[2055239](https://bugs.launchpad.net/bugs/2055239)"
+msgstr ""
+
+#: ../../24.04/2.md 1a351849cebb484fb0432a107ca3cf58
+msgid "[2078737](https://bugs.launchpad.net/bugs/2078737)"
+msgstr ""
+
+#: ../../24.04/2.md 3361230d9d6b42a18e7b006279ea1392
+msgid "timer: recover from corrupted job status file"
+msgstr ""
+
+#: ../../24.04/2.md 90b69410869e4b4d84db1026b116ccc4
+msgid "[2080223](https://bugs.launchpad.net/bugs/2080223)"
+msgstr ""
+
+#: ../../24.04/2.md 3bf080a144bf4e4eb668ce123aa8dfc5
+msgid "Deliver warnings via MotD if cloud-init doesn't succeed."
+msgstr ""
+
+#: ../../24.04/2.md 0547b5ea2f6a491185a20dd0e4f1b7f8
+#: 4cfef979eb144e72bb000328e788b199
+msgid "mdadm"
+msgstr ""
+
+#: ../../24.04/2.md decf7e921a614b989df6796fa56171d7
+msgid "[2070371](https://bugs.launchpad.net/bugs/2070371)"
+msgstr ""
+
+#: ../../24.04/2.md ed3046814c354aa5955a15fcdd71501d
+msgid "mdadm: wait for mdmon when it is started via systemd"
+msgstr ""
+
+#: ../../24.04/2.md aa8d7ba67591439593c1baab67a82962
+msgid "[2069821](https://bugs.launchpad.net/bugs/2069821)"
+msgstr ""
+
+#: ../../24.04/2.md 75ddfa5208ba42e18563035a0d49d9f8
+msgid "mdadm: buffer overflow detected"
+msgstr ""
+
+#: ../../24.04/2.md 7218071a634e482fa76b98c963005e0d
+msgid "u-boot"
+msgstr ""
+
+#: ../../24.04/2.md 1891d524b7844cb984024e665a6fa2f4
+msgid "[2054092](https://bugs.launchpad.net/bugs/2054092)"
+msgstr ""
+
+#: ../../24.04/2.md b70f3ff33d9c4438b922eecac813546c
+msgid "Enable FIT images"
+msgstr ""
+
+#: ../../24.04/2.md 24cfcf5222e7484d9c85b41195ec1894
+msgid "shadow"
+msgstr ""
+
+#: ../../24.04/2.md 4eabe7d637034a9d9dc2f6a0e577f1da
+msgid "[2063200](https://bugs.launchpad.net/bugs/2063200)"
+msgstr ""
+
+#: ../../24.04/2.md ae850b3097fe4e6e9c67c752bdba1cba
+msgid "d/p/lp2063200/*: amend the patch to fix `useradd -D` breakage"
+msgstr ""
+
+#: ../../24.04/2.md 2e76be94823c499e91862cad2d6c1d03
+msgid "[2080518](https://bugs.launchpad.net/bugs/2080518)"
+msgstr ""
+
+#: ../../24.04/2.md 9dee543748254967bd81639a9dc634e6
+msgid "ps: Don't crash when using short option"
+msgstr ""
+
+#: ../../24.04/2.md 323c1c6b9e8149f481f32758c9059800
+msgid "gcc-14-cross"
+msgstr ""
+
+#: ../../24.04/2.md aaee384603fd4190b1c49d8d81cb3ede
+#: ba73075a5584458aa8123a643b0bf206
+msgid "[2073390](https://bugs.launchpad.net/bugs/2073390)"
+msgstr ""
+
+#: ../../24.04/2.md 49707249ca3b4c809a77d48ef56fa952
+#: 680f00f64ecd4960ac20ac66a9de45dc
+msgid "Backport GCC 14.2 to Ubuntu 24.04 LTS."
+msgstr ""
+
+#: ../../24.04/2.md 229b1e189b194277a23793f725b35949
+#: 7237f1fe5f8640bead60d426f3777319 9f83c3f909be4b7db88e0a3886f4270b
+#: c32fa53a4ac14c71acf2b6c60661a898
+msgid "gcc-14"
+msgstr ""
+
+#: ../../24.04/2.md 9ee1998e1ea146ebbc1d07a82c96ffda
+msgid "[2075567](https://bugs.launchpad.net/bugs/2075567)"
+msgstr ""
+
+#: ../../24.04/2.md 8b582c3b6cd24e32b54804a76f2c3e68
+#, python-brace-format
+msgid "s390: Fix high-level builtins vec_gfmsum{,_accum}_128."
+msgstr ""
+
+#: ../../24.04/2.md 5a19cb4e0e1d455482ef457a24e1c73d
+#: ed214a020d8649849fbcd8a36d005184
+msgid "[2071605](https://bugs.launchpad.net/bugs/2071605)"
+msgstr ""
+
+#: ../../24.04/2.md 179f8d8af8bf49ed946617c871508d4e
+msgid ""
+"Adjust for the new glibc behaviour of defining __USE_TIME_BITS64 also on "
+"native 64-bits platforms."
+msgstr ""
+
+#: ../../24.04/2.md 3f4a80e43df74a38994d711a43eabf23
+msgid "[2060619](https://bugs.launchpad.net/bugs/2060619)"
+msgstr ""
+
+#: ../../24.04/2.md 1a55dd9853754ebcbc7d162b8ee2ea73
+msgid "Package the new gfx1030, gfx1036, gfx1100 and gfx1103 offload targets."
+msgstr ""
+
+#: ../../24.04/2.md b6dafbc6a4be4a74b87d0ffc57fa5684
+msgid "binutils"
+msgstr ""
+
+#: ../../24.04/2.md 113ccb795f3140b48e87b164ed41f354
+msgid "[2076024](https://bugs.launchpad.net/bugs/2076024)"
+msgstr ""
+
+#: ../../24.04/2.md 46efe48b40eb4943b8f2330356c67be5
+msgid "Build with -fno-omit-frame-pointer."
+msgstr ""
+
+#: ../../24.04/2.md 00adab83ba7b4355ae6670ca592f94e0
+#: 335abc21a9694382bad106aad09b8c4f 4ff800ce77e44d719c48ec20bc3dae69
+#: c52bb147aa1d4bda992e073e158147e5 cc09766f96eb4447b0f8dd658ae5e065
+#: ddb3ebbf2e7a47a79b45be7de9da816b
+msgid "snapd"
+msgstr ""
+
+#: ../../24.04/2.md 1884e45111544374b16164d6bd1b96a2
+#: 4facfe2ef6a64ea9b34e4c9578eff19e 5756ac0278c04343a3266bffabe7865d
+#: d49b965d0ee74410a4453efc706f222b
+msgid "[2077473](https://bugs.launchpad.net/bugs/2077473)"
+msgstr ""
+
+#: ../../24.04/2.md 779b8d6be16546e69aa5e0ceb9e7592b
+#: 7cecaf24d64a4399bfd2dfb078822f68 cb3678eeb7464f2ebf0d9b9e26daec6e
+#: d22c229b5d294f9cbfc8e090341064e8 e7853742d97941f38b4e087cc36968c9
+#: f632542aa8d848358cb11e8f41c799bc
+msgid "New upstream release,"
+msgstr ""
+
+#: ../../24.04/2.md 42f0de0f986447169dcb87fad82702d3
+msgid "zfs-linux"
+msgstr ""
+
+#: ../../24.04/2.md 1d63f4ad82174af7a2055747b752fd1f
+msgid "[2077487](https://bugs.launchpad.net/bugs/2077487)"
+msgstr ""
+
+#: ../../24.04/2.md d7f81c1863ea4d6388430fa96ef6607f
+msgid "Linux 6.7 support"
+msgstr ""
+
+#: ../../24.04/2.md 6b9bf634b640480b8df655c6f58749a9
+msgid "[2081700](https://bugs.launchpad.net/bugs/2081700)"
+msgstr ""
+
+#: ../../24.04/2.md c9967d85e1c148f5997baf9d192495aa
+msgid ""
+"hook-functions: Call _call_dracut_install instead of manual_add_modules "
+"when using module filters to fix the regression from previous version"
+msgstr ""
+
+#: ../../24.04/2.md 2e2e7ec4e2dd456397fcfed51e9f08ae
+msgid "[2081020](https://bugs.launchpad.net/bugs/2081020)"
+msgstr ""
+
+#: ../../24.04/2.md 4baf88cd8a084d899e95a652876d355a
+msgid "hook-functions: Include all UFS storage drivers"
+msgstr ""
+
+#: ../../24.04/2.md 2571f9fb1b7b440ea3d3be8ccd5e0f67
+msgid "[2081334](https://bugs.launchpad.net/bugs/2081334)"
+msgstr ""
+
+#: ../../24.04/2.md 5241e69be350424fb25d99fa6e7cb581
+msgid ""
+"reduce number of dracut-install calls: stage all kernel module copying "
+"when running scripts in /usr/share/initramfs-tools/hooks and copy all "
+"kernel modules in one go afterwards."
+msgstr ""
+
+#: ../../24.04/2.md 33a8ff9ffe904b58a3951fc19fd82189
+msgid "distro-info-data"
+msgstr ""
+
+#: ../../24.04/2.md bdbf9f4552be49bd83692c510a167134
+msgid "[2084572](https://bugs.launchpad.net/bugs/2084572)"
+msgstr ""
+
+#: ../../24.04/2.md 72f627d74c1846ea809a7295c02792ab
+msgid "Add Ubuntu 25.04 \"Plucky Puffin\""
+msgstr ""
+
+#: ../../24.04/2.md 56fec3e6b2bc4a9293ce287bc2439f68
+msgid "lintian"
+msgstr ""
+
+#: ../../24.04/2.md 1cac95f3e05248ec9804142dc1c143ee
+msgid "[2084708](https://bugs.launchpad.net/bugs/2084708)"
+msgstr ""
+
+#: ../../24.04/2.md 7e6fc2d551b94d1c92c1c342afcee7f6
+msgid "Add \"plucky\" as a known Ubuntu distribution."
+msgstr ""
+
+#: ../../24.04/2.md 44ee3ee5ea7b40b9b0bd7b5e9f68744c
+msgid "mtr"
+msgstr ""
+
+#: ../../24.04/2.md 8f6cb0363ac24087b811c48064287c5b
+msgid "[2069401](https://bugs.launchpad.net/bugs/2069401)"
+msgstr ""
+
+#: ../../24.04/2.md 2df310fc22e74a92a77a08d6250829b6
+msgid "fix crash when using the report option"
+msgstr ""
+
+#: ../../24.04/2.md 45a74d48bfc64036a8c9f7487e73066e
+#: 9e16b37be8554aada4edb4d5aea8f74a
+msgid "software-properties"
+msgstr ""
+
+#: ../../24.04/2.md 07712a03e27e444f951d4478dd2162b8
+msgid "[2073742](https://bugs.launchpad.net/bugs/2073742)"
+msgstr ""
+
+#: ../../24.04/2.md ff21d68794024d76a0b8bca15ca3bbf5
+msgid ""
+"cloudarchive: Enable support for the Dalmatian Ubuntu Cloud Archive on "
+"24.04."
+msgstr ""
+
+#: ../../24.04/2.md 4e1c06bcffb74d5b813838a2f2781493
+msgid "[2069433](https://bugs.launchpad.net/bugs/2069433)"
+msgstr ""
+
+#: ../../24.04/2.md 1476f5c4a7904d65b5bb1add43f1b676
+msgid "Reload the source code state when reloading sources.list"
+msgstr ""
+
+#: ../../24.04/2.md 63cb755a2b8745a293752ff349db437e
+#: 82d0387f96dc4e9db69310380d6f36b8
+msgid "needrestart"
+msgstr ""
+
+#: ../../24.04/2.md 12236aaa53cd4581bb567f1a2400a375
+#: eff2b4334164434abf35f22b1cfb3df3
+msgid "[2089193](https://bugs.launchpad.net/bugs/2089193)"
+msgstr ""
+
+#: ../../24.04/2.md e42b1f48124b44fba092ed9931332b17
+msgid "SECURITY REGRESSION: false positives for killing processes"
+msgstr ""
+
+#: ../../24.04/2.md 01bbcd8572be49bba0c83ce73bca9c05
+#: aca119e097ba424eae6549f2e0658271
+msgid "[2083490](https://bugs.launchpad.net/bugs/2083490)"
+msgstr ""
+
+#: ../../24.04/2.md 619895ebe0d24c03947905f529ef6a52
+#: b5141444ce2f49fe85db407eca24fe2e
+msgid "zip"
+msgstr ""
+
+#: ../../24.04/2.md ad2465cf0e2c45d8894b0961983b4ff6
+msgid "[2062535](https://bugs.launchpad.net/bugs/2062535)"
+msgstr ""
+
+#: ../../24.04/2.md ff09c197548640549fba9f3e778d00a4
+msgid "Fix buffer overflow when filename contains unicode characters"
+msgstr ""
+
+#: ../../24.04/2.md 0b1528e0dfc24e6fabd2896b9ae8f648
+msgid "SECURITY REGRESSION: false positives for killing processes in LXC"
+msgstr ""
+
+#: ../../24.04/2.md faf79c71f064438fba07e62de1314993
+msgid "[2087882](https://bugs.launchpad.net/bugs/2087882)"
+msgstr ""
+
+#: ../../24.04/2.md 68cc4a6d76b94135a8e04f6e8eca58c6
+msgid "libnet-ip-perl"
+msgstr ""
+
+#: ../../24.04/2.md 01453f6e7d224d6d820b20ef948569af
+msgid "[2083236](https://bugs.launchpad.net/bugs/2083236)"
+msgstr ""
+
+#: ../../24.04/2.md 9c579c5801d44b17a46d70c5466f7829
+msgid "Add patch to let Net::IP deal with zero IPs or networks based."
+msgstr ""
+
+#: ../../24.04/2.md 0c04cb8ae12f4cdaae85c02a61ff5778
+#: 25d8d6679e7145299bcbe26c588053b0 5857ffab94664a628af24f4f1efaccfe
+#: aa5cc6bbe6e848a1961401529f2487b2 b6eaf65981fc4ffeae2dc1e8d2e0e55a
+#: f736ec12d27d44e29da75442f99a5a34
+msgid "apport"
+msgstr ""
+
+#: ../../24.04/2.md 17fe243553314730ae0d72098731aa36
+msgid "[2078634](https://bugs.launchpad.net/bugs/2078634)"
+msgstr ""
+
+#: ../../24.04/2.md 36099a907b1b4533a16a58fdaa8bf335
+msgid "Remove obsolete apport init.d and bash-completion conffiles"
+msgstr ""
+
+#: ../../24.04/2.md 2250f9ed778c493c80084d2ff0031035
+msgid "[2073935](https://bugs.launchpad.net/bugs/2073935)"
+msgstr ""
+
+#: ../../24.04/2.md 03c95d94e59b4239ae3c120e51fb1147
+msgid "recent-syslog: read stdout after process completion"
+msgstr ""
+
+#: ../../24.04/2.md 1025cf321ab942438a54ba366632fb7f
+msgid "[2078695](https://bugs.launchpad.net/bugs/2078695)"
+msgstr ""
+
+#: ../../24.04/2.md 6012c9c2ea474fb69a463084231e355f
+msgid "package_hook: Handle failures of removed packages"
+msgstr ""
+
+#: ../../24.04/2.md 579503e85c264c638ca92bf6f092c05f
+msgid "[1537310](https://bugs.launchpad.net/bugs/1537310)"
+msgstr ""
+
+#: ../../24.04/2.md f6ec07d7987548efb42d1994f37df4cc
+msgid "Fix freeze when cancelling/closing Apport"
+msgstr ""
+
+#: ../../24.04/2.md 20a83b1898984d96965a275c4b84d5ba
+msgid "[2073933](https://bugs.launchpad.net/bugs/2073933)"
+msgstr ""
+
+#: ../../24.04/2.md 3e4d2bedcb954144aa61fa9646f64517
+msgid "fix wait_for_gdb_sleeping_child_process"
+msgstr ""
+
+#: ../../24.04/2.md 9a84fdc58fb343be851c970c09535781
+msgid "[2076186](https://bugs.launchpad.net/bugs/2076186)"
+msgstr ""
+
+#: ../../24.04/2.md ee5b0f0085fe4e5c9ae0fe8fb5d90025
+msgid "fix flaky tests waiting for sleep command"
+msgstr ""
+
+#: ../../24.04/2.md ea1586149e8f491ea218455821ceb769
+msgid "libio-dirent-perl"
+msgstr ""
+
+#: ../../24.04/2.md 351e417f67b74aaaaa6cfb3831814fad
+msgid "[2074330](https://bugs.launchpad.net/bugs/2074330)"
+msgstr ""
+
+#: ../../24.04/2.md 9b9249a4204a43318fbe26e0fede424b
+msgid "d/rules: inherit buildflags.mk flags."
+msgstr ""
+
+#: ../../24.04/2.md a4ba76bf3b1943b59f760731dff47345
+#: ab2c83011151438f8fb5fb4b7479be07
+msgid "gcc-13"
+msgstr ""
+
+#: ../../24.04/2.md 37d835bc21ed48f2ac7b7cd6dd24673f
+#: 94fcd2071b344af5b04a234f10e2e34a
+msgid "[2073389](https://bugs.launchpad.net/bugs/2073389)"
+msgstr ""
+
+#: ../../24.04/2.md 43fb58eeae27413fbdca35ea283d0ed7
+#: 7e3c7f1ad7a749c6a95bee6914bd468a
+msgid "Backport GCC 13.3 to Ubuntu 24.04 LTS."
+msgstr ""
+
+#: ../../24.04/2.md a1a6c84c8ad843c6b86e9b4547c3f6bc
+msgid ""
+"Adjust for the new glibc behaviour of defining __USE_TIME_BITS64 also on "
+"native 64-bits platforms"
+msgstr ""
+
+#: ../../24.04/2.md 006a2bd4c88243dfa27807b25de8a95d
+msgid "gcc-13-cross"
+msgstr ""
+
+#: ../../24.04/2.md ac92677ed2b64d38a34b53c1ea8b7f9d
+msgid "edk2"
+msgstr ""
+
+#: ../../24.04/2.md 4b116c1302b04e1d8431903a0adac0f5
+msgid "[2077731](https://bugs.launchpad.net/bugs/2077731)"
+msgstr ""
+
+#: ../../24.04/2.md d818f8b661b04e7aa40504536e940663
+msgid "qemu-efi-riscv64: Fix crash in KVM-based emulation:"
+msgstr ""
+
+#: ../../24.04/2.md f96b3cb727a5498786996b3826b04bfa
+msgid "sbuild"
+msgstr ""
+
+#: ../../24.04/2.md bdac478611c843648a33fb9f2a7055a8
+msgid "[2091811](https://bugs.launchpad.net/bugs/2091811)"
+msgstr ""
+
+#: ../../24.04/2.md 763e02137d6f4209ae111fc6ee747583
+msgid "Add timestamps to the subsection log messages."
+msgstr ""
+
+#: ../../24.04/2.md 3b8de49adea44c498343ca522d306e6e
+msgid "grub2"
+msgstr ""
+
+#: ../../24.04/2.md 6dbca3c1625342768af946a4a083ab6f
+#: d6f4cafcd4c5480ab77de5aa960345bf f1d45c3f9dfc448b8dae37ca7026d28b
+msgid "[2076651](https://bugs.launchpad.net/bugs/2076651)"
+msgstr ""
+
+#: ../../24.04/2.md 9a559f3777dd47628cae2b46409b00bb
+#: cbfdf6f55d7449c0ba1f68d160cbc74f
+msgid "riscv: use time register in grub_efi_get_time_ms()"
+msgstr ""
+
+#: ../../24.04/2.md 29525b539df145599899116f11b1a459
+msgid "grub2-unsigned"
+msgstr ""
+
+#: ../../24.04/2.md 67565f037779443cb8b5ef6d9eeffd95
+msgid "grub2-signed"
+msgstr ""
+
+#: ../../24.04/2.md 28f1ba5c048944b29f7f27c588afe6fb
+#: d4996bc6ae504258a0440fd14592836f
+msgid "Rebuild against grub2 2.12-1ubuntu7.1"
+msgstr ""
+
+#: ../../24.04/2.md d8f705b8e1c347009eb4690052d55f97
+msgid "autofs"
+msgstr ""
+
+#: ../../24.04/2.md 9fd3a4f16c0c4169a7f95e5216d86ce9
+msgid "[2074003](https://bugs.launchpad.net/bugs/2074003)"
+msgstr ""
+
+#: ../../24.04/2.md 75577a944df14ad188e12a07521a11fb
+msgid "fix credential end time comparison"
+msgstr ""
+
+#: ../../24.04/2.md aa4ae7c40f5546c88612ef42e50525b4
+msgid "util-linux"
+msgstr ""
+
+#: ../../24.04/2.md cd0d2c6b2df14461a7afb9b8e1aeece7
+msgid "[2090972](https://bugs.launchpad.net/bugs/2090972)"
+msgstr ""
+
+#: ../../24.04/2.md dc07cce8b88c4548a1c68a521f24dff1
+msgid ""
+"Read the ext4 superblock with O_DIRECT if the first read produces a "
+"checksum failure. This fixes a race where the underlying superblock can "
+"be changed in memory but not on disk, resulting in checksum failures "
+"which in turn causes systemd-udevd to remove by-uuid and by-label "
+"symlinks."
+msgstr ""
+
+#: ../../24.04/2.md ac36d1a7c25a47d1920cf6a761eb7093
+msgid "xfsprogs"
+msgstr ""
+
+#: ../../24.04/2.md 864ca07235594a7b86fa443805053abe
+msgid "[2081163](https://bugs.launchpad.net/bugs/2081163)"
+msgstr ""
+
+#: ../../24.04/2.md fc4a5b18b52344099d51fc05f6d05572
+msgid "fix fsck.xfs run by different shells when fsck.mode=force is set."
+msgstr ""
+
+#: ../../24.04/2.md 52184f944d544f0ba419d200ef0b3c3a
+#: 5d15d4b69e834cd4ac841671cb203739
+msgid "bpftrace"
+msgstr ""
+
+#: ../../24.04/2.md 0689fa9b87a943039690656ac5661a88
+msgid "[2081848](https://bugs.launchpad.net/bugs/2081848)"
+msgstr ""
+
+#: ../../24.04/2.md c64d1b54172d4d4bbc65e8944e23b674
+msgid "Fix underlinking of llvm-18."
+msgstr ""
+
+#: ../../24.04/2.md 46616806d5b843c099456ee47f3063b4
+#: 7e5c224361fc425da7a8c255671c8ad6
+msgid "systemd"
+msgstr ""
+
+#: ../../24.04/2.md f4e0e7284cfd446b81eb9a2066b733fa
+msgid "[2077779](https://bugs.launchpad.net/bugs/2077779)"
+msgstr ""
+
+#: ../../24.04/2.md 649fd9117d404c5b8011ab3b9e9dccb5
+msgid "udev: Handle PTP device symlink properly on udev action 'change'"
+msgstr ""
+
+#: ../../24.04/2.md b5da354f36a649e6a96bcb4d541b73e7
+msgid "[2081192](https://bugs.launchpad.net/bugs/2081192)"
+msgstr ""
+
+#: ../../24.04/2.md 1a0f6b67bac0485e8506b1881708319e
+msgid "core/exec-invoke: Fix missing arguments for PR_SET_MEMORY_MERGE call"
+msgstr ""
+
+#: ../../24.04/2.md 01bd85c4e7ee467a9a3be78e180f9ac5
+#: 4fc3775562d343b2befcdd998c8072fa d0ce6f0ff6974a1484fae534fbef1615
+msgid "tzdata"
+msgstr ""
+
+#: ../../24.04/2.md 792b791040c04c889c3b4c425b0c5be4
+msgid "[2079966](https://bugs.launchpad.net/bugs/2079966)"
+msgstr ""
+
+#: ../../24.04/2.md 5a0c994c53234fb5b1aae80d3928cb7b
+msgid "New upstream release:"
+msgstr ""
+
+#: ../../24.04/2.md 2fbffab52fe34df0b68987c3eb0aa4d9
+msgid "[2070285](https://bugs.launchpad.net/bugs/2070285)"
+msgstr ""
+
+#: ../../24.04/2.md e6714288695d4c13a899c9c993b001d1
+msgid "Make remaining legacy timezones selectable in debconf"
+msgstr ""
+
+#: ../../24.04/2.md 23a2bb29cd49427c8a8640e889a77994
+msgid "cd-boot-images-amd64"
+msgstr ""
+
+#: ../../24.04/2.md 19befa24c49c48738b8fbe4296f2d1e6
+#: 8a141c5d9db44beea494df83a591c042 962c453b54ce477780b79b0633055c64
+msgid "[2096766](https://bugs.launchpad.net/bugs/2096766)"
+msgstr ""
+
+#: ../../24.04/2.md 8583a27c82434ab0ac32baac17162e58
+msgid "Rebuild against grub-efi-amd64-signed v1.202.2+2.12-1ubuntu7.1"
+msgstr ""
+
+#: ../../24.04/2.md 33a1e6b0d28d451d97ffbb2558f3cd6e
+msgid "cd-boot-images-arm64"
+msgstr ""
+
+#: ../../24.04/2.md 810e0bdcae5f43149a5a9506600f6ad4
+msgid "Rebuild against grub-efi-arm64-signed 1.202.2+2.12-1ubuntu7.1"
+msgstr ""
+
+#: ../../24.04/2.md 8fd11a67deab4d5682ed0db3f5cb7b62
+msgid "cd-boot-images-ppc64el"
+msgstr ""
+
+#: ../../24.04/2.md 0ea77ad3e9eb4cfcb14f9db66be9cadf
+msgid "cd-boot-images-riscv64"
+msgstr ""
+
+#: ../../24.04/2.md 6497205efeff4ab6a71e7e59f6bcbb2e
+msgid "[2062166](https://bugs.launchpad.net/bugs/2062166)"
+msgstr ""
+
+#: ../../24.04/2.md 001b3c1e33e842378eec76c0863656a1
+msgid "Rebuild against grub2 2.12-1ubuntu7.1 and u-boot 2024.01+dfsg-1ubuntu5.1"
+msgstr ""
+
+#: ../../24.04/2.md cbfc16f5a7e64ce68071a0ce59dd9e76
+msgid "python-apt"
+msgstr ""
+
+#: ../../24.04/2.md e9c3b798858946018f07831a7d5eb901
+msgid "[2096775](https://bugs.launchpad.net/bugs/2096775)"
+msgstr ""
+
+#: ../../24.04/2.md fec3fded1067447c9341d0ec1200cda2
+msgid "Mirror list update for 24.04.2"
+msgstr ""
+
+#: ../../24.04/2.md bcdcd1f36cf24fdfbd0a129b10040c13
+msgid "[2093024](https://bugs.launchpad.net/bugs/2093024)"
+msgstr ""
+
+#: ../../24.04/2.md a5c548d9c5b44154820fc6c4c33e7168
+msgid "Fix buffer overflow when invoked with `-T -TT`"
+msgstr ""
+
+#: ../../24.04/2.md 0b6446a1e92e45c5b0aa5e9a95de52b5
+#: 1d05a5221a3e4626bf574e5fd8b9c82f 3469aaf54f274587be213617fdbee0ff
+msgid "ubuntu-meta"
+msgstr ""
+
+#: ../../24.04/2.md 97aeb8b125e64c15aebf3dbbe79e03c9
+#: d216a6d2bdbd4b55978b24a853b45538 f2ee97b4e7ba4f1ca72f572f8579b1b2
+msgid "[2062667](https://bugs.launchpad.net/bugs/2062667)"
+msgstr ""
+
+#: ../../24.04/2.md 9b789661f393429fb273a119036f701f
+msgid ""
+"Removed flash-kernel from desktop-minimal-recommends [arm64], desktop-"
+"recommends [arm64] (LP: #2062667)"
+msgstr ""
+
+#: ../../24.04/2.md 52ab7dbc8ce1440abc9255ed5b1f6152
+msgid "[arm64], desktop-recommends [arm64] (LP: #2062667)"
+msgstr ""
+
+#: ../../24.04/2.md 802502738a8945029a644a9ae9103773
+msgid ""
+"Removed qrtr-tools from desktop-minimal-recommends [arm64], desktop- "
+"recommends [arm64] (LP: #2062667)"
+msgstr ""
+
+#: ../../24.04/2.md b9f94907f0b145c09bbdd6f63c3d5e8f
+msgid "[2096974](https://bugs.launchpad.net/bugs/2096974)"
+msgstr ""
+
+#: ../../24.04/2.md 572ffd86cf494542a566efdbce77d262
+msgid "Revert using %z in tzdata.zi data form (LP: #2096974):"
+msgstr ""
+
+#: ../../24.04/2.md a346562962f9488fbc21532ea3c049cf
+msgid "base-files"
+msgstr ""
+
+#: ../../24.04/2.md b2e1d16b9e214e07a1cfec9da4f80d44
+msgid "[2097469](https://bugs.launchpad.net/bugs/2097469)"
+msgstr ""
+
+#: ../../24.04/2.md ad2d595ee01443faba0623a342f771f0
+#, python-brace-format
+msgid "/etc/issue{,.net}, /etc/{lsb,os}-release: bump version to 24.04.2."
+msgstr ""
+
+#: ../../24.04/2.md f79e11dbfb8a4bf18569e7cd5dc380a5
+msgid "[2097317](https://bugs.launchpad.net/bugs/2097317)"
+msgstr ""
+
+#: ../../24.04/2.md 18b1286b635949dea6cdd4acf8083e99
+msgid ""
+"Rebuild against llvm-toolchain-18 1:18.1.3-1ubuntu1 to fix error loading "
+"shared libraries that arises when built against "
+"1:18.1.8-9ubuntu1\\~24.04.. Note this upload reverts the changes from "
+"bpftrace 0.20.2-1ubuntu4.2."
+msgstr ""
+
+#: ../../24.04/2.md:333 d59458c5a4054d80b118effc210be92e
+msgid "Kernel and Hardware support updates"
+msgstr ""
+
+#: ../../24.04/2.md:335 a7b793a1fd6149ca8393f2dd8832f551
+msgid ""
+"Considerable work has been done on improving support for many specific "
+"items of hardware."
+msgstr ""
+
+#: ../../24.04/2.md 074025aaf61d4ecfb31f320e7ef0d966
+#: 13232657281c4d1a80787fcc7af0f66e 1fdfc3113f574ebfbdd962155f06b72c
+#: 206f8d90181343d4b5215fd8e3d03f17 2e063d0fa5cf40a6a32f261cdd1fd59d
+#: 399e2cb46aad4bcfbb32a5f48d4c6e48 3ad2537c0c894dd9a0779d5a9801c717
+#: 4b0cc06077a348d084d481c4c8850a4e 538a81fb114d426780e87413a030a222
+#: 5bda8db31687410083b3fada3fc92449 6639e6c250ae42c49d133f8ee6111a5f
+#: 68261d35352c415d9b7799e216b71bb5 75cdb232bce2407c9d1f117561482aeb
+#: 8214f440d6964b1abb4923fbf10928e3 824dbc732a0b427ab218b47418af8859
+#: 83a086ea9f5a42cf92080d858c5d8c5c 941471d9e98346229c7a0184732dff34
+#: 98378b7abec5416fb12fb267b53c3541 9a994a2ef4a54b4a866add2d344b8a2c
+#: 9add1750ac384559a1f18b6464eff195 a085ca62b42646f0887ded06a5c6041d
+#: a3c3b440a0824413925413081b8d92d6 a721d63a324f47f19d907a3ceb154dd8
+#: ade4caf88be5465f844cc1a2a82887ec af538356b77e452aa588d713583ef608
+#: b48323a80dfb4a7b8f4e05cd5fa78fea c0f930b0bf864a439b4a92e1c6ce2ad0
+#: c6260a0ebfba465bba5338f58aa09722 cae1d7e7e3d748fa90cc032f08026782
+#: eaa6f41e23c5407da2c1335ea3d62595 ed3955f63abe47e59b8d1f83cb4f0d29
+msgid "linux-firmware"
+msgstr ""
+
+#: ../../24.04/2.md 463f1c387ebe4453b5f62f8cd398adcb
+msgid "[2069412](https://bugs.launchpad.net/bugs/2069412)"
+msgstr ""
+
+#: ../../24.04/2.md c81873afaf644f5b94427ab9a37c6190
+msgid "CS42L43 and CS35L56 for soundwire on Intel LNL/ARL"
+msgstr ""
+
+#: ../../24.04/2.md 2c27bda44ceb41739905230aad8c4492
+msgid "[2071771](https://bugs.launchpad.net/bugs/2071771)"
+msgstr ""
+
+#: ../../24.04/2.md 2b3e3e20f33b40ed9a2455ab521f4d7f
+msgid ""
+"Missing firmware for Intel NPU driver on Intel Lunar Lake platform: "
+"Failed to request firmware: -2"
+msgstr ""
+
+#: ../../24.04/2.md 54ed64073e014d9aa55fdc9e50dc2989
+msgid "[2068001](https://bugs.launchpad.net/bugs/2068001)"
+msgstr ""
+
+#: ../../24.04/2.md 462c45c9f727452a8ffba8cd26fcec4d
+msgid "Add support for DCN 3.5.1"
+msgstr ""
+
+#: ../../24.04/2.md 2086037cd638480098e8302099f471c9
+msgid "[2071812](https://bugs.launchpad.net/bugs/2071812)"
+msgstr ""
+
+#: ../../24.04/2.md 7b4c7d58bc7e473f8ed34aac38f2677f
+msgid "Add support for AMD ISP 4.1.1"
+msgstr ""
+
+#: ../../24.04/2.md 9cf5434fecd44ada81958a14f8ac283e
+msgid "[2073047](https://bugs.launchpad.net/bugs/2073047)"
+msgstr ""
+
+#: ../../24.04/2.md c25cdfd56aea4f8c90f328b27aa08113
+msgid ""
+"Regression on Linux 6.8.0-38: Bluetooth adapter (Intel AX200) stops "
+"working after a few suspend/resume cycles"
+msgstr ""
+
+#: ../../24.04/2.md 5276030e279c49d99b5beacb897725e2
+#: d2a9b189a1c64ba4a9705b0b151a6f81
+msgid "nvidia-graphics-drivers-550"
+msgstr ""
+
+#: ../../24.04/2.md 7a98514249304f23831a8e3916b1514e
+msgid "[2075327](https://bugs.launchpad.net/bugs/2075327)"
+msgstr ""
+
+#: ../../24.04/2.md 22df334a386e4ca7a4c99c978c5fe196
+#: 9be09676175649e3822bff6f6a6f4b30 b9d6fe262ee047bc8342284e6592ee6d
+#: c32d2cdce67241a9a34b1848cfa9a1cb da8198dad9ee4813a5173ee64686292d
+msgid "nvidia-graphics-drivers-535-server"
+msgstr ""
+
+#: ../../24.04/2.md 8a2fbe92c4d04253a6fde617d9bc6e74
+msgid "[2071933](https://bugs.launchpad.net/bugs/2071933)"
+msgstr ""
+
+#: ../../24.04/2.md 8f80e16a0dbc4206afb692eeaacfb70c
+msgid "[2063827](https://bugs.launchpad.net/bugs/2063827)"
+msgstr ""
+
+#: ../../24.04/2.md 4073db88655e4e17a9d3962b85aa369d
+#: bc92118e798945d0ad18dcc8a74ad9b6
+msgid ""
+"Add runtime dependency on libnvidia-egl-wayland1. While it is technically"
+" an optional plugin, it is needed to properly support wayland sessions."
+msgstr ""
+
+#: ../../24.04/2.md 90b285a97e1c4f3a8c064970f6619d7a
+msgid "[2062082](https://bugs.launchpad.net/bugs/2062082)"
+msgstr ""
+
+#: ../../24.04/2.md 11621e50c77f4736bf40b430d88e3168
+#: 6ad2aa0a95bb4b8a83b986ac2453b122 9f189892e0004a8594c5ef00111cbbf3
+msgid "ubuntu-drivers-common"
+msgstr ""
+
+#: ../../24.04/2.md 5604020559d54f018892b829c5375236
+#: d7146a3a37474073a19a5ca7f87440ce
+msgid "[2060268](https://bugs.launchpad.net/bugs/2060268)"
+msgstr ""
+
+#: ../../24.04/2.md 401c2d800dee41029f56ddfe96172039
+msgid "Wait for nvidia-drm to settle before opening /dev/dri/card*"
+msgstr ""
+
+#: ../../24.04/2.md 47f7eb56ac864760b59dd3e79d3d0820
+msgid "Remove SimpleDRM device when nvidia-drm loads"
+msgstr ""
+
+#: ../../24.04/2.md 8132e6ba72304df1b5a15761c21ede6b
+msgid "[2077646](https://bugs.launchpad.net/bugs/2077646)"
+msgstr ""
+
+#: ../../24.04/2.md bf2b6563736c4d12b058915e5e80457a
+msgid "Revert \"Change maximum open files limit for the shell\""
+msgstr ""
+
+#: ../../24.04/2.md 317401ce3aee4c1aa29f8bcdb1424dfb
+#: 51c1a85f5bfe4565a19801011ce02d9b ddc881c83c084e619716eb2b21daa822
+#: e70c7d90d1dd4c68902affa81dc06215 ff14adc3a3ef4ee48bb1b3737440f504
+msgid "fwupd"
+msgstr ""
+
+#: ../../24.04/2.md 7dc5ac68dea2450883038ba82052cd47
+msgid "[2077553](https://bugs.launchpad.net/bugs/2077553)"
+msgstr ""
+
+#: ../../24.04/2.md 78b749c662a8432dbbc39ff9ee42653e
+msgid "Improves ESP detection false positives"
+msgstr ""
+
+#: ../../24.04/2.md 70031b39ea9349b98dc69c667d6354e4
+msgid "[2076151](https://bugs.launchpad.net/bugs/2076151)"
+msgstr ""
+
+#: ../../24.04/2.md 4b31e48bbe244e23b33df538bd3a92b2
+msgid "Adds support for mediatek scalar"
+msgstr ""
+
+#: ../../24.04/2.md daee4ec7e8a6463d906982150cf691e7
+msgid "[2077411](https://bugs.launchpad.net/bugs/2077411)"
+msgstr ""
+
+#: ../../24.04/2.md 9b010d9eec2b4dc2aced5e7dd6d21d2a
+msgid "Fixes redfish protocol handling"
+msgstr ""
+
+#: ../../24.04/2.md 87dc6801996e4cc5b0f77089c2be4cee
+msgid "[2077112](https://bugs.launchpad.net/bugs/2077112)"
+msgstr ""
+
+#: ../../24.04/2.md a9277eb886ca458aacd6131132b00d11
+msgid "Missing Huc/Gsc support for Intel GFX Xe driver for Lunar Lake"
+msgstr ""
+
+#: ../../24.04/2.md 5a5cad5e2e1f4d4a97fb2367c96108c2
+msgid "[2077296](https://bugs.launchpad.net/bugs/2077296)"
+msgstr ""
+
+#: ../../24.04/2.md b378e4f37d664f07b28e3da251315669
+msgid "Add more region support of QCOM WiFi WCN7850"
+msgstr ""
+
+#: ../../24.04/2.md c0d063ba5461442ba4ceec6dfd818a1f
+msgid "[2077509](https://bugs.launchpad.net/bugs/2077509)"
+msgstr ""
+
+#: ../../24.04/2.md 08ffde27e80e40d0bdbed3d6928237b7
+msgid "Missing firmware for Intel(R) Wi-Fi 7 BE200 320MHz"
+msgstr ""
+
+#: ../../24.04/2.md a5d86f1642424a24a0f8db5adb23bef4
+msgid "[2073525](https://bugs.launchpad.net/bugs/2073525)"
+msgstr ""
+
+#: ../../24.04/2.md a861816ee6094a86a0657111d42ad597
+msgid "QAT: Add 402xx (CPM2.0c) firmware for Sierra forest and Granite rapids"
+msgstr ""
+
+#: ../../24.04/2.md fa50ae9d8af1460d9d406c3f8ea373a2
+msgid "[2071821](https://bugs.launchpad.net/bugs/2071821)"
+msgstr ""
+
+#: ../../24.04/2.md d1ccee5b215544de8a949923bed5f7af
+msgid "Support Intel IPU7 MIPI camera"
+msgstr ""
+
+#: ../../24.04/2.md 1066079fd70147769cd6cfa8ab98a9fa
+#: 8ec554097b074cc88529b9504c371a64 9415b199ec394b479c1660331ca6acf0
+#: 972db75ca1414e0098f7ac2e3fb6f8a9 ab7e943d5a204007adb3e738dc011f20
+#: afb87e79e8f94d8b8903201c616549f2 e3d12887271a4e1287bcb3bfd0791a86
+msgid "flash-kernel"
+msgstr ""
+
+#: ../../24.04/2.md aa3986c694554008b4992aaa295739b1
+msgid "[2065380](https://bugs.launchpad.net/bugs/2065380)"
+msgstr ""
+
+#: ../../24.04/2.md fb6c025a0e1b4719a5aad7eb7551f4ca
+msgid "db/all.db: Support for Qualcomm x1e80100 CRD board"
+msgstr ""
+
+#: ../../24.04/2.md 21cc24adfdb1422d860edf82a2230c96
+msgid "[2079024](https://bugs.launchpad.net/bugs/2079024)"
+msgstr ""
+
+#: ../../24.04/2.md 42b5f47a8ff641c09740cb81c439d8c7
+msgid "Update mt7925 BT FW to avoid  bluetooth_obex_send failed"
+msgstr ""
+
+#: ../../24.04/2.md 0e763d97369c4f0a8e220a804737d545
+msgid "[2080214](https://bugs.launchpad.net/bugs/2080214)"
+msgstr ""
+
+#: ../../24.04/2.md b35eeb971547429eb868b4947def6e9c
+msgid "Missing DMC firmware for Xe driver for Intel BattleMage"
+msgstr ""
+
+#: ../../24.04/2.md c28d2aa9e0c443d39e138e3189ee335e
+msgid "[2080371](https://bugs.launchpad.net/bugs/2080371)"
+msgstr ""
+
+#: ../../24.04/2.md ff312575119d4b5abe3f3b3b8479c716
+msgid "Add firmware for Cirrus CS35L54"
+msgstr ""
+
+#: ../../24.04/2.md 56f78ff1edab4b7dab7186fa2b02431c
+msgid "[2071698](https://bugs.launchpad.net/bugs/2071698)"
+msgstr ""
+
+#: ../../24.04/2.md 98bffbda749f48409125062da80fe381
+msgid "Integrated Sensor Hub (ISH) support for Intel Lunar Lake platform"
+msgstr ""
+
+#: ../../24.04/2.md b3b1b9c95a954a1ba88c407a8f4038d7
+msgid "[2080428](https://bugs.launchpad.net/bugs/2080428)"
+msgstr ""
+
+#: ../../24.04/2.md b5d2d2b28854456eb3edf3a21b29d16e
+msgid "Updating firmware disabled QCOM WiFi WCN7850 on T14 Gen5 AMD"
+msgstr ""
+
+#: ../../24.04/2.md f0d55aa4e5b147ceba75ed2a13dc6ce6
+msgid "[2078525](https://bugs.launchpad.net/bugs/2078525)"
+msgstr ""
+
+#: ../../24.04/2.md 480024964ebd4236a27021cce8268fe2
+msgid ""
+"Add dtb-probe script to handle missing bcm2710-rpi-zero-2-w.dtb in some "
+"of the 5.15 series kernels"
+msgstr ""
+
+#: ../../24.04/2.md 544fe5d2df9e48acba3d80ca41fffdcc
+msgid "[2082044](https://bugs.launchpad.net/bugs/2082044)"
+msgstr ""
+
+#: ../../24.04/2.md e5269775a1294c6392f45d8b4a98f852
+msgid "New upstream release 550.120"
+msgstr ""
+
+#: ../../24.04/2.md 22bce3589a4d4f8883e869b31f01a86e
+msgid "[2084013](https://bugs.launchpad.net/bugs/2084013)"
+msgstr ""
+
+#: ../../24.04/2.md 269b18e5846143eb885b1e9c6a9b4bc7
+#: 72c0f4a0c01e48e4b559cb7dcd577807
+msgid "nvidia-graphics-drivers-550-server"
+msgstr ""
+
+#: ../../24.04/2.md ef458532fdd54c2a9187b7cfddf6e3e8
+msgid "[2084914](https://bugs.launchpad.net/bugs/2084914)"
+msgstr ""
+
+#: ../../24.04/2.md a2f2180c651c456599f5499059e08563
+#: a612a8b08afe44b49aa0476fb1981e33 fe438faf69a84091b204faa631b24ae2
+msgid "linux-gcp"
+msgstr ""
+
+#: ../../24.04/2.md 23dfb9f2d7e84ba9882f072cc32999e9
+#: b67e8b83de61465683a317d4c751ba1c
+msgid "[2077306](https://bugs.launchpad.net/bugs/2077306)"
+msgstr ""
+
+#: ../../24.04/2.md 1a9d33c8e81c46af97cfd7e0d1e5327a
+#: a5062776c8d2473b8c599b3b3b5dcf03
+msgid "Remove obsolete build flags in derivative kernels"
+msgstr ""
+
+#: ../../24.04/2.md 052ce4aec7824d5cbbba3d5810e62a2d
+#: 07b68f69c0c4412f9aa35daf7d1718a4 09a618e1cfd94d55ad786fe46f2ee1ea
+#: 09fbc4e24ff849ac8d7062aaf5b222f2 0d1db99e902341fe8d64bee80b7328bf
+#: 0f91f7c683b54263932c9e994ee845f6 14d50c18423544b8a66b4feb1fcf3518
+#: 16c161fe1db340a4b9b97d496bb83ede 177561ad92f74f339cd5fe95c091bf3c
+#: 1fe6d915e1ee4b169cc9e9587b762f93 21e8567fb1b0461c8eb91779374356d0
+#: 260a4556b27541708cdbc75209d5d08c 2639dfb4bd4f4fec87a907cefdb552e5
+#: 271d50024ca0429e8af2e08fb883f655 27c075de0406411c91d6b85cdaf5e3b3
+#: 29f0ef404f544790812cfbe9ad7e0711 2d668fd02d5c440ebdfce4aa571e3230
+#: 2d9c3dc7367149dabf1b41aad6f0c538 2ff9da0965a743b3832281a4819118cc
+#: 30e6ef77e0174a2c82b4d52c7cc7de51 4510806d4e0440239eebfab1fc54daa6
+#: 4b1ce132bdde496fb33768af037e138d 4f5a32adc62a4b8e947729150861d86d
+#: 50dae72b817f4af9b60285ea3735fa44 57a86785e6514f9aa6667b1f90534f24
+#: 59fa610be8de48aea6cf734b00597d3b 5da85cd5342346068ee79d67cccc27e4
+#: 5dbac77cf548442b865ed92046d1dbfc 676e61dc04cc495cb791cdca92cbdbe1
+#: 6be37ed274514827ab9a8a4eeb1475f7 706537974cfb448da994afe17320e429
+#: 7309390bf9dd49beb3e0e4b657edaf66 77faec86cc554b69a2b5e1779658bca7
+#: 789d283fa9044e458bc076ad2c0f718b 7ec1b7f28a0d4a7bb96822a1ce49ed02
+#: 7f47e9493b134676834a3b2ae07a0738 8553a29f37614ae5abae53d5ed5034a5
+#: 866200f5e7914e6982d135a7e0d18887 8bfe10c3e46a499f9557df2d2324d04a
+#: 8ce6ede8025d435daf69147180ef3c4c 94f5327d62664c90aa8eda91b69ef007
+#: a005d910bcd841bfb18552fe43f2545d ad2ce40f02b3426980ea1b66620f3673
+#: aec1a94d69c74391b9db3f8f2e06775a b130a2df31cd4eb7afec9a397c3e915a
+#: b29b1ea5adb54bc987428444781245f5 b564a711c24a4d67b4e8908cff8beb6c
+#: b9a7650ecf4741eab3a9ece842823250 c40adb2a9d97493aa6cc4e0a1ea3d482
+#: c7f1fe695a2a4f6488bb91e47521fa53 c94496dc0088498b93a9b6eb7e1f2d3a
+#: cad20b19c83b4b9faad184784de3d27c d99cc6b5d36e410dad64a91defe615ba
+#: e0857303ca214dcbbef5a794b6513e05 e0ae473dded34619a0021d96f5bba931
+#: e2ca3251cfd4424c988d8af42afa32f1 e38a01e8bcc44d09851dca92b9393118
+#: e4b112d91ac14326931ba2115a395723 ef352c9f3a0a4c9b8d5357016b607403
+#: f05c827bab694813a174f546eddcda41 f10aadbaced44512b2b18753b86d0fc4
+#: ff4c565fd1f2471899e2e97cceb804dd
+msgid "linux-oem-6.11"
+msgstr ""
+
+#: ../../24.04/2.md 585f597f68774c718bf632e92a8129a4
+msgid "[2085504](https://bugs.launchpad.net/bugs/2085504)"
+msgstr ""
+
+#: ../../24.04/2.md 9072b260b48b46b799960b93a226aa50
+msgid "iwlwifi 0000:00:14.3: Failed to start RT ucode: -110"
+msgstr ""
+
+#: ../../24.04/2.md 466c6f5033464b9d9a3841846816869e
+#: 7dcc2a73fb6c4a39863ff829ffe789fa ba255902686f4b3a886b1f4c91b5c560
+msgid "[2085485](https://bugs.launchpad.net/bugs/2085485)"
+msgstr ""
+
+#: ../../24.04/2.md 053dae6b51064edeba177565099fb01d
+#: 575960a4a119499ab9264425126da846 bb5d72c2de0044a78d6775ef53414edd
+msgid ""
+"Bluetooth[8086:a876] crash with \"hci0: Failed to read MSFT supported "
+"features (-110)\""
+msgstr ""
+
+#: ../../24.04/2.md 42d529a09e2f453ea22e19caf5a9847b
+#: 59239c30f7cb45619e8556d816b4e092
+msgid "[2085456](https://bugs.launchpad.net/bugs/2085456)"
+msgstr ""
+
+#: ../../24.04/2.md 826851b05ea043b6868e6caa237dd296
+#: 8b5ffb2c42e6454ba0c7387799c3ed83
+msgid "Fix phantom monitor on some machines with kernel 6.11"
+msgstr ""
+
+#: ../../24.04/2.md d0d2cefb19fe4440b4ee29cacacd6a8a
+msgid "[2085437](https://bugs.launchpad.net/bugs/2085437)"
+msgstr ""
+
+#: ../../24.04/2.md 81f3e284092d49cfa574e7f22a7ebf75
+msgid "BT Switch cannot open under Ubuntu 24.04 LTS on MT7920"
+msgstr ""
+
+#: ../../24.04/2.md 381c9754357f434fbe0311a868fae5fa
+#: 43ee2802e0a142158e055f987ebe74ef b6d624d9fad54a88bc788f392e1d7414
+msgid "[2084059](https://bugs.launchpad.net/bugs/2084059)"
+msgstr ""
+
+#: ../../24.04/2.md 554be4002c7c4614b28c5716b13122e7
+#: 604e28e8c8e049f4952bea51dd3f5948 88d269d63d7744e7b6008de5de0bbf61
+msgid "OVTI08F4:00: number of CSI2 data lanes 2 is not supported"
+msgstr ""
+
+#: ../../24.04/2.md a94820c87a384f9fab8bc48360b09f90
+msgid "[2085410](https://bugs.launchpad.net/bugs/2085410)"
+msgstr ""
+
+#: ../../24.04/2.md a12ad6fc9dce492cb3bc4eb27f73e6f1
+msgid "Fix USB device suspend failure while HCD in S4 wakeup"
+msgstr ""
+
+#: ../../24.04/2.md 88dbce8ada654e63ab1c44b371778181
+msgid "[2085398](https://bugs.launchpad.net/bugs/2085398)"
+msgstr ""
+
+#: ../../24.04/2.md 78659c6dae07442fbdd2ad89d8f2cfb8
+msgid ""
+"The ASPM is disabled on Realtek NIC which prevents the system  from "
+"entering s0ix"
+msgstr ""
+
+#: ../../24.04/2.md 4ca0100132704c028120a33985460192
+msgid "[2082225](https://bugs.launchpad.net/bugs/2082225)"
+msgstr ""
+
+#: ../../24.04/2.md ff9f4516e33b400780bc9b9ffc449740
+msgid ""
+"Service LED will show 1A8W when unplug WD22TB4 with TBT3 HDD then resume "
+"from suspend"
+msgstr ""
+
+#: ../../24.04/2.md c3f797fa527244a5bf2efc8fc1c2e8e1
+msgid "[2077941](https://bugs.launchpad.net/bugs/2077941)"
+msgstr ""
+
+#: ../../24.04/2.md 829a04b19ddd4701bc59c88c624a6f54
+msgid "AMD ACP7.1 support"
+msgstr ""
+
+#: ../../24.04/2.md d82d8fc71f4848338e1d7b81285fe52e
+msgid "[2081866](https://bugs.launchpad.net/bugs/2081866)"
+msgstr ""
+
+#: ../../24.04/2.md 5c9539c7ae8d4c23b974cb22017c3136
+msgid "Support ov05c10 camera sensor in Intel ipu-bridge"
+msgstr ""
+
+#: ../../24.04/2.md 3b1ebe0913e64238bd691bafdd4d530e
+#: a6d526cac76e4aa19070a2a21ece1dd4 e23175d24f4c48f3b8c81521871db506
+msgid "[2084808](https://bugs.launchpad.net/bugs/2084808)"
+msgstr ""
+
+#: ../../24.04/2.md 0fdc5bcb64a54561be0d90a0045ca079
+#: a617e6245a304516bba96bb926dcea8b ab233a394058457b8b453e5710a6892d
+msgid ""
+"Dell Alienware system reports errors of dell_wmi_sysman and dell_smbios "
+"in dmesg"
+msgstr ""
+
+#: ../../24.04/2.md 06eb5e5a8b9b4975a1cc6fee4b13ef3b
+#: 1d6c485ceed641cb9664a94fbe1f5602 d8a9f7afc8bc48429819ab280654bd96
+msgid "[2081130](https://bugs.launchpad.net/bugs/2081130)"
+msgstr ""
+
+#: ../../24.04/2.md 284ea1868c2248fbb693cef18b2f2876
+#: cf6e4f855d924ec1b92ee0c485f7dbf8 da93e7af9f4d45b0b2686c4062cc614c
+msgid ""
+"Intel(R) PRO/1000 I219 ethernet adapter [8086:550c] may block entrance of"
+" modern standby"
+msgstr ""
+
+#: ../../24.04/2.md db820daf714e4a209cf0002902babdb4
+msgid "[2084759](https://bugs.launchpad.net/bugs/2084759)"
+msgstr ""
+
+#: ../../24.04/2.md a3aa5000ef884d86bc15e16bd2f6e466
+msgid ""
+"Fix distorted sound output after suspend more than 30 seconds on Cirrus "
+"audio codec"
+msgstr ""
+
+#: ../../24.04/2.md 8482ab1431544a06979c3208dc9ac6d5
+msgid "[2083800](https://bugs.launchpad.net/bugs/2083800)"
+msgstr ""
+
+#: ../../24.04/2.md 96728b3f5bd84162b0fea826dab369ca
+msgid "Dell AIO backlight is not working, dell_uart_backlight module is missing"
+msgstr ""
+
+#: ../../24.04/2.md 14529a8eee674593b3d39b2f619e0920
+#: 17846c8762de4e1188357ffdc11a86e7 c1c69b58062d4c158bbe28e2ac80b1f5
+msgid "[2083905](https://bugs.launchpad.net/bugs/2083905)"
+msgstr ""
+
+#: ../../24.04/2.md 3ddc738b5da341fcbb543fd4d42e4651
+#: 5f01dc05d7d047339bd2c81ea0f8c6b5 f90cafe05e94424e8de7fc4509220dfd
+msgid "Add Intel Arrow Lake-H LPSS PCI IDs"
+msgstr ""
+
+#: ../../24.04/2.md 7401ae179b7d414dacc5faf350f0b77f
+#: a795b668da46476c9f667687795bd22f d20915c562554e4e958ede76de052ba3
+msgid "[2083292](https://bugs.launchpad.net/bugs/2083292)"
+msgstr ""
+
+#: ../../24.04/2.md 07fcd61acd84491f8ff4f3630816980d
+#: 15893dd5f28b443aa6cbfa7c1f62c6e3 aacc91f3770d4fed821705e31a592531
+msgid "Missing device ID for amd_atl driver for AMD Strix platform"
+msgstr ""
+
+#: ../../24.04/2.md 4e2b0a86f4f443068335fc1a5fc61227
+#: 4f0c1b5605e647f5b464fb534f4a7c35 6d1d993613eb4c4297c0b7a55f140565
+#: 753bc3f21bbf48ba8a1b672321d64af3
+msgid "[2079017](https://bugs.launchpad.net/bugs/2079017)"
+msgstr ""
+
+#: ../../24.04/2.md 228a8a4c542f48c9bdb756b16976b0a4
+#: 88edded9117147bc889f7ac16b2d0bca c3e0fc459bca47ae858a2daaf9089f9c
+#: f1ec8582104f4596bcec2b608defa3d6
+msgid "Need driver support for Realtek RTL8126A rev.b 5Gbps ethernet [10ec:8126]"
+msgstr ""
+
+#: ../../24.04/2.md 96efbd59b739487fb9fc07e4e0968fe9
+#: c5ffda99245e4dcb907c058dec8eaea5 f7d8ed9c425b4b36a1e392d984fc9c2e
+msgid "[2078773](https://bugs.launchpad.net/bugs/2078773)"
+msgstr ""
+
+#: ../../24.04/2.md 63a4010f53154e7cab63f695e37c79c3
+#: 69924e6008fe4d169ebacf0e24fec0a5 a74a4c55821345918e71fe6a07f25058
+msgid ""
+"Missing devices nodes for AMD Instinct MI300 card when installed along "
+"with integrated display"
+msgstr ""
+
+#: ../../24.04/2.md 5198fa186040434d856cd3b5022162ef
+#: bc35e04baefd4268aebb75e7d7baec2b fd727e618c6744ed9cd5886dcb69cb53
+msgid "[2081796](https://bugs.launchpad.net/bugs/2081796)"
+msgstr ""
+
+#: ../../24.04/2.md 3ed0ec80716d4ce3bcabd6fa38468e97
+#: 66ee89bee83b446884ad842dad7e09c9 d3386f9dcd364fe583c5ef2b71de67ee
+msgid "Support Qualcomm WCN7851 Dual Bluetooth Adapter 0489:E0F3"
+msgstr ""
+
+#: ../../24.04/2.md 9a2b5c86f46f47f49416264a1346ad71
+#: a29e6c4fc5ac41eab0cd934dc724b1dd e8ef4d701c7547ee8287760c0d387a95
+msgid "[2081810](https://bugs.launchpad.net/bugs/2081810)"
+msgstr ""
+
+#: ../../24.04/2.md 49305a0496d94afe820baaa3f0c5d4ae
+#: 66c469bee908436e99389b649eb1514c c935d6bcc52e4d99ac09ed134e7725c0
+msgid "uncore: Add ARL and LNL support on 6.11"
+msgstr ""
+
+#: ../../24.04/2.md 3e4613b953da4105bce55dcfc6090e9a
+msgid "[2083845](https://bugs.launchpad.net/bugs/2083845)"
+msgstr ""
+
+#: ../../24.04/2.md 2a5d530ee2594111a8b473176e8573f8
+msgid "Setting I/O scheduler to 'none' causes error in oracular"
+msgstr ""
+
+#: ../../24.04/2.md 7a109c8b45b94c5f8c7a68597d86358d
+msgid "[2087815](https://bugs.launchpad.net/bugs/2087815)"
+msgstr ""
+
+#: ../../24.04/2.md 52dd124eb50044ce85a502c09cbb5e83
+msgid "Stalls unless C-states disabled - Intel Lunarlake"
+msgstr ""
+
+#: ../../24.04/2.md afb2fbbe985c405c9c4a94d02062a028
+msgid "[2085945](https://bugs.launchpad.net/bugs/2085945)"
+msgstr ""
+
+#: ../../24.04/2.md d6e833f7f606469e8fee34711e97c23b
+msgid "Unreadable thunderbolt nvm_version under sysfs"
+msgstr ""
+
+#: ../../24.04/2.md f43e0a333d2f4c49a77357622a2b147b
+msgid "[2086668](https://bugs.launchpad.net/bugs/2086668)"
+msgstr ""
+
+#: ../../24.04/2.md 9cff0d82ca04492bb1dff4c21762c60e
+msgid "NVIDIA WANR_ON call trace right after power on or resumed on 6.11 kernel"
+msgstr ""
+
+#: ../../24.04/2.md 6f1cbba60efc46cc9f9b73c97bfb8929
+msgid "[2085853](https://bugs.launchpad.net/bugs/2085853)"
+msgstr ""
+
+#: ../../24.04/2.md 107a2df98c9640c5ad98babe40b48e71
+msgid "Ubuntu 24.04 LTS OS can't install on the nvme(on PCH) with raid on mode"
+msgstr ""
+
+#: ../../24.04/2.md 7aaf2ec76cba4cd7b814098929022765
+msgid "[2085777](https://bugs.launchpad.net/bugs/2085777)"
+msgstr ""
+
+#: ../../24.04/2.md 35b5928c82f04fc8930979cdb33f3711
+msgid "Internal microphone recording voice with noise on Dell D14 AIO systems"
+msgstr ""
+
+#: ../../24.04/2.md 95ba35c1c7ee463b8847b6eabd2d9d92
+msgid "[2080634](https://bugs.launchpad.net/bugs/2080634)"
+msgstr ""
+
+#: ../../24.04/2.md f200caf6ccbb414e982acd4160b084c3
+msgid "Add support for GC 11.5.2 in amdgpu"
+msgstr ""
+
+#: ../../24.04/2.md e5653b75f5a54912be5b91499fec8291
+msgid "[2075564](https://bugs.launchpad.net/bugs/2075564)"
+msgstr ""
+
+#: ../../24.04/2.md def5c0f52d80430a8ae25a510c66112e
+msgid ""
+"Missing fw for Intel Wi-Fi 7 BE201 on Lunar Lake platform: iwlwifi-"
+"bz-b0-fm-c0-*"
+msgstr ""
+
+#: ../../24.04/2.md fbc882fd7d7b4732a9e9ade8aea00a97
+msgid "[2076073](https://bugs.launchpad.net/bugs/2076073)"
+msgstr ""
+
+#: ../../24.04/2.md ffb25d0030d1472297e67b570c34e058
+msgid "Support Mediatek MT7920e"
+msgstr ""
+
+#: ../../24.04/2.md b9141bd0a56a4a6d98cabfbbe469c752
+msgid "[2083833](https://bugs.launchpad.net/bugs/2083833)"
+msgstr ""
+
+#: ../../24.04/2.md 3f194f70ca394f13a1343f4b936858f8
+msgid ""
+"GSC firmware too old for ARL, got 102.0.0.1655 but need at least "
+"102.0.10.1878"
+msgstr ""
+
+#: ../../24.04/2.md f8cb75f5285c4c2abb1477faafe4bea2
+msgid "[2084504](https://bugs.launchpad.net/bugs/2084504)"
+msgstr ""
+
+#: ../../24.04/2.md 9a72e20c84c945a992bcc306bd35fba9
+msgid "Fix regression and add more region support of QCOM WiFi WCN7850"
+msgstr ""
+
+#: ../../24.04/2.md 14940c11eb8841dda3d0ea13ab1a9d31
+#: a705f75db1fa453db387dacf2bc889f4
+msgid "[2077829](https://bugs.launchpad.net/bugs/2077829)"
+msgstr ""
+
+#: ../../24.04/2.md 81c24b9d7fe64d2ab5a28ee9df79d669
+msgid "Missing CS35L56 sof firmware for Dell Bolan platform"
+msgstr ""
+
+#: ../../24.04/2.md 2f22ed07500c41ada6b2e0e62c4383f8
+msgid "[2086749](https://bugs.launchpad.net/bugs/2086749)"
+msgstr ""
+
+#: ../../24.04/2.md a362f4f7c9d74885bba117aa91972822
+msgid "Add BT firmware of Intel BlazarI core"
+msgstr ""
+
+#: ../../24.04/2.md 8a803b1d6d304d7cbef28fb5acb36171
+msgid "dmidecode"
+msgstr ""
+
+#: ../../24.04/2.md 618c8227d5864be4b20eb0172c56d57c
+msgid "[2081611](https://bugs.launchpad.net/bugs/2081611)"
+msgstr ""
+
+#: ../../24.04/2.md 2172f31d691e4a9a9288e64b6e70a71d
+msgid "Add processor support from SMBIOS 3.6.0"
+msgstr ""
+
+#: ../../24.04/2.md 12870097853a4ac488a3f9b57c11f1d0
+#: 14e0be818f264b1c8c921af2a16f12ee 40f7d9f98c674896930f40873f8eb267
+#: 9244521d78974db496d14baf98e42fe0 ef11bee730b24252a835f7bfc30a6b5b
+msgid "firmware-sof"
+msgstr ""
+
+#: ../../24.04/2.md 0b0981687f1444f1aa080ed25a6e8176
+msgid "Missing CS35L56 sof firmware for Dell Bolan platform."
+msgstr ""
+
+#: ../../24.04/2.md 84c7d25ae58e48539d066920553f737a
+msgid "Soundwire support for CS42L43 and CS35L56 on Intel MTL."
+msgstr ""
+
+#: ../../24.04/2.md e556c5511af84572819c1c62d73aeca4
+msgid "[2069417](https://bugs.launchpad.net/bugs/2069417)"
+msgstr ""
+
+#: ../../24.04/2.md a8d3e6f8abc047628d3a0bf84adcd62c
+msgid "Soundwire support for the Intel LNL Gen platforms."
+msgstr ""
+
+#: ../../24.04/2.md 8023bad9ae3545d283b54e36350579bd
+#: 9144c31ddc96478faac09028cc3075f4
+msgid "linux-firmware-nvidia-tegra"
+msgstr ""
+
+#: ../../24.04/2.md c6f57a08c47c4a1cbc975a5c6c0fff68
+msgid "[2086716](https://bugs.launchpad.net/bugs/2086716)"
+msgstr ""
+
+#: ../../24.04/2.md 0298b2aa891341b0aed35002b4933066
+msgid "No change upload to noble for hardware enablement;"
+msgstr ""
+
+#: ../../24.04/2.md a9e915e788f1482d978f237d2d9a939c
+msgid "[2088052](https://bugs.launchpad.net/bugs/2088052)"
+msgstr ""
+
+#: ../../24.04/2.md 57d67a0ad74144af9c053ffac1fd98a4
+msgid "New upstream release 535.216.03"
+msgstr ""
+
+#: ../../24.04/2.md 0382e2997c1d4ccbb7abb617ae26c756
+msgid "[2085502](https://bugs.launchpad.net/bugs/2085502)"
+msgstr ""
+
+#: ../../24.04/2.md c657edf3331746b29c3ee75741d5711d
+msgid "New upstream release 550.127.08"
+msgstr ""
+
+#: ../../24.04/2.md 35d80a22721a4daea5ae56808bf02c02
+msgid "nvidia-graphics-drivers-565-server"
+msgstr ""
+
+#: ../../24.04/2.md 87fbf4d52fd149cc97cca53f3cf79fca
+msgid "[2085094](https://bugs.launchpad.net/bugs/2085094)"
+msgstr ""
+
+#: ../../24.04/2.md 357a5371a7b84dfeab34a2916e0d6612
+msgid "open-iscsi"
+msgstr ""
+
+#: ../../24.04/2.md 0f0e226f1e3c492e83e7aed7f99086fb
+msgid "[2073846](https://bugs.launchpad.net/bugs/2073846)"
+msgstr ""
+
+#: ../../24.04/2.md a9029bfc2c1843e191d9021d67f9395e
+msgid "fix setpriority issue for linux kernel version >=6."
+msgstr ""
+
+#: ../../24.04/2.md 88b7631ea0c14e169558d9c6250a3248
+msgid "[2088151](https://bugs.launchpad.net/bugs/2088151)"
+msgstr ""
+
+#: ../../24.04/2.md a044901de098410cb39c44bcb0bbe49e
+msgid "Intel Be201 Bluetooth hardware error 0x0f on Arrow Lake"
+msgstr ""
+
+#: ../../24.04/2.md 8d42e4c17db7402e8de0b582e69a49e5
+msgid "[2089515](https://bugs.launchpad.net/bugs/2089515)"
+msgstr ""
+
+#: ../../24.04/2.md 0b26235b424646b39b71b0fdf44d157e
+msgid "Adds support for the 1AH AMD CPU models for PMF driver"
+msgstr ""
+
+#: ../../24.04/2.md a9acb49b01c743d2adc4e20daabb9df2
+msgid "[2089199](https://bugs.launchpad.net/bugs/2089199)"
+msgstr ""
+
+#: ../../24.04/2.md d6b126993c774bc381a9b155caafd655
+msgid "Boot freezes with cs42l43 soundwire codec"
+msgstr ""
+
+#: ../../24.04/2.md 368a36071032494b865ddd582f6b35a2
+msgid "[2088972](https://bugs.launchpad.net/bugs/2088972)"
+msgstr ""
+
+#: ../../24.04/2.md 4a1fe2da21ac43e7a3f7fb5f51b92ef3
+msgid "DP/MST Bandwidth issue when connect dual 4k@60Hz or 5k@120Hz on a dock"
+msgstr ""
+
+#: ../../24.04/2.md 04b24e3e9c3a44fa807a769a0c4ab2b4
+msgid "[2088964](https://bugs.launchpad.net/bugs/2088964)"
+msgstr ""
+
+#: ../../24.04/2.md 1e21a8dbf4374082b3e68bff057eee55
+msgid "Disable C1 auto-demotion during suspend for MTL/ARL/LNL platforms"
+msgstr ""
+
+#: ../../24.04/2.md 979cd466942e4daba2b41987bbab8537
+msgid "[2088414](https://bugs.launchpad.net/bugs/2088414)"
+msgstr ""
+
+#: ../../24.04/2.md 529b686a9e8343fd8c424f19288f844a
+msgid "Dell Alienware system reports error of dell_smbios in dmesg"
+msgstr ""
+
+#: ../../24.04/2.md aa32aee7ef3a4a3dbf466fa041caf013
+msgid "[2084693](https://bugs.launchpad.net/bugs/2084693)"
+msgstr ""
+
+#: ../../24.04/2.md b17394e8021e4fe1bf935901619862f2
+msgid "Allow overriding Rust tools"
+msgstr ""
+
+#: ../../24.04/2.md 5992f3f090c24fa5afc519e370359aee
+#: e0facd57a19947ebb590ea267b4c3e1c
+msgid "[2083559](https://bugs.launchpad.net/bugs/2083559)"
+msgstr ""
+
+#: ../../24.04/2.md 9fc902da06b642c59119909c5eeb1bb1
+#: ac091170633b4337b2e89e100f2cc2ff
+msgid "Lack of UART boot output on rb3gen2 even with earlycon"
+msgstr ""
+
+#: ../../24.04/2.md 7bfc2b18aed44a379f432c92e7592383
+#: b2e1d3fcbd744694bd7e36ba3c5e8eec
+msgid "[2078878](https://bugs.launchpad.net/bugs/2078878)"
+msgstr ""
+
+#: ../../24.04/2.md 29f45a1823a54c86a56f49b85ea7240f
+#: e5e1eb82a0a04c059adfc0b4ca843c8e
+msgid "Missing Bluetooth device IDs for new Mediatek MT7920/MT7925"
+msgstr ""
+
+#: ../../24.04/2.md 151e1b75a3594d2b9b272a013bd71456
+#: b8947dccdb6d4db78e8e56e77a7e6111
+msgid "[2077384](https://bugs.launchpad.net/bugs/2077384)"
+msgstr ""
+
+#: ../../24.04/2.md 4a3542be73054849beed67d6d80f8857
+#: 78a42c3032b6408daf8fbd46ac108d2c
+msgid "rtw89: Support hardware rfkill"
+msgstr ""
+
+#: ../../24.04/2.md fd810b5490da46709c45dcbbd6aa14bb
+msgid "thermald"
+msgstr ""
+
+#: ../../24.04/2.md 8e0a3f3a9a244f2f8b724f99e33ead49
+msgid "[2087816](https://bugs.launchpad.net/bugs/2087816)"
+msgstr ""
+
+#: ../../24.04/2.md c051ad5f656743e2ae336753de0abfd9
+msgid ""
+"Include patches for Intel Core Ultra Processors (Series 2) support, also "
+"known as Lunar Lake M and Arrow Lake"
+msgstr ""
+
+#: ../../24.04/2.md 1604baa812c945dd81c8aee2da38ed37
+#: 45a84b39ae3542b989716e4cf9f759ae
+msgid "[2080970](https://bugs.launchpad.net/bugs/2080970)"
+msgstr ""
+
+#: ../../24.04/2.md 03940714814040ab9da5680fd2d868fb
+#: ef0df1c443b742fb82303e0fb417c575
+msgid "Remove backport packaging logic for non-backport kernels"
+msgstr ""
+
+#: ../../24.04/2.md 2fa2e7c3934a4839b70b1bbe5863a6a0
+#: 61cd042292304a2180664746a7e45eda
+msgid "[2081030](https://bugs.launchpad.net/bugs/2081030)"
+msgstr ""
+
+#: ../../24.04/2.md 46f9a29a06d84a2a811913d83d6174fc
+#: 47258bf3c944420e963d12aafd6b6260
+msgid "Clean up packaging bits"
+msgstr ""
+
+#: ../../24.04/2.md 64828d7a9036464d95d1ea1a9ef35b42
+#: 79c36742b12a4098882eb42a327ee394 95f7d22f23a540189853e7b484fd8465
+msgid "linux-gke"
+msgstr ""
+
+#: ../../24.04/2.md ac6e678110af4b2b9701622151ad8f7b
+msgid "[2069802](https://bugs.launchpad.net/bugs/2069802)"
+msgstr ""
+
+#: ../../24.04/2.md 6f8d29b0846f45fca31af3134e9304f4
+msgid "Add support for AMD-Xilinx Kria noble kernel"
+msgstr ""
+
+#: ../../24.04/2.md 9d89dc2bc5274babb7dcf10d83ed57dc
+msgid "[2077981](https://bugs.launchpad.net/bugs/2077981)"
+msgstr ""
+
+#: ../../24.04/2.md 247aa785e1c7439081c3ea4f048b32b6
+msgid "db/all.db: add HiFive Premier P550 to database"
+msgstr ""
+
+#: ../../24.04/2.md 17108580e5e74f1ebe888fd1d97fdbc9
+msgid "[2086774](https://bugs.launchpad.net/bugs/2086774)"
+msgstr ""
+
+#: ../../24.04/2.md ce95ba429aff4ff8ad91528d85f5c165
+msgid "db/all.db: add CM5 entry"
+msgstr ""
+
+#: ../../24.04/2.md 128f4d83199c4b38b3c3362b6cdc879b
+msgid "[2085538](https://bugs.launchpad.net/bugs/2085538)"
+msgstr ""
+
+#: ../../24.04/2.md e8ca96327f444e04884162906757920b
+msgid "Missing Bluetooth firmware for Intel WiFi 7 AX211/BE200/BE201"
+msgstr ""
+
+#: ../../24.04/2.md 971de8c2268d472692cc12a11edf67ed
+msgid "[2087528](https://bugs.launchpad.net/bugs/2087528)"
+msgstr ""
+
+#: ../../24.04/2.md 8e78a5f5d67c45e38839d2f91c72decf
+msgid "Don't compress binary deb packages"
+msgstr ""
+
+#: ../../24.04/2.md db2a21aec45543639da0415f1d561f11
+msgid "[2089207](https://bugs.launchpad.net/bugs/2089207)"
+msgstr ""
+
+#: ../../24.04/2.md 636b032ae0fc43d18f6aaa65f1eac7cd
+msgid "firmware files for the Cirrus CS35L54 and CS35L56 codecs"
+msgstr ""
+
+#: ../../24.04/2.md 962a9a5dc685435597d884fb33481b08
+msgid "[2085433](https://bugs.launchpad.net/bugs/2085433)"
+msgstr ""
+
+#: ../../24.04/2.md 2b6a68a23cf54a18ac680621cb5a8699
+msgid "Support for newer Dell docks"
+msgstr ""
+
+#: ../../24.04/2.md e5c054a870d64301af5dd39d2a296062
+msgid "[2083801](https://bugs.launchpad.net/bugs/2083801)"
+msgstr ""
+
+#: ../../24.04/2.md a869a4c1cd10467a8fea9479c36387dd
+msgid "Support for mediatek scalar"
+msgstr ""
+
+#: ../../24.04/2.md 620e692b7fc944cfbbe70609d6603f3e
+msgid "oem-somerville-magmar-meta"
+msgstr ""
+
+#: ../../24.04/2.md 36d8b4548dcd4408b0a2bae36074ea33
+msgid "[2084747](https://bugs.launchpad.net/bugs/2084747)"
+msgstr ""
+
+#: ../../24.04/2.md 7092275b65df46d5958e54b42a7aa7e2
+msgid "Meta package for Dell Precision 5690."
+msgstr ""
+
+#: ../../24.04/2.md 215d73fa210f4e9a9313b79e1126b845
+msgid "oem-somerville-muk-meta"
+msgstr ""
+
+#: ../../24.04/2.md 69a459e3665b4f5a90b382ddc4ceac05
+msgid "[2084745](https://bugs.launchpad.net/bugs/2084745)"
+msgstr ""
+
+#: ../../24.04/2.md a07167c88a0241879b878b2c434aa7d3
+msgid "Meta package for Dell Precision 5680."
+msgstr ""
+
+#: ../../24.04/2.md 7b3185a1aff3473098ffa667dff88a29
+msgid "oem-somerville-lapras-meta"
+msgstr ""
+
+#: ../../24.04/2.md be0e96bba1464416b5782f8d40069f0c
+msgid "[2084740](https://bugs.launchpad.net/bugs/2084740)"
+msgstr ""
+
+#: ../../24.04/2.md c4e53b9e111a46628d7a754e2efa0c88
+msgid "Meta package for Dell Latitude 7440/7640."
+msgstr ""
+
+#: ../../24.04/2.md 00979dd374494d2787422cfae1c7501e
+msgid "oem-somerville-lapras-13-meta"
+msgstr ""
+
+#: ../../24.04/2.md 6462575e2a1949db97957cb14467b9fd
+msgid "[2084743](https://bugs.launchpad.net/bugs/2084743)"
+msgstr ""
+
+#: ../../24.04/2.md 9e02be8ba51a4229824653bfb39f8bbb
+msgid "Meta package for Dell Latitude 7340."
+msgstr ""
+
+#: ../../24.04/2.md 224efe983a79424fbb24e12f7f8af609
+msgid "oem-somerville-oddish-meta"
+msgstr ""
+
+#: ../../24.04/2.md ec1ea56b543a4e17a850954a3358f5ed
+msgid "[2084750](https://bugs.launchpad.net/bugs/2084750)"
+msgstr ""
+
+#: ../../24.04/2.md 612e544954e74b90aeff2538bb4eaee9
+msgid "Meta package for Dell Latitude 7450/7650."
+msgstr ""
+
+#: ../../24.04/2.md 94aa14da13f24db1a9f5a725930b90c2
+msgid "oem-somerville-tentacool-meta"
+msgstr ""
+
+#: ../../24.04/2.md c1749a87ae3948f29a8429a26ed8a9cf
+msgid "[2084733](https://bugs.launchpad.net/bugs/2084733)"
+msgstr ""
+
+#: ../../24.04/2.md 3c3ec709625640b99b740f6144fc08e4
+msgid "Meta package for Dell XPS 13 9320."
+msgstr ""
+
+#: ../../24.04/2.md 26350d6cf7b64f709df7d30471b7c12b
+msgid "oem-somerville-oddish13-meta"
+msgstr ""
+
+#: ../../24.04/2.md a625fee88e044a4bbc2bd2a3c1bccff8
+msgid "[2084752](https://bugs.launchpad.net/bugs/2084752)"
+msgstr ""
+
+#: ../../24.04/2.md af220e59369043c4a6adb55839215b07
+msgid "Meta package for Dell Latitude 7350."
+msgstr ""
+
+#: ../../24.04/2.md 1ef90fe04f3340e3bde0f8eaaed14a04
+msgid "oem-somerville-oricorio-meta"
+msgstr ""
+
+#: ../../24.04/2.md aad53dd177ac4a2ca4c9211c59bbdb2a
+msgid "[2084756](https://bugs.launchpad.net/bugs/2084756)"
+msgstr ""
+
+#: ../../24.04/2.md fd7aadb494784a1e866d57114f020b96
+msgid "Meta package for Dell Precision 5490."
+msgstr ""
+
+#: ../../24.04/2.md 3f056e351e544a479114e7b91c1f9c92
+msgid "oem-somerville-tentacool-rpl-meta"
+msgstr ""
+
+#: ../../24.04/2.md 70c4409079184eb6ad5323b244d93887
+msgid "[2084737](https://bugs.launchpad.net/bugs/2084737)"
+msgstr ""
+
+#: ../../24.04/2.md db9805ec48a84146a284c60547a35f4f
+msgid "Meta package for Dell XPS 9320."
+msgstr ""
+
+#: ../../24.04/2.md 417a0b1d6fbb4f9d8d106a235efc08f3
+msgid "oem-somerville-treecko-meta"
+msgstr ""
+
+#: ../../24.04/2.md ece178937f3f412c9583a2cb6e2e5091
+msgid "[2088955](https://bugs.launchpad.net/bugs/2088955)"
+msgstr ""
+
+#: ../../24.04/2.md b6a085af14194147ac8da84ae05fb100
+msgid "Meta package for Somerville Treecko."
+msgstr ""
+
+#: ../../24.04/2.md b6908d36b5f44f5eb230ba73ef9d85b3
+msgid "oem-somerville-torchic-meta"
+msgstr ""
+
+#: ../../24.04/2.md 436a2966d9ad4084ab7fbb06be5936b7
+msgid "[2084754](https://bugs.launchpad.net/bugs/2084754)"
+msgstr ""
+
+#: ../../24.04/2.md 6196b6c9d58e42cab7be6e6b3eead817
+msgid "Meta package for Dell Precision 5480."
+msgstr ""
+
+#: ../../24.04/2.md a980907c24af4149a4fcd4ebef7dd4e6
+msgid "[2092001](https://bugs.launchpad.net/bugs/2092001)"
+msgstr ""
+
+#: ../../24.04/2.md 384da69f5c2943959c6f576824c5fea2
+msgid "Add Arrow Lake U/H support to the intel_pmc_core driver"
+msgstr ""
+
+#: ../../24.04/2.md d652c9f899de4030af7b5d8cc6bdb1ed
+msgid "[2069019](https://bugs.launchpad.net/bugs/2069019)"
+msgstr ""
+
+#: ../../24.04/2.md 458776e42d864730acbe67aeabf4cd75
+msgid "Support AMD Strix-Halo Image Signal Processing (ISP) unit"
+msgstr ""
+
+#: ../../24.04/2.md 3e18359bc8d5452f9ba0fbfd2c97831c
+#: 3ff238ff143145a4bebe806a9c7f66c3 8a02e333e9cb49498a105e0d135370b5
+msgid "[2090932](https://bugs.launchpad.net/bugs/2090932)"
+msgstr ""
+
+#: ../../24.04/2.md 042d07f29fc046dabd122af48645a68d
+#: 240b55b1939c4df7b3b5952021e14501 2a4661fdc8ec4c8ea4596109b47b43ac
+msgid "Failed to probe for OVTI02C1: chip id mismatch: 560243!=0"
+msgstr ""
+
+#: ../../24.04/2.md 630ee7b4e93c40858a4745f88cd25735
+msgid "[2091847](https://bugs.launchpad.net/bugs/2091847)"
+msgstr ""
+
+#: ../../24.04/2.md 25f4296513f8482da5539fea7ad66336
+msgid "Prefer BIOS over PMF on some AMD platforms"
+msgstr ""
+
+#: ../../24.04/2.md 216ee52ce27b4668b19b50b53692f38c
+msgid "[2091837](https://bugs.launchpad.net/bugs/2091837)"
+msgstr ""
+
+#: ../../24.04/2.md d8af5df18611424da338449d587f80c0
+msgid "Adding support for Cirrus sof-soundwire audio on Dell Renegade platform"
+msgstr ""
+
+#: ../../24.04/2.md 7df0bbf6eafd4e7ba55aa704a711dd47
+msgid "[2091856](https://bugs.launchpad.net/bugs/2091856)"
+msgstr ""
+
+#: ../../24.04/2.md bcf84e91efcf402c9b0cc602657e8961
+msgid "Fix unnecessary error messages during optional AMDGPU firmware load"
+msgstr ""
+
+#: ../../24.04/2.md 323281b29e1549a6887e0f318614d962
+msgid "[2091546](https://bugs.launchpad.net/bugs/2091546)"
+msgstr ""
+
+#: ../../24.04/2.md 80b1daeeb46f4614afe0a15776a6ff5a
+msgid ""
+"Intel AX211 wireless module [8086:7740] subsys [8086:4090] wrongly "
+"recognized as BE201"
+msgstr ""
+
+#: ../../24.04/2.md 0022b80909d04cadae73e03f2c8bca37
+#: e8140be9669b49c7995839ada87ed0ef
+msgid "[2089885](https://bugs.launchpad.net/bugs/2089885)"
+msgstr ""
+
+#: ../../24.04/2.md b09b969f82234a8c80e9b4528a8dbfb1
+msgid "Support for Cirrus codec on Taroko RPL platform"
+msgstr ""
+
+#: ../../24.04/2.md 2efdceb48b1347c6a26a401b1a458770
+msgid "Add missing tplg file for Dell Tarako RPL platform."
+msgstr ""
+
+#: ../../24.04/2.md 693f5d2fa19c496fb81524cf481f73fb
+msgid "[2093315](https://bugs.launchpad.net/bugs/2093315)"
+msgstr ""
+
+#: ../../24.04/2.md e83b010087c1406e88a4df515c48275c
+msgid "Stuck forever while accessing HID-SENSOR-200011.5.auto/iio:device1 device"
+msgstr ""
+
+#: ../../24.04/2.md 72a8327bde5142628843fa383d3d3968
+msgid "[2093330](https://bugs.launchpad.net/bugs/2093330)"
+msgstr ""
+
+#: ../../24.04/2.md 7054223018e541bbb3fe7a3bc31dc647
+msgid "Fix audio output fail after resume from suspend with CS42L43 codec"
+msgstr ""
+
+#: ../../24.04/2.md be4fdfd2284c446fb11740a72dfe9e97
+msgid "[2091352](https://bugs.launchpad.net/bugs/2091352)"
+msgstr ""
+
+#: ../../24.04/2.md 1ef14f1478a6443087791f3111ad3ea7
+msgid "Enable Realtek NIC ASPM on one Dell Tower platform"
+msgstr ""
+
+#: ../../24.04/2.md 7d9681433029489daa9698c86aa028e4
+msgid "[2092746](https://bugs.launchpad.net/bugs/2092746)"
+msgstr ""
+
+#: ../../24.04/2.md 8d10ef3a703b43efb0d93879f6ac5d6b
+msgid "mt7925: system will sometimes freeze while rebooting"
+msgstr ""
+
+#: ../../24.04/2.md e24aab17f608455e8c238b63b4f01fe6
+msgid "[2092473](https://bugs.launchpad.net/bugs/2092473)"
+msgstr ""
+
+#: ../../24.04/2.md 60923ba65bc947cb8da2d6606f3d8307
+msgid "Fix system freeze issue caused by the btmtk driver"
+msgstr ""
+
+#: ../../24.04/2.md 0e0c1e25c96d4789b12219fa96e654cc
+msgid "[2092373](https://bugs.launchpad.net/bugs/2092373)"
+msgstr ""
+
+#: ../../24.04/2.md af55895b65e349588d5a8ae4d7878604
+msgid "Hotplug in HDMI cable on the dock leads to many xe driver warning messages"
+msgstr ""
+
+#: ../../24.04/2.md 4c59dce3fe684ff7b1d74c06c5b2bc9e
+msgid "[2092186](https://bugs.launchpad.net/bugs/2092186)"
+msgstr ""
+
+#: ../../24.04/2.md 9d62e4ea79754197a4788c1a9092b0c5
+msgid "xe driver can't detect hotplug monitor"
+msgstr ""
+
+#: ../../24.04/2.md 896d0d7bea7844deb3f6cc71bd6ddb02
+msgid "[2085547](https://bugs.launchpad.net/bugs/2085547)"
+msgstr ""
+
+#: ../../24.04/2.md 070a5f28a36c430c8edb5cf98b1ea104
+msgid ""
+"Intel(R) Wi-Fi 7 BE201 320MHz: Direct firmware load for iwlwifi-"
+"bz-b0-gf-a0-*.ucode failed with error -2"
+msgstr ""
+
+#: ../../24.04/2.md 4efb042652b84adfa962e681198b8233
+msgid "[2092225](https://bugs.launchpad.net/bugs/2092225)"
+msgstr ""
+
+#: ../../24.04/2.md 255d748d5b8e4ef09c19c15441dc38ce
+msgid "Add AMD Navi44/48 support"
+msgstr ""
+
+#: ../../24.04/2.md 7bb0eba72e4b490db70cf711c472f1f1
+msgid "[2093077](https://bugs.launchpad.net/bugs/2093077)"
+msgstr ""
+
+#: ../../24.04/2.md e0d61b4783f14deaaf4a8cd77a555d50
+msgid "Update sof-rpl-cs42l43-l0.tplg to fix Mic Mute LED."
+msgstr ""
+
+#: ../../24.04/2.md 0db7932a5bb14a51918b664e34f818e4
+msgid "wireless-regdb"
+msgstr ""
+
+#: ../../24.04/2.md be3e45652b78497dab2c81f644f64677
+msgid "[2073274](https://bugs.launchpad.net/bugs/2073274)"
+msgstr ""
+
+#: ../../24.04/2.md cc6add2694bb4299ad20632f96851778
+msgid "Backport to noble"
+msgstr ""
+
+#: ../../24.04/2.md c0a6cabe91f7414aab89b92f087fa2b6
+msgid "[2093200](https://bugs.launchpad.net/bugs/2093200)"
+msgstr ""
+
+#: ../../24.04/2.md dbe89ac268f04f30afcf6e1bcbb8db15
+msgid "db/all.db: Add more RISC-V boards"
+msgstr ""
+
+#: ../../24.04/2.md 8253782155194eb39b55179d8a1fd0ca
+msgid "[2092216](https://bugs.launchpad.net/bugs/2092216)"
+msgstr ""
+
+#: ../../24.04/2.md cfdb976ec6774174afac08133391da30
+msgid "db/all.db: Add entry for Raspberry Pi 500"
+msgstr ""
+
+#: ../../24.04/2.md 0add56409c724c369909ab427271e741
+msgid "[2095032](https://bugs.launchpad.net/bugs/2095032)"
+msgstr ""
+
+#: ../../24.04/2.md 2e3f54286d824001a6274330e8cbdf5c
+msgid "New Nvidia Jetson firmware release v36.4.3 (Jetpack 6.2)."
+msgstr ""
+
+#: ../../24.04/2.md 1cd6071c1a654f6ba1a5a91d0febfc26
+#: 2f33b182a84f4d90a1030002f65eab1c 3cf2de1d86634e7db2f7783062337bd6
+#: 56143ef1587d42f6b970f4e6ef52dd40 65185ee222ce423a89ad3ab9fd201fc9
+#: 7193bf5746d446b39ebd2cbd0c70172a 8f10a782e1fd454fb1c7124f6f9f8a5c
+#: a615cc4b2264481683e6906b67c497a8 ca38653e499b4e289d1c3cdefa7058ad
+#: db1733267dc64184a9db856e98b0d0bb e1867290efd341058745474280b1d57e
+#: f1790696cdb64e9a96b504ccdde581f3
+msgid "linux-nvidia-6.11"
+msgstr ""
+
+#: ../../24.04/2.md 1cb784a8fadd4cb9b196e431449bab5b
+#: 38211229d4304ff09521c6da97ec706c
+msgid "[2097240](https://bugs.launchpad.net/bugs/2097240)"
+msgstr ""
+
+#: ../../24.04/2.md 8156b5733fee4a57890f1d89d087f47a
+msgid "Add firmware for 6.11 HWE kernel"
+msgstr ""
+
+#: ../../24.04/2.md 656cbd1a07fd4809890a046f2e5214d3
+#: 7653dc15dd854b48aec280413e33beac e04ae749af284476a763929fe726a503
+msgid "[2089357](https://bugs.launchpad.net/bugs/2089357)"
+msgstr ""
+
+#: ../../24.04/2.md 66d91d41781744dd98740536d6c18d06
+#: a154d6b1a83b4cc5b941a0b9a1b14bd4
+msgid ""
+"Poor bluetooth performance on Lenovo X13s // Add firmware for 6.11 HWE "
+"kernel"
+msgstr ""
+
+#: ../../24.04/2.md 134e2a78b0f547a492953965d9dc0840
+#: 2c492d83155d4994bb2ddecd8300dd40 3ff56f99121c45329c71a89dce656780
+#: 585cfedac4d1470291ac4c48ab47338b 5950a772840f4c96a92daf115862fb1e
+#: 59ba7dcb502e4afdb27fca96549128d9 6c40696247e348b7a5894815825e2adc
+#: 7e92451a81a6478389dfb67f8a26c78f a25751c0e96f4a9682a4d6071d8b7f51
+#: b06e5ae1523f43fe988c709b39583d49 d49ffd0f1cb348e081f69547bf600829
+#: d504944b12214019b7fcf36f281e9bbc da43cff8ac86444fae3fecc69eca39f2
+#: e282c89f625649bb9d09acbc87836d58 e9e0e3f5ff644d31af9858b36ad33c93
+msgid "linux"
+msgstr ""
+
+#: ../../24.04/2.md 6e78f1ae35314b00a6b60d33deb17209
+#: f259881e28a24b3f9aea55648ba6fa71
+msgid "[2093677](https://bugs.launchpad.net/bugs/2093677)"
+msgstr ""
+
+#: ../../24.04/2.md 5a3d7bb264b44fdca2cf69189efaba8e
+#: a0d3f6db1ac74463bb540e6dbac8670a
+msgid "noble/linux: 6.8.0-53.55 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/2.md 24a1bf452b1a49b19394ef432ca95e3b
+#: af14b75f8d6e42c8b728164892a8c44e
+msgid "[2050083](https://bugs.launchpad.net/bugs/2050083)"
+msgstr ""
+
+#: ../../24.04/2.md 33e6b207dbd14458bb724babceee46c8
+#: e167899a992f4cbc959997425c24293c
+msgid "generate and ship vmlinux.h to allow packages to build BPF CO-RE"
+msgstr ""
+
+#: ../../24.04/2.md 542762f6589e4d68bacf5a2e2152b17c
+#: f51fe0bcc6614be092a86d6a1a0b56d4
+msgid "[2091941](https://bugs.launchpad.net/bugs/2091941)"
+msgstr ""
+
+#: ../../24.04/2.md 73fc0e2eff7c487bb0c4ffa874f51370
+#: e397973734ed4c608f091ef269e25532
+msgid "Unable to boot as a guest on VMware ESX"
+msgstr ""
+
+#: ../../24.04/2.md 8c0df64413684c8aac69a7196d56744e
+#: a36c2470b3b64fae80cfc88a55ab8297 b173538a80c146a487270deec8a62e70
+#: c9e831b255b04819af8a952d3d8706cc
+msgid "[2091744](https://bugs.launchpad.net/bugs/2091744)"
+msgstr ""
+
+#: ../../24.04/2.md 4810dd93b1c94423ab2221f6aa7b7ab5
+#: 68e291815f034a86ae2b4564024b3ee1 b112f9a80d3741589ef9a318568527ff
+#: eee1bb16bd744628b7da7193d7b3c007
+msgid "When /dev/vmbus/hv_kvp is not present, disable hv-kvp-daemon"
+msgstr ""
+
+#: ../../24.04/2.md 58a162d3323b4ba3a6edb7a46f0e37a7
+#: 9be1e98117c44689bb4b02d24f8c74b0 b71f7d73c3d34415864d6ebd7202926b
+#: faab969ae38a4b32bd33c45e8f14253d
+msgid "[2091184](https://bugs.launchpad.net/bugs/2091184)"
+msgstr ""
+
+#: ../../24.04/2.md 128f1bf667ff4b5c86f2dbd27691916c
+#: 332b5e9603904564928fe365a61ce5a3 4a97c3f2ba8b48279ff92fcd54ac9392
+#: 5ea219b00d6a4beb861e4a1cb92132e0
+msgid "Backport \"netkit: Add option for scrubbing skb meta data\" to 6.8"
+msgstr ""
+
+#: ../../24.04/2.md 08bf0e68051346e496d7968d0c0c1803
+#: 9a5afb45b3254b7585b1600d863d1a98 9f069cb12300442e9e465245a6800614
+#: b746291537704c95ad32f5b0fa8c71c7
+msgid "[2093146](https://bugs.launchpad.net/bugs/2093146)"
+msgstr ""
+
+#: ../../24.04/2.md 2925c5ff6ad94fe28fc2c1165aeca543
+#: 2b8a257c342948869233a01c2b28e5d5 40baa048d910491f89113d4fa6f3100f
+#: 4a1841882af84b54b55a6d8eae5a3f17
+msgid ""
+"KVM: Cache CPUID at KVM.ko module init to reduce latency of VM-Enter and "
+"VM- Exit"
+msgstr ""
+
+#: ../../24.04/2.md 801abec04fdf4d5eb738197cc4b88283
+#: 8267c4649de04e91b19675993b8fd425
+msgid "[2090852](https://bugs.launchpad.net/bugs/2090852)"
+msgstr ""
+
+#: ../../24.04/2.md 267e9619b9ca4186b0c72d18082a602d
+#: 5f96dd5ef6d449319ae0941dda3d072a
+msgid "power: intel_pstate: HWP interrupt support for maximum ratio changed"
+msgstr ""
+
+#: ../../24.04/2.md 5c3e1f575b5b45f4ae231fd036ed5a40
+#: 983290b8f4f44a4d99199e2532a83417
+msgid "[2089884](https://bugs.launchpad.net/bugs/2089884)"
+msgstr ""
+
+#: ../../24.04/2.md 934d3fc6c963469094409b75281a7d03
+#: da11b45cf9274817ae59138e8d3a1d06
+msgid "Noble update: upstream stable patchset 2024-11-29"
+msgstr ""
+
+#: ../../24.04/2.md 1823d2c4774f4ec7a3ac083262036e40
+#: 5d3a234502b143a38fe325836d9ee1d2 b89f6a2bac2943e288bae4a98a7e7fe0
+#: e3b4f292c593468a94ffbee94268d70e
+msgid "[2089327](https://bugs.launchpad.net/bugs/2089327)"
+msgstr ""
+
+#: ../../24.04/2.md 0acce8597d6c4926a652ed73096c4858
+#: 28083f85f58e49e3b357ddeeeb02755f 769f345a18a6400c9de39c29543d9f81
+#: daa82f4365594d85a4a1f4a5d70be7e2
+msgid "By always inlining _compound_head(), clone() sees 3%+ performance increase"
+msgstr ""
+
+#: ../../24.04/2.md 59682a7f19ff4aafb261c6b7a0e53b13
+#: 843cea2f0549437d8bce18d5ee54168f a7a09008016b48b9bc7bd16b7254f1a6
+#: ec032bfb30b642c7abf2bc555147d8f2
+msgid "[2086587](https://bugs.launchpad.net/bugs/2086587)"
+msgstr ""
+
+#: ../../24.04/2.md 2edb8ae3176445d9bd7f6455790ff790
+#: 8ff0607208df4dbd8fb2fac37efcddae b1ae7ab225034026af9d5fb0262af586
+#: ec67289143f94286a8955d403cc43e71
+msgid "Random flickering with Intel i915 (Comet Lake and Kaby Lake) on Linux 6.8+"
+msgstr ""
+
+#: ../../24.04/2.md 31106e2629e44e0f812395c5d4fb1750
+#: 55a14c88bd034c599351a2ee75ddf6d0 66c800f2e12a4593aaad4646cfa406bc
+#: 87e964c367854e6f840b3b65edab1fc5 89c73491eba9499388cedebbbbdee474
+#: c16092743c0f4f5fb8a36a04cbb882d6 cbab70bd97df42d3b79afd493c61d616
+#: d5c0049e499c45db9681346e6d755b5e
+msgid "[2086606](https://bugs.launchpad.net/bugs/2086606)"
+msgstr ""
+
+#: ../../24.04/2.md 531c016566604e8b98c245512e31f9a8
+#: 616b64d43b674972aaa7c0d49865be48 69833aa148284a5995998a86e6a368e6
+#: 8c3041a9a3c9465fb15996e6dc0bd910 980023937c024ab08ce594c6f2d8e2a9
+#: ba0eac381d3d4643867fd9a7e26301fa c62597ba110343bf9285593faab85a78
+#: e712d2684d5243be8e0da3a09040c657
+msgid "Add list of source files to linux-buildinfo"
+msgstr ""
+
+#: ../../24.04/2.md 099ed50190ca43018f4824d2c1ef952d
+#: 65b5952a437f44a4aa36f1f1c33af51e 66badac782c24a94aae37582cc9cbd79
+#: 9f9647c55fca4a138f93937f86f13687
+msgid "[2087853](https://bugs.launchpad.net/bugs/2087853)"
+msgstr ""
+
+#: ../../24.04/2.md 718298014328473a912dfa1bbc3e6f3d
+#: 7238025bea1c4ef5a5b5d70b53965a57 99abf60c14b644549bb5c7d30ed03751
+#: a4512c7c5a674f5f98977434103fa0d5
+msgid "UFS: uspi->s_3apb UBSAN: shift-out-of-bounds"
+msgstr ""
+
+#: ../../24.04/2.md 265c795fdab04e76bd9c22954a0d8b28
+#: 297f500e83e7417eac657b8319c9ae49 39b884a2a9c043fea7093434a013c484
+#: 7bb3a2a1db4542a0ae4cf2f78b64fafb
+msgid "[2087983](https://bugs.launchpad.net/bugs/2087983)"
+msgstr ""
+
+#: ../../24.04/2.md 226d662010e444bfa140bbb2af89f0dc
+#: 42079ed9a3124be699297b2c6c3ee67e 9fe9ad9c23564defbaf4fe7ea6b79e2f
+#: b97864d668a045aebc2bf431b123fb93
+msgid "Mute/mic LEDs don't function on HP EliteBook 645 G10"
+msgstr ""
+
+#: ../../24.04/2.md 31104909abca434d99a752f4118834e7
+#: 9c97a906daa5456bb4dcdef433d92af1
+msgid "[2089340](https://bugs.launchpad.net/bugs/2089340)"
+msgstr ""
+
+#: ../../24.04/2.md 1115904093ef4af7be557984021a288c
+#: a92d6448440f488fbb70a7c8c8d9daa7
+msgid "Noble update: upstream stable patchset 2024-11-22"
+msgstr ""
+
+#: ../../24.04/2.md 40f10de319614d1a9bf2d9770955ed7a
+#: 5a79ddf136304ce19783e06e079b398b
+msgid "[2087519](https://bugs.launchpad.net/bugs/2087519)"
+msgstr ""
+
+#: ../../24.04/2.md 009523c1f215485e80a9f5212b9aba58
+#: 82f7d7dcaa7144ce9b2ed254151c7270
+msgid "Noble update: upstream stable patchset 2024-11-08"
+msgstr ""
+
+#: ../../24.04/2.md 06c49f22f4ff48498434b29e216ea717
+#: 177ccf4753cc4da19f64f5d01b0bfb4d 20e053f007c740b1b523778157eecf93
+#: 45693e92dc1b4ace86328223bc9b1f31 4de5dddb989843c5944e001f75592d4b
+#: 65624eebff6f49b6bc4b7c73d4ef0157 a48056e39f804708923528de5a53007b
+#: ad0a47ce68b141f589c87edd46457db8 b40ddb042a2c41d1a88345cbd4c3d522
+#: d7092afff4d1414a91d41d354247d812 d753046038fc4cbe8bf5497257425532
+#: dbe50f16eb6d43aca65800798c8e371c e15d728f319b416bacf3167e82ac767d
+#: e44535c971834247ab51c0d8bbc69495 edc71a4242eb40e5a2dbeff31b002931
+#: ef29d3712e7146c4aad1f1c9c12abf72 ffeed715ec6d4f9ebc7c5fcaf1699b9d
+msgid "linux-lowlatency"
+msgstr ""
+
+#: ../../24.04/2.md 3d0095fff30a427691df7b993a432c01
+msgid "[2093660](https://bugs.launchpad.net/bugs/2093660)"
+msgstr ""
+
+#: ../../24.04/2.md acd5f3c676be4058a3c06d4f27764253
+msgid "noble/linux-lowlatency: 6.8.0-53.55.2 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/2.md 107a9afdf1604592a6c7a68fdfc56e3c
+#: 4114c63dbe5d451e9a7527ce5ebbaaa0 6461a57c45ce4a6198d0748de7a92916
+#: 704cb49b68c44ee09eebbae9b2e31e46 86ae07cf3fa7469aadffdd1000e5d1b4
+#: 92829057ee2a4ca2b5a0d0567e33af0b a2d6328d207449ff991a0f75b9912dc5
+#: b01b118672ec461c9a297ff894d57f0e d2068b6facba49fc930b4346c7637c3b
+#: d2bc466b8b95439f9bd6864d5778ee68 d756d91e602a48d7baa4e71d636d7949
+#: e37ad946d22149eb8d69750274e0ee1e ec1933df94104fa795da747c3491fe93
+#: fa0a098e2c974060b006563101d3340b ff3fbbb44db343819a6c40f94d594603
+msgid "linux-hwe-6.11"
+msgstr ""
+
+#: ../../24.04/2.md 7d75dffaa4a442659664d86328dac7e9
+#: fb92e5426a6e40c7896484628890ea87
+msgid "Poor bluetooth performance on Lenovo X13s"
+msgstr ""
+
+#: ../../24.04/2.md 79209e13df7f42da9c4ea97d0fc87a08
+#: b24fc9a9a07440ab9b7fa4b2a65dca96
+msgid "[2091990](https://bugs.launchpad.net/bugs/2091990)"
+msgstr ""
+
+#: ../../24.04/2.md 6112cdf395344113909c5b2d1638ae35
+#: 91639575503049e38a73302173d2f694
+msgid ""
+"ovs/linuxbridge jobs running on ubuntu jammy broken with latest kernel "
+"5.15.0-127.137"
+msgstr ""
+
+#: ../../24.04/2.md 9b778cf209b1469ea0f3e333113dddd2
+#: c14ec88ffb2c4132a1e483bb5254ea79
+msgid "[2085950](https://bugs.launchpad.net/bugs/2085950)"
+msgstr ""
+
+#: ../../24.04/2.md aa728a39f6314c13ae5a3bf118abba57
+#: e1a692c311fe47a6a45962f8e079621f
+msgid "asus: Fix thermal profile initialization on Lunar Lake"
+msgstr ""
+
+#: ../../24.04/2.md 9bbe36555166431787e304f7ce38ae62
+#: a922ac1b1e7c4ed3a9142fdd2bfb3a60
+msgid "[2085944](https://bugs.launchpad.net/bugs/2085944)"
+msgstr ""
+
+#: ../../24.04/2.md 8bdd356315f44b9580ec7a2a6b023745
+#: cd0bad8ff13e4a468293051cf68ae994
+msgid "drm/xe: Fix LNL getting wedged after idling"
+msgstr ""
+
+#: ../../24.04/2.md 0464c41821bd4471b08699048267dc10
+#: 1dd5f0e9c1734e0ca2de636340e184f7 21ae4d7f71444feaae83ae23351470ff
+#: 2a4afbef8a254985b34b535f14b9af19 4286838daa04423baed4c6b8d955191c
+#: 50ff423926e7476989eddcee2ca1cfcc 536db039ac8a493eb351819156e80883
+#: 698227aaf4a7458f9c0053dbf7523a3b 73033cec9ccc444892623612a8f87ee7
+#: 7661fee42a1640cfb733023184fcabcb bbdc29f28276414bb623dceccb5c5cf7
+#: c3a30743d04548d9b02ee8cd25b8d17e c9cdb8748b804035b3922d5d248fe0ac
+#: cd4f0472f6924607a5283228e3d69945 db4902e8e257463b88222cceec4ca33d
+#: e73f4c37c6a146f4b91989c3b90353e5 f21ac19f658a430ea5a9b6e26be0dcf5
+msgid "linux-lowlatency-hwe-6.11"
+msgstr ""
+
+#: ../../24.04/2.md dd836be14a5b481d80f70f8361c1460b
+msgid "[2093633](https://bugs.launchpad.net/bugs/2093633)"
+msgstr ""
+
+#: ../../24.04/2.md 28cb09133c9448799f554b0f8dc192b3
+msgid "noble/linux-lowlatency-hwe-6.11: 6.11.0-1009.10~24.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/2.md:563 9b8d162aa86149d39c84d4007905c885
+msgid "Unsorted changes"
+msgstr ""
+
+#: ../../24.04/2.md 4204b409af284417a397a6f0795d0148
+msgid "tmux"
+msgstr ""
+
+#: ../../24.04/2.md 409490dcc82a47b4a8640523c35e4403
+msgid "[2068393](https://bugs.launchpad.net/bugs/2068393)"
+msgstr ""
+
+#: ../../24.04/2.md d17aed3fe8a64de4854342028c402c7a
+msgid ""
+"d/p/lp-2068393-fix-sixel-invalid-colour-register.patch: Fix SIXEL invalid"
+" colour register crash and remove SIXEL images before reflow."
+msgstr ""
+
+#: ../../24.04/2.md 8f114d9150844bac84ad690ef6b03b62
+msgid "retry"
+msgstr ""
+
+#: ../../24.04/2.md ca47f8524e2848f7aabc317bb787beb8
+msgid "[2080616](https://bugs.launchpad.net/bugs/2080616)"
+msgstr ""
+
+#: ../../24.04/2.md fffd1c82909843bb99d90b4c4ec876ce
+msgid "No change rebuild for MIR promotion"
+msgstr ""
+
+#: ../../24.04/2.md e24ba18ab99649a6aad49c0de7998f6b
+msgid "autopkgtest"
+msgstr ""
+
+#: ../../24.04/2.md 73b58de9f1f04d5e89640ed241d4b513
+msgid "[2071609](https://bugs.launchpad.net/bugs/2071609)"
+msgstr ""
+
+#: ../../24.04/2.md d18dce2f271c4843813e144039dcd538
+msgid "New upstream version"
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/24.04/3.po
+++ b/docs/locale/ja/LC_MESSAGES/24.04/3.po
@@ -1,0 +1,3704 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../24.04/3.md:2 f8d4b9753c304c30ac18843b87d5f539
+msgid "Changes in Ubuntu 24.04.3"
+msgstr ""
+
+#: ../../24.04/3.md:4 fddbb4193281498ebb5ed1e7045d1d82
+msgid ""
+"This is a brief summary of bugs fixed between Ubuntu 24.04.2 and 24.04.3."
+" **This summary covers only changes to packages in *main* and "
+"*restricted*, which account for all packages in the officially-supported "
+"images; there are further changes to various packages in *universe* and "
+"*multiverse*.** Some of these fixes were by Ubuntu developers directly, "
+"while others were by upstream developers and backported to Ubuntu. For "
+"full details, see the individual package changelogs."
+msgstr ""
+
+#: ../../24.04/3.md:12 4342a97fdbee45d49c033f1aecd7f80a
+msgid ""
+"In addition to the bugs listed below, this update includes all security "
+"updates from the [Ubuntu Security "
+"Notice](https://ubuntu.com/security/notices?order=newest&release=noble&details=)"
+" affecting Ubuntu 24.04.2 LTS that were released up to and including "
+"August 4, 2025."
+msgstr ""
+
+#: ../../24.04/3.md:16 ce91248e725c4dbcb177dd98057de988
+msgid "Installation bug fixes"
+msgstr ""
+
+#: ../../24.04/3.md:18 4860dd8b421b44ab9dc16ad7caa7f550
+msgid ""
+"Updated CD images are provided with this release, including fixes for "
+"some installation bugs. (Many installation problems are hardware-"
+"specific; for those, see “Hardware support bugs” below.)"
+msgstr ""
+
+#: ../../24.04/3.md 51274e1892934c8cad4225943c088a0f
+#: 563fd875e87a4a29b585ac61b1155530 5a63d13dd5b540209b4ecf4df047f44f
+#: 98d1907fa7a74f42bdeee74e9b423c4d b270798c65be4655a297ec14f6ba195c
+#: e64616eb91a642b28f4fb20e095ee2c2
+msgid "Source Package"
+msgstr ""
+
+#: ../../24.04/3.md 043ccc895ece4f1f9cb9285bc0c528d7
+#: 1024d578d1344f34808436128fc2cd21 198d666941da42d2a137ac7f72b0ea8d
+#: 3754787d613941b29e78d603f67a9bb9 57dc2d50635642cda820b06018f5b784
+#: 59c32139dead4355afe2198d5f342be4
+msgid "Bug  #"
+msgstr ""
+
+#: ../../24.04/3.md 3a198662afdb4a908c38855288c8f92e
+#: 7125709e8f354bcf8b93b10d41c862b8 7f78f150669a405784d383b0f150e9aa
+#: 9f7f13033d554d048d2ce1497de24d56 a1c38f26f0874819be904735a1107af4
+#: ff3baaeece1046bdbe149a80c6bb9168
+msgid "Description"
+msgstr ""
+
+#: ../../24.04/3.md 04edc7873a65473eb3d7f95d53ead8da
+#: 2a9e207d77a9440ab3601cd285cd0918 7900e8f158c946aa93421835198f4d59
+#: 7e3f9368faeb4fcd9736f0384ded7ae5 9f30efd359ce4b26aea5269408f83be0
+#: b2f6c411a574492c92da8ad534b84453 f0eb7287e0f746fa99c2ccb05fe9ab56
+msgid "livecd-rootfs"
+msgstr ""
+
+#: ../../24.04/3.md 492460c06e344234bf869cd2b517ffc1
+#: 7475515470444477be40f14060529d65
+msgid "[2098105](https://bugs.launchpad.net/bugs/2098105)"
+msgstr ""
+
+#: ../../24.04/3.md 0c10af6834b442ce89a0570f4f77cb88
+msgid "Fix build failure when using lowlatency-hwe-24.04, as ubuntustudio does."
+msgstr ""
+
+#: ../../24.04/3.md fcc8c37be4344180a77bfaae7fb050d0
+msgid "Enable the HWE stack for 24.04.2."
+msgstr ""
+
+#: ../../24.04/3.md 12ba6e0a056e489dacb874e503a249ef
+msgid "[2098306](https://bugs.launchpad.net/bugs/2098306)"
+msgstr ""
+
+#: ../../24.04/3.md 5d5c6ff1f90646a8858ca8309766a8bd
+msgid "Add 6.11 kernel apparmor features' preseeds."
+msgstr ""
+
+#: ../../24.04/3.md af270889c4994c0b9c325267dacb740f
+msgid "[2098622](https://bugs.launchpad.net/bugs/2098622)"
+msgstr ""
+
+#: ../../24.04/3.md 8d0f0e2431ca4f39acca37be35e781b7
+msgid "Do not build HWE kernel layer on RISC-V as there is no HWE kernel there."
+msgstr ""
+
+#: ../../24.04/3.md eb0298b7e7654c388f1e4554fc6551b9
+msgid "[2092205](https://bugs.launchpad.net/bugs/2092205)"
+msgstr ""
+
+#: ../../24.04/3.md de777e6669464d6ba0db0c46f3311cba
+msgid "risc-v: directly copy device trees to /boot/dtb."
+msgstr ""
+
+#: ../../24.04/3.md a5d38e2e1af345e4a7589bdbfa547151
+msgid "[2099993](https://bugs.launchpad.net/bugs/2099993)"
+msgstr ""
+
+#: ../../24.04/3.md 7ba731716f2b48949892218b9deafe6c
+msgid "riscv: add SUBARCH 'jh7110'."
+msgstr ""
+
+#: ../../24.04/3.md e921d0ad894a4e39b8a07361dd436d3f
+msgid "[2083554](https://bugs.launchpad.net/bugs/2083554)"
+msgstr ""
+
+#: ../../24.04/3.md 95a9f65b3a1a46e6900ad1a10fdf7964
+msgid ""
+"Remove some cruft referencing the subiquity snap, which can result in "
+"'error: snap \"subiquity\" is not installed' messages being printed on "
+"the terminal."
+msgstr ""
+
+#: ../../24.04/3.md fcf2d45c798a4c6f9528de41716a38d1
+msgid "initramfs-tools"
+msgstr ""
+
+#: ../../24.04/3.md 33ea60e7314947f2bc4f6307bfc3bdd3
+msgid "[2091904](https://bugs.launchpad.net/bugs/2091904)"
+msgstr ""
+
+#: ../../24.04/3.md 2b19f1110ba24d3c83599ed8837d3e47
+msgid "configure_networking: Configure IPv4 or IPv6 based on iBFT IP address"
+msgstr ""
+
+#: ../../24.04/3.md 137c70f159e945c1a52ac5da574e9c11
+msgid "dracut"
+msgstr ""
+
+#: ../../24.04/3.md 4443dfbb2a5741dc9cf6ed804d12f3b9
+msgid "[2095518](https://bugs.launchpad.net/bugs/2095518)"
+msgstr ""
+
+#: ../../24.04/3.md aaa748b5b04e4f7b9aa18fb9d6068102
+msgid "Fix missing compressed blobs that match wildcard fwpath"
+msgstr ""
+
+#: ../../24.04/3.md c7d2e3b9b2d54996a479b162da5240cc
+msgid "cd-boot-images-riscv64"
+msgstr ""
+
+#: ../../24.04/3.md 16982aa0ba964c759588c54532963c1b
+msgid "[2104572](https://bugs.launchpad.net/bugs/2104572)"
+msgstr ""
+
+#: ../../24.04/3.md e5f1ecca7c1d43c7b4231c227a016567
+msgid ""
+"Use \"echo 'search.file /.disk/info root' > tree/EFI/boot/grub.cfg\" to "
+"find the correct rootfs."
+msgstr ""
+
+#: ../../24.04/3.md 498edbc1356947dab7410fbe59ff5a28
+#: bade3f443c364cc982554ed6d278d641
+msgid "u-boot"
+msgstr ""
+
+#: ../../24.04/3.md 9d944ade28394d3aac4ede10ea931787
+msgid "[2098421](https://bugs.launchpad.net/bugs/2098421)"
+msgstr ""
+
+#: ../../24.04/3.md 2c9000e0b6e3424c8fcda47e152f7614
+msgid ""
+"Fix parsing of RISC-V ISA extensions Support new device-tree property "
+"riscv,isa-extensions replacing riscv,isa"
+msgstr ""
+
+#: ../../24.04/3.md 7dfb0deb4d47466391c71d72db565357
+msgid "[2110301](https://bugs.launchpad.net/bugs/2110301)"
+msgstr ""
+
+#: ../../24.04/3.md 9d2a154a35a94fadab615e91459cbe17
+msgid ""
+"Backport from questing to enable boot on Pine64 Star64 and DeepComputing "
+"FML13V01"
+msgstr ""
+
+#: ../../24.04/3.md:35 886198837a1c44369b1a108d6a81008b
+msgid "Desktop fixes"
+msgstr ""
+
+#: ../../24.04/3.md:37 0b76f17c68aa4b4d9ff5130820bd0234
+msgid ""
+"These changes mainly affect desktop installations of Ubuntu and other "
+"Ubuntu-based desktop systems."
+msgstr ""
+
+#: ../../24.04/3.md 425ac6ad7d54484783d0d2e760fcd57a
+#: aae0d59b72f54b1a92b1b7f192177fdf
+msgid "pipewire"
+msgstr ""
+
+#: ../../24.04/3.md 7241b5426dd14d6f9da7ac0fb2368376
+msgid "[2061687](https://bugs.launchpad.net/bugs/2061687)"
+msgstr ""
+
+#: ../../24.04/3.md 68dead4970974171813e69b743bf2d6d
+msgid ""
+"replace our incomplete cherry pick by the version that landed upstream as"
+" part of merge request #2145"
+msgstr ""
+
+#: ../../24.04/3.md 75c92f26e64c4be3aeb5246bec20d70c
+msgid "[2100497](https://bugs.launchpad.net/bugs/2100497)"
+msgstr ""
+
+#: ../../24.04/3.md 6c1d03843d9643a3b82a5e66c0e2adca
+msgid "Fix duplicated audio samples played after silence"
+msgstr ""
+
+#: ../../24.04/3.md 27af99ce014f46b5ac764f7a963fc4fc
+msgid "gnome-shell-extension-desktop-icons-ng"
+msgstr ""
+
+#: ../../24.04/3.md 2491f16c22d340038e4ba6ab60a478c4
+msgid "[2067831](https://bugs.launchpad.net/bugs/2067831)"
+msgstr ""
+
+#: ../../24.04/3.md f9e1f957b3824ebe9dba8b1680121fec
+msgid ""
+"Backport code from upstream to fix arrow keys closing the rename popup "
+"instead of moving the cursor"
+msgstr ""
+
+#: ../../24.04/3.md d2c69aef11684b319aee3e9b252bc6b1
+msgid "packagekit"
+msgstr ""
+
+#: ../../24.04/3.md 41cb25c458d24f5d877f280fd06d1c90
+msgid "[2066183](https://bugs.launchpad.net/bugs/2066183)"
+msgstr ""
+
+#: ../../24.04/3.md 3c8313113f3241dea67b643354493ce0
+msgid ""
+"Backport patch to make PackageKit uninstallable from graphical software "
+"centers"
+msgstr ""
+
+#: ../../24.04/3.md 35aad79f7f904a1bbda841e5a405672f
+#: 3625f94b5cfb459db3f3c2d061a5d2a4 4f9e0d4a160a45a9929f300b06270043
+#: 85fae371864c4b6ba0af0d4efb4ac489 895a24642b1f4c59aede515f54025152
+#: 8b7ed2fe428c47f19743041321c2a292 9965edbcbcd9450a9c366b1d85174312
+#: b09d86a284fe406ab95fb9d8b4533995 b44292a453ad4de098fb4a53519721dc
+#: bc5cedd958004b05a1b265aacc717019 bd25e0ca9065439ea7a4ab78ff733a45
+#: c7993e4684914f248b1687f90f841cc6 d9aef3db618648bea84da82a826ae2f2
+#: f464fa74d9854b92ba1a5819dadda194
+msgid "mutter"
+msgstr ""
+
+#: ../../24.04/3.md e6bed8e1355640c28ada8346cb5fc9e5
+msgid "[2080698](https://bugs.launchpad.net/bugs/2080698)"
+msgstr ""
+
+#: ../../24.04/3.md b5c9214956544731bc7fb3dfd0e841d8
+msgid "Backport patch to avoid full framebuffer damage when dragging a window"
+msgstr ""
+
+#: ../../24.04/3.md 167ed85407214a7393c609e3e2a9e46b
+#: 55c33b6f15d7481b8221a5c56a26567f
+msgid "[2090824](https://bugs.launchpad.net/bugs/2090824)"
+msgstr ""
+
+#: ../../24.04/3.md 134542137ac44df6a4e85d6078557a82
+msgid "Backport patches to fix crash with pointer-constraints and touch"
+msgstr ""
+
+#: ../../24.04/3.md 872688f2ef57401896221c7af046bd61
+msgid "[1966635](https://bugs.launchpad.net/bugs/1966635)"
+msgstr ""
+
+#: ../../24.04/3.md 5cd60167ae05468a83f0544ae1f452d3
+msgid "Backport patches to fix touchscreen drag&drop"
+msgstr ""
+
+#: ../../24.04/3.md 326a60a1d7fb42cb998391393cbae550
+msgid ""
+"The above patches require and include the fix for. even though that bug "
+"does not exist on Noble."
+msgstr ""
+
+#: ../../24.04/3.md 2535f057bc894fb3a560bd36651336d5
+msgid "[2087831](https://bugs.launchpad.net/bugs/2087831)"
+msgstr ""
+
+#: ../../24.04/3.md 02c5dfabe700497587106cb7ae53a858
+msgid ""
+"debian/patches: Synchronize touchscreen enabled state when adding it to "
+"device mapper, which fixes suspend/resume related issue"
+msgstr ""
+
+#: ../../24.04/3.md 76ff556a9e0f4b1db13529ff1f0ab583
+msgid "[2093237](https://bugs.launchpad.net/bugs/2093237)"
+msgstr ""
+
+#: ../../24.04/3.md b827bea858734df2b252c7995ba41b7e
+msgid "Backport patches to fix crash when closing apps with subsurfaces"
+msgstr ""
+
+#: ../../24.04/3.md 333fd2b042fe4dc788cf9f5a34c36415
+msgid "[2097415](https://bugs.launchpad.net/bugs/2097415)"
+msgstr ""
+
+#: ../../24.04/3.md 492875c40b79475ba4f21bfacac22013
+msgid "Backport patches to fix drag&drop from X11 to Wayland windows"
+msgstr ""
+
+#: ../../24.04/3.md bd7ea38667fa4722b2908c82f3c3583c
+msgid "[2085634](https://bugs.launchpad.net/bugs/2085634)"
+msgstr ""
+
+#: ../../24.04/3.md e969795c066a430f9ae71b1c305f71a4
+msgid "Backport patches to fix possibly out of sync selection"
+msgstr ""
+
+#: ../../24.04/3.md 6c0a1c7944204659a770c7f52fa4dfd5
+msgid "[2099879](https://bugs.launchpad.net/bugs/2099879)"
+msgstr ""
+
+#: ../../24.04/3.md cebefc751793446795bded94f7648e45
+msgid ""
+"Backport patches to fix handling of pixel formats with no alpha, which "
+"fixes rendering of dialogs in IntelliJ IDEA."
+msgstr ""
+
+#: ../../24.04/3.md 05cf87b3480b489489e9fe8d132a6381
+msgid "[2063005](https://bugs.launchpad.net/bugs/2063005)"
+msgstr ""
+
+#: ../../24.04/3.md 25f0f418c2e847d289aa38d9b6ca8089
+#: 90a67170fd9640ccab5cdf344dd4f3e3
+msgid ""
+"Add clutter-Repick-actors-when-touches-emulate-button-clicks.patch to "
+"resolve touchscreen problems on X11"
+msgstr ""
+
+#: ../../24.04/3.md 59061f36232e41f5a2b4559d2a5ed6cf
+msgid "[1904237](https://bugs.launchpad.net/bugs/1904237)"
+msgstr ""
+
+#: ../../24.04/3.md 3a373f682d9546539f8d058b836d85c7
+msgid "[2111902](https://bugs.launchpad.net/bugs/2111902)"
+msgstr ""
+
+#: ../../24.04/3.md 3f0dda5da17a4ce381e99530aecfcc45
+msgid "Backport patches to fix AMD platform Nvidia dGPU screen freeze in Wayland."
+msgstr ""
+
+#: ../../24.04/3.md 4a931af0d6504c9089d5629f8694ecc6
+msgid "[2111698](https://bugs.launchpad.net/bugs/2111698)"
+msgstr ""
+
+#: ../../24.04/3.md 1560eaa894d94d67ac23e012428da4c3
+msgid "Fix issue where glxgears runs slower than display refresh rate"
+msgstr ""
+
+#: ../../24.04/3.md e7c648120a0d4119958b6167b2eeb318
+msgid "[1978905](https://bugs.launchpad.net/bugs/1978905)"
+msgstr ""
+
+#: ../../24.04/3.md 47ff74ccecfe4b35a35cb2f9f8bae5d3
+msgid ""
+"Add onscreen-native-Return-the-correct-number-of-EGL-modifier.patch to "
+"fix multi-monitor reverse PRIME support on desktops where Nvidia is "
+"primary and an integrated GPU is secondary."
+msgstr ""
+
+#: ../../24.04/3.md dc909d797f8e440c966040c050c69ca0
+#: efb72fd6a0de4292bd1add030a318a44
+msgid "malcontent"
+msgstr ""
+
+#: ../../24.04/3.md 01f9eebed2ba41d6adcdba3832e94815
+msgid "[2092815](https://bugs.launchpad.net/bugs/2092815)"
+msgstr ""
+
+#: ../../24.04/3.md 70c037c15b424360a4571cd22cde09af
+msgid "Fix opening Settings"
+msgstr ""
+
+#: ../../24.04/3.md ff85e5914cdf42929f8de95e52396189
+msgid "[2091544](https://bugs.launchpad.net/bugs/2091544)"
+msgstr ""
+
+#: ../../24.04/3.md c5e8c1a23c0249d6a5b829a73c2c5f4d
+msgid "Re-show the control panel in the app list"
+msgstr ""
+
+#: ../../24.04/3.md 7d471cefcd674a3f9d8a45abb9f97674
+msgid "plymouth"
+msgstr ""
+
+#: ../../24.04/3.md fa4d79b23ca144a2bcfaa88bd0adca04
+msgid "[2096806](https://bugs.launchpad.net/bugs/2096806)"
+msgstr ""
+
+#: ../../24.04/3.md 13f3787378784227a34934986bf03758
+msgid ""
+"Add label-freetype-fix-fallback-not-working-when-fc-matc.patch to fix "
+"missing fonts resulting in missing text"
+msgstr ""
+
+#: ../../24.04/3.md 096af93316d04a10be76329c77c08b49
+#: 84b2519de2f94c9c9377824d045aca74 ed1bef6ee5304857878f0718dfd11c60
+#: fab43c59a197469cb1cc7506d80d3ab4
+msgid "gtk4"
+msgstr ""
+
+#: ../../24.04/3.md 6993ae662e704e51b2166a29e035bc6f
+msgid "[2096803](https://bugs.launchpad.net/bugs/2096803)"
+msgstr ""
+
+#: ../../24.04/3.md ca998aaf6ab14231a5f52b6ce82fd8e9
+msgid ""
+"missing-sources: Update emojibase to match what was done in gtk 4.16.8 to"
+" update the emoji chooser for Unicode 16"
+msgstr ""
+
+#: ../../24.04/3.md 8f347619b88e4200a118604b97323c00
+msgid "[2106744](https://bugs.launchpad.net/bugs/2106744)"
+msgstr ""
+
+#: ../../24.04/3.md ae4a9e2bc28c457cbbcec79f1ddaa324
+msgid "Cherry-pick upstream fix for Orca not reading shortcuts in actions ."
+msgstr ""
+
+#: ../../24.04/3.md eeaf7c0e976f4f81bf58bf45dd6b0105
+msgid "[2098698](https://bugs.launchpad.net/bugs/2098698)"
+msgstr ""
+
+#: ../../24.04/3.md 509a5e17c98d45d68d74b1dd5ac657d2
+msgid "Depend on libgles2 (Closes: #1077287)"
+msgstr ""
+
+#: ../../24.04/3.md ff496a81500f4625a14569d888f19a2c
+msgid "[2066062](https://bugs.launchpad.net/bugs/2066062)"
+msgstr ""
+
+#: ../../24.04/3.md f104cfaac70449d39f0186257e45a0e2
+msgid "Fix keyboard navigation in lists with only a single item"
+msgstr ""
+
+#: ../../24.04/3.md 3f5aa6dfc2c248a3afd83ef36de7d490
+#: 7e05fcd166f941ea942c21b099ff5751 9274d146cb23417aa0d102c2c8a36e94
+msgid "gnome-shell"
+msgstr ""
+
+#: ../../24.04/3.md 486de5b6774c4c3fa8ea3350e90c0ed1
+msgid "[2098016](https://bugs.launchpad.net/bugs/2098016)"
+msgstr ""
+
+#: ../../24.04/3.md fc93451c71bb40c69b05c12a5bdc930d
+msgid ""
+"Backport patch for connecting to a new Wi-Fi network from the log-in "
+"screen"
+msgstr ""
+
+#: ../../24.04/3.md 1db91ebc0e3840c5a2cdd3e4aa44eb31
+msgid "[2039340](https://bugs.launchpad.net/bugs/2039340)"
+msgstr ""
+
+#: ../../24.04/3.md 66b81e8c004049288fea547ea633bc17
+msgid "Backport patch to fix setenv/getenv crash on startup"
+msgstr ""
+
+#: ../../24.04/3.md eab5fbe0bd914e5bb01a350951b822ba
+msgid "gnome-shell-extension-ubuntu-dock"
+msgstr ""
+
+#: ../../24.04/3.md 130f6a19150a4c13b6ecfd5a411aa532
+msgid "[1997550](https://bugs.launchpad.net/bugs/1997550)"
+msgstr ""
+
+#: ../../24.04/3.md 20e93d82fe0d4f78990a050d7a820a45
+msgid "Fix window selected from preview not getting focus"
+msgstr ""
+
+#: ../../24.04/3.md 1e7c086f6cab4d32b6f3b167d92491d1
+msgid "[2092181](https://bugs.launchpad.net/bugs/2092181)"
+msgstr ""
+
+#: ../../24.04/3.md b5cfa33aeb9547cdb9706654aaf21a5a
+msgid "Backport patches to fix the Shift behaviour in OSK"
+msgstr ""
+
+#: ../../24.04/3.md abcdf50259594e4ea41594fd2d5481a6
+msgid "xorg-server"
+msgstr ""
+
+#: ../../24.04/3.md d46ce7c6f4d346e9a13cae2bb198dacc
+msgid "[1861609](https://bugs.launchpad.net/bugs/1861609)"
+msgstr ""
+
+#: ../../24.04/3.md 602260f776ca4840bc2f7d548512a51e
+msgid ""
+"If a client application has not called DRI2ScreenInit(), "
+"DRI2Authenticate() and DRI2CreateDrawable2() cause the X server to crash."
+" This patch adds some sanity checks to ensure the X server stays running."
+msgstr ""
+
+#: ../../24.04/3.md 70d83a471bbd448498f31f17664127d8
+#: 8e108f2c8bca4e9282a5941558afbab7
+msgid "update-notifier"
+msgstr ""
+
+#: ../../24.04/3.md 0bceeb3f50b047fe9db885f8d2f86bb3
+msgid "[2083937](https://bugs.launchpad.net/bugs/2083937)"
+msgstr ""
+
+#: ../../24.04/3.md a83e5b34645548ff885ea49b97590336
+msgid "Remove obsolete broken CFLAGS/LDFLAGS overrides"
+msgstr ""
+
+#: ../../24.04/3.md b72c214137814b3399d375f7c4232a04
+msgid "[2103445](https://bugs.launchpad.net/bugs/2103445)"
+msgstr ""
+
+#: ../../24.04/3.md a3e43bfe060e47d5988f6967bf6c79e6
+msgid "update-notifier: Do not call GdkX11 functions on Wayland"
+msgstr ""
+
+#: ../../24.04/3.md c6c075c3a6924da1bdc0bf2b15772d01
+msgid "gtk+3.0"
+msgstr ""
+
+#: ../../24.04/3.md 538de08db8b148e69117a6ad386d0b9b
+msgid "[2096777](https://bugs.launchpad.net/bugs/2096777)"
+msgstr ""
+
+#: ../../24.04/3.md 7f3f873c95ec49d58d29e2914326ed15
+msgid ""
+"missing-sources: Update emojibase to match what was done in gtk 3.24.48 "
+"to update the emoji chooser for Unicode 16"
+msgstr ""
+
+#: ../../24.04/3.md f1b79355f09a436395965b20d2d15fd8
+msgid "xserver-xorg-input-libinput"
+msgstr ""
+
+#: ../../24.04/3.md 9d8c68987e804633908d439d23dff1f5
+msgid "[2103967](https://bugs.launchpad.net/bugs/2103967)"
+msgstr ""
+
+#: ../../24.04/3.md 5c78e8c0caaf4b60a101adba4ef599a1
+msgid ""
+"d/patch: add map-some-specific-high-keycodes.patch, which forcibly maps "
+"mic mute key and touchpad function keys to F20-F23"
+msgstr ""
+
+#: ../../24.04/3.md a13d445a5f0740cdbf79091a4601aa7c
+msgid "xwayland"
+msgstr ""
+
+#: ../../24.04/3.md 333292570139410b8695a085232523ec
+msgid "[2096653](https://bugs.launchpad.net/bugs/2096653)"
+msgstr ""
+
+#: ../../24.04/3.md 48334947edc547059c4aea8fcc43db6d
+msgid ""
+"Backport patches to avoid crash after the busy-loop fix. With the busy-"
+"loop fixed, XWayland can now proceed further and may encounter a new "
+"crash."
+msgstr ""
+
+#: ../../24.04/3.md 743d15c6de2143ae8fbf2ef15e5eb964
+#: f6f811d5f1bd45429ff663b69f373b57
+msgid "grilo-plugins"
+msgstr ""
+
+#: ../../24.04/3.md 7cf32826fb7d4821a1884f5e4f985559
+#: b7d0c0d5400b494891423e3b763453be
+msgid "[2093324](https://bugs.launchpad.net/bugs/2093324)"
+msgstr ""
+
+#: ../../24.04/3.md a01caeb6125a4ae497f840ec9690db3e
+msgid "Re-enable dLeyna plugin"
+msgstr ""
+
+#: ../../24.04/3.md 138319f60bd64894a566d9326fbe6272
+msgid "Recommend dleyna-server"
+msgstr ""
+
+#: ../../24.04/3.md 15abec7ddb35441fb88e265ee82affd0
+#: 47a5da7ca97645cf9252d5d40e4f59e7 527a28cd0d8c4f7d9f956d021362ecce
+#: 8922cecb20284ef891518b4e026bca24 8cf8aa0e6fe64016a5abdd69a63f14d0
+msgid "update-manager"
+msgstr ""
+
+#: ../../24.04/3.md 92ef197f09af46879958963f3e785c74
+msgid "[2109339](https://bugs.launchpad.net/bugs/2109339)"
+msgstr ""
+
+#: ../../24.04/3.md 55a81cb01e7945c5b33af02d339e165c
+msgid "test_update_origin.py: Update to noble, and packaged archive keys"
+msgstr ""
+
+#: ../../24.04/3.md be487d3447d145399518701c5e8a76dc
+msgid "[2109339]"
+msgstr ""
+
+#: ../../24.04/3.md 639466c4f55e42fca5bf6adbd212fd78
+#: f9e43cb931974d80ab65f5b5ee08af93
+msgid "[1105371](https://bugs.launchpad.net/bugs/1105371)"
+msgstr ""
+
+#: ../../24.04/3.md 172fa8759eaf423aa812e01453f62b2c
+msgid ""
+"Screen reader: announce status header for update dialogue . Although that"
+" was claimed to be fixed in the previous version, the part of the patch "
+"corresponding to it was actually left behind."
+msgstr ""
+
+#: ../../24.04/3.md 18623432c265430486d73df9e59b872f
+msgid "[2068805](https://bugs.launchpad.net/bugs/2068805)"
+msgstr ""
+
+#: ../../24.04/3.md d0fe264e7ead45d3beb5e3e62d67a5c7
+msgid ""
+"When all packages are unselected, install button goes away; Fix it not "
+"coming back after once a package is selected again ."
+msgstr ""
+
+#: ../../24.04/3.md cead38d3aa8945069a72d81e73a39307
+msgid ""
+"Screen reader: announce status header for update dialogue and checkbox "
+"state when the highlighted package changes or is toggled."
+msgstr ""
+
+#: ../../24.04/3.md 1e97d53f349740368271e59e1eb0d80e
+#: 7e2545e535cd40e8ad02bc1bb9b9f442
+msgid "alsa-ucm-conf"
+msgstr ""
+
+#: ../../24.04/3.md d40a27d4c6f44502a9f4a07db0cffd48
+msgid "[2100732](https://bugs.launchpad.net/bugs/2100732)"
+msgstr ""
+
+#: ../../24.04/3.md 33a49a2187ac4235bd0f68988e1b786c
+msgid "Add rt713 & rt1318 LED control"
+msgstr ""
+
+#: ../../24.04/3.md 3c5bbb4ad48b4c72a064d98a4c25c11e
+msgid "[2106464](https://bugs.launchpad.net/bugs/2106464)"
+msgstr ""
+
+#: ../../24.04/3.md ddcc98f5e2c04c0e84ed394773e40587
+msgid "Change the default output volume of headphone for rt722"
+msgstr ""
+
+#: ../../24.04/3.md 4a1975445ecf49c084189dd0ddff1c70
+#: f3ded47352b94d86a2dea2f780ab251c
+msgid "libpciaccess"
+msgstr ""
+
+#: ../../24.04/3.md 44b788378e6b40dabcc7e2a4920529f8
+msgid "[2111684](https://bugs.launchpad.net/bugs/2111684)"
+msgstr ""
+
+#: ../../24.04/3.md 7be8fa1565b34ff1bf824d104f8189fe
+msgid ""
+"AMD platform A + N config selected wrong primary GPU in Xorg d/p/0001"
+"-linux_sysfs-Identify-boot_vga-by-acpi-companion-hid.patch"
+msgstr ""
+
+#: ../../24.04/3.md bd848f628ca541098d3a4c7369862f62
+msgid "[2115574](https://bugs.launchpad.net/bugs/2115574)"
+msgstr ""
+
+#: ../../24.04/3.md 0cb839ef44bd40448033e21d608b9cfd
+msgid ""
+"Revert to 0.17-3build1 since the previous update appears to cause "
+"inability to log in to the desktop on some systems"
+msgstr ""
+
+#: ../../24.04/3.md 1987767d8e3b40a5b3840679305fc95c
+#: 5a4f41a0b8b64923ad08b9832be9f383
+msgid "nautilus"
+msgstr ""
+
+#: ../../24.04/3.md 42260df2d10c4a7d9718e18feb5b5c1d
+msgid "[1813171](https://bugs.launchpad.net/bugs/1813171)"
+msgstr ""
+
+#: ../../24.04/3.md baa0130ccacf4ef385304e1f3ade30f3
+msgid "Includes crash fix for (LP: #1813171)"
+msgstr ""
+
+#: ../../24.04/3.md 5fc6f8c2261c40edaa404462a8a5a87b
+msgid "[2095129](https://bugs.launchpad.net/bugs/2095129)"
+msgstr ""
+
+#: ../../24.04/3.md 6daaf730cc494b73b7618db29e13c3ed
+msgid "Includes crash fix for (LP: #2095129)"
+msgstr ""
+
+#: ../../24.04/3.md a9a4ab3c6c9246bab0251d80eb3dc66f
+msgid "gnome-initial-setup"
+msgstr ""
+
+#: ../../24.04/3.md aad47984f70143e6b23f691ebd972f9c
+msgid "[1797868](https://bugs.launchpad.net/bugs/1797868)"
+msgstr ""
+
+#: ../../24.04/3.md 1344e5069d674015b41e14e66059d78c
+msgid "a11y: Add accessibility to some Ubuntu pages"
+msgstr ""
+
+#: ../../24.04/3.md:93 400c6a8377b4441085fd2f36bfd220d2
+msgid "Server and Cloud related fixes"
+msgstr ""
+
+#: ../../24.04/3.md:95 2af93b231ee0455b8eee2bb27b5e957c
+msgid ""
+"These changes mainly affect installations of Ubuntu on server systems and"
+" clouds."
+msgstr ""
+
+#: ../../24.04/3.md 18f6bc353e0a406a92b8da3fb5c7eebd
+#: 3097545484e24d1d9648166f900cf3d7 36960dbbd349461b9366eda3f8aa6951
+#: 50e0990e0b384114ba4155296fbb208b 603c5ac3132c4cfbbb89cf1a91e392fe
+#: a61be4b235ae4acc8bca6e757699468b d730acc2d12a4e93a53d1c299769ae6a
+msgid "cloud-init"
+msgstr ""
+
+#: ../../24.04/3.md 0e5752b9e9224bf4b8b65d4a32700d03
+msgid "[2097319](https://bugs.launchpad.net/bugs/2097319)"
+msgstr ""
+
+#: ../../24.04/3.md 71abf450caa640c0b927ae1198445b2f
+msgid ""
+"Pull in the upstream commit works around a limitation in AWS's IMDS "
+"(GH-5971)"
+msgstr ""
+
+#: ../../24.04/3.md 07b94dbcdb064a2e9eebe996a9e2a56f
+msgid "[2094149](https://bugs.launchpad.net/bugs/2094149)"
+msgstr ""
+
+#: ../../24.04/3.md 29e6cfff4b6a46ce9bb8dcd110e696d4
+msgid "Revert breaking change on stable release"
+msgstr ""
+
+#: ../../24.04/3.md 3b11c75425d643d5ac47192c482a1a10
+msgid "[2097441](https://bugs.launchpad.net/bugs/2097441)"
+msgstr ""
+
+#: ../../24.04/3.md 892d2129d31f45378d5cfba41c16e265
+msgid "This patch missed waiting for mounts"
+msgstr ""
+
+#: ../../24.04/3.md ec96f7cd97274c539c3149776590b350
+msgid ""
+"[2094179](https://bugs.launchpad.net/bugs/2094179) "
+"[2094208](https://bugs.launchpad.net/bugs/2094208) "
+"[2094857](https://bugs.launchpad.net/bugs/2094857) "
+"[2094858](https://bugs.launchpad.net/bugs/2094858)"
+msgstr ""
+
+#: ../../24.04/3.md c72b05db5ac342a592abfe0fd26288e1
+msgid ""
+"Upstream snapshot based on 24.4.1. List of changes from upstream can be "
+"found at https://raw.githubusercontent.com/canonical/cloud-"
+"init/24.4.1/ChangeLog"
+msgstr ""
+
+#: ../../24.04/3.md 9abc443d944144129a9871a0d488f2ea
+msgid "[2100963](https://bugs.launchpad.net/bugs/2100963)"
+msgstr ""
+
+#: ../../24.04/3.md e2136adae08a4dd79eb25d03280a3d7b
+msgid "cherry-pick fixes for MAAS traceback"
+msgstr ""
+
+#: ../../24.04/3.md befac744d04b4d3a84381e70470d10d8
+msgid "[2092333](https://bugs.launchpad.net/bugs/2092333)"
+msgstr ""
+
+#: ../../24.04/3.md c14671bc0495491183aa443a203e5cce
+msgid "d/control: Fix how cloud-init-base overwrites cloud-init files."
+msgstr ""
+
+#: ../../24.04/3.md 418d9f697dbe4ab88439ae039a68fc34
+#: 7ee442f304644c6a97251aa20149876d 837097d3955a4c45bcec7c55f1ab5b6b
+msgid "gce-compute-image-packages"
+msgstr ""
+
+#: ../../24.04/3.md 56a4628951ea457393625b30248f30d9
+#: 968af4fa43f242bcb351b378da1b79fb
+msgid "[2106629](https://bugs.launchpad.net/bugs/2106629)"
+msgstr ""
+
+#: ../../24.04/3.md 694f81b47c9f47eb9042a3adabfc76d4
+msgid "This script overwrites any hostnames set via cloud-init."
+msgstr ""
+
+#: ../../24.04/3.md 834d5add461a42b29c4e753f4ed18923
+msgid "[2104165](https://bugs.launchpad.net/bugs/2104165)"
+msgstr ""
+
+#: ../../24.04/3.md b151721fa9524e6782fa8071cf602759
+msgid ""
+"Upstream snapshot based on 25.1.2. List of changes from upstream can be "
+"found at https://raw.githubusercontent.com/canonical/cloud-"
+"init/25.1.2/ChangeLog"
+msgstr ""
+
+#: ../../24.04/3.md:109 1e1a73146f6a4db69f000305787d75ea
+msgid "Base platform fixes"
+msgstr ""
+
+#: ../../24.04/3.md:111 816df2a336bd46a48f1e32dfd5c7a486
+msgid ""
+"These changes affect the core fundamental components of all the Ubuntu "
+"flavors."
+msgstr ""
+
+#: ../../24.04/3.md e5b3f7cf735747c28e3bf14f86863ad1
+msgid "lvm2"
+msgstr ""
+
+#: ../../24.04/3.md 209794d8ec074a42ae453f2ec8796b76
+msgid "[2084233](https://bugs.launchpad.net/bugs/2084233)"
+msgstr ""
+
+#: ../../24.04/3.md 3b98c94ec9d94896ad5281800b896e49
+msgid "Remove libaio from being skipped by memlock"
+msgstr ""
+
+#: ../../24.04/3.md 1cf555d413954609accb9c73f5102315
+#: 684d51d532b541a1a68ab8e85201aa8f 714994d553704838b1ef66cde6bc31d3
+#: 866adfae9ac741d692d98a77e03c2100 86807a1bb7354901b5ea4b66b2553cf3
+#: c4b509d953494c8bada33a7edeb78cc9
+msgid "libvirt"
+msgstr ""
+
+#: ../../24.04/3.md f8ecb0276719455e8c0920653619d8f5
+msgid "[2084136](https://bugs.launchpad.net/bugs/2084136)"
+msgstr ""
+
+#: ../../24.04/3.md a4abf3835e6b46cabffc6c3b0e9d019e
+msgid ""
+"d/p/u/lp-2084136-fix-get-number-block-io-throttle-params.patch: Fix issue"
+" preventing the user to obtain the number of block I/O parameters."
+msgstr ""
+
+#: ../../24.04/3.md 7550e28bc42a4d58b7cbfb8b6163b5e7
+msgid "[2095488](https://bugs.launchpad.net/bugs/2095488)"
+msgstr ""
+
+#: ../../24.04/3.md 534cff173795410792eff717bb3d0d99
+msgid "Fix compiler macro to correctly detect RISC-V"
+msgstr ""
+
+#: ../../24.04/3.md f26c1dfe73404cc28323a338c7809315
+msgid "[2051239](https://bugs.launchpad.net/bugs/2051239)"
+msgstr ""
+
+#: ../../24.04/3.md b20a33bb09674d918542dc6fb819a392
+msgid "Add full boot order support on s390x"
+msgstr ""
+
+#: ../../24.04/3.md 93032217267d4017ad9455ca37d131d1
+msgid "[2100024](https://bugs.launchpad.net/bugs/2100024)"
+msgstr ""
+
+#: ../../24.04/3.md 2106ace3453845e789eb047333833ddc
+msgid "apparmor: Allow SGX if configured"
+msgstr ""
+
+#: ../../24.04/3.md 5671c87ec7c441c8b568c1bd15eb51a8
+msgid "[2108995](https://bugs.launchpad.net/bugs/2108995)"
+msgstr ""
+
+#: ../../24.04/3.md 43e86c6c36554776885996e329369b24
+msgid "Move README.Debian to libvirt0 package ."
+msgstr ""
+
+#: ../../24.04/3.md 511fdb35bec64fe2a4eb586537a0f6e7
+msgid "[2106812](https://bugs.launchpad.net/bugs/2106812)"
+msgstr ""
+
+#: ../../24.04/3.md 4414f38478ef4bcebe82cbc6560abb88
+msgid ""
+"d/p/u/lp2106812-cpu_map-Drop-mpx-from-x86-cpu-models.patch: Memory "
+"protection extensions (MPX) were introduced in Intel Skylake generation "
+"CPUs and provided hardware support for bound checking. This feature will "
+"not be supported in Intel CPUs beginning with the Ice Lake generation. "
+"Remove missing mpx feature so that libvirts detects correctly CPU models "
+"(Icelake, ..) instead of the old Blackwell"
+msgstr ""
+
+#: ../../24.04/3.md 0bf31a1345c942a8a8207588dd694f94
+#: 28f67f04b4d74049933080af13dfc6b8 2f9dbe5c6fff4e1eb6365b080b14df32
+#: 7ec0737497b04824a4c1e7aceccd6c54 c202354536b44226bafa688d9d60b3a3
+#: c8e0e166835d4ce08d23c479e2677309 ea282159b6144277936082765d57d3ed
+msgid "qemu"
+msgstr ""
+
+#: ../../24.04/3.md 8f5f9451c2df4a08b9676fea3d22b0d7
+msgid "[2095169](https://bugs.launchpad.net/bugs/2095169)"
+msgstr ""
+
+#: ../../24.04/3.md 2b78df474c764dea803fefcec63183b2
+msgid "Fix emulation of RISC-V Vector instructions"
+msgstr ""
+
+#: ../../24.04/3.md 53de38605b084860a08d90d9c8615509
+#: c395584f837d47f2b56ad20e56f7f6d2
+msgid "[2049698](https://bugs.launchpad.net/bugs/2049698)"
+msgstr ""
+
+#: ../../24.04/3.md 6a455fcffb2c4beb8ea14e06fbb50e5a
+#: d849694f8a764f4b86b8bf9d49dfefba
+msgid "d/p/u/lp2049698/*: Add full boot order support on s390x"
+msgstr ""
+
+#: ../../24.04/3.md 11256bf2e6984759919086ee07f0d519
+#: e2cc51cecc3d4443b8fd5af0cd08531b
+msgid "[2072564](https://bugs.launchpad.net/bugs/2072564)"
+msgstr ""
+
+#: ../../24.04/3.md 9fc20dac5d5042bd9a50588c6846578e
+#: b4e2a2b667704fa797ce7eb145764f43
+msgid "Fix qemu-aarch64-static segfaults running ldconfig.real"
+msgstr ""
+
+#: ../../24.04/3.md 5fc994ee77934026bca4151fdbe8c15f
+#: b0195ba1e10f463da287363c5e41a483
+msgid "[2101944](https://bugs.launchpad.net/bugs/2101944)"
+msgstr ""
+
+#: ../../24.04/3.md 034af7f8deca483bacdde0230033e32a
+#: 98436b4ee11740ddb2f79be35c119624
+msgid ""
+"d/p/u/lp2101944/*: Synthesize IBPB_BRTYPE and SBPB CPUID bits to the "
+"guest as described in AMD's Speculative Return Stack Overflow whitepaper."
+msgstr ""
+
+#: ../../24.04/3.md 8d3675ba785242329c8b9d0cec63f6e1
+msgid "libnvme"
+msgstr ""
+
+#: ../../24.04/3.md 02230b1b62f44c25b79ea9354cf99b95
+msgid "[2079836](https://bugs.launchpad.net/bugs/2079836)"
+msgstr ""
+
+#: ../../24.04/3.md 3de7a1a52dc4428d951e06fbd9246085
+msgid "Fix size reporting for nvme devices based on lba_count :"
+msgstr ""
+
+#: ../../24.04/3.md 36c4808c3e8d46a4bd1835528324e761
+msgid "cryptsetup"
+msgstr ""
+
+#: ../../24.04/3.md 2c01332f16ed485cb03a490f7ff00f53
+msgid "[2054390](https://bugs.launchpad.net/bugs/2054390)"
+msgstr ""
+
+#: ../../24.04/3.md 1938b3184bc4436c9e94b4f722ece1fe
+msgid "Refine proc mounts entries traversal"
+msgstr ""
+
+#: ../../24.04/3.md 177a9ea2880348b5a8fbeaa2ec84d119
+#: 3f8fe7109ef24734bba54564fa63903c 5437c98fba20498faf42ba6f2c932404
+#: dfa55a68418a4dd5a9179d448f2b63a7 f72222ce9f5f43e29f7065265579f781
+#: fabac53a0f9949b5bbe67eaee20ebe5b
+msgid "snapd"
+msgstr ""
+
+#: ../../24.04/3.md 9052d873ed0e458cae639584dac1df97
+msgid "[2090938](https://bugs.launchpad.net/bugs/2090938)"
+msgstr ""
+
+#: ../../24.04/3.md ffa258f9a08c49918a16d518df911c1e
+msgid ""
+"AppArmor prompting (experimental): disallow /./ and /../ in path "
+"patterns. Fix 'snap run' getent based user lookup in case of bad PATH"
+msgstr ""
+
+#: ../../24.04/3.md 89af84089ba946eabe1ffce4990db297
+msgid "[2084730](https://bugs.launchpad.net/bugs/2084730)"
+msgstr ""
+
+#: ../../24.04/3.md efc870b048d24e9685332f85a031ac5c
+msgid ""
+"Fix generation of AppArmor profile with incorrect revision during multi "
+"snap refresh. Fix refresh app awareness related deadlock edge case"
+msgstr ""
+
+#: ../../24.04/3.md 2aefd83995a64070a6df1062455f99af
+msgid "[2083961](https://bugs.launchpad.net/bugs/2083961)"
+msgstr ""
+
+#: ../../24.04/3.md 4bfb32c6b83445888f51b2978b33b286
+msgid ""
+"Fix ignoring snaps in try mode when amending. Fix reloading of service "
+"activation units to avoid systemd errors"
+msgstr ""
+
+#: ../../24.04/3.md 415f69af38e84234bf6cb51ea06d2467
+#: e74af39a75274e4c887555a8e0b1886e
+msgid "[2085535](https://bugs.launchpad.net/bugs/2085535)"
+msgstr ""
+
+#: ../../24.04/3.md d9ec73b57f284dd4acbdc681d5b190b3
+#: f12c4e1c7304431bbb56ed97a5517005
+msgid ""
+"Alleviate impact of auto-refresh failure loop with progressive delay. "
+"Dropped timedatex in selinux-policy to avoid runtime issue"
+msgstr ""
+
+#: ../../24.04/3.md efb2460993c34eeab8bde9dbb2b07035
+msgid "[2086203](https://bugs.launchpad.net/bugs/2086203)"
+msgstr ""
+
+#: ../../24.04/3.md 222605d1012241eca1c90c5020ea5855
+#, python-brace-format
+msgid ""
+"mount-control interface: add support for nfs mounts. "
+"network-{control,manager} interface: add missing dbus link rules"
+msgstr ""
+
+#: ../../24.04/3.md 281c24f1405a4ad2ac930b8f9a39887e
+#: 375458cac2fd4080adb4cba1250a68eb 9eaa9bce5a6b482e84eb22665bc407ab
+msgid "wireless-regdb"
+msgstr ""
+
+#: ../../24.04/3.md 5c207bff9276452ebd6eed3173d2e58a
+#: 6b48e634382b4194a5363068af22a6bf
+msgid "[2096979](https://bugs.launchpad.net/bugs/2096979)"
+msgstr ""
+
+#: ../../24.04/3.md 44fae85aa8824f7ca16dffd28985fbcb
+msgid "debian/control: Conflict with old boot-managed-by-snapd"
+msgstr ""
+
+#: ../../24.04/3.md a38a411506c3479dafef83d4106b5d01
+#: ea627f9deada4ffb83332be92ad8a3ee
+msgid "bluez"
+msgstr ""
+
+#: ../../24.04/3.md 2caf9ee63ef048fb887bea46af4fbe8d
+msgid "[2085162](https://bugs.launchpad.net/bugs/2085162)"
+msgstr ""
+
+#: ../../24.04/3.md 12a12c09867d47dcbd5cc55f06ab3276
+msgid ""
+"Add git-reconnect-fix.patch to resolve reconnection problems for devices "
+"after a suspend or restart"
+msgstr ""
+
+#: ../../24.04/3.md 9715df3661ff4f1084befc9c9397a8a1
+msgid "[2092158](https://bugs.launchpad.net/bugs/2092158)"
+msgstr ""
+
+#: ../../24.04/3.md 05e30ee4309743fe89f658790d62efbd
+msgid ""
+"add reconnect-hsp-on-a2dp-reconnect.patch to fix HSP/HFP connection after"
+" resuming from suspend on systems with NVIDIA proprietary driver."
+msgstr ""
+
+#: ../../24.04/3.md 66166c5e68634c33a2c937624a22c920
+#: 836ae8066edb4fa2989ed2542e0df380 933f0139052c4cdca35eef65815aaa25
+#: a27a72988f3445539a09be1293729946 ae28096da72a496cb798f30773d6d325
+#: cff9d855c1cc426287247f9e06bf3a67 f962ed6c489a44e8adfe1dc6092e1aca
+msgid "apport"
+msgstr ""
+
+#: ../../24.04/3.md d3445dc26dad401596c2e1f31aa22e4d
+msgid "[2097264](https://bugs.launchpad.net/bugs/2097264)"
+msgstr ""
+
+#: ../../24.04/3.md 1dea631bf9674fd9936f27e64810ff07
+msgid "Fix FTBFS when building on the LP infra"
+msgstr ""
+
+#: ../../24.04/3.md ce4479c1cd8b40cc8b100911d99393ac
+msgid "[2098415](https://bugs.launchpad.net/bugs/2098415)"
+msgstr ""
+
+#: ../../24.04/3.md 687d75ea5cf347e890d49ad700981520
+msgid ""
+"d/package-hooks/ubuntu-desktop-bootstrap.py: attach files with root and "
+"add subiquity traceback, curtin logs, subiquity or system journal, "
+"hardware information, and check if snap updated ."
+msgstr ""
+
+#: ../../24.04/3.md 6accc6b11d63487382c49de1c921698d
+msgid "[2098423](https://bugs.launchpad.net/bugs/2098423)"
+msgstr ""
+
+#: ../../24.04/3.md 5c840ed8df024a3bbecf530b77a5ab75
+msgid ""
+"d/package-hooks/subiquity.py: fix typo in path to curtin apt "
+"configuration ."
+msgstr ""
+
+#: ../../24.04/3.md 4e4640af99214506bd2cdda7665447dc
+msgid "[2006981](https://bugs.launchpad.net/bugs/2006981)"
+msgstr ""
+
+#: ../../24.04/3.md a20f0bc78fe64304b5adaae352655fdc
+msgid "apport-gtk: check for available display on startup"
+msgstr ""
+
+#: ../../24.04/3.md 6f4ef32444a442e0b8fc8c568b091830
+msgid "[2100313](https://bugs.launchpad.net/bugs/2100313)"
+msgstr ""
+
+#: ../../24.04/3.md 0b03fe19d44a45308c5ab3778fb429f3
+msgid ""
+"python3-apport: Bump python3-problem-report dependency to >= 2.28 for "
+"CompressedFile class"
+msgstr ""
+
+#: ../../24.04/3.md 66e1f6304b3b402cb41677050b88c4bc
+msgid "[2076269](https://bugs.launchpad.net/bugs/2076269)"
+msgstr ""
+
+#: ../../24.04/3.md 3d858825ad9f499a83715c36b583c798
+msgid "do not check for exact encoded gzip data"
+msgstr ""
+
+#: ../../24.04/3.md 481b03037fd84a9cbb2091e842d0e22d
+msgid "[2112466](https://bugs.launchpad.net/bugs/2112466)"
+msgstr ""
+
+#: ../../24.04/3.md 9c6da817e2fb46ac962e2f3e759f8873
+msgid "SECURITY REGRESSION: exception during core dump handling"
+msgstr ""
+
+#: ../../24.04/3.md 1289737d97274de4ab2604bb6b5e398e
+#: 17f92c8549ed473ca7a27b47b12c775f 2128cd34a8bc4b1385de96def275aa60
+#: 3b0d9fe18f3c48e194935376306d9e7b a847f51b65c94c23b1841ebaa65a7f4b
+#: a953a7eb3482496ca659b78b056f36e5 ca8f985ca2644b89b9971ad35ae5f3e1
+#: e8b8439e23424b1db8473ff5c9ff17eb
+msgid "ubuntu-drivers-common"
+msgstr ""
+
+#: ../../24.04/3.md 772e85b81e4746d78d50423744d2e015
+msgid "[2083329](https://bugs.launchpad.net/bugs/2083329)"
+msgstr ""
+
+#: ../../24.04/3.md b7b171e910074a3490ab86a9e3faeb43
+msgid "Improve SimpleDRM+NVIDIA fix across kernel versions"
+msgstr ""
+
+#: ../../24.04/3.md 3344ef9a7bc044b38864fc6ba179926a
+#: 8fafcd57a7b942a08a7472b2259ebd05
+msgid "[2085962](https://bugs.launchpad.net/bugs/2085962)"
+msgstr ""
+
+#: ../../24.04/3.md 0f8d4bf30d6f42279da3b4aa1d87dfc7
+#: 221297babc454ecdb50da6a5efa33add
+msgid "fix searching for lrm drivers matching linux-image-virtual"
+msgstr ""
+
+#: ../../24.04/3.md 0eb4407556ed43819ecf3231e622bec7
+msgid "[2083709](https://bugs.launchpad.net/bugs/2083709)"
+msgstr ""
+
+#: ../../24.04/3.md 4418d365f06e49e7beb7c4bbf6174f17
+msgid "fix install --gpgpu handling"
+msgstr ""
+
+#: ../../24.04/3.md 57dd82aba0c04fc6b664be1b06ee85ee
+msgid "[2090924](https://bugs.launchpad.net/bugs/2090924)"
+msgstr ""
+
+#: ../../24.04/3.md c6bed75c17714f51a29f10d19eb6da7d
+msgid "Add --include-dkms option to listing drivers"
+msgstr ""
+
+#: ../../24.04/3.md 124a20a8427b44c688e4f2594ffea91d
+msgid "[2081970](https://bugs.launchpad.net/bugs/2081970)"
+msgstr ""
+
+#: ../../24.04/3.md d0f03022a1524d199e3b1cec66abcd26
+msgid "Sort the output list of matching nvidia drivers"
+msgstr ""
+
+#: ../../24.04/3.md 7b9e3a947eeb4d8180c020f1e920523e
+msgid "[2081967](https://bugs.launchpad.net/bugs/2081967)"
+msgstr ""
+
+#: ../../24.04/3.md 6c267015546343b8a9b95d17724caf4b
+msgid "NVIDIA 560 release should suggest -open variant first"
+msgstr ""
+
+#: ../../24.04/3.md cfc5fa71868a4241a8cc0af45ca47c0b
+msgid "[2081881](https://bugs.launchpad.net/bugs/2081881)"
+msgstr ""
+
+#: ../../24.04/3.md 36878a37041349d2965c97873b40a2d0
+msgid "Add more useful help text for --gpgpu See."
+msgstr ""
+
+#: ../../24.04/3.md 134908ebfc8c4c0a96c4a46462a3a0db
+#: 14a8f93c7f6147d481e83eda3a794f5f c9556cceae824cc4ad9d4fab1d13b81c
+msgid "systemd"
+msgstr ""
+
+#: ../../24.04/3.md 40b624e48be74531886c9d2c8805a5a1
+msgid "[2088069](https://bugs.launchpad.net/bugs/2088069)"
+msgstr ""
+
+#: ../../24.04/3.md f4c2ea38f3f9475ab659cf5e3d49f725
+msgid "stub: add magic cmdline option to force EFI handover"
+msgstr ""
+
+#: ../../24.04/3.md 031ded775d7248aa9a826cdecc1f27bb
+msgid "[2091657](https://bugs.launchpad.net/bugs/2091657)"
+msgstr ""
+
+#: ../../24.04/3.md 415189f1e03f4661a98dd28d96e56204
+msgid "localed: use Ubuntu Core hack for locale.conf and vconsole.conf"
+msgstr ""
+
+#: ../../24.04/3.md 7e1492767dcc4db48b68612db2641710
+msgid "[2098183](https://bugs.launchpad.net/bugs/2098183)"
+msgstr ""
+
+#: ../../24.04/3.md 5dc6fd1be085490da63c244340fb6948
+msgid "Preserve IPv6 configurations when `KeepConfiguration=dhcp-on-stop` is set"
+msgstr ""
+
+#: ../../24.04/3.md 7ee7fcac5ef948d99e77ffab9d698ace
+#: 86d9f88953594627be1caab8d77c1d39 f86ee735875242cc84343f76492bbaba
+msgid "openssh"
+msgstr ""
+
+#: ../../24.04/3.md 47c4c5a245af4aa5a0b9e6758c0a5a5f
+msgid "[2076023](https://bugs.launchpad.net/bugs/2076023)"
+msgstr ""
+
+#: ../../24.04/3.md cd3b3664d6884aa3971ea0501441062f
+msgid "sshd-socket-generator: do not parse server match config"
+msgstr ""
+
+#: ../../24.04/3.md 8e429ad792c64d93a2cf1a5253d95a5a
+msgid "[2069041](https://bugs.launchpad.net/bugs/2069041)"
+msgstr ""
+
+#: ../../24.04/3.md c067d7d245bf4cddbd73bc0b7185c153
+msgid ""
+"d/p/sshd-socket-generator.patch: add note to sshd_config Explain that a "
+"systemctl daemon-reload is needed for changes to Port et al to take "
+"effect."
+msgstr ""
+
+#: ../../24.04/3.md 06f7ac0530c44a72959b4f9e12ae4a95
+msgid "[2080216](https://bugs.launchpad.net/bugs/2080216)"
+msgstr ""
+
+#: ../../24.04/3.md a11e84c3edf14ff8bb925240d0c0514b
+msgid "Explicitly listen on IPv4 by default, with socket-activated sshd"
+msgstr ""
+
+#: ../../24.04/3.md 95d61a94ee1d417ba4fb268ee53955f1
+#: a3b11ded321d497f90a2285b9582e759 be3477fac975469c91e76e77b459d236
+#: e62a4c715b2a45fab4bae284d86c5e95 ff8b0e3d8f094ce182a710469e03f50d
+msgid "zfs-linux"
+msgstr ""
+
+#: ../../24.04/3.md 266b8e9a19004057bb1a9054b59d39b0
+msgid "[2081678](https://bugs.launchpad.net/bugs/2081678)"
+msgstr ""
+
+#: ../../24.04/3.md 9ef5517c1999404990cdb0c8681701d5
+msgid "task txg_sync:696 blocked"
+msgstr ""
+
+#: ../../24.04/3.md 6360a34615cb4966b989bdc9f579a6e0
+msgid "[2057693](https://bugs.launchpad.net/bugs/2057693)"
+msgstr ""
+
+#: ../../24.04/3.md 4f1826eb3cf24e8696a95884c66f9aea
+msgid ""
+"Activating autotrim results in high load average due to uninterruptible "
+"threads"
+msgstr ""
+
+#: ../../24.04/3.md 3c455fe43a274fa898f093fc687f2c49
+msgid "[2077926](https://bugs.launchpad.net/bugs/2077926)"
+msgstr ""
+
+#: ../../24.04/3.md 815eac3220c546d498fa529fc61f4039
+msgid "crash in openzfs - 2.2.2 not supported on 6.8"
+msgstr ""
+
+#: ../../24.04/3.md 46a6f8f740644839b28a1f84c03f61cd
+msgid "[2082060](https://bugs.launchpad.net/bugs/2082060)"
+msgstr ""
+
+#: ../../24.04/3.md 668dd7f2dba746cf9ba5ff12bd2c6d34
+msgid "Fix \"field-spanning write\" errors on zpool import :"
+msgstr ""
+
+#: ../../24.04/3.md db3189505e964afca7fedfc754ebf065
+msgid "[2110885](https://bugs.launchpad.net/bugs/2110885)"
+msgstr ""
+
+#: ../../24.04/3.md 7a619b1cf4f74e29a4461b4903472ece
+msgid ""
+"Prevent superblock access when filesystem is being torn down (e.g. "
+"snapshot unmount)"
+msgstr ""
+
+#: ../../24.04/3.md 1a914722256147068241e0b96547d996
+#: 21992990241846acaa44f701884daf1e 8ded04484bb5438eaaaae0e754837ccf
+#: cac0654b49df4785b1c2370be19bacc7
+msgid "rsyslog"
+msgstr ""
+
+#: ../../24.04/3.md 8c2e244a7ea94202aff16b0f2114dd6f
+msgid "[2056768](https://bugs.launchpad.net/bugs/2056768)"
+msgstr ""
+
+#: ../../24.04/3.md d711b89cd0c44ea58b9eea6e45aef754
+msgid "d/usr.sbin.rsyslog: add apparmor rule to allow reading systemd sessions"
+msgstr ""
+
+#: ../../24.04/3.md 99093d702d2740a8b016b2c24e1a1564
+msgid "[2073628](https://bugs.launchpad.net/bugs/2073628)"
+msgstr ""
+
+#: ../../24.04/3.md 84643db449ca4ac3a48f9cc16300a303
+msgid ""
+"d/usr.sbin.rsyslogd: add AppArmor rule to allow the imjournal module to "
+"work"
+msgstr ""
+
+#: ../../24.04/3.md bb2a68e2ee784beaa55d34725e4d2356
+msgid "[2061726](https://bugs.launchpad.net/bugs/2061726)"
+msgstr ""
+
+#: ../../24.04/3.md 5a0aea6b1f7f4120bde297dfc79d3365
+msgid ""
+"d/usr.sbin.rsyslogd: add AppArmor rule to allow access to disable_ipv6 "
+"inside /proc"
+msgstr ""
+
+#: ../../24.04/3.md d5418017f64f4047b040e2de9f3c122d
+msgid "[2100765](https://bugs.launchpad.net/bugs/2100765)"
+msgstr ""
+
+#: ../../24.04/3.md 05801f7219484da18350b7a8d996cd05
+msgid "d/t/logcheck: when checking the journal, only consider current boot"
+msgstr ""
+
+#: ../../24.04/3.md 33906b1834d54af5ba393d7e21713318
+#: 7ebbd05bb617412297a71005c0a32592 986c34dfd5ac42d78a01f0a79ec0c569
+#: cea6ff01d1064c6ab70c4af1125c8ddd e71d5c691db74d68ba3769c191e8e9ad
+#: eff633cb335a4431bf83d437f4240107
+msgid "software-properties"
+msgstr ""
+
+#: ../../24.04/3.md abfdec0aef6947ba9e9d03d1775a905c
+msgid "[2086844](https://bugs.launchpad.net/bugs/2086844)"
+msgstr ""
+
+#: ../../24.04/3.md 04ef14f4f60d44508c8b28cae04eb1ee
+msgid "cloudarchive: Enable support for the Epoxy Ubuntu Cloud Archive on 24.04 ."
+msgstr ""
+
+#: ../../24.04/3.md f5889e8a9712417aa12729720b016092
+msgid "[2098805](https://bugs.launchpad.net/bugs/2098805)"
+msgstr ""
+
+#: ../../24.04/3.md fb08c4b2c15a41e1805277c8cc627fe2
+msgid "announce \"APT line\" in add dialog."
+msgstr ""
+
+#: ../../24.04/3.md d814b06efc4a43d2ace5e17af5162b79
+msgid "[2098812](https://bugs.launchpad.net/bugs/2098812)"
+msgstr ""
+
+#: ../../24.04/3.md f10e106b5b2449ad8fe9bf7814a2e656
+msgid "announce token validity"
+msgstr ""
+
+#: ../../24.04/3.md bda0563c33704053977d22d8db9cc182
+msgid "[2098807](https://bugs.launchpad.net/bugs/2098807)"
+msgstr ""
+
+#: ../../24.04/3.md d767667b2a184bf695b5bf19a88964d8
+msgid "announce compliance and hardening expander."
+msgstr ""
+
+#: ../../24.04/3.md 9071ae7a3a634e43ac447a92da0b47c7
+msgid "[2098809](https://bugs.launchpad.net/bugs/2098809)"
+msgstr ""
+
+#: ../../24.04/3.md 6863375356ce407c8d08e3c04485ae99
+msgid "announce \"Add APT Repository\" for this dialog."
+msgstr ""
+
+#: ../../24.04/3.md e56a56900a4c49889457f72ecf9b5e0b
+msgid "[2091547](https://bugs.launchpad.net/bugs/2091547)"
+msgstr ""
+
+#: ../../24.04/3.md 17ac0919def44ea299092c7e35cbf182
+msgid "Updates: set labelled-by relation for the combo widgets"
+msgstr ""
+
+#: ../../24.04/3.md 476266358c5d42c8bef617b77fc4b53f
+#: 6e01afc6ed15412ab10fe0799a9706bc ab30c8d9ee9a4e1ca8a7d29bb2272da4
+msgid "netplan.io"
+msgstr ""
+
+#: ../../24.04/3.md e53f20ec74644116bbad4d03de664b9d
+msgid "[2103603](https://bugs.launchpad.net/bugs/2103603)"
+msgstr ""
+
+#: ../../24.04/3.md cddfa2140b1845d790d4730c848424f9
+msgid "Backport netplan.io 1.1.2-2"
+msgstr ""
+
+#: ../../24.04/3.md 00de89c0b41846e6a69a22f9be2e2928
+msgid "ubuntu-settings"
+msgstr ""
+
+#: ../../24.04/3.md 9c3aa5bda0464b30ad34eebf8cb95ae2
+msgid "[2078759](https://bugs.launchpad.net/bugs/2078759)"
+msgstr ""
+
+#: ../../24.04/3.md ae3142c7713e43b2b2d9f29c4c6a0e9d
+msgid ""
+"workaround a netplan limitation leading to the file comments being "
+"removed on config refresh which confuses debsums"
+msgstr ""
+
+#: ../../24.04/3.md 05999b50a1ac4447a3b76d9f4b6abc80
+#: 94251bf363cd4b3da4a3cf528513d85e
+msgid "[2083029](https://bugs.launchpad.net/bugs/2083029)"
+msgstr ""
+
+#: ../../24.04/3.md d53208142a5f40d6b4152738945ee08b
+msgid "Fix networkd file permissions during `netplan try` restore"
+msgstr ""
+
+#: ../../24.04/3.md 5a72fb31959d47cb88f53ec190ee0b52
+msgid "Prevent netplan-generate from running during `netplan try`"
+msgstr ""
+
+#: ../../24.04/3.md a1bbb0025b084c169107bce0ae13886d
+msgid "apparmor"
+msgstr ""
+
+#: ../../24.04/3.md 71db15e6505142c08f3dcd7e5b4c81f6
+msgid "[2078467](https://bugs.launchpad.net/bugs/2078467)"
+msgstr ""
+
+#: ../../24.04/3.md c3309a0a37104e13bb59aa93529fd2a7
+msgid ""
+"d/p/u/fix-redefinition-of-ignored-var.patch Fixes a regression caused by "
+"a commit that changed the number of return values for the "
+"get_next_to_profile() function."
+msgstr ""
+
+#: ../../24.04/3.md 5956dd47608c471a858030a08ef95842
+msgid "libsdl2"
+msgstr ""
+
+#: ../../24.04/3.md 01c87d4c6196438fb149bfc2187f8655
+msgid "[2085140](https://bugs.launchpad.net/bugs/2085140)"
+msgstr ""
+
+#: ../../24.04/3.md 59a36b6e86994b47a218c38a60d9d7b2
+msgid ""
+"Address a performance issue during joystick/gamepad detection, caused by "
+"device enumeration. Speed it up by using udev info instead of opening "
+"each device file."
+msgstr ""
+
+#: ../../24.04/3.md 702e2d1572c54deb8cbcb97643096779
+msgid "distro-info-data"
+msgstr ""
+
+#: ../../24.04/3.md 103c3f6ff26c466cb2984f00db38b843
+msgid "[2107391](https://bugs.launchpad.net/bugs/2107391)"
+msgstr ""
+
+#: ../../24.04/3.md 28c0e59883cf46f8b756ea1802dd01ec
+msgid "Add Ubuntu 25.10 \"Questing Quokka\""
+msgstr ""
+
+#: ../../24.04/3.md 21bb2de249b3409f84aefd4693e5b26a
+msgid "grub2-signed"
+msgstr ""
+
+#: ../../24.04/3.md 67f4a3d77a7346b9b94023ece49e7659
+msgid "[2055835](https://bugs.launchpad.net/bugs/2055835)"
+msgstr ""
+
+#: ../../24.04/3.md 5ab76b66ab37461bb377e9a7ebf69344
+msgid "Rebuild against grub2 2.12-1ubuntu7.3"
+msgstr ""
+
+#: ../../24.04/3.md 8a65649687a84d02bc8913265b6dc42a
+msgid "lintian"
+msgstr ""
+
+#: ../../24.04/3.md a95537cf2a4c412b875fd897088c2aaa
+msgid "[2109817](https://bugs.launchpad.net/bugs/2109817)"
+msgstr ""
+
+#: ../../24.04/3.md 64716409c05f4a34a22a7ad2e0c4006e
+msgid "Add questing as a known Ubuntu distribution."
+msgstr ""
+
+#: ../../24.04/3.md 01450eab0dd1491b8b4492d6ba5f895f
+#: 795eabb1a36e4777b01db0d7cc02cab9 9dbac281a6484caa9590201d25b39323
+#: a8b7bec4238d4aa8a5dee7118eb996d2 a93d8709ef4c42f98599eb6aea047d22
+#: dd43fb08cafb40088fe18524ae124462 ededd8a7c3ee4bf79fcf760a2c098bac
+msgid "apt"
+msgstr ""
+
+#: ../../24.04/3.md 7c59388730e24921980fd30cc1e7f517
+#: 84a7043b8ce841b2890f2f51f9c49664 888294fc110c4f7b962a2f4961fcc659
+msgid "[2073126](https://bugs.launchpad.net/bugs/2073126)"
+msgstr ""
+
+#: ../../24.04/3.md 3d0074b6dc494fa49a3e8ca1f1f6e9a9
+msgid "Revert increased key size requirements from 2.8.0-2.8.2"
+msgstr ""
+
+#: ../../24.04/3.md 5fe77ff04c6745e5854cac32174c6751
+msgid "[2078720](https://bugs.launchpad.net/bugs/2078720)"
+msgstr ""
+
+#: ../../24.04/3.md fd9124340a1541baa55bf2f27a07038b
+msgid ""
+"Fix keeping back removals of obsolete packages; and return an error if "
+"ResolveByKeep() is unsuccessful"
+msgstr ""
+
+#: ../../24.04/3.md 92f299bddfd64338894881c0c1333543
+msgid "[2083697](https://bugs.launchpad.net/bugs/2083697)"
+msgstr ""
+
+#: ../../24.04/3.md 3b1e7104302c46a49eb7571a72b3c25f
+msgid ""
+"Fix buffer overflow, stack overflow, exponential complexity in apt-"
+"ftparchive Contents generation"
+msgstr ""
+
+#: ../../24.04/3.md c4deadc1b8304a80b064f1fa77ed2cc3
+msgid "[2073126]"
+msgstr ""
+
+#: ../../24.04/3.md 3515cf1c202846a3a150bd75d7306eb0
+msgid ""
+"Only revoke weak RSA keys for now, add 'next' and 'future' levels "
+"(backported from 2.9.7)"
+msgstr ""
+
+#: ../../24.04/3.md f287ef09d7bd43078c1e8e717f8c2aa4
+msgid ""
+"Introduce further mitigation on upgrades from 2.7.x to allow these "
+"systems to continue using rsa1024 repositories with warnings until the "
+"24.04.2 point release"
+msgstr ""
+
+#: ../../24.04/3.md cf7b297edd564223bbfebd16076b0c97
+msgid "[2060721](https://bugs.launchpad.net/bugs/2060721)"
+msgstr ""
+
+#: ../../24.04/3.md 849655b5f94d42db830d046d5cb204e7
+msgid ""
+"Revert \"Temporarily downgrade key assertions to \"soon worthless\"\" We "
+"temporarily downgraded the errors to warnings to give the Launchpad PPAs "
+"time to be fixed, but warnings are not safe"
+msgstr ""
+
+#: ../../24.04/3.md a5dcb5bf27fd492780f1ae4161344680
+msgid "sbuild"
+msgstr ""
+
+#: ../../24.04/3.md b5261d6b94da488fa27ba6c72215b042
+msgid "[2109853](https://bugs.launchpad.net/bugs/2109853)"
+msgstr ""
+
+#: ../../24.04/3.md 045a23c9f0d64425a39f530323f9d609
+msgid "make sbuild usable for 'user@org.com' users"
+msgstr ""
+
+#: ../../24.04/3.md 51137a4595db40a59c72e20700c36752
+#: 5edd2cf5af6d4300bb1705cc8d05fd5d ab60671d0398452ca9035f8f1dfcef08
+#: b40d2f1fc9344b5897b19dab4c2005c9
+msgid "util-linux"
+msgstr ""
+
+#: ../../24.04/3.md 157deef5e83847489b07f3c869e1addc
+#: 2f19db47d2624cf9b89041b8f54716a4 91663853262c47f59728f57a0ef59f7e
+#: dfe1b35ba26b444180ce010aadf4be02
+msgid "[2111723](https://bugs.launchpad.net/bugs/2111723)"
+msgstr ""
+
+#: ../../24.04/3.md eb190e4d95ae4340beeb826c90c35c79
+msgid ""
+"debian/patches/ubuntu/lp-2111723-0001-lscpu-New-Arm-Cortex-part- "
+"numbers.patch: [PATCH 1/4] lscpu: New Arm Cortex part numbers. Thanks to "
+"Jeremy Linton <jeremy.linton@arm.com>."
+msgstr ""
+
+#: ../../24.04/3.md 1c4870abc31f4da685cff234d48a2421
+msgid ""
+"debian/patches/ubuntu/lp-2111723-0002-lscpu-use-CPU-types-de- "
+"duplication.patch: [PATCH 2/4] lscpu: use CPU types de-duplication. "
+"Thanks to Karel Zak <kzak@redhat.com>."
+msgstr ""
+
+#: ../../24.04/3.md 09ac065602d8465c9410e6d2af084aea
+msgid ""
+"debian/patches/ubuntu/lp-2111723-0003-tests-update-lscpu-vmware_fpe- "
+"output.patch: [PATCH 3/4] tests: update lscpu vmware_fpe output. Thanks "
+"to Karel Zak <kzak@redhat.com>."
+msgstr ""
+
+#: ../../24.04/3.md b0f9870c1376459caef70fabd93cdc76
+msgid ""
+"debian/patches/ubuntu/lp-2111723-0004-tests-add-dump-from-ARM-with- "
+"A510-A710-A715-X3.patch: [PATCH 4/4] tests: add dump from ARM with "
+"A510+A710+A715+X3.  Thanks to Karel Zak <kzak@redhat.com>."
+msgstr ""
+
+#: ../../24.04/3.md 2a520a6251ae4b108f57fb2fc5a0f10d
+msgid "gnome-calculator"
+msgstr ""
+
+#: ../../24.04/3.md bbc4bbf14ead4473b9ec7fa1edef584d
+msgid "[2100300](https://bugs.launchpad.net/bugs/2100300)"
+msgstr ""
+
+#: ../../24.04/3.md 6ea8f409f65646c28e293e95a547def2
+msgid "Includes currency conversion fix"
+msgstr ""
+
+#: ../../24.04/3.md:197 71a39d9b01d44fcaaae8296ee4a70a37
+msgid "Kernel and Hardware support updates"
+msgstr ""
+
+#: ../../24.04/3.md:199 e6b8f175839c462bb7da9623b702094b
+msgid ""
+"Considerable work has been done on improving support for many specific "
+"items of hardware."
+msgstr ""
+
+#: ../../24.04/3.md 0cbc7c324ffd4dceb41a3c2abc7a6a8a
+#: 166f54ee722c4a79b6c89bd23bc32f79 1a45d764ddba4aa8a6a29e27f81b7fa8
+#: 1b6abc6d777945ad9a621576ba0200a9 20505b10ba0d4ab6a2ca12cb8981b324
+#: 249d165c7e7242578a1d0db87f27ddb0 251084428d9241f28c09c8bec52b931c
+#: 2629c5b7ee6e40b588a20a66f65bc5ff 2cbb922f2ee04e65bd45c389ab02d906
+#: 3537b9a3c80643e79099763225b68f1e 8b741c62e9ae4725933a1f86a103c043
+#: 912c812903ef4e208ec3f5d0a54a4838 b8403d36be77422f8ed53f932175c136
+#: e2575692e818473bab5a1119fc6980e3 e2c6e17130b0427381a5a8daa7ae9e62
+#: ecf2617e33b54cc8a13626f213a8cb90 eefa68c0142d4879aeb9cb361f06663b
+msgid "linux-nvidia-lowlatency"
+msgstr ""
+
+#: ../../24.04/3.md 085e80a6a23641c9bc368a6d35fd14a8
+#: 2ed303c8e1ba4f4fbd455b2894f2f358 36a304a121254839b65d17554d0c7ca4
+#: 592b93cc872b49869a74812858755ce5 74e8b05043534324bc8a6ee741c91e64
+#: 83dbd4df5d4346e2a8192f437d54c063 860061d3be3e4e629a26f1fd0c392a83
+#: 9beb6e17f6294239bbd8bf3bea5b0c73 c0769894345947e7afc49f9476508815
+#: cdda924ff73a4a41848262b63f776223 daa84658a6ca4d24aaf8c807508683b9
+#: ffef60165e3a4194b21d6da376f5fac3
+msgid "[2093957](https://bugs.launchpad.net/bugs/2093957)"
+msgstr ""
+
+#: ../../24.04/3.md 0196e39c14784854b26d92d11bc745c8
+#: 27f50950d89d4340b2a110e31211313b 498cb7081ee449678993cb4424758bbc
+#: 5ace4e4a98734c9a9a77c63cce6913a5 6feb144425d544eab4011363c9b3ffb0
+#: 7eeabb6d392d47979da0dd3fe4910df7 a2f918f334724ce5b2e96d0448ccdeb6
+#: c2c59d9cc90f41f9953129695ec4911b c361036a791044f28260ff15a6be2e40
+#: c87c39ef56fc4b93a3394804df20ce96 dfd70becfb694689b5e172e9a64218d4
+#: eb7fe9369fac4aff98428baf24faebf3
+msgid "Enable Coresight in Perf"
+msgstr ""
+
+#: ../../24.04/3.md 669489623fac468c94672ebd2c893c57
+msgid "[2080970](https://bugs.launchpad.net/bugs/2080970)"
+msgstr ""
+
+#: ../../24.04/3.md 78514500d28e41acb431c478730fcaa3
+msgid "Remove backport packaging logic for non-backport kernels"
+msgstr ""
+
+#: ../../24.04/3.md 55b65223a8bc40d68be69264dded5d3c
+#: 5f0e432667884395b189978562003907 846e02e3f2964d7bba3100827b6c5ddf
+#: 94e42f7253cd40f69bf18ee54e0d4377
+msgid "[2092141](https://bugs.launchpad.net/bugs/2092141)"
+msgstr ""
+
+#: ../../24.04/3.md 0c394a2dc34440b98f98731179255567
+#: 91aac82913f444e683f34171a57f104e 93984890294a47bd95c6bd7c48321681
+#: 952938c1a201429abb8cd8de7d34f37e
+msgid "ETE tracing failure on multi-socket system"
+msgstr ""
+
+#: ../../24.04/3.md 4f73d305ddfa498e8609f731bac1ade4
+#: 71c7b70172fc41c1ab12df550947f56e 81879d83347f4ba388e4a48ceed60e44
+#: b0f0693165884b5fba006faf203649f2
+msgid "[2091186](https://bugs.launchpad.net/bugs/2091186)"
+msgstr ""
+
+#: ../../24.04/3.md 20a8f20e55a3400c90afff1f6d0d3454
+#: 9edfe5f82743446e8f6eaaf036562860 a2c21b9f1f4d4e60b8ff87416863edaf
+#: f872f61b41264ceb8e0413f1ceaa8d3c
+msgid "Pull-request to address ACPI/HMAT messages at boot"
+msgstr ""
+
+#: ../../24.04/3.md 2c191d8d43b64e4b8e5b29db8f13ec91
+#: 4c617f63fe144489ab0245352c285510 4cccddc33bf340e086c73ae6671ec584
+#: 4f01568329da4e439f37264146d3414d 6323cde18bd147f59ed36dc8b8892f5f
+#: 6c6bd239c721419aa0bef1caa3855569 6e2a26a89b3d4f13ab79c08e7d6e591f
+#: 7cefc5d763584557a6e921913b902a2f 7d8e7cb5638e41dcac680c0de0f414ea
+#: 8427c714ea02492888cfe60c41ec617c 8a497c01a943444788d1e40447b0afd7
+#: 96539f3583734cf9ab9db7af9a02759e a8e16bae52d549aca7690eb1aa37e82b
+#: f6a58859441d47b1b13d6b0b86781c79
+msgid "[2050083](https://bugs.launchpad.net/bugs/2050083)"
+msgstr ""
+
+#: ../../24.04/3.md 059d0b407eeb44dba978d1e4c7f798c1
+#: 1ad991b97e4a4f07bc8c04ae58015fa7 36cc59baf92d4efebcab47efd206a370
+#: 3838181906774dd0b45730b22a43842e 4e98ff862c8d4773a1b7fcc047b0abbb
+#: 5e2cb891ed364e7c980ffaada391cfe6 792b2540eb5e4656a1958426e0f1b1e5
+#: 7adf5f5434864698a73005f45249c13e 7ebe913bb61240bc86bd3d115cdc94e3
+#: 9b0e34606ee7417abb57af6b1ffb01c6 ac025e17fe0f4cb58bf8460db5c12fa9
+#: b53e99ae2d474f4187ef6a69f5163259 e249adfe6f9c48eb9ae4073c4349c4bd
+#: fb5899c2305245608e5b1dc4a9af96db
+msgid "generate and ship vmlinux.h to allow packages to build BPF CO-RE"
+msgstr ""
+
+#: ../../24.04/3.md 2b184d3146834829924de1615359fbe7
+#: 2d27151b9b46489c8d0266332377aa92 3bdad69c7a0e48a4a6d152a059773dc5
+#: 74eafdfbde7e4b0e9f82e7124b8eb2b9 932ef79976144a5ea72c450f17afb9c2
+#: af65507264f947a3bbeb246ba04fc644 c62e47dcc4054e7aba1c28269a109186
+#: e0b012de228d465f81729b8a3799c0e9 e9a355a910f94c27a9165da8b4a7c97a
+#: ec215f30ca85472b85c071747cd66c83 edb0dce2250448da93704778430e98fd
+#: f2c7d7543c0e49608d569b2f74a75609 f56c7983a025451ba30552f7eb7266e0
+#: f61eaf3ec8db4b82ba341c9bf8368325
+msgid "[2091941](https://bugs.launchpad.net/bugs/2091941)"
+msgstr ""
+
+#: ../../24.04/3.md 15e8151c3d494a319070e2312c5ca46c
+#: 22b31098d7f749799276f06bc6957755 2b49d1e57a4d4f2e8d111691b66dd464
+#: 437f016496954450a8cfdb873d21dd4f 5e8426b8679a409da4357ccfee3172df
+#: 611a9faaac9e4aaa9e9a9c0420d6622c 6dbefdc619e142ebbae4c64196d75754
+#: 76754190c7544d139889d925098aca79 7e1ddac2570a4fbc8565094a0468cffe
+#: 840e39aecd2243fc840fd8204830c5a7 c04238f253d34d10ada0df67718fca7b
+#: dcab67da496c4a92aa0b82b4116aa7f2 e25182eae3124c9abf26afdddc9e959f
+#: fcda2a2592d04b2687b99bcfe69a789a
+msgid "Unable to boot as a guest on VMware ESX"
+msgstr ""
+
+#: ../../24.04/3.md 0c081e17a64d4cc38d8c8ef0a28e978e
+#: 1605de47f0234820a2149f53b5865ee0 28728bbf29ee4759a8629a1283e2e629
+#: 50a1ce3bb6114c5a90308e15438cac14 6caa21c6ea26466096d89274594fa5ac
+#: 6de3b3528d944993a1c760dcb4d0b2e7 9210281d8a9a4839a40b7aa948015f0a
+#: ad526c4668c84f1d9fb9e9ee8b7fb564 bf2739d598284efcb7b5c0f881dd3d8a
+#: c21ec1b079164123ab55d2d407226451 e0342ba40eb34e388228b8b9dca7f641
+#: e1fc5a9d96e3434d8a3c67db1d293d50 f0f391e68ff44501a5258b7414f0d1ca
+#: f78556a4cfe8452b81a68a2ecbb8bc51
+msgid "[2090852](https://bugs.launchpad.net/bugs/2090852)"
+msgstr ""
+
+#: ../../24.04/3.md 01171cbaf4e049e2b6ac752a85ae6ec7
+#: 05160817aa33454db29a94d09f259cad 104935fd185a4b76b4d3f23a24b12894
+#: 2bb67e49570642689cc305b405b19431 5c07a1b73a784ac09f058e5ff229d146
+#: 6b0b78f4a2f547ebb1f5cc3a72bb6a63 7d5256cec8754c6bafaf8284bd9daa53
+#: 8821e2e6596349f1b68e8cef32985a73 9a138ffc2ae34b43b620681c28646181
+#: ac26a54ca2e146ca96fe2928ecb10d0a baf5b45856a94584b7dca9957b8f74b9
+#: c17d2b7032d64357bafd49bd803a1b77 dfce9c5a03534319952892f3fd733ac3
+#: ed2d70d324f048d9bca029d5cd6ca034
+msgid "[SRU] power: intel_pstate: HWP interrupt support for maximum ratio changed"
+msgstr ""
+
+#: ../../24.04/3.md 1f5670b0b7704accb1268b84cf97cb5d
+#: 203711455cf14d1384e5dcacb7a269d5 508e6adfd94846628f314e3dc966381a
+#: 5503be61dfb447838dab679c398d4eee 70023030f45e496fbf363184c9a8fc28
+#: 8ab4c38c1bb5451483bf9fdf60583b37 9e07a5b8c1294f6683d481d88b369810
+#: ae43b97a44ba434cabf84a73338a266e b06552a5f9ef47799ae7e92b0bf89c65
+#: b452791603dd4934abca32f098e765a9 ba78cb4fedbe49a1afa2d80deb1eced3
+#: c10ce361f0b34748a34fff5849495633 de8f35e216d54a679e434238f128f859
+#: e00bbcb621384919a22bc0797b1797a9
+msgid "[2086210](https://bugs.launchpad.net/bugs/2086210)"
+msgstr ""
+
+#: ../../24.04/3.md 0c7cfc4db0824d32b7c7fc976b663ce6
+#: 327b488e14d64dfc8c3f049dda439010 52a264556f6b435dbfd1a925f347f053
+#: 61cf0326154b40869fb0407065368679 6d1edafa0c5c4c44a1604906fe503e59
+#: 8dcd3808c9ef455a8d75b38cb7a7a208 8ef7c0b67d3544ada207e8991e8f8aa2
+#: a9352dafa3094c6b8061048b8b41bce2 c2d9786049db4647a83bb9d93d9ade6e
+#: dc4a664e67574f6d9d26ae685a0097c7 de8440455cc54858a10f20a75b60e393
+#: dfe58ddd4ca740a9a48d1f0d0bb6b980 ef11c7b07fc04b34ba831c7b61639760
+#: fda3cb243cdb4b1398911d98a0494ee1
+msgid "Backport some AppArmor complain-mode profile bugfixes from Oracular"
+msgstr ""
+
+#: ../../24.04/3.md 16b040fb2c7d480b873481ae21cfb65f
+#: 26071c717000446b8972f85e11051ef4 3667a5d47969424ca3398786000c3872
+#: 37f7a1c683a9493e9eb1d852d670c409 3c2d1df84313469fa082731682cde6c0
+#: 627d927f30b5430cb0d59222930b6b77 6b13f6a611904652913d4f0768dd6a9b
+#: 6b3b381815664abb80094a68e9788a0c 83d7d6c42e484c9f9afd5d51d8384fcd
+#: 846cf215223b4668b4cb4d3bfc2649a5 8ee03271522a4a95b1434286de9fd1ae
+#: b16fdbec8df64098959896f5ce1e5e79 b8a26e9f18424195b5ce5b1516be8639
+#: bd5120fe7a924eed823c259d51f474ec bdcb5e79d1b34bb18521ee8595161e3a
+#: c6e3afb3d1c6469793216b848856efb8 df9ed40ecbc14e6cbc3873c0bb37ce71
+#: e0cb428c382040368cb4ec9354d16218 e6e3d9c4d4734d3c943dc59e0038492f
+#: f0ad82be0fde41e7b0194867fbe51fdd f663b22fac7341c8ab96a9e09f7237b1
+#: ffaa681c992a433cbf6c0efbccd7ea83
+msgid "[2095370](https://bugs.launchpad.net/bugs/2095370)"
+msgstr ""
+
+#: ../../24.04/3.md 0ad11b3ebda84281b800c0be76d57d9f
+#: 0d9ee249b5ed463e8b22b321ca95b1fa 163f755013fa40b987b8a01f95b88dbc
+#: 1b1c646a3e55479f99ac7f34f0175763 250f4586c7594eef83aa6786be9b262b
+#: 27a8724f66e341049bc357ba55664e56 34cf3b148d95433caba962ccb7102487
+#: 4e1d8b1484ad4159aedd937114372502 5bdc898f28b34bb896e05b7f57bec7e3
+#: 61f6502d8ac742e986d4c6de7e950610 7748fbc4fac649ad8369944a8195b874
+#: 881a2105baee41eb914e73cec9a58b0c bff3409f1ff84af09e0a2ef34ac48cee
+#: d02d8865c2da4396956b1b5a058daa20 d08f99b0c7104230ba9b05b87c89f7b1
+#: d242ba0ecba14b468705610072dc4f48 da8893330c8b4cce962f35ef8a746fc0
+#: e6f6975b06d240d8b3a3d2319d2d9843 eab4661fad4c42728f3856a965079f09
+#: eeba9303cc844ca7872f9049d3e1fdbc fdd2a559a67541c9bf3024ddd6ea4b44
+#: ffecc6c9b1434cda8648bd20332ab0c1
+msgid "AppArmor early policy load not functioning"
+msgstr ""
+
+#: ../../24.04/3.md 07e7c639233b4b3aa573b60a8105da64
+#: 0e203d94e7134de79af20a18ec71987d 128a58cd2d9346eaa41d2ce1dfbea1e6
+#: 149efd83cce64c13bd1478f98c598a1d 1a148dbb4b404bfca3b1d29c92c42df7
+#: 1e36eb7ecd4b42ca8b502f50d527f5ef 3e73407d989344b1ac4563ccf702dae0
+#: 4ace61d252a14b07b947b49cc1a8de83 4e2eb4766160419fb73702f054ceb54a
+#: 5f4e9449d75b493c885d07629a8834e3 7973008c9425496a86461dc93a85465f
+#: 991fe30ced954833af5f42e2bbddec50 9b05ef40a08f4e029d53e226cf3ed835
+#: a680a6bc100249da8880ec199508f6d7 ab9bf6dabf504634a4c323811773c184
+#: b9af45d1c1514f2b8cf4454d74269c73 d201322af2554d4299a954358eca442f
+#: d46c9011344b4992abcd0f31fc1c24bf d6f73796727e499cbeefe872e71dd1d9
+#: dc8399b127714386b63eedd5fb724fd7 e1a11572264442aaa5edd28f2c5f3813
+#: f39282c6445a4b64b27f6956e85ddf29
+msgid "[2067900](https://bugs.launchpad.net/bugs/2067900)"
+msgstr ""
+
+#: ../../24.04/3.md 13d516fa5d7d44c987cbe2ff334eff7c
+#: 18554b7474ed41e3ba687e0acb58ae84 1b409dd13e324ce29aeb72dd476c2eb2
+#: 21307d494c57465d884613d5e22ee842 224af26fc97c49bdbdd70fde0335c23e
+#: 23e5189c03e3476f90a5d9422631f77a 2d1ee0b1fa1149fb8e7806179125af72
+#: 6cfebe78855a4f3ea897ba432f5ec68c 6e96e7a4b67f430184468a3b15e65b43
+#: 8e81268fd28b4427a1cec0fe5887686b 91f400110d1842918e18b103d3101e58
+#: ab9588eefb014a86aa5e6f66865b0667 b66374f1f7c14b7299f3c4272ba640d2
+#: bac0d86e282a4ca4902a5961fef7ec76 bfdad12e85754251ae33808488a83fc3
+#: ce4381a0c41d4c7db58f2c77d17d8551 dcc02446e99b4bb9acf04b1b221c9db4
+#: debda5c538a44b1aae7442cade4a1bae e0818456d31047a8ab74dc0d350ceecd
+#: e37f0e36f29840939a8508df5bdbd21d f036dc8cd8c049fcba6f231521ba196e
+#: f653aa74d9d7401fb801198334625f41
+msgid "apparmor unconfined profile blocks pivot_root"
+msgstr ""
+
+#: ../../24.04/3.md 11a7f6f161d84382945cc670744f4895
+#: 1b45e923501b4aff848c18416a97ff5a 35a3289ec1e348e19b40d297e42275de
+#: 58231457f01645f8bfa1c2443b8c340f 5ac63f4c267f45b9a258fc19084fc763
+#: 5d15cfa5903647d3ac4969627ff71fe5 6b0013bc867e4d00bc6339352f5a24ae
+#: 6dfc5f2a8326432abc91f9ea5f98fb88 8718e622330d4919aa33f28bceed226f
+#: 94cc73f22cdc4afb988f289e899ad8c0 acea8895132840cc8f67e619aca96479
+#: add1a125c2a949ee9ca4e9d5056bc5f5 b21a9085d7d94b4db77387012ae343e7
+#: c1b0275606b74c49adc66f916709e973 c624add51ecc405bafeda1031805a093
+#: e0ee490fadca444da705b399580fee9f
+msgid "[2098104](https://bugs.launchpad.net/bugs/2098104)"
+msgstr ""
+
+#: ../../24.04/3.md 06cc6fb010454c8091bd5884b35a707a
+#: 09bd5ee89da44a3e919c58298aded627 16cc605ad1a94c2aa294199c5e6d6934
+#: 21b64258d0a640078616f2176da2372d 2ad6edf189e04389933e1fadac1149a3
+#: 2d3f5f7733d040609d7e0bd511f0b439 300f69eb7b374a5b91444443f76aa7df
+#: 3203b29f397d499286c8a9798582b444 7c231c3da368430a9e0e97986779fe6e
+#: 9384d54e030e430f9b55f15dc8c65f0a 9b68195efd464e719e66577e8aeed510
+#: a18258823e9743248105733f913f6905 be09e439c2444b4298935521dd890907
+#: c770f98d688b488cb60b39e9c4982ba2 ee50db4c46db4547bd25ea080bd61481
+#: fa7c0339a4224446b86de450670fe1aa
+msgid "Patchset for TUXEDO devices"
+msgstr ""
+
+#: ../../24.04/3.md 277f36a4ad7346d4ad8b0c42e4ccfef7
+#: 44d75770a58c4e9e9b6bc56d2dc617d6 58b94ff891b6412c9abe32ff7c4263a3
+#: 5963ad6221a14d088482948992897bfe 7826566cdd9a4e8285765562146719e5
+#: 7d6681f908e04f7cb3de1d27fcd01e67 88cf775ecfa14fcd8c1ea75afb9e74a9
+#: 9a9a202cede34c178651e94afebbbf1a a390545ed6774f40b0cc1c6ae3226d66
+#: b2955d482363479d8498391e32e5d8ed c76f99a402d74e71bd310bd9d6a790c6
+#: d574abd6e9ff45e1beb0720c2614913a ef036b60fceb4ca9b0463a055322d58e
+#: f14d82291d9b46138d64a8ba9d6d3052
+msgid "linux-nvidia"
+msgstr ""
+
+#: ../../24.04/3.md 0aad24539a7b469db0c74efc0e304259
+#: 4d99eb1d27de4f4081d910fd89f117a5 4df8d735890f4cfd9bbaa9bc8f7c059a
+#: 7183d55731c14600bfb6b27fc5183bd1 7b7268255c5b4ed1bc6c3efd6603f29b
+#: 87e21fcff3694292857f53864ef47ef8 943df36ecef84eabb0c4bd54e8f246c3
+#: ab2cb77548474fac88dbb9c7f1f4ebd7 b3ec9ac47ae440f9b2d2aff9b0425dc1
+#: e04e1dcfa5694d58a9aedc38e6493ef1 e3cf70965c9a4b5087fe9776c2b227cb
+#: e7bad74b31794527ab1d67af8096ef43 fb5c3dbdde7d4e999f3d3727a20f4d09
+msgid "linux-nvidia-tegra"
+msgstr ""
+
+#: ../../24.04/3.md 20024bde8e0f4dd5bc723cc9aba6ac6d
+#: 23bffb435c1e4c2180bf8d2645d2f823 6f202bde4f204065a145e34867ea1b1d
+#: 7418f2322ded465894bcea86f3db2398 feb756d048384365ac1a36628c7c7076
+msgid "linux-nvidia-6.11"
+msgstr ""
+
+#: ../../24.04/3.md 0032e538d4624bbe863857424d21486c
+#: 0dd7536257554cb2afc619bac9008c29 12e1d114e8514c158e4be9752a128424
+#: 3835744a62034bed8dd12ca170f82642 432f10a50e4344108a72df0c2a9fc48b
+#: 5cec9867edc846619891f47f4cf1655f 8590cbe381ed48db9c654fd51cad6f51
+#: 8aed7de12fef4aafb4c1dacd492284a0 a511839fa7f94f6a9f90c7aa0bf96f91
+#: cfa6c3cbd3364529bcf1e2a2ca9cc092 d8795181c23c40f38a5ecf06ef32c74f
+#: dcd5fab856294e30aa78d5c76ae18824 de8507f78aac421f981d3753792a5248
+msgid "[2106022](https://bugs.launchpad.net/bugs/2106022)"
+msgstr ""
+
+#: ../../24.04/3.md 3c68c03c5f204c26963c6766b2e5ba47
+#: 4a9f2a6b5bb943e88a745a1990eaf28d 6827bbacf41947c19e732387d7baef6f
+#: 82acae79c5644164ab2866664fd4da70 b0f5d6e75c43454482f249780758e1c0
+#: bae0912c96624672aaa09a18f52a52cd d0414b3e308e4e6198e9718d026b964b
+#: d095a145d2074051978765b3ffcea89a e7621aab29f148b2a880b68d28b0928f
+#: eea86cc38f394c3393023967a0ee8711 f62114d8176843e99bada101678cdd2e
+#: fa93f75a42af4df4a7e722cb3daa6126 fd73a213da1047e49c6365a3040e08fc
+msgid ""
+"log_check/kernel_tainted failed with kernel warnings at "
+"kernel/time/timer_migration.c:543 on Oracular"
+msgstr ""
+
+#: ../../24.04/3.md 5e76f6ac9f0b4ec580cbfc069a9c800d
+#: 88cc9fed1b844f4a8aa043e5706e3489 92c6a1c781d84f859b44972c0c4376f0
+#: ee881d9349f84b17afe9f5fe696cdef3
+msgid "linux-nvidia-6.14"
+msgstr ""
+
+#: ../../24.04/3.md 4578ed7b42df4444ad9b527bf8b5ba89
+msgid "[2061930](https://bugs.launchpad.net/bugs/2061930)"
+msgstr ""
+
+#: ../../24.04/3.md a4974add224249da8ec41632f2532dc1
+msgid ""
+"linux-nvidia-6.5_6.5.0-1014.14 breaks with earlier BIOS release, and "
+"modeset/resolutions are wrong"
+msgstr ""
+
+#: ../../24.04/3.md afd93c3b30374cdd81db4d3550f29a20
+msgid "[2059814](https://bugs.launchpad.net/bugs/2059814)"
+msgstr ""
+
+#: ../../24.04/3.md 837b0f0a22854fa8b5698d10e1e535fe
+msgid "Enable GDS in the 6.8 based linux-nvidia kernel"
+msgstr ""
+
+#: ../../24.04/3.md f1a4a8e91215406fa9ced138dc04f37c
+msgid "[2060327](https://bugs.launchpad.net/bugs/2060327)"
+msgstr ""
+
+#: ../../24.04/3.md c2886d21fbfa4391afa50042a7014b48
+msgid ""
+"Reapply the linux-nvidia kernel config options from the 5.15 and 6.5 "
+"kernels"
+msgstr ""
+
+#: ../../24.04/3.md 56d1c849cf474eb2b82593b89e92c656
+msgid "[2112600](https://bugs.launchpad.net/bugs/2112600)"
+msgstr ""
+
+#: ../../24.04/3.md 4b740f2ff2734841bf9d0f6bd5d929da
+msgid "IOMMU: Support contiguous bit in translation tables"
+msgstr ""
+
+#: ../../24.04/3.md 5d15d9761a034245844f8e1244a27317
+#: 6e29d6d0987d46218aba13f434968274 af5cf11292ca4299aebd1360cc178399
+#: b3447befa78a430586a9560b2bbac046
+msgid "[2106281](https://bugs.launchpad.net/bugs/2106281)"
+msgstr ""
+
+#: ../../24.04/3.md 19a927a75d624cb2a94052d5d210b1a1
+#: 333f3ad1c5d14ac5ad0b6440135d55db a21c0cc5ff16444fbb29856751d7cb45
+#: d0ebb72663c64253818e8bad9168cb18
+msgid "Null pointer dereference in gVNIC driver"
+msgstr ""
+
+#: ../../24.04/3.md d33b03a4d26c42a19455fa4119a559c2
+msgid "[2109728](https://bugs.launchpad.net/bugs/2109728)"
+msgstr ""
+
+#: ../../24.04/3.md f31fd1ee8de04b2eb3bf1d105de8d014
+msgid "NVIDIA OOTM fails to compile due to small CONFIG_FRAME_WARN"
+msgstr ""
+
+#: ../../24.04/3.md 04169febb14d44e483f8e9c97d0c96e3
+#: bb742d5df1e54bc3b83e41360e90b30c
+msgid "[2102249](https://bugs.launchpad.net/bugs/2102249)"
+msgstr ""
+
+#: ../../24.04/3.md 78db5465dc914d6295c9661cb9acd4d9
+#: ddff870ba1fa467ca4dded70d32b9c2c
+msgid "Noble real-time patchset update: Merge changes from 6.6-rt LTS"
+msgstr ""
+
+#: ../../24.04/3.md 1ba849bbcacc425997f22febe35961b7
+#: 217c7cd2f3fd43709b5eeb18760a7e67 25dd85c806cd4bac80dccf198d0a4782
+#: 51d43f3de31048f69ff2b21f236181d6 609b76f5b58941e6aea371f7eeec51d6
+#: 6248dc121c71440eb054dff63a554f85 cb53954fe13c4b008350d8b35278429f
+#: dc30fba932b74a24b360ef74e31876cc f96b35de7c994f10945a4d5b1dbc0571
+#: fe5d536407134377b9ff15f20f857262
+msgid "linux-lowlatency"
+msgstr ""
+
+#: ../../24.04/3.md 2f25de78cd8c4eb6b25b3a4a56e2eb14
+#: 451322c959f84540aaf0410a59c77611 524c4cf35dc746fa8ce20c2406b3331c
+#: 663a45c2829949379daa144f51584779 7add7a54b3844e70b7759bde4e7a952d
+#: 8f2393e761f14f6aa267c7b935cf0f7a 96e7ea6fe5b24bc9bdf55c25a5d5edf2
+#: caf08788fc8c4cc19b2174d699f62b84 d2f08d9609834daaa20e8a8913e8b9df
+#: fae8bbfe1f1c4aea814674796f446ed4
+msgid "linux-riscv"
+msgstr ""
+
+#: ../../24.04/3.md 156adb66425b449baf462147c8724da1
+#: 2b1409f260884fdba4bbef7287bc9b26 4497b1216ccb447188ec146e6779c2de
+#: 48c79d68bfe143418f719eec8a879ff6 5cb179c275bc4b16a862e50ef59c0e1c
+#: 6b82bbd116a14340baf4605db2a7b0f0 7b277cb56fa541459b8b4b783d5dfb35
+#: ad8f079836be458a8bf09081ac88c4f6 c7007ab1c8384a67b3a5d803be179b7d
+#: ce9b56606c6f49c19817c925d6273774 f33ca0abbddb489f976166a4224540d2
+msgid "linux-gke"
+msgstr ""
+
+#: ../../24.04/3.md 1cbf8f82631245f0a21c55d3882299a7
+#: 463fc7388df944c0875ab92ca05ae89d 46e932d98cab454d96de9fa99e24c8cd
+#: 50358d8c9370497cb1408b2426520a95 76b5cb1a07dd41318eba3766f313b543
+#: 8038f8d6852f48fe9059eb8fff558199 82d73cc6cc02429cb76dfd6027f5c8ee
+#: bb9e3c5459c04b12be0fdb13a442e75c c3a2521ab1d746659a699c9fff80bbf5
+#: cb74a80a655043ec92dc0d2fc711728b f5ce2f4201434cc79122ce2d2b7ea289
+msgid "linux-gcp"
+msgstr ""
+
+#: ../../24.04/3.md 0bc2e6e75740440c8efa3dc0902203e8
+#: 14ff7608279d46efb1dd63f2e83f4a73 18d4dc5e4bab41f88a0b63befc105b51
+#: 37eb713de1384bc6a5003759d29ca57b 7e8e6f44e23247b5afaeb5d3ad81e5cf
+#: 980640c1c8624e79a8520c6664da0d8e a02c3ccc303b4440b921bca7fc5d90a1
+#: a21caa22dc8a481cac3cbf6836436f60 bb343f38b28d4d0a81b91aee43f4c4d8
+#: d8481efc75a940db93d4d491bb434eb7 e0e510937b6d4a80b8a8ed4501667097
+msgid "linux-aws"
+msgstr ""
+
+#: ../../24.04/3.md 008ab749c67b4980926810174c2fa8b6
+#: 14480acc300c4b30ae21c2ecc89658c1 25187b1bc8504012a4a741be511c8206
+#: 40d928f2c8ab4ccdac21be32a9b1d52e 5b05fcb1dd684e63ba0e3dec131f2725
+#: 9453264a1d7d4d158f6c433bde85dbaa b14ca74fe6304749a1b17c714bfac0b0
+#: b5b1d95f7d6f4d648241e391d772668c c71e43f844bd423189c30c69af42ba8a
+#: ec2fc8b8f73f40d19657ed33b3ecc727
+msgid "linux-oracle"
+msgstr ""
+
+#: ../../24.04/3.md 022a995febd04219a267a94a797a5dc2
+#: 2b91effcd4da4108a26986768dd8fe18 3aa9c5cf8e124b35881e5e58344235d5
+#: 490efc1c9b284c34965faefe28b108e1 4ce83d07e7874673998465d2bdd997fa
+#: 541caf857f1f48cab68bc176c836dec4 850d3070e2d844bb841b00095d623b93
+#: a439c3bbb2f3440784be64318e3b0ada afcef684ad4f42eab41974d15097b9a8
+#: ca559ffd31c7480e9c0a8af214aa2f73 dab6ded66a9a4287a38f6cffe1f647e4
+#: faa09a46558c4bd18d020bda8a88535a
+msgid "linux-raspi"
+msgstr ""
+
+#: ../../24.04/3.md 296f60b186b54ae5858327ae4c0555d2
+#: 30253d2d3c234febbbd930e6e56bad86 39da5942a3064aa2b5b53308df3416dd
+#: 4ea5b509e2314854a98321edc51e6baa 53bd574d6ea64eb4bcc2c36f3178cf79
+#: 5f39fe6869a641b9aa52db27cd0d49f5 63fec28bc47a47b18b5b03c9522190d6
+#: 680a8340308b4df5ace64978dce9d25a 6e1de42dc1b14584b7a6543045077542
+#: 6f5d8b3c2be043aa8163f23610a0a366 6f8fa17ff25a4829a23ffef11a7f17c2
+#: 7a704d342c6d481fa01593132a61edb8 800ba0917b5c4fe284389dbbf34dab1d
+#: 8459f636f37b4a089a31b27adb347218 8a55f1e4e27d434092d196bf9507f51d
+#: 8d1402f857b1451b82bc04bd95f94414 8ecd58f57e6b4440b05e5179e8fd89cb
+#: 93d1246eab934db88795e5c10ee7fcbc 9b670dea61034770a2a3da5aab4239ee
+#: 9f64fd444faf4719914af11449ee0c26 af882611cb5944d0b1f2c1c3f2c376ed
+#: b3839f9864534e61b7b090796864fdc0 babbbf1e23a34faeb746daafa75912a8
+#: c0f1cbf7239f4d75b23584deb5665204 cf7dd7477b064344a778a3261f185517
+#: d44b0992f6134bf98b1105aabbd83577
+msgid "linux-firmware"
+msgstr ""
+
+#: ../../24.04/3.md 99bc0b5729224e8a811ac483931e1c44
+msgid "[2093400](https://bugs.launchpad.net/bugs/2093400)"
+msgstr ""
+
+#: ../../24.04/3.md 854880e93a4d42c1a84bce8f089875c8
+msgid "With OLED panel attached to amdgpu the glxgear fps is too low"
+msgstr ""
+
+#: ../../24.04/3.md c27a1c94365f44fab4394da4d417e6a3
+msgid "[2093304](https://bugs.launchpad.net/bugs/2093304)"
+msgstr ""
+
+#: ../../24.04/3.md 4b686bb653e544269724975c1a5a23d7
+msgid "Add missing audio firmware files for Realtek rtl1320 amplifier"
+msgstr ""
+
+#: ../../24.04/3.md 1f640cf8fa8247939fa5c9b3a3b88b67
+msgid "[2095334](https://bugs.launchpad.net/bugs/2095334)"
+msgstr ""
+
+#: ../../24.04/3.md 48b4a08769a44e7b8c9c7cf5ae7fb3bb
+msgid "No sound output from one of the speaker on HP ZBook[cs35l56]"
+msgstr ""
+
+#: ../../24.04/3.md 8698ff501d8449f88e8fca6154ee755e
+#: d8d0519041e843fcb095c4e8cc860829 ebf1807bfae147a2960b0d79634d94e6
+msgid "linux-ibm"
+msgstr ""
+
+#: ../../24.04/3.md 093c3fa7b9334f2b8abfc4d98def67c3
+#: 1c2f1156591d4f6cb86c48258fce93bd 3022130b33b74b62bef244df47b5ac36
+#: 422c4fbf1ec14a74a702d02d83d57ec0 424f8065b04245b89290d9df6c24ba03
+#: 4ff5ca52a54a4b74bb81f871f6d1c163 56a2e108211b431c9fb0d2d13fda17bd
+#: 56bbc052ede94f648b8a01915f578166 61cdd58aface4eddae9d9498e6dc6756
+#: 6a7c7c51c2ff4795a4e61eb46e265e11 79403c788d6f4e7b99676d5773327955
+#: 7d3257fd5715495690d393ae5450170e 85ddb19b697445bb83948dfad8a23dd5
+#: 873fcc9202fd41fda48e9b8a9f2047c0 8b93a77d0f7b4c36834a067d54f2a9af
+#: 8f68c95d1b7044c2b5098f9f1e61471e ae68a7b5e82f485693fb6608ffe8119a
+#: b743cee5722c43029b2d64f62699eb3d e3359cf6c59b4cdb9f535457105b3490
+#: eecd7920019d4c45b3036b69caa0073f f1c8525b365d418e99207089d6313258
+msgid "linux-oem-6.11"
+msgstr ""
+
+#: ../../24.04/3.md 3aaa542cb03b48d3afbd5b3d2f9332bc
+#: 441821ae0a354b9086077dc704175a0a 9815efd5a23d4c0ca2665175e8ff86fe
+#: ddaaace3ca374e52a41ea9dff99e9593
+msgid "linux-gcp-6.11"
+msgstr ""
+
+#: ../../24.04/3.md 69ef07ce504d4a13a943cd5d4c77ac4f
+#: 93eefe5aa2104caa803869ab773c5603 f37f4bd24cde4b78a9ed1025eaa4195f
+msgid "linux-oem-6.8"
+msgstr ""
+
+#: ../../24.04/3.md 1976def34bf146868964ea4eeade8f7f
+#: 97153cec5f994f1ab878e1acf4b3dee8 991066d8dd7d438bab250f766e91499e
+#: e29cd5a4a8cb4604af28571045778596
+msgid "linux-hwe-6.11"
+msgstr ""
+
+#: ../../24.04/3.md 1ef90299deeb4b449b71fd3d83d0b0d4
+#: 4eac19ff50f74a54a170c3dc238727b4 6345933ef729401097ed87cd7e5160f2
+#: 7bd8d16665d5475fbf9a36dd7173ee04 825e5347843c43388f0a22ee4323a517
+#: 98a92ed71c2c4d189eef5b885ef0dca5 ab9cf04344f84bca816fdef30d86c017
+#: c253c99386fa4f09abe7b7bd7d4c7cb9 c63a67217dc848de92de2faa11e870e7
+#: ce090c9a766f431bb359d1d8fdb63f5f d651aa4b7ee7423ea01af0a6aa2e4e6d
+msgid "linux-azure"
+msgstr ""
+
+#: ../../24.04/3.md 3c92d591c52f44c0b2776806beab5949
+#: f1adc0e3ebbc4e8184946f6e96160786 fe3739239c05445ca4de68ba2c7e48a8
+msgid "[2090880](https://bugs.launchpad.net/bugs/2090880)"
+msgstr ""
+
+#: ../../24.04/3.md 0324bf7b9f3c44a58c8e147a01a54f37
+#: 2043346a6bce4e1ebc227b4d78cc0b21 af506591b4574150ad600f266033cbb5
+msgid "Azure: backport SMB lease key fixes"
+msgstr ""
+
+#: ../../24.04/3.md 025e2a89300246638e3651c947775d5e
+#: 5aa775f8b47847408e8a823770de1360 64a798a64d8c4381810bc88fc38e88e3
+#: 7556c97584604272b0d5118e858c4d52
+msgid "linux-lowlatency-hwe-6.11"
+msgstr ""
+
+#: ../../24.04/3.md 6e9439e42e2844a0b2ac8f729b5bf112
+#: b1c736e4813a4c03a3f069f97388b79c c42b466678d84a8fa318421a5cf62659
+#: ce152ac8aee04efe8d9dbc3bfebeb026
+msgid "linux-azure-6.11"
+msgstr ""
+
+#: ../../24.04/3.md 89377591e8994014bda1a89b69a3e54e
+#: cae948940f1e44eea8fd0e4f600bc7b5
+msgid "[2103768](https://bugs.launchpad.net/bugs/2103768)"
+msgstr ""
+
+#: ../../24.04/3.md f1773a9a023d42ef95231567491f3d99
+#: f844185bd6194a3aaa44c30e294eda3b
+msgid "Add support for Realtek 8852BE-VT[10ec:b520]"
+msgstr ""
+
+#: ../../24.04/3.md a0cfeb7b9d9e4cc99797ea11d9cf22dd
+msgid "[2103753](https://bugs.launchpad.net/bugs/2103753)"
+msgstr ""
+
+#: ../../24.04/3.md 13416a5929674d97b60273844a2ec595
+msgid ""
+"Run sysfs_attachment will be stuck forever (HID- "
+"SENSOR-200011.16.auto/iio:device4)"
+msgstr ""
+
+#: ../../24.04/3.md adf7bdfd2a8b400e9a75d1cac0c60bde
+msgid "[2103680](https://bugs.launchpad.net/bugs/2103680)"
+msgstr ""
+
+#: ../../24.04/3.md 1674e8685cd645de88638b6e3812a36c
+msgid "System freezes when running the memory stress test"
+msgstr ""
+
+#: ../../24.04/3.md 15b5b345ee444d2c857145368e7e9dab
+msgid "[2103569](https://bugs.launchpad.net/bugs/2103569)"
+msgstr ""
+
+#: ../../24.04/3.md 8d677e47e69449b0b799a9e7846e44b3
+msgid "Enable Realtek NIC ASPM on more Dell platforms"
+msgstr ""
+
+#: ../../24.04/3.md c55abfe0c5f144fe83893b22c9bb636e
+msgid "[2102065](https://bugs.launchpad.net/bugs/2102065)"
+msgstr ""
+
+#: ../../24.04/3.md 0580e69a585c40f6a56dbacc8a93ded1
+msgid "[Enablement] TI AMP TAS2781 Enablement (2)"
+msgstr ""
+
+#: ../../24.04/3.md 809ef7a4a2b64804bdad2275be1e84da
+msgid "[2100820](https://bugs.launchpad.net/bugs/2100820)"
+msgstr ""
+
+#: ../../24.04/3.md 7199b52be7ea44b7b13ed5b3dcc387a0
+msgid "proc_thermal_pci 0000:00:04.0: failed to add RAPL MMIO interface (2)"
+msgstr ""
+
+#: ../../24.04/3.md 0178da51173645d38b141b751a3544d2
+#: 0fd350bbaee54425a94e122aaad3b15c 10a09119de5a47f2aaca8251fbf1fe39
+#: 13706bbd38ee4b80994253d2c812aba7 185a116dc1764f3ebd60a31ca6c46f89
+#: 1b00f80a424f43e89df4b22cdbec9f1d 2488a64fb6114880a647b30aabcaeb97
+#: 3eb210998af1493d969b0668711879c2 44dbd48a22054109852a0466e6c8dafe
+#: 46d18135ae334e1b9be866eb9b1ce7aa 4e6fb356d45a4dc6bed1a657564f6cca
+#: 51f78c113d24406eb839ff47110bc3c7 57ca01d2b3794874baa19bd6cff0108e
+#: 5c3c86275c854508b6c05b4a5b8be797 5ef186a83e574cccb705d718644d4227
+#: 61869ff676e84373bdd967dcf62f2f5b 69dc9a2cbad8448d9f64a77b400fe85d
+#: 6a1cf94259bf45a0b16fab177b8051ae 6bec7a7092f54d75b560a976b5af990e
+#: 6f384ca1ea644eff8c441b320d435882 77980feebfe74c339cc942696f9987c8
+#: 8b6f7c9423154432aba662346e6a6e73 8d94ec50a0824392a8ec741011a48b8d
+#: ac5853d4f7bc44029e50aa1fe6edd2ef afc22df640714d3bb0cf381e83d041cf
+#: bbc8502b106c4ff592d9f9debc1ed841 bc5d6c9187f44bf898773fc7df5096bc
+#: c962403677974deab7a96c5961f52800 c9fd08d6d3e144189df5d54e4fb666e5
+#: dadd9287cbb442f4b38f3de22d313da6 e13ae2d22a454cb99bbf2769a470413e
+#: e8f1fac71aac488889a7beb5333f2738 e9703b835691482aa364a71f9bfc3a11
+#: edf775a918aa4ad1bd047bc6497ab502 ff04577c52c94b7ab5a408b0d2fa4002
+msgid "linux-azure-nvidia"
+msgstr ""
+
+#: ../../24.04/3.md 9f647efa235f4636948a7f2ce0dbdd88
+msgid "[2100199](https://bugs.launchpad.net/bugs/2100199)"
+msgstr ""
+
+#: ../../24.04/3.md bdc3f8fd8ca34d0fa5e287b742833d84
+msgid "iommu NULL pointer dereference in tegra241_vintf_alloc_lvcmdq"
+msgstr ""
+
+#: ../../24.04/3.md 40bb22166e5d4db79c6b2dd5ba220ad0
+msgid "[2097573](https://bugs.launchpad.net/bugs/2097573)"
+msgstr ""
+
+#: ../../24.04/3.md d9ed415ba94e4836bc830859bf05c184
+msgid "Grace CMDQV Support"
+msgstr ""
+
+#: ../../24.04/3.md 90a5e2a2918d4fe5b1b72cdb4606553f
+msgid "[2096924](https://bugs.launchpad.net/bugs/2096924)"
+msgstr ""
+
+#: ../../24.04/3.md a15f8ffdeed94639b2c0c35ce0c0371d
+msgid "New MANA patches for backport"
+msgstr ""
+
+#: ../../24.04/3.md 656070bd8136405496f2bb5cc5589ea6
+#: f1ef4352b5d64a1db8dfa8485bf0ec0d
+msgid "[2097336](https://bugs.launchpad.net/bugs/2097336)"
+msgstr ""
+
+#: ../../24.04/3.md 8a075cf632dc458c91b6349ee87feb1d
+#: dc6929c0c6734a499f3eaab91e0c7cf0
+msgid "Update new FW for AMD ISP"
+msgstr ""
+
+#: ../../24.04/3.md 84820c17aad749caaf077436b938b441
+#: df1cf760a96f4ef3b0ffe69f4fa87e05
+msgid "[2098979](https://bugs.launchpad.net/bugs/2098979)"
+msgstr ""
+
+#: ../../24.04/3.md 44a47334dc104b3181904fbfa27bdff1
+#: eff7bff2c0954c10a8d0fc5a78742176
+msgid "[SRU] Add amdnpu firmware"
+msgstr ""
+
+#: ../../24.04/3.md 00845f625d9f44d78c2fe337eb776840
+#: 383f856ad3eb43e2bd5d77f1c01c1597
+msgid "[2100740](https://bugs.launchpad.net/bugs/2100740)"
+msgstr ""
+
+#: ../../24.04/3.md 5a1a637dffb44b5db15d9baa17f44094
+#: 6200654e54da4f70b8791e3eeeef7ee1
+msgid "Prevent MT7920 from waking up to L0 during s2idle"
+msgstr ""
+
+#: ../../24.04/3.md 20219d5eb2a8497a9d1e9c3f5d58aaed
+#: 3ffb9432a1f44b4c8b2032c1ca3ce692
+msgid "[2100769](https://bugs.launchpad.net/bugs/2100769)"
+msgstr ""
+
+#: ../../24.04/3.md 2c48a010127c43158e7463eae9f0a1bd
+#: 35ed77c303c74a6ebd1e6af4cc285530
+msgid "Update amdgpu FW for GC 11.5.1"
+msgstr ""
+
+#: ../../24.04/3.md 1b656863d9344eb0aa41e94d5fc65f7b
+#: 678f7d566e5649a8a66bb1857c293dbb
+msgid "[2101841](https://bugs.launchpad.net/bugs/2101841)"
+msgstr ""
+
+#: ../../24.04/3.md 13e5a375f85248ee83e0ba5dac4fbfd5
+#: 20502bad5f3c4cfa8cfd90f108152e47
+msgid "Dell AIO of Intel ARL platform may freeze after playing video streaming"
+msgstr ""
+
+#: ../../24.04/3.md 0ba2769efc194f119898bbe30a95e2e2
+#: dd4a4bd13ba6497bac48d3491930d8ed
+msgid "[2102196](https://bugs.launchpad.net/bugs/2102196)"
+msgstr ""
+
+#: ../../24.04/3.md abe001790190402a84be05950913d747
+#: e35b023ec1ac47db871e2b8021949242
+msgid "The GSC firmware load failed on Intel ARL platforms"
+msgstr ""
+
+#: ../../24.04/3.md 5fe7587928744b399a4594b251a407b2
+msgid "linux-base"
+msgstr ""
+
+#: ../../24.04/3.md 0db86905e12c4ea09f46be076904b60a
+msgid "[2018128](https://bugs.launchpad.net/bugs/2018128)"
+msgstr ""
+
+#: ../../24.04/3.md 721a042fef13462f92d558f85101dbf5
+msgid "Add missing Apport links for kernel packages"
+msgstr ""
+
+#: ../../24.04/3.md 55936faa5708456c879c8cacc38eaa46
+msgid "[2106502](https://bugs.launchpad.net/bugs/2106502)"
+msgstr ""
+
+#: ../../24.04/3.md d13774bc1e1e42959b192bdadb634468
+msgid "kernel NULL pointer dereference in cvs_dev_fw_dl_data after suspend/resume"
+msgstr ""
+
+#: ../../24.04/3.md f345573ece6a4ea6a34d690c1f69f4f7
+msgid "[2106354](https://bugs.launchpad.net/bugs/2106354)"
+msgstr ""
+
+#: ../../24.04/3.md 0830ee9974924ebcb8d6a38c95eb3db1
+msgid ""
+"Qualcomm WCN785x Bluetooth (USB ID 13d3:3623): Headphones fail to connect"
+" or have non-functional microphone"
+msgstr ""
+
+#: ../../24.04/3.md 21e36d774d79414ab15e7914b129b249
+msgid "[2105970](https://bugs.launchpad.net/bugs/2105970)"
+msgstr ""
+
+#: ../../24.04/3.md 92b3137fc5de4ee4a6daace88ca40156
+msgid "Fix the mic-mute led on HP G12 laptops w/ ALC3315+CS amplifier"
+msgstr ""
+
+#: ../../24.04/3.md 1255f78faa87490db6c1db708dc7a316
+msgid "[2089555](https://bugs.launchpad.net/bugs/2089555)"
+msgstr ""
+
+#: ../../24.04/3.md ee742271c0194ba5ba088546467b701f
+msgid "mmc0 error on boot with eMMC CM5"
+msgstr ""
+
+#: ../../24.04/3.md b0b60c7ab491446385ab7418400d9c99
+msgid "[2099685](https://bugs.launchpad.net/bugs/2099685)"
+msgstr ""
+
+#: ../../24.04/3.md 2de3984399cb4b1ba21cff3c3521ec64
+msgid "GPIO sysfs disabled in raspi kernel"
+msgstr ""
+
+#: ../../24.04/3.md a650cf3fdb254327a5b9eba7aed991d6
+msgid "[2107762](https://bugs.launchpad.net/bugs/2107762)"
+msgstr ""
+
+#: ../../24.04/3.md 95f82f7d061f4f7e8c3db8b61a7f648d
+msgid "Fix UCSI call trace on some platforms"
+msgstr ""
+
+#: ../../24.04/3.md 1874b95904e546aab4545c0e119cffa5
+msgid "[2107310](https://bugs.launchpad.net/bugs/2107310)"
+msgstr ""
+
+#: ../../24.04/3.md cc3a31128c4345fd87bcace1eb1b1edf
+msgid "Fix Cirrus codec CS42L43 resume failure"
+msgstr ""
+
+#: ../../24.04/3.md f1b33a9049a340659e643d32d3abaf0e
+msgid "[2107439](https://bugs.launchpad.net/bugs/2107439)"
+msgstr ""
+
+#: ../../24.04/3.md 27f8a24d26db406392640e67e86bc2a6
+msgid "Cannot recognize two 4k@60hz external monitors on SD25 DOCK"
+msgstr ""
+
+#: ../../24.04/3.md 3e93a5f4d3a74bd7b66426a80b30e536
+msgid "linux-aws-6.11"
+msgstr ""
+
+#: ../../24.04/3.md 7c04b33f06074db28b4a0ea374234a41
+msgid "[2102200](https://bugs.launchpad.net/bugs/2102200)"
+msgstr ""
+
+#: ../../24.04/3.md 66fda47eda0f4dc0b1310906fd7fadff
+msgid "Support wifi 6GHz for Philippines on Qualcomm WCN6856"
+msgstr ""
+
+#: ../../24.04/3.md 0a98947c1c5a44d58bb2cb6014ef7c3b
+msgid "[2105425](https://bugs.launchpad.net/bugs/2105425)"
+msgstr ""
+
+#: ../../24.04/3.md fb690c161bee4fc4a85e7d8b37d8388a
+msgid "Support GPU driver on Qualcomm QCS6490 / SA8775"
+msgstr ""
+
+#: ../../24.04/3.md e9a2a1d452f04a88862ab4c6b570a6f0
+msgid "[2106436](https://bugs.launchpad.net/bugs/2106436)"
+msgstr ""
+
+#: ../../24.04/3.md 503d26572f1c4f43b55f8cba89bf3732
+msgid "Add support for QAT Gen5 device with the 420xx (CPM2.2) firmware"
+msgstr ""
+
+#: ../../24.04/3.md 0d9a3c4e0e4f4eb2b5efb490986f4447
+msgid "[2106802](https://bugs.launchpad.net/bugs/2106802)"
+msgstr ""
+
+#: ../../24.04/3.md 537fd041e1eb40b595eb7d6323391b8c
+msgid "Fix amplifier cs35l56 dsp fw name for HP LAPZ platform"
+msgstr ""
+
+#: ../../24.04/3.md 598d9baa32ca489fbb4724ff8a083f87
+msgid "[2103582](https://bugs.launchpad.net/bugs/2103582)"
+msgstr ""
+
+#: ../../24.04/3.md 96db870aa5bf42d295a4fa7379fcf971
+msgid ""
+"/sys/power/suspend_stats/total_hw_sleep not increased after "
+"suspend/resume on AMD GPU of DCN 3.5"
+msgstr ""
+
+#: ../../24.04/3.md ab0dfffb5ade4457ac27366082b2db72
+#: ec35a1f0a9c5474fb8360920c4deabdd
+msgid "[2111220](https://bugs.launchpad.net/bugs/2111220)"
+msgstr ""
+
+#: ../../24.04/3.md 39e1bfb24cd64851b3a6b9dd8279600d
+#: 67d8257de8cd4fc6a6da9bbfbac81cc1
+msgid "ACPICA: Add support for printing AML arguments when trace point enabled"
+msgstr ""
+
+#: ../../24.04/3.md 53326ead042c451586113e79d129eaad
+msgid "[2109314](https://bugs.launchpad.net/bugs/2109314)"
+msgstr ""
+
+#: ../../24.04/3.md 0f19f3494087445a86ff39729b088121
+msgid "Mediatek MT7920 WLAN card does not respect Wireless Radio Control in BIOS"
+msgstr ""
+
+#: ../../24.04/3.md d01420d3d8ed4fa3b4726a1f207c706f
+msgid "[2106923](https://bugs.launchpad.net/bugs/2106923)"
+msgstr ""
+
+#: ../../24.04/3.md 22806f22b3c54cb09275f0210c389c8e
+msgid "Fix divide by zero errors in DML2"
+msgstr ""
+
+#: ../../24.04/3.md 2ea02ed08ce24db2bc42a971d45a3a4a
+#: 95380f8f0ff54c01851c375e57cf3292
+msgid "[2110092](https://bugs.launchpad.net/bugs/2110092)"
+msgstr ""
+
+#: ../../24.04/3.md 8578eddb7d5240babaac240eaa757b15
+#: 8e1d6aaa92344ff396c4cfb55cd6f26b
+msgid "Support AMD Image Signal Processing (ISP) unit V4.0"
+msgstr ""
+
+#: ../../24.04/3.md 2c8c22eead7040219be22752ba8b7f85
+#: fd06088fb188435c953f2cdca1c13f1f
+msgid "[2106807](https://bugs.launchpad.net/bugs/2106807)"
+msgstr ""
+
+#: ../../24.04/3.md 017ade7d394b46d990cb151d9ae116be
+#: 39bb7ac0f3db4685bd6b291117d3655f
+msgid ""
+"Privacy LED may not be turned on on OEM Renegade platform with Intel IPU7"
+" camera"
+msgstr ""
+
+#: ../../24.04/3.md 071f5b3359af4a008856dc958e06a8ee
+#: 101dff7b049745719d65afc08a8dfc80 be97251744ea426c9d0dbe69e90e0c05
+#: f2de3f810b324da9b466f6295606b792
+msgid "linux-oem-6.14"
+msgstr ""
+
+#: ../../24.04/3.md cc2156404bbb484989ff1c944016477a
+msgid "[2107603](https://bugs.launchpad.net/bugs/2107603)"
+msgstr ""
+
+#: ../../24.04/3.md 6f583a7270c84db6b761b517c77250d8
+msgid "[SRU] Fix hardware error 0x85 of WCN785x bluetooth"
+msgstr ""
+
+#: ../../24.04/3.md de41d499d6db42da8b67e58e86a4c597
+msgid "[2109472](https://bugs.launchpad.net/bugs/2109472)"
+msgstr ""
+
+#: ../../24.04/3.md 43c7d0a7e2d74c28b7641d83c3e5de89
+msgid ""
+"Left/right audio channels swapped on platforms equips TI TAS2781 Class-D "
+"Amplifier"
+msgstr ""
+
+#: ../../24.04/3.md 899e3bc0cae345aa80aa4000872d33da
+msgid "[2109796](https://bugs.launchpad.net/bugs/2109796)"
+msgstr ""
+
+#: ../../24.04/3.md 76daec915c9b4f95af959f8ab81bb586
+msgid "[SRU][O/N] Support Wi-fi and Bluetooth for Nvidia DGX Spark Platform"
+msgstr ""
+
+#: ../../24.04/3.md 8055d5898a7f476eab406773360d2277
+msgid "[2111517](https://bugs.launchpad.net/bugs/2111517)"
+msgstr ""
+
+#: ../../24.04/3.md c336fb89953d4c7080eed7342b7eaf5b
+msgid "Update GuC firmware to v70.44.1"
+msgstr ""
+
+#: ../../24.04/3.md 27d9091d544748689f0d21593f13e551
+#: 28710257df17423b8e057189e9fd6097 3bf44b53f7fb40e39428dbdfe029a9db
+#: 41276f3c650647d48c63e6090aa032b9 489622e6c51142dea73316d8ba9488de
+#: 553dad24d86b4111ae4a6adedaecf066 63cb6f5dc8a643e1a0a3643aa30998b0
+#: 63fb2f46d757497d9f41c7ff01450c64 69567c3038da4782850e6602541520c8
+#: 69dc559d36024620b8a3663f5037696e 777ae2ea1bbd47d0aa9a6346982df91f
+#: 77cb535592a94820918d5cf8a51af0b0 8978c82833114679888c272300445c7f
+#: a7801fc3c20b4253962e4ebdce318362 c12257e0045547918322b69dd2c30359
+#: c363cc608c964195a1a75c5fa5e10474 c4acd699ab9e4652bd674d219528f514
+#: c5573e9923014ff19847621089a33ff4 e9ca92b37a7840ff811812da85aadc13
+#: f14505d4e8f14af0aff308f0f6787be4
+msgid "linux-gcp-6.14"
+msgstr ""
+
+#: ../../24.04/3.md a91a95d2d4834596973dcf838c485337
+#: c3de65389fdb41b3a3aee0a28cb3b6cb
+msgid "[2106091](https://bugs.launchpad.net/bugs/2106091)"
+msgstr ""
+
+#: ../../24.04/3.md 274a126be47b44509baba78b4e03dc2f
+#: 979425f6ec0d4813a318cc995bb9aeaf
+msgid "Missing bpftool binary on riscv64"
+msgstr ""
+
+#: ../../24.04/3.md 181ffe11e1be44639e9a754c082ff58b
+#: 185ff33cc54b4619be21279138e82ec7
+msgid "[2106115](https://bugs.launchpad.net/bugs/2106115)"
+msgstr ""
+
+#: ../../24.04/3.md 0e4180d192294dd3bfadb3641202f8ce
+#: 676a41f5bb0640dda8db63958e6f88a1
+msgid "Expose IFLA_VXLAN_FAN_MAP version via sysctl/proc"
+msgstr ""
+
+#: ../../24.04/3.md 2783989b425740539b65a0526ff054ad
+#: a5925c44859e472aa0a1b09b5b79b781
+msgid "[2104297](https://bugs.launchpad.net/bugs/2104297)"
+msgstr ""
+
+#: ../../24.04/3.md 358b9713cd5a48edbfdbad143d649db2
+#: a7c96c996f4c45eaaba3a0afdf5d9bee
+msgid "not able to install a Power9 bare metal with Ubuntu 25.04 Plucky"
+msgstr ""
+
+#: ../../24.04/3.md 76d86778d29c4d07850855f4cda6e8dc
+msgid "[2102237](https://bugs.launchpad.net/bugs/2102237)"
+msgstr ""
+
+#: ../../24.04/3.md 011a3bb21288486b90d55e7c44183aa3
+msgid "Disconnected paths for mqueues show a TODO in the kernel logs"
+msgstr ""
+
+#: ../../24.04/3.md 58ff5d7471484c41bbc85940566d3fe0
+msgid "[2102680](https://bugs.launchpad.net/bugs/2102680)"
+msgstr ""
+
+#: ../../24.04/3.md 605a21b6a05c4299b742c5690239233f
+msgid ""
+"Installation of AppArmor on a 6.14 kernel produces error message "
+"\"Illegal number: yes\""
+msgstr ""
+
+#: ../../24.04/3.md ba4c7ef3145e4c699bf80a8e75b8b92d
+msgid "[2103460](https://bugs.launchpad.net/bugs/2103460)"
+msgstr ""
+
+#: ../../24.04/3.md 95cba592daa3492690e0e4887d8e8821
+msgid "QRT AppArmorUnixDomainConnect test failures on Plucky 6.14 kernel"
+msgstr ""
+
+#: ../../24.04/3.md 2e17e1d920874ddf9fd7cfe91513b3f9
+msgid "[2103981](https://bugs.launchpad.net/bugs/2103981)"
+msgstr ""
+
+#: ../../24.04/3.md 5699689364b54a588de566d966f21b57
+msgid "Mouse cursor flashes using the 'xe' DRM driver"
+msgstr ""
+
+#: ../../24.04/3.md 458f743d623e4410a47a52bac1d93805
+#: 7edfc8542fcb41d9b2b263c5796203d7
+msgid "[2100858](https://bugs.launchpad.net/bugs/2100858)"
+msgstr ""
+
+#: ../../24.04/3.md 13c9cf30b803468d8e62019b7456121d
+#: cbc82c563a4a498493755b7ed607ed7f
+msgid "Snapdragon X Elite: Sync concept kernel changes"
+msgstr ""
+
+#: ../../24.04/3.md 14c64f6eadd946d6a33af43d274c686d
+msgid "[2103653](https://bugs.launchpad.net/bugs/2103653)"
+msgstr ""
+
+#: ../../24.04/3.md a98b0b73ea7e425fa0ee50b9eb508c82
+msgid "python perf module missing in plucky's kernel"
+msgstr ""
+
+#: ../../24.04/3.md aa9b309f99284788b9d65ce34fbf885a
+msgid "[1613393](https://bugs.launchpad.net/bugs/1613393)"
+msgstr ""
+
+#: ../../24.04/3.md 24506a576b3a4915818b247a609f5ce8
+msgid "Provide linux-perf package"
+msgstr ""
+
+#: ../../24.04/3.md a1c4c8d984044084bdea9c36d7acfcee
+msgid "[2007308](https://bugs.launchpad.net/bugs/2007308)"
+msgstr ""
+
+#: ../../24.04/3.md 0d212cc0db20456f827a5dc987116cc8
+msgid "linux-tools-common: bpftool wrapper causes build failure for xdp-tools"
+msgstr ""
+
+#: ../../24.04/3.md bca6635902f541f781e08b305e69e437
+#: cc5ce1cd09d843118ea2415f4fc82a12
+msgid "[2028253](https://bugs.launchpad.net/bugs/2028253)"
+msgstr ""
+
+#: ../../24.04/3.md 36dd99d3a2af4b8fab5c89a491b56e0c
+#: 9195a2d1426b406eac76143f32e59803 f289d42351544cd1afbd44558eda655b
+msgid "update apparmor and LSM stacking patch set"
+msgstr ""
+
+#: ../../24.04/3.md 2d629ab134d44ccf9ec5d7153b12202d
+msgid "[2032602](https://bugs.launchpad.net/bugs/2032602)"
+msgstr ""
+
+#: ../../24.04/3.md d4374508b7de460abe7285d51c6cd780
+msgid "[1981437](https://bugs.launchpad.net/bugs/1981437)"
+msgstr ""
+
+#: ../../24.04/3.md 93876e9467f04caaad3ff9d8f827e5ff
+msgid "RISC-V kernel config is out of sync with other archs"
+msgstr ""
+
+#: ../../24.04/3.md 5934ffa5ae5b4e4da7e604945eb09f02
+msgid "[2096812](https://bugs.launchpad.net/bugs/2096812)"
+msgstr ""
+
+#: ../../24.04/3.md 9a8713cdd02b471dbed4d811c9bf83b7
+msgid "[25.04 FEAT] In-kernel crypto support MSA 11 HMAC"
+msgstr ""
+
+#: ../../24.04/3.md 63d2c9efadaf4e1b9945a3794e9ce4a0
+#: 7a590076ecb8471684b8360a0ff69ba5 cecc237826f04349b9869c3f91400889
+#: f82f4444d64d435a8bb784693f776433 fd808b11b7594741b60e6885cd19b340
+msgid "linux-oracle-6.14"
+msgstr ""
+
+#: ../../24.04/3.md 057c901f9fe446ac87201ccab8e9c177
+msgid "linux-signed-aws-6.14"
+msgstr ""
+
+#: ../../24.04/3.md 52a5ee45b02f46ec801da3da6761fe16
+#: cf9d05cf72d3440f8873cd83edef7290
+msgid "[2027818](https://bugs.launchpad.net/bugs/2027818)"
+msgstr ""
+
+#: ../../24.04/3.md 2ede912b51a44b4ea03d3c773b7c479f
+#: ae349be2144d4eeb83a44b2e82abd87d
+msgid ""
+"SIGNEDv5: add ubuntu-core-initrd support to the linux-generate ancillary "
+"package"
+msgstr ""
+
+#: ../../24.04/3.md 3796c88fb234490cb777b43d30232433
+msgid "[2114157](https://bugs.launchpad.net/bugs/2114157)"
+msgstr ""
+
+#: ../../24.04/3.md 9771b5d0b81448b9a36729fd1caad049
+msgid ""
+"glxgears -fullscreen has noises on the gear edges on AMD Hawk Point "
+"platforms with QHD panel"
+msgstr ""
+
+#: ../../24.04/3.md 3ad4aae1d5e843ea8d77f969caaa2a42
+#: 6620cfb45c854fff966dcb6874763bee 782ef6ee26e3433f9ff20b25ea9fb924
+#: 908f4f04481a446fa8c5d650b97662d5 a136ee5a4ef843878283c27bf4d8d273
+#: c14a740e82ff4e69bd0c4bfed6e18a11
+msgid "[2105402](https://bugs.launchpad.net/bugs/2105402)"
+msgstr ""
+
+#: ../../24.04/3.md 0873e319d51249928dac9998e21040ae
+#: 1e127b302fab4793a2883fd86ff1508e 5788b978f2e646be83ee865caf05fe11
+#: a4fdca3447ea46feb02923a2eee63c5b ba4b202dc1da4c21bc4047c85f71eb40
+#: ca06e47324524806a6e063f064c4ff4b
+msgid "Plucky fails to boot on (older) Macs"
+msgstr ""
+
+#: ../../24.04/3.md 2e2ecf17ffba41a6ae242c50a4996479
+msgid "linux-riscv-6.14"
+msgstr ""
+
+#: ../../24.04/3.md 7d514373ef7e4caa80d0e87605481f3e
+msgid "linux-signed-aws"
+msgstr ""
+
+#: ../../24.04/3.md c24ae283bea14bd3b3074b06908e7430
+msgid "linux-hwe-6.14"
+msgstr ""
+
+#: ../../24.04/3.md f7bbe8f03e2d488191f7912d1e391ce2
+msgid "linux-aws-6.14"
+msgstr ""
+
+#: ../../24.04/3.md 1c4722e03d534c9e83419da9cddabddd
+#: 2d737f2f40d44bdeaf8e610d91781c0c 67d6d81e2bf3403dad96dfac027926f8
+#: ac615a710705429781b3d5b7bef14dcd b869f9548c334033a0301ef1df6f9248
+#: be6fc0986a2a48adad1529335789103b c7fcd6f21b7d42f9aef836cd9b7a5b0c
+#: c91dff990b824bc4a50a381ab7edda70 da8f5d34e0434908a04f13aa8db763f1
+#: fe84a96c61f34b99a97587309a9de418
+msgid "linux"
+msgstr ""
+
+#: ../../24.04/3.md c56f479f58c2468bbe169cc460deef17
+msgid "net-snmp"
+msgstr ""
+
+#: ../../24.04/3.md b6865de56bf7448084ab000c50413753
+msgid "[2056257](https://bugs.launchpad.net/bugs/2056257)"
+msgstr ""
+
+#: ../../24.04/3.md 89a754bad212414f961b002e43cbf916
+msgid ""
+"d/p/lp-2056257-Add-Linux-6.7-compatibility-parsing-proc-net-snmp.patch: "
+"fix parsing on newer kernels"
+msgstr ""
+
+#: ../../24.04/3.md 02279a489e12499a8889d00e9686bf40
+#: 5fd6092f7d014f909d122f6b4b08e687 628406e4a50e43acb33a247cb6c15a4c
+msgid "flash-kernel"
+msgstr ""
+
+#: ../../24.04/3.md 71df44bf0947471e9a70f4f77e69e7e5
+msgid "[2097008](https://bugs.launchpad.net/bugs/2097008)"
+msgstr ""
+
+#: ../../24.04/3.md ee6af588763f467881a4d4151d091af0
+msgid "db/all.db: Add CM5 Lite to flash-kernel database"
+msgstr ""
+
+#: ../../24.04/3.md fb4ab07d12be4434ba9063a2869e4310
+msgid "[2092737](https://bugs.launchpad.net/bugs/2092737)"
+msgstr ""
+
+#: ../../24.04/3.md ce6668be43f24345acaf72b79c47a1ae
+msgid "db/all.db: Fix entries with \"Kernel-Flavors: arm64\"."
+msgstr ""
+
+#: ../../24.04/3.md fb66b80f99e4451c8d60b5a6fabec9a9
+msgid "[2116161](https://bugs.launchpad.net/bugs/2116161)"
+msgstr ""
+
+#: ../../24.04/3.md 93d24a7b4d854fe88bf55f1bf2783579
+msgid "db/all.db: Add entry for DeepComputing FML13V03"
+msgstr ""
+
+#: ../../24.04/3.md 9be1af287be2431885f5a192a1b1ff95
+#: e8255877edb24299984328ed4b09cadb
+msgid "broadcom-sta"
+msgstr ""
+
+#: ../../24.04/3.md 44f05fe620fc47128120a5a76a990e16
+#: a7658a22ac304dab9ece4600c3428e79
+msgid "[2110927](https://bugs.launchpad.net/bugs/2110927)"
+msgstr ""
+
+#: ../../24.04/3.md 5c483a12685b42b78f953ed9398e0f97
+#: 605f6ab29042422097985209a884d698 ba0b32e83ae24c0cad93d520b850dd77
+msgid "Support linux 6.14"
+msgstr ""
+
+#: ../../24.04/3.md 227c72cf7f7f498da403d8375056c47b
+#: 3c823036deab486d8b6030ad845f494d 4ea0d205f0064938ab5668c8be47234e
+#: 4fc7fb198446473b92aaacdfe9eef5f1 55ee8309916b45dbafbbc774e1e52312
+#: 5d3bf2635cc5456aaa8f09a08033baf4 5d9ead3698d74715ab183822e11484a9
+#: 7888234b6adb4149b724cca3a46efae8 7f861d3ff56c44a798c4317a0cbae11f
+#: 937462d406de4b9f902897b6ab5f9522 96cf88bef5d743a9997a1f490c81d5f2
+#: ae86ed01b35d4dc085b214a0072061a2 c5237173d3fb4c8897fac5df9644e1f8
+#: cf98fe05172748c09c2d85d07d9223f7 d025dd80576544ec9e2bb3be3e49205c
+#: dc9e7e7a1f064798aacdbef42575370a e913461234394bdcb455ceef3177a23c
+msgid "[2089884](https://bugs.launchpad.net/bugs/2089884)"
+msgstr ""
+
+#: ../../24.04/3.md 0173c98ab170401e81575769b0ddb25f
+#: 1007fcf9fa4942d2a788458d5862154e 1ee14813f25c4695b2ad25b60d41eb59
+#: 3a47e98e9691468d97e1d4f6b5a622d5 3e57aad15fa74e529e8a18b61c95b53a
+#: 4610cc282512498298096995382c3bfd 46549a6471924f15a3b5d206b2dddaa9
+#: 5bd0c6b42bf441cab2882344d016272f 714dcf81338846b4839bcb6bc1d89812
+#: 7b7b6c7d1ec74b0d918f10a8c2289574 ad2732056da84a7aa600ce2bcd3f0837
+#: bf9ddd31315d4c75b39865a36e7cbc1d c14562ab01784607ab7d150aaa70c1a2
+#: ef23e2968f6d435fa87ea3597b664e8d f54c3781727c4ae8af2f25846b0f8876
+#: fa6310d5a5c04b01b78edf7bbe645972 fefcc95273274a80b9142f5fd01ba83b
+msgid "Noble update: upstream stable patchset 2024-11-29"
+msgstr ""
+
+#: ../../24.04/3.md 05f6f56a4edb46fead71a918aeb20245
+#: 18d6560d566f412ba45e5011d40a6fa8 32aedb405f3344efbbe0779052ef5e8b
+#: 4cec72f967aa417fb7edaa4812617b97 5f94c628e33744e8ba00b1535a83dddc
+#: 6307062df88e4939a41dd4344f935c74 6406c26ab17e41ffa9b414d928e3a5df
+#: a2fad108211b47359527eba1bc51b024 b1993744de5c4d5c9988030c9c73930a
+#: bc923a14538d45bb86b19b47295e6100 bdbb1b080a4945f9b3430c846e093c74
+#: dc45d88c005f4dac88ff40998f53f6c1 eff303bed92047f59bc370bca1704793
+#: f048a4d7306a4890b10fa2c0fec5af33
+msgid "[2089340](https://bugs.launchpad.net/bugs/2089340)"
+msgstr ""
+
+#: ../../24.04/3.md 051ed6ccb40e432cad1591dfb7b34a89
+#: 08c98f4c8b54432dbf83cc3afb63645d 1ed9f49d6116421388889d7fecf898b6
+#: 20f261503971426fad28947873a76132 2bb4a7f8f70c4ecfa039a2524d4b16a5
+#: 3c64a0d39c0343968fe169341bff2c90 5ce387b78d774be68c099511a760248b
+#: 5d17bff1458c4a2e8a34632d7a8eef05 6f116a14cb6340a5b0b2e5428704f818
+#: 711b60e7277c42a7a4896de658a2c87f 7330c7c3b7624a679bad79d52682523a
+#: 8705706672d6485bb0c25f4f307be83a b0625350c54e40fc9c39202a64979116
+#: ddbd917a84f34a1d91d410ea057b03ab
+msgid "Noble update: upstream stable patchset 2024-11-22"
+msgstr ""
+
+#: ../../24.04/3.md 0f7d017ad92e4482b1ae1ffd7d89ae1d
+#: 1acb92cdb639436982bb257b1e0f875e 30f06e57b4ac4442a9ee44e4204f0a56
+#: 8b21bd658c1f4a91a8861f6c370e6be4 8fcfe53586044020896b055546d49b0c
+#: 91e520173b204373b91db261c409e056 c78c1787ce374aa9a88fd56fe7178c39
+#: d274d73e596f480380917ce79ff7b8f1 debc8bf9571248d9823ceb40f2d8c5ef
+#: e3f3e99bbcbd4028a662da5026269894 e843fe50668741968e6ce8eacef9e030
+#: e9a550911c074be1b7aa1e7efd9cc56b efe5503ee8d94a55becd3cb0da277360
+#: f751ed15b5d84276b0cc02509f862b95
+msgid "[2087519](https://bugs.launchpad.net/bugs/2087519)"
+msgstr ""
+
+#: ../../24.04/3.md 0577cbf378e846b6b7bd21649d34b792
+#: 2198c6e4035446d19be65648278b6e43 428d66b0b70c452aa6b061f1ef500079
+#: 42d1111a0336404ba37a3edf46561739 583d4f777b664fa1b295daa0804b546c
+#: 79cc1833ff034be8986651606a8a47ba 8c0d1356d0d64f0b87ff6f6d3784ff85
+#: 8cfbef14d31d4657930c15ddd91e445b 8d6f533eb6b945c4b2678ea822fed286
+#: 95900c381bb9456988fa6f6d2bdeacd2 a4cfa174776140809d65b456073bfd90
+#: ab9f247862be4ee093bd7ea4b854f42c d52a14fe4bd54e09a45a586a9b29161d
+#: d9e4fd86e1ae4f9d9e85f562e638c4df
+msgid "Noble update: upstream stable patchset 2024-11-08"
+msgstr ""
+
+#: ../../24.04/3.md:501 2e58e936e4b94a9f91f533c48c0fd49d
+msgid "Unsorted changes"
+msgstr ""
+
+#: ../../24.04/3.md d1bfabd926d84a57a522863f280c00f4
+msgid "openldap"
+msgstr ""
+
+#: ../../24.04/3.md 2c82b9c4c0714c8a92bee1ed229c3243
+msgid "[2090806](https://bugs.launchpad.net/bugs/2090806)"
+msgstr ""
+
+#: ../../24.04/3.md 5b8715f478a246a19f8384461ad8226a
+msgid ""
+"Fixup TIMEOUT and NETWORK_TIMEOUT options so they work correctly when SSL"
+" is involved. Before they would never timeout, causing freezes on "
+"connection failure. Now they timeout as expected."
+msgstr ""
+
+#: ../../24.04/3.md 7f8b563655234a4293a27ac168f1bd7a
+#: d5e0b3766c6d42c0a83efc46d6415c97
+msgid "landscape-client"
+msgstr ""
+
+#: ../../24.04/3.md 1240019b058c47218d3f8b12b2245ded
+msgid "[2052834](https://bugs.launchpad.net/bugs/2052834)"
+msgstr ""
+
+#: ../../24.04/3.md c0fd67b07dae4b629d957972d30fe42b
+msgid ""
+"include all non-filtered network interfaces that have a valid MAC address"
+" in the API response."
+msgstr ""
+
+#: ../../24.04/3.md 9da1c989c7d642849dea21d3b927c465
+msgid "[2084586](https://bugs.launchpad.net/bugs/2084586)"
+msgstr ""
+
+#: ../../24.04/3.md 3497812b8d2347ff8e9903b780cc5c20
+msgid "d/control: add python3-yaml dependency to landscape-client"
+msgstr ""
+
+#: ../../24.04/3.md bf72bbb66da649c58aeb8c8304b48cb2
+#: ea7418bbbd49487f8556bc2a75ba2788 fb8c2c7d0d9d4de29e0b86e439a4777f
+msgid "fwupd"
+msgstr ""
+
+#: ../../24.04/3.md e227aba9c7cb498a9b2dfee5cfac8e4b
+msgid "[2097728](https://bugs.launchpad.net/bugs/2097728)"
+msgstr ""
+
+#: ../../24.04/3.md deb91b4db5564af5b1188b5c072bd186
+msgid "Fix updating dell dock PD F/W"
+msgstr ""
+
+#: ../../24.04/3.md 2e373b081500452bbe8709d3211ba5bd
+msgid "[2104109](https://bugs.launchpad.net/bugs/2104109)"
+msgstr ""
+
+#: ../../24.04/3.md 881c8e05afde4859b57f7e765a92b0d7
+msgid "Fix updating dell dock RMM F/W"
+msgstr ""
+
+#: ../../24.04/3.md f32e6ce54ea04eff84a053750dc6aeb6
+msgid "[2110209](https://bugs.launchpad.net/bugs/2110209)"
+msgstr ""
+
+#: ../../24.04/3.md 59d12af1a85d46bd99cf550eb9f50cc5
+msgid "Fix dell dock RMM FW info missing on some devices"
+msgstr ""
+
+#: ../../24.04/3.md e085bebd7c7b48bcae68735c5a9c8c03
+msgid "pollinate"
+msgstr ""
+
+#: ../../24.04/3.md 3b649a9baa2a47679e5d64e4c2793856
+msgid "[2097596](https://bugs.launchpad.net/bugs/2097596)"
+msgstr ""
+
+#: ../../24.04/3.md 130edeecbf314f54b4960c49f6a5bea8
+msgid "Relicensing check_pollen"
+msgstr ""
+
+#: ../../24.04/3.md 5f266ee3fe494045b1a781c9e01cbe1f
+#: ffac2ce31f8046d7bb5b335528b9fe20
+msgid "freeradius"
+msgstr ""
+
+#: ../../24.04/3.md b02ba8c7ec564a1782cf1ec87d6a8fd2
+msgid "[2087740](https://bugs.launchpad.net/bugs/2087740)"
+msgstr ""
+
+#: ../../24.04/3.md 39deeaf53b36434c8cff05d29e4e836b
+msgid "fix duplicate packet sends on COA calls"
+msgstr ""
+
+#: ../../24.04/3.md f5e57259ffeb4040a52cb1ea8ed5cdfe
+msgid "[2104372](https://bugs.launchpad.net/bugs/2104372)"
+msgstr ""
+
+#: ../../24.04/3.md dbe06c002e904255b7596bce0ea4e829
+msgid "Fix crash due to ping packet from status server"
+msgstr ""
+
+#: ../../24.04/3.md 0540239e58b14e9683f95f6772f60d12
+msgid "dns-root-data"
+msgstr ""
+
+#: ../../24.04/3.md 0cef173c3a6147e18e3d0540570f3df8
+msgid "[2086795](https://bugs.launchpad.net/bugs/2086795)"
+msgstr ""
+
+#: ../../24.04/3.md bfaa3902f99f48baa33cc0f98ed7052b
+msgid "Backport data update to include DNSSEC root trust anchor of KSK-2024"
+msgstr ""
+
+#: ../../24.04/3.md 3717ba235dc4429e8e09f965ca6100cb
+#: b3bbc7de4f7c4e8abf11200f3bac7db8
+msgid "open-iscsi"
+msgstr ""
+
+#: ../../24.04/3.md 3d0a1c0b98f64b87a56f87e9923d55b7
+msgid "[2097808](https://bugs.launchpad.net/bugs/2097808)"
+msgstr ""
+
+#: ../../24.04/3.md 2d4ccdbfdb974afcbfcce5934c328b7f
+msgid "IPv6 support for iBFT iSCSI boot"
+msgstr ""
+
+#: ../../24.04/3.md 88c48614f1a040578dfc8904905f8695
+msgid "[2098515](https://bugs.launchpad.net/bugs/2098515)"
+msgstr ""
+
+#: ../../24.04/3.md 941d7f75b58c438ab30437697194b851
+msgid ""
+"add a flag to skip network configuration when iscsi is set to 'auto' but "
+"no iBFT data is present. Thanks to Alec Warren <alecwarren19@gmail.com>."
+msgstr ""
+
+#: ../../24.04/3.md d9eb30c82e044c7b9b3d410e0fdf63f3
+#: f2cc70467c9a4aadb74cf0c773412193
+msgid "libinput"
+msgstr ""
+
+#: ../../24.04/3.md fba862d585514494b4991e4fa041a37e
+msgid "[2095464](https://bugs.launchpad.net/bugs/2095464)"
+msgstr ""
+
+#: ../../24.04/3.md b26bdb362cbd4961be2879b4629c9f54
+msgid "Disable pressure event for Dell haptic touchpads"
+msgstr ""
+
+#: ../../24.04/3.md df9d2bb68b704a80b458c43378b9b049
+msgid "[2108966](https://bugs.launchpad.net/bugs/2108966)"
+msgstr ""
+
+#: ../../24.04/3.md e89abf534dfc4f5da3cded520cad8bb2
+msgid "Correct ThinkPad X9-15 Gen1 Touchpad Functionality"
+msgstr ""
+
+#: ../../24.04/3.md f59a1f0504eb4e56b76ffb12582fa23b
+msgid "nvidia-graphics-drivers-550-server"
+msgstr ""
+
+#: ../../24.04/3.md 3d249a4d5aed4cb3bb3235c9b2a09ae9
+msgid "[2114726](https://bugs.launchpad.net/bugs/2114726)"
+msgstr ""
+
+#: ../../24.04/3.md f803fda82fbc47abab78528565c4a9a3
+msgid "Add transitionals to 570"
+msgstr ""
+
+#: ../../24.04/3.md 77d8c116cf0943f2b6e79b7e33124247
+msgid "thermald"
+msgstr ""
+
+#: ../../24.04/3.md f58904becece4d89bf7eeaf1a7a92d05
+msgid "[2092701](https://bugs.launchpad.net/bugs/2092701)"
+msgstr ""
+
+#: ../../24.04/3.md a2fed8af35df497eae8335a4e957237a
+msgid "Downgrade \"Unsupported condition\" error messages"
+msgstr ""
+
+#: ../../24.04/3.md 787c93e49ec44c71b9346ede40336b3f
+#: c85418b999c04bb198d34708163c2bd6 ddbc05cd630f46479097fcc04c7cce98
+msgid "sosreport"
+msgstr ""
+
+#: ../../24.04/3.md b1bb63139906416aa36768499d29370d
+msgid "[2091858](https://bugs.launchpad.net/bugs/2091858)"
+msgstr ""
+
+#: ../../24.04/3.md b6c6d11f123d4df5a93bf9851c483965
+msgid "New 4.8.2 upstream release."
+msgstr ""
+
+#: ../../24.04/3.md 538d6c07a066492baa60f403ee600033
+msgid "[2101134](https://bugs.launchpad.net/bugs/2101134)"
+msgstr ""
+
+#: ../../24.04/3.md 90dedda4c97147c1a0cebb7f40f0abb4
+msgid "Resolve obfuscation issues"
+msgstr ""
+
+#: ../../24.04/3.md e64eb6f322df4b818ce10ebe2d3041bd
+msgid "[2102199](https://bugs.launchpad.net/bugs/2102199)"
+msgstr ""
+
+#: ../../24.04/3.md 79742b67d29c4548a5604d75d5f0f1a7
+msgid "Resolve username clean issues"
+msgstr ""
+
+#: ../../24.04/3.md f83026d41a4347fbab80fbc600975088
+msgid "tzdata"
+msgstr ""
+
+#: ../../24.04/3.md 57cd132079144f8d995f5767fb1d6706
+msgid "[2107950](https://bugs.launchpad.net/bugs/2107950)"
+msgstr ""
+
+#: ../../24.04/3.md ca32fba46fe242bf9a95a91fb6fa76c9
+msgid "Update the ICU timezone data to 2025b"
+msgstr ""
+
+#: ../../24.04/3.md 3604ad307c9d451a9562e44cef42fc02
+#: eba0963de4b94a69a149465f9c78cdd8
+msgid "libfprint"
+msgstr ""
+
+#: ../../24.04/3.md f5623f3ed56a4e1b873eb5674d198ef9
+msgid "[2097831](https://bugs.launchpad.net/bugs/2097831)"
+msgstr ""
+
+#: ../../24.04/3.md 338b2d8f6f914cd4959a348251cbdee5
+msgid "d/p: Add new Synaptics devices 06cb:0107 and 06cb:0108"
+msgstr ""
+
+#: ../../24.04/3.md 8e3e7e5eb4a846e689d46febf06207f9
+msgid "[2114712](https://bugs.launchpad.net/bugs/2114712)"
+msgstr ""
+
+#: ../../24.04/3.md e5d051608c794d15b552db3546e18f8f
+msgid "d/p: Add new Synaptics device 06cb:019d"
+msgstr ""
+
+#: ../../24.04/3.md a55f2336e2ce400c99474d24ac50ee4c
+msgid "pci.ids"
+msgstr ""
+
+#: ../../24.04/3.md 0123769adc0f40978127697307d19b64
+msgid "[2100918](https://bugs.launchpad.net/bugs/2100918)"
+msgstr ""
+
+#: ../../24.04/3.md 135fb424130542369d7b0f76d341185a
+msgid ""
+"Correct the labeling of Intel Wireless-AC 9560 CNVi Wi-Fi interface on "
+"Jasper Lake platforms."
+msgstr ""
+
+#: ../../24.04/3.md 49d4daf7eb36467ba86aed19902b8e5b
+#: 6a60309e3e544930bf91bb19da5aa47b 6ab8d735c84e4d208a80b5092f55cb3e
+#: 761ca893447448a0b5680ee39c5b933e 7cf260aa74ea4f3fb1c6eeed177b2227
+#: ac415a029bc548449caf0dc5e3fe1b3b ac521e3deb68469d8cfde4540057a032
+#: c69dc9f83df44580a22fe090da843c36 db5fe31d5cc34aa583c88613c81770ae
+#: dbcebe996fd04a139b1d69ce141eaf2b fd758170c13c4554a11279f25455ce9c
+msgid "ubuntu-advantage-tools"
+msgstr ""
+
+#: ../../24.04/3.md d60d443e690f4f8489fa5a970f26325b
+#: eb621659e7e24f6d91b9450b126cbead
+msgid "[2106660](https://bugs.launchpad.net/bugs/2106660)"
+msgstr ""
+
+#: ../../24.04/3.md 1d0d21e901ae4de5aa9d509f51ffed06
+msgid "Backport 35.1ubuntu0 to noble"
+msgstr ""
+
+#: ../../24.04/3.md 5340bad289ca4eb1be8db16436838693
+msgid ""
+"LXD: store the configuration in /var/lib/ubuntu-advantage instead of "
+"/var/lib/ubuntu-pro"
+msgstr ""
+
+#: ../../24.04/3.md 3a2e010fbe504dcea0701ec4805d2b10
+#: e5fd7e3d75a44a1382956f10b522759f
+msgid "[2083665](https://bugs.launchpad.net/bugs/2083665)"
+msgstr ""
+
+#: ../../24.04/3.md 91e9ef510f0a4a38bf166c90b31b6504
+msgid "d/control: drop strict dependency on python3-pkg-resources"
+msgstr ""
+
+#: ../../24.04/3.md 4f7b1931ee964ef3a693a82fc28d6996
+msgid "[2070095]"
+msgstr ""
+
+#: ../../24.04/3.md 71533937c6ce4f95824c70a231bbf4b8
+msgid "[2084677](https://bugs.launchpad.net/bugs/2084677)"
+msgstr ""
+
+#: ../../24.04/3.md 209ad1b1bed5441cbdf63c6b5d1241f0
+msgid "only run the apt upgrade hook when run as root"
+msgstr ""
+
+#: ../../24.04/3.md b7b3e3400bb14ae088dce0f1c1641ae7
+msgid "[2091327](https://bugs.launchpad.net/bugs/2091327)"
+msgstr ""
+
+#: ../../24.04/3.md e5f5e629492d416f8a04f743720636e4
+msgid "deduplicate entries in 'pro help' output"
+msgstr ""
+
+#: ../../24.04/3.md 898ccce7c103455d92e5d6b2c5d701fe
+#: d290714762ca41fbbebf7897446d620c
+msgid "[2098862](https://bugs.launchpad.net/bugs/2098862)"
+msgstr ""
+
+#: ../../24.04/3.md 726fa24f8333448abeb0bfbc37462ca7
+msgid "apt-hook: set C++ standards version to c++17 for APT 2.9.30 compatibility"
+msgstr ""
+
+#: ../../24.04/3.md 456638661f464037a2625a6f0116173b
+msgid "tests: remove argparse error tests from unit tests"
+msgstr ""
+
+#: ../../24.04/3.md 9cc8405462334e4d91186b0348724373
+msgid ""
+"Drop direct dependency on python3-pkg-resources to resolve priority "
+"mismatch"
+msgstr ""
+
+#: ../../24.04/3.md b8c2a2771f6e479f8498e97dd6706898
+msgid "[2112382](https://bugs.launchpad.net/bugs/2112382)"
+msgstr ""
+
+#: ../../24.04/3.md 24cb05294065416da4aba37a23c7dacc
+msgid "Backport 36ubuntu0 to noble"
+msgstr ""
+
+#: ../../24.04/3.md 097ec1807ecc4afca1afe1f6e2fe5813
+msgid "[2111610](https://bugs.launchpad.net/bugs/2111610)"
+msgstr ""
+
+#: ../../24.04/3.md f506215fb25849ff952392da21c36fed
+msgid "return all affected packages for a cve"
+msgstr ""
+
+#: ../../24.04/3.md d3be9cea520448eba6668ef19e49ada8
+msgid "rpi-eeprom"
+msgstr ""
+
+#: ../../24.04/3.md efc65e12889b4141acfaafda12ec5b03
+msgid "[2095175](https://bugs.launchpad.net/bugs/2095175)"
+msgstr ""
+
+#: ../../24.04/3.md ef021009a3744cdca2b12cb7e61621a4
+msgid ""
+"Include Breaks/Replaces on rpi-eeprom-firwmare to ensure partial upgrades"
+" from earlier version can succeed"
+msgstr ""
+
+#: ../../24.04/3.md a0ddc49230414d63887b4a5d753382e1
+msgid "google-guest-agent"
+msgstr ""
+
+#: ../../24.04/3.md 9d2ec644f3084c60b944a663105c9cc0
+msgid "[2096765](https://bugs.launchpad.net/bugs/2096765)"
+msgstr ""
+
+#: ../../24.04/3.md 2558e02371b74e568b4371d8cff577aa
+msgid "New upstream version for upstream tag 20250116.00."
+msgstr ""
+
+#: ../../24.04/3.md 6f375e62aeea41e5860f963e72b84c42
+msgid "google-osconfig-agent"
+msgstr ""
+
+#: ../../24.04/3.md ef9865a23d46485597320ce130843d76
+msgid "[2096657](https://bugs.launchpad.net/bugs/2096657)"
+msgstr ""
+
+#: ../../24.04/3.md 813535c3b4b04e77be9ef8ef6da39934
+msgid "New upstream version for upstream tag 20250115.01."
+msgstr ""
+
+#: ../../24.04/3.md 605cf066bc1a408faee17fb28fd5a7f7
+msgid "No change rebuild for Noble."
+msgstr ""
+
+#: ../../24.04/3.md 3d6e31f1c8354330bf25d0cdb2bbe5a6
+msgid "[2106195](https://bugs.launchpad.net/bugs/2106195)"
+msgstr ""
+
+#: ../../24.04/3.md 0e11ef393e8e4913af2e1ebbadb698c9
+msgid "New upstream version for upstream tag 20250328.00."
+msgstr ""
+
+#: ../../24.04/3.md 49161a88c5de4c228cecdc90ead68d30
+#: 5ac6da0554db4235b03509bc4061cef3 e81b4ffe78a14a0d82b32cb21fc44fb7
+msgid "runc-app"
+msgstr ""
+
+#: ../../24.04/3.md 3339f47f908f4ef9856be15a387d08f4
+msgid "[2076981](https://bugs.launchpad.net/bugs/2076981)"
+msgstr ""
+
+#: ../../24.04/3.md e744f1d13adc44ccb618363ebf808cba
+msgid "Do not install example/test utilities"
+msgstr ""
+
+#: ../../24.04/3.md 8da974dfb070442ead512f5654f3f297
+msgid "[2098665](https://bugs.launchpad.net/bugs/2098665)"
+msgstr ""
+
+#: ../../24.04/3.md de172dbdebd5414cab7ad6c21b600b67
+msgid "d/control: build with golang 1.24"
+msgstr ""
+
+#: ../../24.04/3.md 14ec56d9c3a2482b917bb23506d18c58
+msgid "[2076340](https://bugs.launchpad.net/bugs/2076340)"
+msgstr ""
+
+#: ../../24.04/3.md ccd2df16d06642839406fbc90ba2d3a2
+msgid ""
+"d/rules: set GO111MODULE to auto. No-change rebuild to pick up changed "
+"build flags on ppc64el and s390x."
+msgstr ""
+
+#: ../../24.04/3.md dde0144ad1d440c0aa8d36576e938057
+msgid "Backport to noble"
+msgstr ""
+
+#: ../../24.04/3.md 9c55f31e839b4826840aa4b0174537cf
+msgid "[2094190](https://bugs.launchpad.net/bugs/2094190)"
+msgstr ""
+
+#: ../../24.04/3.md 6e09505d5bc24906aaa4263bc020f415
+msgid "New upstream version 2024.10.07"
+msgstr ""
+
+#: ../../24.04/3.md c63023ea53494c9499da0b3fc849df4d
+msgid "horizon"
+msgstr ""
+
+#: ../../24.04/3.md 3657c39ca49e493a88e8dcef17768a92
+msgid "[2045394](https://bugs.launchpad.net/bugs/2045394)"
+msgstr ""
+
+#: ../../24.04/3.md 1f18cc2f2f9c49b8a1cc53cc0e1fa2f1
+msgid ""
+"d/openstack-dashboard.postinst: Retry compress to avoid race condition in"
+" pyscss. Thanks to Santiago Vila <sanvila@debian.org> and Thomas Goirand "
+"<zigo@debian.org>"
+msgstr ""
+
+#: ../../24.04/3.md 56253c6a995c4b55b283a34463f3adc9
+#: f9a96138eeaa430ca1353e7fbdaaa8b3
+msgid "rdma-core"
+msgstr ""
+
+#: ../../24.04/3.md 0e81c23e52ea43f5834aa6e8a26a9de8
+#: 43b4d188f1b94155910968e0e08ea7f2
+msgid "[2100089](https://bugs.launchpad.net/bugs/2100089)"
+msgstr ""
+
+#: ../../24.04/3.md 5013c2ff9bf247d88acf2057b97b933d
+msgid "Revert non-MANA 50.0-2ubuntu0.1 changes"
+msgstr ""
+
+#: ../../24.04/3.md e5e9dcfecbab4d21994c7531e08febdb
+msgid ""
+"Incorporate all upstream changes to Microsoft Azure Network Adapter "
+"(MANA) RDMA provider"
+msgstr ""
+
+#: ../../24.04/3.md 30a52bac45e14b78b0fc0da862bc0316
+#: 8b7a8f0758f1453fad96f066341e29a2
+msgid "libtraceevent"
+msgstr ""
+
+#: ../../24.04/3.md 8fe08a7a145a42d9829560c0c410c316
+msgid "[2062118](https://bugs.launchpad.net/bugs/2062118)"
+msgstr ""
+
+#: ../../24.04/3.md 36b477202362444eb1e29d5e2413833d
+#: b4ad41d520724f268ac1685bc6325209
+msgid ""
+"d/p/0004-fix-file-endianness.patch: make file_bigendian the same as "
+"host_bignendian in tep_alloc()"
+msgstr ""
+
+#: ../../24.04/3.md 6c15fb0f408f4caf80d091076d701110
+msgid "[2101149](https://bugs.launchpad.net/bugs/2101149)"
+msgstr ""
+
+#: ../../24.04/3.md 2239512bdff04f9eb8c915451341e17c
+msgid "edk2"
+msgstr ""
+
+#: ../../24.04/3.md 4a419df9ed434d498991e853679162bc
+msgid "[2101903](https://bugs.launchpad.net/bugs/2101903)"
+msgstr ""
+
+#: ../../24.04/3.md 0558c103978840a6a3e54399ac037d15
+msgid ""
+"ovmf: cherry-pick patch from upstream to \"use user-specified "
+"opt/ovmf/X-PciMmio64Mb value unconditionally\". ."
+msgstr ""
+
+#: ../../24.04/3.md 9092fe1c7e4d4e88aebb58f88e8e91dc
+msgid "autopkgtest"
+msgstr ""
+
+#: ../../24.04/3.md 3a774bbd7d864039b850c11c5bdd2a98
+msgid "[2106167](https://bugs.launchpad.net/bugs/2106167)"
+msgstr ""
+
+#: ../../24.04/3.md 881c5d271c4643e2967a4e9b96679134
+msgid "No-change backport from Plucky"
+msgstr ""
+
+#: ../../24.04/3.md a8c84923913344418536b8cc4d899768
+msgid "walinuxagent"
+msgstr ""
+
+#: ../../24.04/3.md 0f803abb155648418b3d6b59ac4438ac
+msgid "[2063046](https://bugs.launchpad.net/bugs/2063046)"
+msgstr ""
+
+#: ../../24.04/3.md fc49051841e64e7e9fd423aaecc9e78e
+msgid "Drop the use of nose :"
+msgstr ""
+
+#: ../../24.04/3.md 9649c8eee7cb4157a6081fc8bfa1a5b1
+msgid "sl-modem"
+msgstr ""
+
+#: ../../24.04/3.md 88a982a59eff480aa2942f8f5fef2c38
+msgid "[2111377](https://bugs.launchpad.net/bugs/2111377)"
+msgstr ""
+
+#: ../../24.04/3.md 84654813bea74cc993888fee8cab47e5
+msgid "alsa-lib"
+msgstr ""
+
+#: ../../24.04/3.md 636e2c2052764cfead28dcbe65c9886b
+msgid "[2111271](https://bugs.launchpad.net/bugs/2111271)"
+msgstr ""
+
+#: ../../24.04/3.md 5bc3b9b9c4764953bcd6256606d88eb9
+msgid "Add patch to allow HDA-Intel configuration support (lp: #2111271)."
+msgstr ""
+
+#: ../../24.04/3.md 2623c1c57692420a9987d2eb83ab643b
+msgid "nginx"
+msgstr ""
+
+#: ../../24.04/3.md c160219341244ea4a11615f686fc608d
+msgid "[2081308](https://bugs.launchpad.net/bugs/2081308)"
+msgstr ""
+
+#: ../../24.04/3.md bab6d993c07f40c3a4a0fd1338168d9d
+msgid ""
+"Add ConditionFileIsExecutable to SystemD service file, prevents starting "
+"of service if nginx is not installed"
+msgstr ""
+
+#: ../../24.04/3.md e3db2a68cf614951b6face3832066bd2
+msgid "acct"
+msgstr ""
+
+#: ../../24.04/3.md ddff8fd974b34073bb30dcee7c11a858
+msgid "[2095035](https://bugs.launchpad.net/bugs/2095035)"
+msgstr ""
+
+#: ../../24.04/3.md 24bbc8f759db4a1da9fb7466250c468e
+msgid ""
+"debian/patches/07_sprintf-buffer-overflow.patch: Fix buffer overflow in "
+"dev_hash.c"
+msgstr ""
+
+#: ../../24.04/3.md 2e95e5dd1d31468389f944f2fcdcff72
+msgid "remmina"
+msgstr ""
+
+#: ../../24.04/3.md 8f2f09677e6b4a45ad04a3382feff274
+msgid "[2111952](https://bugs.launchpad.net/bugs/2111952)"
+msgstr ""
+
+#: ../../24.04/3.md cf1448d9fac247aabd285d9828038813
+msgid ""
+"d/p/lp-2111952-01- skip_credential_prompt_if_already_saved.patch: Do not "
+"prompt user for credentials if they are already saved. Thanks to Hiroyuki"
+" Tanaka <myheroyuki@outlook.com>."
+msgstr ""
+
+#: ../../24.04/3.md 84915f224045450cb653c126b3b0e480
+msgid "ubuntu-raspi-settings"
+msgstr ""
+
+#: ../../24.04/3.md 11017ade91a04e8a97bb01494b169734
+msgid "[2069827](https://bugs.launchpad.net/bugs/2069827)"
+msgstr ""
+
+#: ../../24.04/3.md 7c728b78f37e4f60abe4b75b716be829
+msgid ""
+"etc/cloud/cloud.cfg.d/99-fake-cloud.cfg moved from ubuntu-raspi-settings-"
+"server to ubuntu-raspi-settings as it now applies to both server *and* "
+"desktop images"
+msgstr ""
+
+#: ../../24.04/3.md 2ce90517e45b4a4b86df7dfed4ed43a8
+msgid "gzip"
+msgstr ""
+
+#: ../../24.04/3.md eb852d1e83fe4f198e6dc8cdd1df2d03
+msgid "[2083700](https://bugs.launchpad.net/bugs/2083700)"
+msgstr ""
+
+#: ../../24.04/3.md 3a1f79bf781c427b9029bd019a5a177e
+msgid ""
+"d/p/0001-maint-fix-s390-buffer-flushes.patch: align the behavior of "
+"dfltcc_inflate to do the same as gzip_inflate when it hits a premature "
+"EOF"
+msgstr ""
+
+#: ../../24.04/3.md 0e099e2e1bb943979f5e9bc2559ba47c
+msgid "dnsmasq"
+msgstr ""
+
+#: ../../24.04/3.md 0455026441e449fdbadd2312f7906c22
+msgid "[2026757](https://bugs.launchpad.net/bugs/2026757)"
+msgstr ""
+
+#: ../../24.04/3.md 1b64cea251c64d7db6b8098bbd65f3a7
+msgid ""
+"d/p/fix-crash-when-reloading-DHCP-config-on-SIGHUP.patch: Confusion in "
+"the code to free old DHCP configuration when it's being reloaded causes "
+"invalid pointers to be followed and a crash ."
+msgstr ""
+
+#: ../../24.04/3.md 3b1909cc0cec4899b1c614cf8e346eaa
+#: 7eae1b10b93043008168fe9d930b5902
+msgid "mysql-8.0"
+msgstr ""
+
+#: ../../24.04/3.md 88df3740de8447daa791d4296561da16
+msgid "[2112151](https://bugs.launchpad.net/bugs/2112151)"
+msgstr ""
+
+#: ../../24.04/3.md 4551c5c0309d41e69aa902877133079d
+msgid "Add su directive to logrotate config to run as mysql user and adm group ."
+msgstr ""
+
+#: ../../24.04/3.md 5dbd5200c3a74945a28b9a8871fb4457
+msgid "[1850980](https://bugs.launchpad.net/bugs/1850980)"
+msgstr ""
+
+#: ../../24.04/3.md f93c22ef711d49e5989b5e468e175aa7
+msgid ""
+"Update logrotate script to test if mysql-server is online before flushing"
+" logs ."
+msgstr ""
+
+#: ../../24.04/3.md 6cc3a8f4971e4f9ead6b5677aa00665d
+#: d5df00c66a2844c59179e138ea0e25c6 f58ec9e444f54bff8dc53a55650b60e4
+msgid "ceph"
+msgstr ""
+
+#: ../../24.04/3.md 040a371738724db19d5aaa9b459f8eba
+#: a1f9d5db936745aaac659ec68e25cc71
+msgid "[2097605](https://bugs.launchpad.net/bugs/2097605)"
+msgstr ""
+
+#: ../../24.04/3.md d5a213ed83d6470fa19121ee5d07bfd0
+msgid "d/p/snapshot-upgrade-fix.patch: Remove logging as it crashed Ganesha"
+msgstr ""
+
+#: ../../24.04/3.md 94ba4e179ff04d1fa8bc7a35a2d4a5bf
+msgid "New upstream stable release ."
+msgstr ""
+
+#: ../../24.04/3.md 0b053dd10ce845cb94072675d7c7b389
+msgid "[2089565](https://bugs.launchpad.net/bugs/2089565)"
+msgstr ""
+
+#: ../../24.04/3.md 2a49ad887ed14ac68c39c2742360c5a6
+msgid "d/p/snapshot-upgrade-fix.patch: Fix upgrade crashing ."
+msgstr ""
+
+#: ../../24.04/3.md 56a5198fe1cd4c0d887fba19e3bd7c4b
+msgid "firmware-sof"
+msgstr ""
+
+#: ../../24.04/3.md c42e94135f554228a6f94829c25228d3
+msgid "[2114252](https://bugs.launchpad.net/bugs/2114252)"
+msgstr ""
+
+#: ../../24.04/3.md e717e9a5d84a4d94950de49cdc6032c9
+msgid "Update cs42l43 and cs35l56 to v2.12.1 for 6.14 kernel"
+msgstr ""
+
+#: ../../24.04/3.md 0b61d2a9505f4ba1925b2f08a4c10055
+#: 51c47eb3d2354783b06b94edc2d8c89c 67ef8793ce7f4fe7a12e35c8e3dfd970
+#: 6e0b85984056463fbf73a4b260ca0af4 84577ca94ce841858d572e33fdb2f890
+msgid "samba"
+msgstr ""
+
+#: ../../24.04/3.md 0bc19a3b52a84215bfb16b8c183fce59
+#: 25277e9a582b4780848c3e2cd408bc2b
+msgid "[2107395](https://bugs.launchpad.net/bugs/2107395)"
+msgstr ""
+
+#: ../../24.04/3.md 94c159cf1b2f465392c46d7e8fdd64e5
+msgid ""
+"d/p/fix-motd-gpo-list-empty.patch: fix crash when listing an empty MOTD "
+"GPO"
+msgstr ""
+
+#: ../../24.04/3.md 793a17e938b84cfb99879a65f7551370
+msgid ""
+"d/p/fix-update-motd-gpo.patch: replace patch with upstream's version, "
+"which includes another fix for the case of updating an existing MOTD GPO"
+msgstr ""
+
+#: ../../24.04/3.md 6de063b22e2b4676b3f4d8e30b70a9e5
+msgid "[2078854](https://bugs.launchpad.net/bugs/2078854)"
+msgstr ""
+
+#: ../../24.04/3.md be29d0a0fd264035b2e2bdf7e75203bf
+msgid "d/p/gpo-segfault-fix.patch: fix segfault in samba-gpupdate"
+msgstr ""
+
+#: ../../24.04/3.md 5dea60d4316d4f6681dcb79caadb678e
+msgid "[2088094](https://bugs.launchpad.net/bugs/2088094)"
+msgstr ""
+
+#: ../../24.04/3.md 86687ed4581148ed9989eb0d79f31735
+msgid ""
+"d/p/deprecated-readfp-configparser.patch: fix crash in samba-tool due to "
+"using removed method"
+msgstr ""
+
+#: ../../24.04/3.md a03bfb40f0e04708a50d8460b3586977
+msgid "[2092308](https://bugs.launchpad.net/bugs/2092308)"
+msgstr ""
+
+#: ../../24.04/3.md 5a863d1ba1954db091643c4157d7ba83
+msgid ""
+"d/p/fix-update-motd-gpo.patch: fix crash when updating an already "
+"existing MOTD GPO"
+msgstr ""
+
+#: ../../24.04/3.md 5001837ea8ac4ad7849a613bd2338d4b
+msgid "squid"
+msgstr ""
+
+#: ../../24.04/3.md 460e4972074c4e40bf0212666ffbf8be
+msgid "[2085197](https://bugs.launchpad.net/bugs/2085197)"
+msgstr ""
+
+#: ../../24.04/3.md 449365c2f7a9424baba227f00423a00f
+msgid "New upstream version 6.13"
+msgstr ""
+
+#: ../../24.04/3.md 66bdb177e6b643879a63cef22a0304cc
+msgid "gvfs"
+msgstr ""
+
+#: ../../24.04/3.md 0d72b7b8e71f49cc88d2eac943d7a2db
+msgid "[2109538](https://bugs.launchpad.net/bugs/2109538)"
+msgstr ""
+
+#: ../../24.04/3.md ea055d913e914bd094d0d3a060b0370e
+msgid ""
+"disks2: Increasing reference count when updating volume to fix crashes "
+"when mounting encrypted partitions"
+msgstr ""
+
+#: ../../24.04/3.md 7520c770e6cf4dc7abdd2096b6a2376f
+msgid "power-profiles-daemon"
+msgstr ""
+
+#: ../../24.04/3.md be68e1317e5943cb93e0342e02ba3910
+msgid "[2115041](https://bugs.launchpad.net/bugs/2115041)"
+msgstr ""
+
+#: ../../24.04/3.md c99f8ef86af54e418b18fe3c05f46f7a
+msgid "Recognize the custom ACPI platform profile"
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/24.04/4.po
+++ b/docs/locale/ja/LC_MESSAGES/24.04/4.po
@@ -1,0 +1,5214 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../24.04/4.md:2 13bbd56785fe45689fc60a354ec0a913
+msgid "Changes in Ubuntu 24.04.4"
+msgstr ""
+
+#: ../../24.04/4.md:4 f776c1b8612e41338994c1590a92569b
+msgid ""
+"This is a brief summary of bugs fixed between Ubuntu 24.04.3 and 24.04.4."
+" **This summary covers only changes to packages in *main* and "
+"*restricted*, which account for all packages in the officially-supported "
+"images; there are further changes to various packages in *universe* and "
+"*multiverse*.** Some of these fixes were by Ubuntu developers directly, "
+"while others were by upstream developers and backported to Ubuntu. For "
+"full details, see the individual package changelogs."
+msgstr ""
+
+#: ../../24.04/4.md:12 8ddf824e58e54cd2a78a8def27be9f5a
+msgid ""
+"In addition to the bugs listed below, this update includes all security "
+"updates from the [Ubuntu Security "
+"Notice](https://ubuntu.com/security/notices?order=newest&release=noble&details=)"
+" affecting Ubuntu 24.04.4 LTS that were released up to and including "
+"February 12, 2026."
+msgstr ""
+
+#: ../../24.04/4.md:16 ee0b16de1ce3400da5462633f59869d9
+msgid "Installation bug fixes"
+msgstr ""
+
+#: ../../24.04/4.md:18 4bf53f53ef13482d8d833a71732721cf
+msgid ""
+"Updated CD images are provided with this release, including fixes for "
+"some installation bugs. (Many installation problems are hardware-"
+"specific; for those, see “Hardware support bugs” below.)"
+msgstr ""
+
+#: ../../24.04/4.md 0a1d098782b04ef9bac7014bf91630e3
+#: 0f5d11b89d39450a8d3470fc5a72e9f0 1016f9fe4c9245919f2230ae4ab88017
+#: 13e7a05e0d1d4afd85ae4a91391d3df9 3de10a7367c048e3b13b9f28bc970f98
+#: 463fded7e92e41829f9c8051ca5e4895
+msgid "Source Package"
+msgstr ""
+
+#: ../../24.04/4.md 19c4daf751de4eb590719c11348bb0a2
+#: 2df89b77595748a28fd25b19002f7764 5e0613b4a83049e08085d23dd1760b28
+#: 824a0903b17841b6acb0e8caf7698433 a076856bf80e4ac59c92ce9f4894a82e
+#: c2ab3b5acf7740faaf980c93bc2f320b
+msgid "Bug  #"
+msgstr ""
+
+#: ../../24.04/4.md 31a543286ddc4651b445c59ee2dde9ad
+#: 3ede71227a1347ecb8441c38cb993407 7633a7adac284d67928c043ee165f171
+#: b4e15d1ce0294b7e98c366a1d92df767 d423f6a1b2ec4585b544a9cb837fcb70
+#: e071940b4c9a44acb6863d801afc1429
+msgid "Description"
+msgstr ""
+
+#: ../../24.04/4.md 52e67a3adabe4d248ee8cd01c545fcff
+#: e370ad2be6e64c06abed5e2da9644fe6
+msgid "livecd-rootfs"
+msgstr ""
+
+#: ../../24.04/4.md de8a53ec50ef4ab4a774d331b96c5d84
+msgid "[2116199](https://bugs.launchpad.net/bugs/2116199)"
+msgstr ""
+
+#: ../../24.04/4.md aaea0914d32c4efb86699ef739ee8ae8
+msgid "Add 6.14 kernel apparmor features' preseeds"
+msgstr ""
+
+#: ../../24.04/4.md c52287290f1140248f3920c89c0a2a9d
+msgid "[2069391](https://bugs.launchpad.net/bugs/2069391)"
+msgstr ""
+
+#: ../../24.04/4.md ca044842f38f404c8821acddba167bb9
+msgid "Override cloud-init.service in /etc so as to not invalidate debsums"
+msgstr ""
+
+#: ../../24.04/4.md:25 dc7319581c1b4539ab18360f6d1fffca
+msgid "Upgrade bug fixes"
+msgstr ""
+
+#: ../../24.04/4.md:27 797ea07aa99b45cc87fc194bf47f7c56
+msgid ""
+"These changes fix upgrade issues, smoothing the way for future upgrades "
+"to later releases of Ubuntu (and not only)."
+msgstr ""
+
+#: ../../24.04/4.md fa5d921f5d93465783b85d90abfc90c5
+msgid "ubuntu-release-upgrader"
+msgstr ""
+
+#: ../../24.04/4.md 6c90ac49b4484b758774b953e1a91304
+msgid "[2138637](https://bugs.launchpad.net/bugs/2138637)"
+msgstr ""
+
+#: ../../24.04/4.md 6fe7f2cc5c0440aa83a21293ce98fe96
+msgid "Run pre-build.sh: updating mirrors for point release"
+msgstr ""
+
+#: ../../24.04/4.md:33 d3cd36352f774183a50f201f2dafd205
+msgid "Desktop fixes"
+msgstr ""
+
+#: ../../24.04/4.md:35 3ec36f8d4de847bba290db46b5c4d312
+msgid ""
+"These changes mainly affect desktop installations of Ubuntu and other "
+"Ubuntu-based desktop systems."
+msgstr ""
+
+#: ../../24.04/4.md 83ef839ab3b245ee8688eb3b34706ab5
+msgid "simple-scan"
+msgstr ""
+
+#: ../../24.04/4.md b228d82846834137b4a5198d8006e279
+msgid "[2112619](https://bugs.launchpad.net/bugs/2112619)"
+msgstr ""
+
+#: ../../24.04/4.md c9dbe3d48d7940bea435730cdb6f6175
+msgid ""
+"d/p/lp2112619-postprocessing-fixes.patch: fix postprocessing error "
+"handling and script output"
+msgstr ""
+
+#: ../../24.04/4.md 4d4885ec0d7d44639a75f234ff842a6b
+msgid "wireplumber"
+msgstr ""
+
+#: ../../24.04/4.md 8bb277e1adff4899a64c28bc87ba343c
+msgid "[2122640](https://bugs.launchpad.net/bugs/2122640)"
+msgstr ""
+
+#: ../../24.04/4.md fd0bb26098b041439ffd94be096e3c27
+msgid ""
+"Prevent bluetooth profile switch to output some sound on another device "
+"during the transition"
+msgstr ""
+
+#: ../../24.04/4.md 1d46c2db88dc421db77d86cf179e8a3f
+#: 3b893c58db014a6ea48cf8c3f7779c6b
+msgid "gnome-remote-desktop"
+msgstr ""
+
+#: ../../24.04/4.md 79ad23b0ae7c4d4d9fda3a45ccb18611
+msgid "[2127792](https://bugs.launchpad.net/bugs/2127792)"
+msgstr ""
+
+#: ../../24.04/4.md 17b4dc44279a410abf96073fd5833305
+msgid ""
+"d/p/lp-2127792-fix-nvenc-blackwell.patch: Fix NVENC video streaming on "
+"blackwell GPUs"
+msgstr ""
+
+#: ../../24.04/4.md a35ddb10621c4398aad46448689e9b2a
+msgid "nautilus"
+msgstr ""
+
+#: ../../24.04/4.md 1fb0b3a847c84b6a8362042656102291
+msgid "[2130347](https://bugs.launchpad.net/bugs/2130347)"
+msgstr ""
+
+#: ../../24.04/4.md 16838957ac7c41aea84f36cb35fc3f28
+msgid "Fix trash banner visibility"
+msgstr ""
+
+#: ../../24.04/4.md 9b114a29b5d14dd0acdb099449394b8f
+msgid "gnome-settings-daemon"
+msgstr ""
+
+#: ../../24.04/4.md 2f5bc26147ba4d2c98b9cad8c3a606be
+msgid "[2016914](https://bugs.launchpad.net/bugs/2016914)"
+msgstr ""
+
+#: ../../24.04/4.md b8c336bff25f440193ae7ce0daf83d28
+msgid ""
+"d/p/u/handle-invalid-token.patch: Fix SIGSEGV on start-up when an invalid"
+" token is provided: ."
+msgstr ""
+
+#: ../../24.04/4.md bf588ff31547420b9abbc1fd38d387ff
+msgid "pipewire"
+msgstr ""
+
+#: ../../24.04/4.md 065a5e2e0e624f369a561ac107fc25b9
+msgid "[2131647](https://bugs.launchpad.net/bugs/2131647)"
+msgstr ""
+
+#: ../../24.04/4.md b15e9efdd1b346978f5c26794d4d7a46
+msgid "Fix v4l2oopback devices not work with pipewire"
+msgstr ""
+
+#: ../../24.04/4.md 6702c4df8edc44389a4c0e454d27c227
+#: 841de36e9af44c078a64b1bd09e38ebc
+msgid "[2072130](https://bugs.launchpad.net/bugs/2072130)"
+msgstr ""
+
+#: ../../24.04/4.md 0058209e3d514745a60a474469bd2538
+msgid "Backport headless session persistence"
+msgstr ""
+
+#: ../../24.04/4.md e1511af8db5749beb9f2d60bdbad8018
+msgid "wayland-protocols"
+msgstr ""
+
+#: ../../24.04/4.md 05a5c17c4aca4864b7f256504ed8348d
+#: 6ea680c4499b44b09dbfbc163fc397ae 7fa6e9b01bb3494b9bda550dee2813bb
+#: dadb8343a78f4e0bbc738d71771772e8
+msgid "[2126037](https://bugs.launchpad.net/bugs/2126037)"
+msgstr ""
+
+#: ../../24.04/4.md 5454195759cf4e458a4d673e1434ccc5
+#: 5afbad5c449c454f83f1902b90857b95 cf8f852f38b64f97baa565d15b9e8a13
+#: d5e53fc9234142ffa8885ad360d939e8 fcdbe386442f4175b3a0b687787bf128
+msgid "Backport to noble"
+msgstr ""
+
+#: ../../24.04/4.md a66e4fea0d2049328c7dc07c4c324154
+msgid "software-properties"
+msgstr ""
+
+#: ../../24.04/4.md 5754b54a386d44dfabd72ba61ad0e63b
+msgid "[2111400](https://bugs.launchpad.net/bugs/2111400)"
+msgstr ""
+
+#: ../../24.04/4.md a79b7c7c3a5b4463be7f33e6156b7683
+msgid ""
+"cloudarchive: Enable support for the Flamingo Ubuntu Cloud Archive on "
+"24.04"
+msgstr ""
+
+#: ../../24.04/4.md 0fdeeacc09a44f6e9d54f7868564c6e3
+#: e84f3f6282dd42668c3c1210bca8a823 f79a1f6010d94d9cb3171fe213ee5219
+msgid "gnome-shell-extension-desktop-icons-ng"
+msgstr ""
+
+#: ../../24.04/4.md bb7cd815a2284fef87400f405533304b
+msgid "[2117725](https://bugs.launchpad.net/bugs/2117725)"
+msgstr ""
+
+#: ../../24.04/4.md 3000caccb9e040668f30533387a5c046
+msgid "a11y: Use human name for desktop windows"
+msgstr ""
+
+#: ../../24.04/4.md d8989e9645334371a22847b4d99a8115
+msgid "[2116085](https://bugs.launchpad.net/bugs/2116085)"
+msgstr ""
+
+#: ../../24.04/4.md 1babb1b918264f3dbd1e992126a47a23
+msgid "a11y: Describe the popup in new folder"
+msgstr ""
+
+#: ../../24.04/4.md b1a9f33db8bf49ba8abb9c1d2ca602a9
+#: c35bf26e5a704fa3a7adbfa80c1d8110 d68fb2129f454d4e848646d92e2f6899
+msgid "ubuntu-drivers-common"
+msgstr ""
+
+#: ../../24.04/4.md d2a5030b55ec4f48a807215c27e52dc2
+msgid "[2071829](https://bugs.launchpad.net/bugs/2071829)"
+msgstr ""
+
+#: ../../24.04/4.md 9012130542ce499a98e4872babbcc37d
+msgid "Remove outdated dependency to fix ADT failures"
+msgstr ""
+
+#: ../../24.04/4.md acc814167795423b8efb0dea391e4666
+msgid "[2115537](https://bugs.launchpad.net/bugs/2115537)"
+msgstr ""
+
+#: ../../24.04/4.md 8851f285aedf45bfb008b7188fd3d709
+msgid "Clarify gpgpu flag help text"
+msgstr ""
+
+#: ../../24.04/4.md 08f49b76cfef4f95b106d31625147d9c
+#: 0f903bb4b0a5407cba0f021a68240fa3 1e76fef61d7c489f9ce364f84456e7e5
+#: 266fd0e324664a21bcac12f878b9b43a 9167a1cc2967402d82c0802b276358b4
+#: ba231af6e49441bcbc446f7b07a17373 dfbd8d3ecf0f4280963742515f711661
+msgid "gdm3"
+msgstr ""
+
+#: ../../24.04/4.md 01ec64d65e8743c094164007b20d3e83
+#: e4133736b9054dc1883f3e17426e1977
+msgid "[2124220](https://bugs.launchpad.net/bugs/2124220)"
+msgstr ""
+
+#: ../../24.04/4.md 83483388d2ab4101ac7ccc13650ea300
+msgid "Add hardware matching rule for preferring wayland"
+msgstr ""
+
+#: ../../24.04/4.md 39b1b584a3bc4dbd968e649b3d286fc3
+msgid "[2120413](https://bugs.launchpad.net/bugs/2120413)"
+msgstr ""
+
+#: ../../24.04/4.md 469042b7797b4ec39dc1b583f223480c
+msgid ""
+"Add retry_preferred_display_server_before_fallback.patch to fix the "
+"problem that the existing retry strategy cannot retry the preferred "
+"session when the preferred session accidentally crashes during startup"
+msgstr ""
+
+#: ../../24.04/4.md 40b8712f52084ff6a0f43b0100fddb28
+msgid "[2115451](https://bugs.launchpad.net/bugs/2115451)"
+msgstr ""
+
+#: ../../24.04/4.md 3e55cad2d7da4d579935a94347ebe012
+msgid ""
+"Add local-display-factory-Match-simpledrm-in-a-substring-inst.patch to "
+"ensure the login screen does not start before the real DRM kernel driver "
+"is loaded"
+msgstr ""
+
+#: ../../24.04/4.md 03f7f4da421244c6a721d0ba1c81a412
+msgid "Prefer Wayland if a specific environment variable is set"
+msgstr ""
+
+#: ../../24.04/4.md 4091246ae7f745cb98b74241696225e5
+msgid "wsl-pro-service"
+msgstr ""
+
+#: ../../24.04/4.md 260ce6246c4b41ff90abaccc8a00692b
+msgid "[2106757](https://bugs.launchpad.net/bugs/2106757)"
+msgstr ""
+
+#: ../../24.04/4.md 3c00cc585ad34fa0a44997f7f0198407
+msgid "Upgrade to upstream version 0.1.18: :"
+msgstr ""
+
+#: ../../24.04/4.md 139889bc1e7f4809a721bcf3c82b1ed0
+msgid "adsys"
+msgstr ""
+
+#: ../../24.04/4.md 03dd9b6fdb504b02ae58709bfdebc17a
+msgid "[2125134](https://bugs.launchpad.net/bugs/2125134)"
+msgstr ""
+
+#: ../../24.04/4.md f42867a1666e4456ba47fcd971e41e3f
+msgid "internal/ad/adsys-gpolist: Allow searching GPO list by UserPrincipalName"
+msgstr ""
+
+#: ../../24.04/4.md 2f690349f0ce43d9b6511cde8a4d670a
+msgid "[2129777](https://bugs.launchpad.net/bugs/2129777)"
+msgstr ""
+
+#: ../../24.04/4.md adb6ee725e36497eacee908c96497e02
+msgid "Fix fallback session with auto-login"
+msgstr ""
+
+#: ../../24.04/4.md 06ef162b94ac40de9c4663b7d98fc15a
+#: aaedca9d097d435b9f17a6ca3c97b16b
+msgid "gnome-control-center"
+msgstr ""
+
+#: ../../24.04/4.md 30c480b62a7646c59c55b69cf8db7125
+msgid "[2114995](https://bugs.launchpad.net/bugs/2114995)"
+msgstr ""
+
+#: ../../24.04/4.md 6457536d0e93482c9a5d3bd82c0e7993
+msgid ""
+"Fix accessibility in the Appearance panel: now the name of the stock "
+"backgrounds is pronounced when using a screen reader"
+msgstr ""
+
+#: ../../24.04/4.md 06225263786647559c2b5a178add5574
+msgid "[2115973](https://bugs.launchpad.net/bugs/2115973)"
+msgstr ""
+
+#: ../../24.04/4.md c7d9c43d2496464eb112f3b5ce8afdf2
+msgid "d/p/a11y: several accessibility patches"
+msgstr ""
+
+#: ../../24.04/4.md 2764299d762d48a58055f86ed94e01f3
+#: 498246fc68d84be19ef460f8074bee5e 4c94fd3f8ca74701afced998a26f7009
+#: 79e0fd81190d42abb217183b1ae193d3 a256e5f2594748adb38be7c10b88f4e1
+#: c1c2bdf97f464a80ae543bfba22258eb cb18961c71a24b198531d503619e0b22
+#: f92a62f3fa88487c95270f5b7a8d2d6b
+msgid "gnome-shell"
+msgstr ""
+
+#: ../../24.04/4.md 5ad0c2c57094427293cf5541dcb97e84
+msgid "[2120331](https://bugs.launchpad.net/bugs/2120331)"
+msgstr ""
+
+#: ../../24.04/4.md bf9db844815c4d54b6f7671e4d85a923
+msgid "Fix quicksettings connections to enterprise AP"
+msgstr ""
+
+#: ../../24.04/4.md 8d25d57d43124783975fda305f6a01ef
+msgid "[2120734](https://bugs.launchpad.net/bugs/2120734)"
+msgstr ""
+
+#: ../../24.04/4.md d7026ecd723e4fe3b5a71e4dd629a9b1
+msgid "Update Wi-Fi icons between disconnect and adapter deactivation"
+msgstr ""
+
+#: ../../24.04/4.md 076301bb61d84809bbf2357231387ad2
+msgid "[2121786](https://bugs.launchpad.net/bugs/2121786)"
+msgstr ""
+
+#: ../../24.04/4.md f57800628f8b426da3ad1879a6425eed
+msgid "d/p: Fix memory leak when using a custom theme"
+msgstr ""
+
+#: ../../24.04/4.md 0558e72b7b534fa494f2fb151a0c880c
+#: 1b831ec1f96846de9a7d1aee8d7ad454
+msgid "[2115948](https://bugs.launchpad.net/bugs/2115948)"
+msgstr ""
+
+#: ../../24.04/4.md ece566342ab14163b24272740f2a9065
+msgid "authPrompt: Notify error messages in GDM login/unlock"
+msgstr ""
+
+#: ../../24.04/4.md b3ed164c820941c2b2014e328e0bc28b
+msgid "Fix accessibility issues in Gnome Shell/GDM/Unlock"
+msgstr ""
+
+#: ../../24.04/4.md 3ea7dc243fa543deae61d790bc326406
+msgid "[2125156](https://bugs.launchpad.net/bugs/2125156)"
+msgstr ""
+
+#: ../../24.04/4.md 1dfbb582f77343e29cb428123bf07235
+msgid "Prevent coinstallation of conflicting Nvidia Drivers"
+msgstr ""
+
+#: ../../24.04/4.md 362e6092944d405a8adaa1fbf74c4643
+#: 3ec210afa62d48e3810d1fbb1778b776 585757bb12974372b3376919422ac393
+#: 822de556cbd34909ac8b0a38b189e570 863fe85fad7f43d793f7baf5b3bf34be
+#: ebcc39029d264c2fb0ebd963381e4180 fb8202713513466d939eefd2671627f6
+msgid "mutter"
+msgstr ""
+
+#: ../../24.04/4.md cc22c65d08cc41008af9a89093863393
+msgid "[2130619](https://bugs.launchpad.net/bugs/2130619)"
+msgstr ""
+
+#: ../../24.04/4.md 1b8d39c65628475c8180e8d46fdc0324
+msgid ""
+"Fix possible crash during output changes, introduced in the previous "
+"upload"
+msgstr ""
+
+#: ../../24.04/4.md d11962afdfe4461c8c0966c0eab4ae59
+msgid "[2085423](https://bugs.launchpad.net/bugs/2085423)"
+msgstr ""
+
+#: ../../24.04/4.md f1bb2679c4dc4c1d80f5de669fd8385a
+msgid "d/p: Fix privacy screen enum definitions"
+msgstr ""
+
+#: ../../24.04/4.md 7da32f4a5437459fbef514318a25f00b
+msgid "[2121517](https://bugs.launchpad.net/bugs/2121517)"
+msgstr ""
+
+#: ../../24.04/4.md c65f50eca69a49a7837ed0329fe0146d
+msgid "d/p: Correctly track the current privacy screen state"
+msgstr ""
+
+#: ../../24.04/4.md 8902b78d40fd4612a2580eba6ec89804
+msgid "[2131283](https://bugs.launchpad.net/bugs/2131283)"
+msgstr ""
+
+#: ../../24.04/4.md 9bb3a7b058214bc49ace253e217a8a4f
+msgid "Add Preferring Wayland to Dell Gorgon Point Platform"
+msgstr ""
+
+#: ../../24.04/4.md 617015f644244a39bf7bc3009b18909a
+msgid "[2131690](https://bugs.launchpad.net/bugs/2131690)"
+msgstr ""
+
+#: ../../24.04/4.md fb083cdf543c4dd2bdd165edf2557572
+msgid "Fix grouping icons"
+msgstr ""
+
+#: ../../24.04/4.md e3f4aecccd174424ba611f70a51f4588
+msgid "[1971434](https://bugs.launchpad.net/bugs/1971434)"
+msgstr ""
+
+#: ../../24.04/4.md b2e635732e674e08b8c8b91f35f244b1
+msgid "d/p: Make sure the monitor is powered off when screen blanks"
+msgstr ""
+
+#: ../../24.04/4.md 18d3a97e5e9f4fd9a2f825f681c71833
+msgid "[2133206](https://bugs.launchpad.net/bugs/2133206)"
+msgstr ""
+
+#: ../../24.04/4.md e6bc6b955b964987881370375f8b6ce0
+msgid "d/p: Fix input deadlock when dragging windows with touch on X11"
+msgstr ""
+
+#: ../../24.04/4.md b133ad322ba943f09242736893373a93
+msgid "[2131575](https://bugs.launchpad.net/bugs/2131575)"
+msgstr ""
+
+#: ../../24.04/4.md 8fca66d1c8ce45e985dfc6301be3b5bd
+msgid "d/p: monitor-manager: Improve tiled monitor handling"
+msgstr ""
+
+#: ../../24.04/4.md 746b4b2590d943c1b968deff773d2ed4
+msgid "[2116717](https://bugs.launchpad.net/bugs/2116717)"
+msgstr ""
+
+#: ../../24.04/4.md 2efce712a4774c16a8d4b8d25055d4fb
+msgid "d/p: Never close a notification banner that is about to show"
+msgstr ""
+
+#: ../../24.04/4.md 425872845ab9473bb23ed013bedbfeb5
+msgid "[1991001](https://bugs.launchpad.net/bugs/1991001)"
+msgstr ""
+
+#: ../../24.04/4.md bb1d54ebfbeb4597afc7169f2de76242
+msgid "d/p: Fix magnifier zoom in 'cursor pushes content around' mode"
+msgstr ""
+
+#: ../../24.04/4.md 5208a7e3d86d4ff8a9ccf19b9b3584c0
+msgid "[2135115](https://bugs.launchpad.net/bugs/2135115)"
+msgstr ""
+
+#: ../../24.04/4.md 0720d30acbc843c5ade6ea706a2c7668
+msgid "d/p: Silence warning introduced in the previous upload"
+msgstr ""
+
+#: ../../24.04/4.md 4def87a894234e66836fdf848bcfec0b
+msgid "Backport remote session persistence"
+msgstr ""
+
+#: ../../24.04/4.md d3e62809b046459493ac21cde6629b6b
+msgid "[2127933](https://bugs.launchpad.net/bugs/2127933)"
+msgstr ""
+
+#: ../../24.04/4.md 9363c6b7998e401d8d431344492ec5cb
+msgid ""
+"d/p/lp-2127933-fix-unattended-ethernet-icon.patch: Update indicator icon "
+"on connectivity changes"
+msgstr ""
+
+#: ../../24.04/4.md 05bd77124b9f42ffbd3f84583f365d84
+msgid "wsl-setup"
+msgstr ""
+
+#: ../../24.04/4.md 8f8057985a674e368da43ae04537efb1
+msgid "[2138661](https://bugs.launchpad.net/bugs/2138661)"
+msgstr ""
+
+#: ../../24.04/4.md 52d2e4447f594e248ac93285980400ea
+msgid "Case-fold Windows username before sanitization"
+msgstr ""
+
+#: ../../24.04/4.md:82 7da8cd82118745ada7aa842997e53803
+msgid "Server and Cloud related fixes"
+msgstr ""
+
+#: ../../24.04/4.md:84 48711977a558472691cef9c033e0b5a1
+msgid ""
+"These changes mainly affect installations of Ubuntu on server systems and"
+" clouds."
+msgstr ""
+
+#: ../../24.04/4.md c1259bbb0d9a4e2ab3193e1d5d3f348a
+msgid "samba"
+msgstr ""
+
+#: ../../24.04/4.md bcfc1f8a9bd54da5a9df4342c0437e25
+msgid "[2116098](https://bugs.launchpad.net/bugs/2116098)"
+msgstr ""
+
+#: ../../24.04/4.md d72bc388fb5c41ea8294efdc14b9c76b
+msgid ""
+"Upcoming changes to Windows Server enforce security checks even on "
+"schannel secured NETLOGON connections causing winbind's netlogon dc "
+"discovery calls to fail: :"
+msgstr ""
+
+#: ../../24.04/4.md 52876c10512f4b649eecc824ff2ef63d
+#: c26dad80abdb42a7ad96911d84d2e702
+msgid "heat"
+msgstr ""
+
+#: ../../24.04/4.md 83b8fc67f95347c38df6aa30f7ce6e02
+msgid "[2116890](https://bugs.launchpad.net/bugs/2116890)"
+msgstr ""
+
+#: ../../24.04/4.md cb4a0f6040d34162b5812f347cee290e
+msgid "Fix wrong shebang in loguserdata.py"
+msgstr ""
+
+#: ../../24.04/4.md 5c42d07b1b1349af9a14b3c60fa42b0d
+#: b76102c492644e1e85f480ffa3acb6f6 fc7ebfd8bff645f78d3865d42bbaedf9
+msgid "qemu"
+msgstr ""
+
+#: ../../24.04/4.md 68bcd3ad83314381bef77cc45797807a
+msgid "[2101053](https://bugs.launchpad.net/bugs/2101053)"
+msgstr ""
+
+#: ../../24.04/4.md 4ca70880118c45bba4ebf3c56c379a0f
+msgid ""
+"d/p/u/lp-2101053-pci-acpi-Windows-PCI-Label-Id-bug-workaround.patch: fix "
+"windows virtio network by tolerating a bad acpi call"
+msgstr ""
+
+#: ../../24.04/4.md b4e606b1f6eb44bebc4be5f942edaedc
+msgid "sssd"
+msgstr ""
+
+#: ../../24.04/4.md bb22ddc5719d48c697ad6ed3e3b42a27
+msgid "[2109673](https://bugs.launchpad.net/bugs/2109673)"
+msgstr ""
+
+#: ../../24.04/4.md 41dc4b86b05d4325b5f46d8dba8c7975
+msgid ""
+"Updating apparmor profile for smartcard authentication. Allow access to "
+"sssd configuration directory, pcscd socket and libraries required for "
+"PKCS#11 module initialization"
+msgstr ""
+
+#: ../../24.04/4.md e6d4c0cb55e147f6a7a5166fdd1d29de
+msgid "openvswitch"
+msgstr ""
+
+#: ../../24.04/4.md f8e76d79c667494b8951fd8f016f9f13
+msgid "[2109823](https://bugs.launchpad.net/bugs/2109823)"
+msgstr ""
+
+#: ../../24.04/4.md d6640f8546b446f5af971c9d91eec05e
+msgid "New upstream 3.3.4 release"
+msgstr ""
+
+#: ../../24.04/4.md 60356c70860b4c4fb4a6b5ef0f309f19
+msgid "mysql-8.0"
+msgstr ""
+
+#: ../../24.04/4.md 553a026685434e64b3c955421264e7ec
+msgid "[2120936](https://bugs.launchpad.net/bugs/2120936)"
+msgstr ""
+
+#: ../../24.04/4.md f05ad841da994cfa8bc7d88dbde22920
+msgid "Modify logrotate script to silently exit if mysql service is not active: ."
+msgstr ""
+
+#: ../../24.04/4.md 1cbcb2ff7080416489b72b7ab49ca1b7
+msgid "isc-kea"
+msgstr ""
+
+#: ../../24.04/4.md 87959d314c4a4c0d8116e0cbb524144c
+msgid "[2121327](https://bugs.launchpad.net/bugs/2121327)"
+msgstr ""
+
+#: ../../24.04/4.md 68f543abeed4403b96dd66769859c562
+msgid "d/usr.sbin.kea-lfc: add lock permission to logger_lockfile"
+msgstr ""
+
+#: ../../24.04/4.md 4848a4df438d4933b6a44bee6961104b
+msgid "azure-vm-utils"
+msgstr ""
+
+#: ../../24.04/4.md 983b9a356b304703a60ae03a8d1a1f2e
+msgid "[2116077](https://bugs.launchpad.net/bugs/2116077)"
+msgstr ""
+
+#: ../../24.04/4.md 3bfc524065084fc18e7af0933e3db762
+msgid "Backport from devel, first time in Noble: ."
+msgstr ""
+
+#: ../../24.04/4.md a509861e9b7b41d682bbed23878f491d
+msgid "openvpn"
+msgstr ""
+
+#: ../../24.04/4.md 40ad114387e04b018f72c2349081e8fb
+msgid "[2108860](https://bugs.launchpad.net/bugs/2108860)"
+msgstr ""
+
+#: ../../24.04/4.md cdc0ab845def4b909f71d648baa0dd61
+msgid ""
+"d/p/handle_intentional_route_push_float_ip.patch: Fix floating IP due to "
+"\"route VPN_IP net_gateway\", which can lead to incorrect blocking of a "
+"source IP switch for 60 seconds immediately after connection setup"
+msgstr ""
+
+#: ../../24.04/4.md 7e6a3888c48c47fd97ba1149fb3bcf1a
+msgid "cloud-init"
+msgstr ""
+
+#: ../../24.04/4.md 9ef3b107602f42b587703e93fb4a71d5
+msgid "[2120495](https://bugs.launchpad.net/bugs/2120495)"
+msgstr ""
+
+#: ../../24.04/4.md be446844e19140129ade373f4ae59ec9
+msgid ""
+"Upstream snapshot based on 25.2: . List of changes from upstream can be "
+"found at https://raw.githubusercontent.com/canonical/cloud-"
+"init/25.2/ChangeLog"
+msgstr ""
+
+#: ../../24.04/4.md f1345eb44e5343d19490f5e1270c8071
+msgid "horizon"
+msgstr ""
+
+#: ../../24.04/4.md 354a82de20c24c6a8ef488f0998b166a
+msgid "[2110279](https://bugs.launchpad.net/bugs/2110279)"
+msgstr ""
+
+#: ../../24.04/4.md 59e87e7a88d74402a90d9fe89c1dc7e8
+msgid "New upstream release for OpenStack Caracal"
+msgstr ""
+
+#: ../../24.04/4.md 8a6189508aac4a4c984baf45ccd53710
+msgid "openssh"
+msgstr ""
+
+#: ../../24.04/4.md 229a24ae845b4b3abfa5b489aab2b318
+msgid "[2111226](https://bugs.launchpad.net/bugs/2111226)"
+msgstr ""
+
+#: ../../24.04/4.md 2152d0f18c1e4b65b311608d90758ef3
+msgid "d/p/systemd-socket-activation.patch: allow AF_VSOCK sockets"
+msgstr ""
+
+#: ../../24.04/4.md 5849ec70f99748e591a39af1dc1aa320
+#: 8dd13bbbf5444d1c85b7f8bf67ef072b 9aeaceb2b0a94f349f7ee9053eff0776
+#: f6b38eadf5e24f72961ab4b822035c73
+msgid "nova"
+msgstr ""
+
+#: ../../24.04/4.md 511f214969c4483091e4c5eae30f24de
+msgid "[2091033](https://bugs.launchpad.net/bugs/2091033)"
+msgstr ""
+
+#: ../../24.04/4.md 9165b57d98ef480db04d2f3d541a8af3
+msgid "libvirt: Wrap un-proxied listDevices() and listAllDevices()"
+msgstr ""
+
+#: ../../24.04/4.md ab72097f656b4be0b3b8999179ea6494
+msgid "[2098892](https://bugs.launchpad.net/bugs/2098892)"
+msgstr ""
+
+#: ../../24.04/4.md cc2d0325a1204fef80b2715c6ff97e0b
+msgid "libvirt: Fix regression of listDevices() return type"
+msgstr ""
+
+#: ../../24.04/4.md 6cfc4dcfaf0f49108a26ca66db9d9070
+msgid "[2054446](https://bugs.launchpad.net/bugs/2054446)"
+msgstr ""
+
+#: ../../24.04/4.md e8cb5e9d2ec24f5d98fe45568f961299
+msgid "Fix device type when booting from ISO image"
+msgstr ""
+
+#: ../../24.04/4.md c6e82251fb1b42de86531d9ad5bcdf7a
+#: d91702fa671245b8b21036c37c803861 ed7e200801a647f7a804ed0acbf5ce36
+msgid "libvirt"
+msgstr ""
+
+#: ../../24.04/4.md fa17b2e8da7b4c2d9f78dd8de0a12923
+msgid "[2117467](https://bugs.launchpad.net/bugs/2117467)"
+msgstr ""
+
+#: ../../24.04/4.md f077ae66c2b14af49d8af6442a5ab3e6
+msgid ""
+"d/p/u/lp-2117467-virdevmapper-device-name-for-targets.patch: "
+"virdevmapper: Always use device name for finding targets. This ensures "
+"that all the target devices of a multipath device are added to the "
+"namespace/cgroup of the guest domain. Closes: ."
+msgstr ""
+
+#: ../../24.04/4.md bff70a2ea71149f8a36348170a9b0eef
+msgid "[2120278](https://bugs.launchpad.net/bugs/2120278)"
+msgstr ""
+
+#: ../../24.04/4.md 173d590a748c45c4baf82b148dbb8b8d
+msgid "d/p/u-aa/lp2079869-* : virt-aa-helper: Avoid duplicate when append rule"
+msgstr ""
+
+#: ../../24.04/4.md 154a0857e30d4a878fd19e012f0560d1
+msgid "cinder"
+msgstr ""
+
+#: ../../24.04/4.md 2ae02324ae9543ceb537ee21b7003e55
+msgid "[2121812](https://bugs.launchpad.net/bugs/2121812)"
+msgstr ""
+
+#: ../../24.04/4.md 568ce53fb07f4409b6a0d095e086eabd
+msgid "d/p/lp2121812.patch: Fix defaults for netapp node model"
+msgstr ""
+
+#: ../../24.04/4.md 93efc17ed00441c190dfc0ae070c9196
+msgid "[2095364](https://bugs.launchpad.net/bugs/2095364)"
+msgstr ""
+
+#: ../../24.04/4.md 2b291afa80604229b6fe698cbab4f02b
+msgid ""
+"Fix 500 error when using the /servers/detail endpoint when missing a "
+"request_specs record in the database"
+msgstr ""
+
+#: ../../24.04/4.md 9c17e2aa50e24e8691c61f4146ec95ce
+msgid "dovecot"
+msgstr ""
+
+#: ../../24.04/4.md e66d2bf3708b4aa68ae4b934081018dc
+msgid "[2107773](https://bugs.launchpad.net/bugs/2107773)"
+msgstr ""
+
+#: ../../24.04/4.md 6fdee5e06dfa4598ade73746e28d1383
+msgid "Update PBKDF2 salt length to be FIPS 140-3 compliant: ."
+msgstr ""
+
+#: ../../24.04/4.md 735329854b9b45c6adf78f38c1118e17
+#: 73da56abcdea4ae2ba7e8285a3cc1f4e 7444c5b9df6040a2ba399847be7e767a
+msgid "azure-proxy-agent"
+msgstr ""
+
+#: ../../24.04/4.md e30b2458050d42959ed03e8f2d288b5b
+msgid "[2125930](https://bugs.launchpad.net/bugs/2125930)"
+msgstr ""
+
+#: ../../24.04/4.md b1d251fcbef94ee6934ead1a134afbf7
+msgid ""
+"d/p/fix-systemd-deps-cycle.patch: ensure the service is terminated on "
+"system shutdown"
+msgstr ""
+
+#: ../../24.04/4.md b1826984c18947ebb1a447d23a9e2653
+msgid "[2122345](https://bugs.launchpad.net/bugs/2122345)"
+msgstr ""
+
+#: ../../24.04/4.md 3a7aa7dacb404a23bf75a96c8f466955
+msgid ""
+"d/p/fix-systemd-deps-cycle.patch: fix dependency cycle in the unit file. "
+"Use DefaultDependencies=no to remove the dependency on basic.target"
+msgstr ""
+
+#: ../../24.04/4.md 51e58d44daf9483c8c1960469f32588c
+msgid "[2115197](https://bugs.launchpad.net/bugs/2115197)"
+msgstr ""
+
+#: ../../24.04/4.md 554e4a9c91384728b42582d2e5eb3c43
+msgid "edk2"
+msgstr ""
+
+#: ../../24.04/4.md 84509864b20a449a9c895d90f1df4b54
+msgid "[2122286](https://bugs.launchpad.net/bugs/2122286)"
+msgstr ""
+
+#: ../../24.04/4.md f69c3e5ab75a4e81b6952a78cbf5b8ce
+msgid "d/rules: Build OVMF.amdsev.fd"
+msgstr ""
+
+#: ../../24.04/4.md 188ca16b80974af08dcf1accb7282cad
+#: 3522b3c1b65b455db8196e382244a498 79725952cd6142a0b8058998eedc7041
+#: cd999640066b4d80ab53f92bfb91d211 ef251f09f8b140b383f0db25ea412f20
+msgid "ubuntu-advantage-tools"
+msgstr ""
+
+#: ../../24.04/4.md 0b2e773742ea4bf5a8618282fee0ea8b
+#: 57c642f2ba354983938880e8568852f1
+msgid "[2129712](https://bugs.launchpad.net/bugs/2129712)"
+msgstr ""
+
+#: ../../24.04/4.md a07925d966564cb59adc996f864e54a3
+msgid "Backport 37.1ubuntu0 to noble"
+msgstr ""
+
+#: ../../24.04/4.md b3439b35391745c3ab74495791bdef72
+msgid ""
+"do-release-upgrade: immediately release the APT lock acquired to run the "
+"post-upgrade hook"
+msgstr ""
+
+#: ../../24.04/4.md 80839b152a4940a8a24034c1625964b0
+msgid "[2123870](https://bugs.launchpad.net/bugs/2123870)"
+msgstr ""
+
+#: ../../24.04/4.md 93b5547ba15040b9a29e021658c06f21
+msgid "d/apparmor/ubuntu_pro_[apt_news"
+msgstr ""
+
+#: ../../24.04/4.md 4caedb1a8e4b488a975bc7d0ccd4823d
+msgid "[2125453](https://bugs.launchpad.net/bugs/2125453)"
+msgstr ""
+
+#: ../../24.04/4.md 42b7b5ce9b60470c813a62a7b1ac609d
+msgid "New upstream release 37"
+msgstr ""
+
+#: ../../24.04/4.md dde18412c2834dd89c3afc6940af54d3
+msgid "[2107604](https://bugs.launchpad.net/bugs/2107604)"
+msgstr ""
+
+#: ../../24.04/4.md 76b03d7802c6461b8845676692e72723
+msgid "upgrade-lts-contract"
+msgstr ""
+
+#: ../../24.04/4.md 9a944c4d15754dd0a48baf4f6d52df8d
+msgid "mdevctl"
+msgstr ""
+
+#: ../../24.04/4.md 27889c05506a43b4820ecbc46cb91f5a
+msgid "[2121264](https://bugs.launchpad.net/bugs/2121264)"
+msgstr ""
+
+#: ../../24.04/4.md 96830b5abc2d41f59eef411ddee1dba5
+msgid "d/p/main-binary-already-installed.patch: adjust binary path in udev rules"
+msgstr ""
+
+#: ../../24.04/4.md 6148a73e288a42bf88def8ca0ab16251
+msgid "netplan.io"
+msgstr ""
+
+#: ../../24.04/4.md 4a03a0da8a18457aa289e63e10074c34
+msgid "[2127195](https://bugs.launchpad.net/bugs/2127195)"
+msgstr ""
+
+#: ../../24.04/4.md 37aedbd5280b4ea59a8a9b8ff999dcb2
+msgid "Backport netplan.io 1.1.2-8ubuntu1"
+msgstr ""
+
+#: ../../24.04/4.md 0756585b75174f1e83d05aa0d8849b40
+msgid "[2127492](https://bugs.launchpad.net/bugs/2127492)"
+msgstr ""
+
+#: ../../24.04/4.md 239239b11ec84bb4857cc6b6c8b380df
+msgid "d/p/u-aa/lp2127492-*: apparmor: Allow AMD-SEV device access for AMD-SEV VM"
+msgstr ""
+
+#: ../../24.04/4.md 9bd999ccb1ae42129e34d2623e2f7634
+msgid "[2127974](https://bugs.launchpad.net/bugs/2127974)"
+msgstr ""
+
+#: ../../24.04/4.md 32d7bf5004394925b4d817ed917c76ff
+msgid "smbios: Fix buffer overrun when using path= option"
+msgstr ""
+
+#: ../../24.04/4.md 65c3ba66d78d4eedaab4225636f0fb1a
+msgid "multipath-tools"
+msgstr ""
+
+#: ../../24.04/4.md 2a8f8e32ccd64a20b2e408d32d1c7709
+msgid "[2116901](https://bugs.launchpad.net/bugs/2116901)"
+msgstr ""
+
+#: ../../24.04/4.md 6dad04ff76354d439bf276a38741a492
+msgid "d/p/0005-hpe-msa-gen7-support.patch: add support for HPE MSA gen7 arrays"
+msgstr ""
+
+#: ../../24.04/4.md 1677cfe1db06495390b3b1ea8fe5aa09
+msgid "ceph"
+msgstr ""
+
+#: ../../24.04/4.md 0800ac8eeb024949b8806a42dc4c1a68
+msgid "[2134985](https://bugs.launchpad.net/bugs/2134985)"
+msgstr ""
+
+#: ../../24.04/4.md d92c5da4a96043f3b9929de1eb296e26
+msgid ""
+"d/clean: Remove entries added in 19.2.3 SRU to fix regression in "
+"rendering ceph-mgr-dashboard due to missing JavaScript files"
+msgstr ""
+
+#: ../../24.04/4.md 7c66310e08ed4022ab1a34fe48376825
+msgid "[2097539](https://bugs.launchpad.net/bugs/2097539)"
+msgstr ""
+
+#: ../../24.04/4.md ebd2f39f7dc54cd9b80b8da059a6e824
+msgid "Fix stack update when reauth = trusts: ."
+msgstr ""
+
+#: ../../24.04/4.md 660a201090a940b2bea3e93981ccde98
+msgid "numactl"
+msgstr ""
+
+#: ../../24.04/4.md e3e7517378a94ddaa782270c4faef1cb
+msgid "[2136104](https://bugs.launchpad.net/bugs/2136104)"
+msgstr ""
+
+#: ../../24.04/4.md 52828bdd10c94fd58ceae3eef67ac7a1
+msgid ""
+"d/p/fix-stray-errno.patch: save and restore errno when probing for "
+"SET_PREFERRED_MANY"
+msgstr ""
+
+#: ../../24.04/4.md 09acdff0b3e447bd85e682c482c92bf8
+msgid "keystone"
+msgstr ""
+
+#: ../../24.04/4.md 1b99539ce5464fef99384d8f4211db32
+msgid "[2112477](https://bugs.launchpad.net/bugs/2112477)"
+msgstr ""
+
+#: ../../24.04/4.md f671909f85f64a3cbc043741efe515af
+msgid "Fix query for all users in a group while using AD nested group searches"
+msgstr ""
+
+#: ../../24.04/4.md 4be316600c754a21a89df9bff14a5c25
+#: ae3fab4519c74b64b59bbc5856c3ccc8 c2871504eb2c4973a6bfa8c380d8f704
+msgid "openldap"
+msgstr ""
+
+#: ../../24.04/4.md 23848bb019404f84a92c2ccc45a3595a
+msgid "[2127665](https://bugs.launchpad.net/bugs/2127665)"
+msgstr ""
+
+#: ../../24.04/4.md 842a6807dba544d387a0359b269549a1
+msgid "New upstream version: :"
+msgstr ""
+
+#: ../../24.04/4.md e141f66100ec4e05aa8a440d0cec382e
+msgid "[2125685](https://bugs.launchpad.net/bugs/2125685)"
+msgstr ""
+
+#: ../../24.04/4.md be2bbc9698f74d4d989feb99b8ff07c0
+msgid "pbkdf2 iteration configuration support"
+msgstr ""
+
+#: ../../24.04/4.md 89726e53adbd40b18c907e336bd506d5
+msgid "[2121816](https://bugs.launchpad.net/bugs/2121816)"
+msgstr ""
+
+#: ../../24.04/4.md e3525ddaa1874ed7aa378e902caae20d
+msgid "Enable build of ppm password quality check module"
+msgstr ""
+
+#: ../../24.04/4.md 8517b563f2244d6b960ca47a76f77796
+msgid "frr"
+msgstr ""
+
+#: ../../24.04/4.md 54647563cb6348648293244c053c9e69
+msgid "[2113448](https://bugs.launchpad.net/bugs/2113448)"
+msgstr ""
+
+#: ../../24.04/4.md 5247a8040a194434903dd93d15833606
+msgid ""
+"d/p/lp2113448-evpn-vxlan-macs: fix forgetting learned MACs on redundant "
+"EVPN over VXLAN links"
+msgstr ""
+
+#: ../../24.04/4.md 16ed40663f304ab298e09426e8b3f27d
+msgid "[2131822](https://bugs.launchpad.net/bugs/2131822)"
+msgstr ""
+
+#: ../../24.04/4.md 8a82d731ee364dbb86a4c124dc4d2c64
+msgid "Do not expose arch-caps when not available on AMD CPUs"
+msgstr ""
+
+#: ../../24.04/4.md:132 7a133a1354744f3a9855273133feb652
+msgid "Kernel and Hardware support updates"
+msgstr ""
+
+#: ../../24.04/4.md:134 372925ae08294388863a1492f1e1e032
+msgid ""
+"Considerable work has been done on improving support for many specific "
+"items of hardware."
+msgstr ""
+
+#: ../../24.04/4.md 951d53096f144bb7b264e735e2ada556
+#: c52649edde7e4958aa36e02d85ddc767
+msgid "linux-riscv-6.14"
+msgstr ""
+
+#: ../../24.04/4.md 06027e7829854e02b964922e6853327d
+msgid "[2112578](https://bugs.launchpad.net/bugs/2112578)"
+msgstr ""
+
+#: ../../24.04/4.md 9d8b811344fc433c83241a2de1b67b61
+msgid "riscv64: KVM does not release harts"
+msgstr ""
+
+#: ../../24.04/4.md 70c8cda8774646f1b233bfd71d50ae8d
+#: c752ac1a48984361873995ce62160103
+msgid "linux-nvidia-6.14"
+msgstr ""
+
+#: ../../24.04/4.md 39e2b9ab42bd4646b305309e5462e40f
+#: 880ccdc38330489c97ee8249ef941a37
+msgid "[2105402](https://bugs.launchpad.net/bugs/2105402)"
+msgstr ""
+
+#: ../../24.04/4.md 463c5a64b6604fefa8bcff4368b19bac
+msgid "Plucky fails to boot on (older) Macs"
+msgstr ""
+
+#: ../../24.04/4.md 2118166e40b8439888ee377d2e45a3b3
+#: 229a024dde284461b3e81adde3020fee 321da9abee3240cebd6e11c27e2bf466
+#: 51e73dc0ef334a1e82a7513ba9d5a810 539d0b9080df46678b64ab31ce756a5b
+#: 6873b90841a449efb19b193b129f67dd 6f040be69bfe4bf5ab232bd19e99d8f7
+#: 7fd466fd12504fc4be49ab587a1b0a72 825819572f2c498dab2cab9c021e702e
+#: e6b08e6ba73b4e4f9bd114d5b60d4a1a fa65f03faba34a6d84f92e1b38d09fb9
+msgid "linux-aws"
+msgstr ""
+
+#: ../../24.04/4.md 017571eafe2f4ae7981deb15c66e8662
+#: 93a4cbaa43b84939b05cc1996230d36a a1aaf527d44b45a7902a2f3308e97196
+#: c40e1b22e3a34f30accd95d011b4e8e1
+msgid "[2081030](https://bugs.launchpad.net/bugs/2081030)"
+msgstr ""
+
+#: ../../24.04/4.md 7ca4e053435e4bb0aaf383882ce31aa8
+#: 84aa25f1a1824d74b39e14ea07cf7cf9 9d6aae8c5a2d42e39aa362e8cd402baa
+#: faafb20f11ca4c01a0277d96bfc9fccd
+msgid "Clean up packaging bits"
+msgstr ""
+
+#: ../../24.04/4.md 08a36fe6f2684acdba283c2c860e031a
+#: 0eb8d358d4c24c479902829a645179bd 28b47b8f966a400d81a080ba1a214bc7
+#: 2ac4ca2ad17e4af9bdd98dd3e151cdf0 49ab8c217f9445cbbf3dd6df4ad994cf
+#: 5d28cc626b534346a402b17d1a869482 c37bbf5ee57f4e56a87041a834d3e063
+#: e875224cc46f4e01b04104d2d5293503 e9487d17b8224df78cadaef7d8a81fcc
+#: fede81fcadeb4673ad703179dd96da0b
+msgid "linux-oem-6.14"
+msgstr ""
+
+#: ../../24.04/4.md 89c4a65e199d49a2acb2c0f7fd61e25d
+msgid "[2120350](https://bugs.launchpad.net/bugs/2120350)"
+msgstr ""
+
+#: ../../24.04/4.md 2b1afda3e8ee40e1ad06db420607debd
+msgid "noble/linux-oem-6.14: 6.14.0-1010.10 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 50a3e4b68dfd46a481b2a9c5b922026f
+msgid "linux-oem-6.11"
+msgstr ""
+
+#: ../../24.04/4.md 686a807b5f8d447bb6cf33014aaf9542
+msgid "[2116646](https://bugs.launchpad.net/bugs/2116646)"
+msgstr ""
+
+#: ../../24.04/4.md 20d5ea6e1e55493786e0ce4bde6beec3
+msgid "noble/linux-oem-6.11: 6.11.0-1027.27 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 1d874ba3151343f0b6565902c9fc730e
+#: 9c1f8b9aa95b4abfa828e67fc948c366
+msgid "linux-azure-nvidia-6.14"
+msgstr ""
+
+#: ../../24.04/4.md a6a5c5d21f764bc58b6606bae3e282c6
+msgid "[2117629](https://bugs.launchpad.net/bugs/2117629)"
+msgstr ""
+
+#: ../../24.04/4.md 3d77cb449e824481a4c2f9d2a251b5c6
+msgid "noble/linux-azure-nvidia-6.14: 6.14.0-1003.3 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 1640ba68232c44179bbb3735fc5aee78
+#: 34983cd2a17f409b9cde07aa8b93eb80 518f423394334e8d91c6698a51d3f508
+#: 534dfa7dc74446e0a0b142dc1a5e5e94 6d6026e398794a2ea936e2200b0b072a
+#: 6fa8b0554ad04038b64fb29732fbaa00 8ad40b6e9dbc4518b84e6fedbe137792
+#: aa9fcd632d73424a8648f0c5e564a603 cddbddb8817e43e6972c76dcbf8fdb97
+#: cdfa5f313db0440bb4b5bae9b956bfc2 dbaa34467f584c668023cbacd1d35c33
+#: e5e7600efe7f4e12999b96ed21882fb0 f3af64d99da24281bb42ffb06e5821c1
+#: fe0e1fd120ac45cf97d55066f1794f76
+msgid "linux-gke"
+msgstr ""
+
+#: ../../24.04/4.md 27f580d709b6420698ffa129401c482e
+#: 3f90c1dec7824a4d88dfe9cd3d55e476
+msgid "[2116645](https://bugs.launchpad.net/bugs/2116645)"
+msgstr ""
+
+#: ../../24.04/4.md 4557e572e53a496aace95820fbd1f099
+#: 808949a5ac644458af84260bdd3d05c0
+msgid "noble/linux: 6.8.0-70.70 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 0fae8f88bca549e19fc633a06cf8d4c2
+#: 97d8e3ac6324496589f9cee6c3db7c9c
+msgid "bluez"
+msgstr ""
+
+#: ../../24.04/4.md 4ab7967578a54085adad5a2e95cfedbd
+msgid "[2119741](https://bugs.launchpad.net/bugs/2119741)"
+msgstr ""
+
+#: ../../24.04/4.md 045111ce355c4ff2bb41ab5048f75053
+msgid ""
+"d/patches: device-Fix-Pair-Method-not-setting-auto_connect.patch to fix "
+"devices not setting autoconnect correctly"
+msgstr ""
+
+#: ../../24.04/4.md 0e5f2ac2818f4795afbf8c9c165824ff
+#: 230da9d91c974cb7b9cbab1c99d6680e 4b1fac9be45341b9921827a6d485fa50
+#: 4bcb6a7249d044b388a47119f7ba37d6 52ad44c0f38948cfab382fd2435bcd5d
+#: 53adf7850b7a4c178263b4bd2ee9d152 5e4e393706964eec83bb9c1838d909a6
+#: 7027f37c9ccd484ba9bb42322683cf88 715b13f839d1494eab91ad2fc3b1961a
+#: 9b32e8273f174b1ea1d5b669a26e66ee cc0522dcb6bc4ac79f546b2f147e21d0
+msgid "linux-gkeop"
+msgstr ""
+
+#: ../../24.04/4.md 54edf4597e0046c89111eb742b496e0e
+msgid "oem-sutton-deon-meta"
+msgstr ""
+
+#: ../../24.04/4.md d20b897bee4246369313119be53ef172
+msgid "[2092164](https://bugs.launchpad.net/bugs/2092164)"
+msgstr ""
+
+#: ../../24.04/4.md d2c41233d648450cb06c323885f7c542
+msgid "Meta package for Sutton Deon"
+msgstr ""
+
+#: ../../24.04/4.md d26f0a2f4bc2465cab9189ea1cb583da
+msgid "oem-sutton-delphi-meta"
+msgstr ""
+
+#: ../../24.04/4.md 817e3baf8ae14099be494ff3015a3e9a
+msgid "[2092163](https://bugs.launchpad.net/bugs/2092163)"
+msgstr ""
+
+#: ../../24.04/4.md c4cfd8c0241447be87f181c70a356b6d
+msgid "Meta package for Sutton Delphi"
+msgstr ""
+
+#: ../../24.04/4.md e0be2e11bf854330a4e6da9c493c1faf
+msgid "oem-sutton-debby-meta"
+msgstr ""
+
+#: ../../24.04/4.md 35f454d2c54c470aafd811220e6a651e
+msgid "[2092162](https://bugs.launchpad.net/bugs/2092162)"
+msgstr ""
+
+#: ../../24.04/4.md b57c4166596a4cf68782e650d9c93537
+msgid "Meta package for Sutton Debby"
+msgstr ""
+
+#: ../../24.04/4.md 7b390f14855e468aaf76f0da77b4eab9
+msgid "oem-sutton-davan-meta"
+msgstr ""
+
+#: ../../24.04/4.md ce87031c28df4ded96a2e4b90a3c794b
+msgid "[2106606](https://bugs.launchpad.net/bugs/2106606)"
+msgstr ""
+
+#: ../../24.04/4.md 5c35ba321ec942f7b8a6ea498005efd5
+msgid "Meta package for Sutton Davan"
+msgstr ""
+
+#: ../../24.04/4.md 64f598a7c28047dd8b0ba229fbe4f372
+msgid "oem-sutton-darwin-meta"
+msgstr ""
+
+#: ../../24.04/4.md 2b030a7d75d74f828ca148b43ceb2ff5
+msgid "[2100412](https://bugs.launchpad.net/bugs/2100412)"
+msgstr ""
+
+#: ../../24.04/4.md d3c046659a35453599b66a989c80523b
+msgid "Meta package for Sutton Darwin"
+msgstr ""
+
+#: ../../24.04/4.md 8bfdec79dd0047f9b5a75e063f2198a9
+msgid "oem-sutton-darsha-meta"
+msgstr ""
+
+#: ../../24.04/4.md 1259dce3bbc743b98750489ca82e099b
+msgid "[2099860](https://bugs.launchpad.net/bugs/2099860)"
+msgstr ""
+
+#: ../../24.04/4.md 94b6dcc7397a48989be5122182345bad
+msgid "Meta package for Sutton Darsha"
+msgstr ""
+
+#: ../../24.04/4.md 575832626e514e15b6b1d28ede62657e
+msgid "oem-sutton-darra-meta"
+msgstr ""
+
+#: ../../24.04/4.md 849cc784956040e89631d8e745c7c323
+msgid "[2102003](https://bugs.launchpad.net/bugs/2102003)"
+msgstr ""
+
+#: ../../24.04/4.md 02b745089eff47b2a4cbb960bbae7405
+msgid "Meta package for Sutton Darra"
+msgstr ""
+
+#: ../../24.04/4.md 44864aac354e4801ac797fe53d0640fd
+msgid "oem-sutton-darko-meta"
+msgstr ""
+
+#: ../../24.04/4.md 5713d3d5275c444faca2f6e397d7ce0d
+msgid "[2093145](https://bugs.launchpad.net/bugs/2093145)"
+msgstr ""
+
+#: ../../24.04/4.md b959724d3d784c21bc05c1c79814297b
+msgid "Meta package for Sutton Darko"
+msgstr ""
+
+#: ../../24.04/4.md a45af2f7cca14f949adac99c7f4d5872
+msgid "oem-sutton-dapper-meta"
+msgstr ""
+
+#: ../../24.04/4.md 7633507b5fec4142aa64730c2e8264da
+msgid "[2100411](https://bugs.launchpad.net/bugs/2100411)"
+msgstr ""
+
+#: ../../24.04/4.md 17d84daac23d4a35b78e526a6b381861
+msgid "Meta package for Sutton Dapper"
+msgstr ""
+
+#: ../../24.04/4.md b8cc9b3733144559b46306c6390fe864
+msgid "oem-sutton-danya-meta"
+msgstr ""
+
+#: ../../24.04/4.md a2b8d430b6c84d3d85edef713127d9f5
+msgid "[2091341](https://bugs.launchpad.net/bugs/2091341)"
+msgstr ""
+
+#: ../../24.04/4.md fe8aa91305754ccf9fabc21c6123c733
+msgid "Meta package for Sutton Danya"
+msgstr ""
+
+#: ../../24.04/4.md 4df77be427554036bac9207bc3123dff
+msgid "oem-sutton-danton-meta"
+msgstr ""
+
+#: ../../24.04/4.md a5efd53ac9a047ad9aed107f898c20f8
+msgid "[2091340](https://bugs.launchpad.net/bugs/2091340)"
+msgstr ""
+
+#: ../../24.04/4.md f8297465424b487bbc159dfdaf72caa9
+msgid "Meta package for Sutton Danton"
+msgstr ""
+
+#: ../../24.04/4.md 85e171f2c1ca42ae8195a3979f15ca78
+msgid "oem-sutton-dannon-meta"
+msgstr ""
+
+#: ../../24.04/4.md 5bfc8893499a4bfcaaab9b830ea40e5f
+msgid "[2092789](https://bugs.launchpad.net/bugs/2092789)"
+msgstr ""
+
+#: ../../24.04/4.md 5c15fe4994fb43baa11db5fa808a2426
+msgid "Meta package for Sutton Dannon"
+msgstr ""
+
+#: ../../24.04/4.md 590ebdafed704f01b4469c61b792ac3a
+msgid "oem-sutton-danik-meta"
+msgstr ""
+
+#: ../../24.04/4.md 7b3a690df0564289a1e58a4aeff0b0af
+msgid "[2089111](https://bugs.launchpad.net/bugs/2089111)"
+msgstr ""
+
+#: ../../24.04/4.md c861f55b136b4f5493f65cdaf672ca2c
+msgid "Meta package for Sutton Danik"
+msgstr ""
+
+#: ../../24.04/4.md 8cb8b3de3e254e0a989d724e0b07990e
+msgid "oem-sutton-daniela-meta"
+msgstr ""
+
+#: ../../24.04/4.md 8826e3e53be343e3bcd10d4f4d645024
+msgid "[2089553](https://bugs.launchpad.net/bugs/2089553)"
+msgstr ""
+
+#: ../../24.04/4.md f1cbc868b99d43daa7e624e62ff18217
+msgid "Meta package for Sutton Daniela"
+msgstr ""
+
+#: ../../24.04/4.md 3b0e172a424a4e05b10a8783b2cd3321
+msgid "oem-sutton-danica-meta"
+msgstr ""
+
+#: ../../24.04/4.md 12c5e6ae98034057a7d4c6b1c500ac4a
+msgid "[2099859](https://bugs.launchpad.net/bugs/2099859)"
+msgstr ""
+
+#: ../../24.04/4.md 640995d1ee104e5aa6fd16033b3826f7
+msgid "Meta package for Sutton Danica"
+msgstr ""
+
+#: ../../24.04/4.md d33d10e5a0fa41088d62c00fe1690aab
+msgid "oem-sutton-dangola-meta"
+msgstr ""
+
+#: ../../24.04/4.md d1749e4a6cd447e08e51e735f730c36f
+msgid "[2092788](https://bugs.launchpad.net/bugs/2092788)"
+msgstr ""
+
+#: ../../24.04/4.md 4e0124b6678d41b98cd6cd6f956adf1a
+msgid "Meta package for Sutton Dangola"
+msgstr ""
+
+#: ../../24.04/4.md 3b2b827da8b94f319df0a7251a7fec13
+msgid "oem-sutton-dancho-meta"
+msgstr ""
+
+#: ../../24.04/4.md 8983844c76664105af41d43252aada89
+msgid "[2100409](https://bugs.launchpad.net/bugs/2100409)"
+msgstr ""
+
+#: ../../24.04/4.md e7d77176fa1247cc9d54b0ea1aaf27c5
+msgid "Meta package for Sutton Dancho"
+msgstr ""
+
+#: ../../24.04/4.md b4d81b4a295f41d8ba5add4a01b70b9f
+msgid "oem-sutton-damian-meta"
+msgstr ""
+
+#: ../../24.04/4.md 075dd8d9da204187b65a99b60b3b174d
+msgid "[2100407](https://bugs.launchpad.net/bugs/2100407)"
+msgstr ""
+
+#: ../../24.04/4.md 0f346a283335435a9a328a4b180f2f83
+msgid "Meta package for Sutton Damian"
+msgstr ""
+
+#: ../../24.04/4.md 6b964481a28f41d6874b6b11be0f9c2c
+msgid "oem-sutton-dalida-meta"
+msgstr ""
+
+#: ../../24.04/4.md ffe9bc2a52df4dff8d08b9d4cce204a8
+msgid "[2100406](https://bugs.launchpad.net/bugs/2100406)"
+msgstr ""
+
+#: ../../24.04/4.md 29d43b13dfb24f94a91596a51e91d53f
+msgid "Meta package for Sutton Dalida"
+msgstr ""
+
+#: ../../24.04/4.md 02db68c418a34ef18d3b7a975b9dc121
+msgid "oem-sutton-dalia-meta"
+msgstr ""
+
+#: ../../24.04/4.md 3caf7e6385de4deb990d036ac0d733f4
+msgid "[2089782](https://bugs.launchpad.net/bugs/2089782)"
+msgstr ""
+
+#: ../../24.04/4.md 044f0d7fb139407095034ebcdea642d7
+msgid "Meta package for Sutton Dalia"
+msgstr ""
+
+#: ../../24.04/4.md d6946396f6394342ad886b99a85938a2
+msgid "oem-sutton-daley-meta"
+msgstr ""
+
+#: ../../24.04/4.md d9e387010e0d4d668fb05de14eae650d
+msgid "[2101930](https://bugs.launchpad.net/bugs/2101930)"
+msgstr ""
+
+#: ../../24.04/4.md ddeddcba52b544439ade33fee5ffc050
+msgid "Meta package for Sutton Daley"
+msgstr ""
+
+#: ../../24.04/4.md 5aa4054fd78442718180e81ed5c1105b
+msgid "oem-sutton-dakota-meta"
+msgstr ""
+
+#: ../../24.04/4.md 511974bfa58a49edaea62f4ac127d22e
+msgid "[2100405](https://bugs.launchpad.net/bugs/2100405)"
+msgstr ""
+
+#: ../../24.04/4.md c9afce34751e42478340708c07d25c95
+msgid "Meta package for Sutton Dakota"
+msgstr ""
+
+#: ../../24.04/4.md 7ab7d9fb59bf47bc92ac9b9996d76204
+msgid "oem-sutton-dakari-meta"
+msgstr ""
+
+#: ../../24.04/4.md c0a1146ba1b447599ecee2b1b88186e5
+msgid "[2100402](https://bugs.launchpad.net/bugs/2100402)"
+msgstr ""
+
+#: ../../24.04/4.md a3682bcf85ba42fc9ccc243caf72cfc4
+msgid "Meta package for Sutton Dakari"
+msgstr ""
+
+#: ../../24.04/4.md 4f20026a78f34194a1157fdbd0e6baed
+msgid "oem-sutton-daiwa-meta"
+msgstr ""
+
+#: ../../24.04/4.md 26bb8dd84b1c4fc1bab755af74d66929
+msgid "[2093144](https://bugs.launchpad.net/bugs/2093144)"
+msgstr ""
+
+#: ../../24.04/4.md ebfc59f3ae6e45ad946a2a7a7e79b571
+msgid "Meta package for Sutton Daiwa"
+msgstr ""
+
+#: ../../24.04/4.md 35a1e36dccf745d28cc79894ecaa07db
+msgid "oem-sutton-daisy-meta"
+msgstr ""
+
+#: ../../24.04/4.md 86c57da97cc84f2db8de2828456e3bc0
+msgid "[2092787](https://bugs.launchpad.net/bugs/2092787)"
+msgstr ""
+
+#: ../../24.04/4.md faaef91d0d2f4552b61f918c9c5f8ecf
+msgid "Meta package for Sutton Daisy"
+msgstr ""
+
+#: ../../24.04/4.md 0b5fc8a949a74d88a2697c698762face
+msgid "oem-sutton-dada-meta"
+msgstr ""
+
+#: ../../24.04/4.md 7aef5956e0da4842a4f2be3bd171fc5f
+msgid "[2091339](https://bugs.launchpad.net/bugs/2091339)"
+msgstr ""
+
+#: ../../24.04/4.md 963c5add809d471e859b107e9f062e53
+msgid "Meta package for Sutton Dada"
+msgstr ""
+
+#: ../../24.04/4.md 69d180055896459cad9a0dbf5f7ddd6b
+msgid "oem-sutton-dacia-meta"
+msgstr ""
+
+#: ../../24.04/4.md dc76e622baa44ca4ba33b55927257c4b
+msgid "[2089108](https://bugs.launchpad.net/bugs/2089108)"
+msgstr ""
+
+#: ../../24.04/4.md 230964bba428427a9c9e6f03194c2794
+msgid "Meta package for Sutton Dacia"
+msgstr ""
+
+#: ../../24.04/4.md 9607b9078db34334bc4555b45f321dfd
+msgid "oem-sutton-cayla-meta"
+msgstr ""
+
+#: ../../24.04/4.md a587571d813743839a197ea2674fbc37
+msgid "[2089107](https://bugs.launchpad.net/bugs/2089107)"
+msgstr ""
+
+#: ../../24.04/4.md d809bfff31d149028ff393d89bf24a1a
+msgid "Meta package for Sutton Cayla"
+msgstr ""
+
+#: ../../24.04/4.md 90a318d9587443cdb0b0b5f54517f991
+msgid "oem-sutton-cason-meta"
+msgstr ""
+
+#: ../../24.04/4.md 6e22ff4d4b2d45e689f2bba117b1a4c0
+msgid "[2089106](https://bugs.launchpad.net/bugs/2089106)"
+msgstr ""
+
+#: ../../24.04/4.md 3bf8b91c05f445159f42d4d7db66afd3
+msgid "Meta package for Sutton Cason"
+msgstr ""
+
+#: ../../24.04/4.md c3fefab3cb3d4b64a2fa9d3d556f442d
+msgid "oem-sutton-calix-meta"
+msgstr ""
+
+#: ../../24.04/4.md e77830751e4542148b56ad2d72fb5798
+msgid "[2089105](https://bugs.launchpad.net/bugs/2089105)"
+msgstr ""
+
+#: ../../24.04/4.md 0ca7b68edd754f02a0e519857b6a8d0c
+msgid "Meta package for Sutton Calix"
+msgstr ""
+
+#: ../../24.04/4.md f15ede0c31524d01a304e118d046bfa9
+msgid "oem-sutton-caley-meta"
+msgstr ""
+
+#: ../../24.04/4.md eff70d38ff024c6482da3e1f954f42a6
+msgid "[2089104](https://bugs.launchpad.net/bugs/2089104)"
+msgstr ""
+
+#: ../../24.04/4.md 418487b221b04e4c9020c2a7d4e2895a
+msgid "Meta package for Sutton Caley"
+msgstr ""
+
+#: ../../24.04/4.md b64af3df27b54dbbba0c4bf8bbfc256c
+msgid "oem-sutton-calanthe-meta"
+msgstr ""
+
+#: ../../24.04/4.md b800869467f54e82a7137bc360b526c2
+msgid "[2047834](https://bugs.launchpad.net/bugs/2047834)"
+msgstr ""
+
+#: ../../24.04/4.md 8303628247cd48998e64eb95a4848c1c
+msgid "Meta package for Sutton Calanthe"
+msgstr ""
+
+#: ../../24.04/4.md 434e36ad2bea4912a8a74c45a3fef56b
+msgid "oem-sutton-baz-meta"
+msgstr ""
+
+#: ../../24.04/4.md 4314e9d3340a4ba29216785279077086
+msgid "[2089552](https://bugs.launchpad.net/bugs/2089552)"
+msgstr ""
+
+#: ../../24.04/4.md 96b76e4eca1146318116cd37db619b54
+msgid "Meta package for Sutton Baz"
+msgstr ""
+
+#: ../../24.04/4.md 8334456d6b0c48bebbb39e1274ceadd4
+msgid "oem-sutton-bast-meta"
+msgstr ""
+
+#: ../../24.04/4.md 5e61b8dc23b44657883618291ab75170
+msgid "[2089115](https://bugs.launchpad.net/bugs/2089115)"
+msgstr ""
+
+#: ../../24.04/4.md 824e762e5969449bbfff3c9a4a23c134
+msgid "Meta package for Sutton Bast"
+msgstr ""
+
+#: ../../24.04/4.md b2c94e3e2a3547c0bde50ce2ae33e78a
+msgid "oem-sutton-bash-meta"
+msgstr ""
+
+#: ../../24.04/4.md 4d9db6d9c215485a9cf0365b8aff8569
+msgid "[2089114](https://bugs.launchpad.net/bugs/2089114)"
+msgstr ""
+
+#: ../../24.04/4.md c774bfbde5d34b039a22b664ab10ecb6
+msgid "Meta package for Sutton Bash"
+msgstr ""
+
+#: ../../24.04/4.md c345b995fa1b40c383894e8728c3baea
+msgid "oem-somerville-boldore-meta"
+msgstr ""
+
+#: ../../24.04/4.md 8936053800364a5ba97cc37e14bfcad1
+msgid "[2089077](https://bugs.launchpad.net/bugs/2089077)"
+msgstr ""
+
+#: ../../24.04/4.md f436276a3201427f8d7a95406f44aaec
+msgid "Meta package for Somerville Boldore"
+msgstr ""
+
+#: ../../24.04/4.md 65adcf72e38140f79b6657f430dcba87
+msgid "oem-somerville-aggron-meta"
+msgstr ""
+
+#: ../../24.04/4.md e046d14f20744ce480a32cbacc15a5ea
+msgid "[2089075](https://bugs.launchpad.net/bugs/2089075)"
+msgstr ""
+
+#: ../../24.04/4.md 53e2e7ace4bc48eb81ce15cfc0de234f
+msgid "Meta package for Somerville Aggron"
+msgstr ""
+
+#: ../../24.04/4.md 9743aab12c64437c9713f24c04638bc1
+msgid "oem-somerville-delcatty-meta"
+msgstr ""
+
+#: ../../24.04/4.md 84ab52e7794741259d783f1ff0cb2fc3
+msgid "[2089080](https://bugs.launchpad.net/bugs/2089080)"
+msgstr ""
+
+#: ../../24.04/4.md 938a021655514fedb6db1c6300d152bb
+msgid "Meta package for Somerville Delcatty"
+msgstr ""
+
+#: ../../24.04/4.md 03b4a28f47f24aa4bfc550345a8680e0
+#: 0a22d05d8c1443abbd2135a1b1bf4848 1711d2a64f5f4376b7c571b6eb124bd5
+#: 18ae18cdcfaf4ca4a6575f0637d15dec 1948890ecedd47eba2f6a78e105afe3f
+#: 1a565918685b4e27995e445bd6650e1e 26112999d2224c0f94c29545d0c0bd4c
+#: 413b475e88ee4c9ca3d5b5c9596d467d 4a37bf831d84419e9a05faad6daef2a4
+#: 4abb85fd9371427c9cfb45da75107e55 4c1454479d5a49bfb7519ababeff5c8e
+#: 50308525521b4056803e8e9ad82cf196 56862417f0fb4926b6fbf0e845446f7a
+#: 5874ca2dab2c49ae93f0100819b3137a 5d8bacab62b0472ebcba65c29d9ee7f5
+#: 638d5761282744bebaa05dac7e7ffaa5 67d6af747d09472f9a4804a6ca058fef
+#: 69a0c91b27c249b9baec4dfd59c51bcf 6b19d893f5fe4a91be90890c33705ec1
+#: 767ab2ed78af489387002a309d45dcb3 79be1c9fbd9d47489899cdf073ce263e
+#: 8b9d392e9fba48b698bb8804f13a9996 9039d737b3c34f928070572de033cb92
+#: 93fe27aa38b846738b46d9214f159baf 9586a6632e42492f9eef1708820035f7
+#: 9bb98f6f3b9149379da8a60a3b21e570 9c52e797cd254c8ca4fc3fb8266f10b3
+#: a6af37360e60458f8f44adb71610635b b84ce589b91041d3b42f91751edd63ff
+#: b8934f6b9f59472b9c96db8913d768a2 bd8e8a3980e343f4be9b70164aa3a1d3
+#: c55212fecce444c480bf59631953fb3d cb3ab9ce0d96478b99ed1f0c8312fcb8
+#: d6fca0741585461fb94f93c7915b5231 ef74fb1910434b798660f687bd562b02
+#: fdc8848c2f8b4649947b673f385797c4
+msgid "linux-firmware"
+msgstr ""
+
+#: ../../24.04/4.md 12dfa0b972704eb89bdf2778dec73c74
+#: 94e58adafc374dafb709b11a6cf86915
+msgid "[2119501](https://bugs.launchpad.net/bugs/2119501)"
+msgstr ""
+
+#: ../../24.04/4.md 6487a82e234745dfb06d349867fb4b51
+#: e95accc8b25d4841ac6dffb0445e2d98
+msgid "[SRU] AMD Image Signal Processing (ISP) firmware update"
+msgstr ""
+
+#: ../../24.04/4.md d43d92fa76324e8bb28bacba642017b9
+msgid "[2110106](https://bugs.launchpad.net/bugs/2110106)"
+msgstr ""
+
+#: ../../24.04/4.md 277b9c177b404c71babb9bd24c2b5a2a
+msgid "Support WiFi 6GHz for Philippines on Intel iwlwifi chips"
+msgstr ""
+
+#: ../../24.04/4.md e8caba34bbed45758d79c2ea0263606d
+msgid "[2117463](https://bugs.launchpad.net/bugs/2117463)"
+msgstr ""
+
+#: ../../24.04/4.md ce00699f72b44be2997da5770c004a0e
+msgid "Update GC 11.5.1 microcode"
+msgstr ""
+
+#: ../../24.04/4.md 06fb83ce4be24d81bc1c9337029ae090
+msgid "[2119210](https://bugs.launchpad.net/bugs/2119210)"
+msgstr ""
+
+#: ../../24.04/4.md 540b93a77ecc4e479565e89f5747e228
+msgid "Navi44 fails to load amdgpu"
+msgstr ""
+
+#: ../../24.04/4.md f1ca89ec60094e219b5407d1f4000059
+msgid "[2118886](https://bugs.launchpad.net/bugs/2118886)"
+msgstr ""
+
+#: ../../24.04/4.md 3594ac55207846d6a5812fc80c63418e
+msgid "Bluetooth firmware is missing for Intel AX203 card"
+msgstr ""
+
+#: ../../24.04/4.md d278306de195458a9c4dff91d9ea1f3d
+msgid "[2119627](https://bugs.launchpad.net/bugs/2119627)"
+msgstr ""
+
+#: ../../24.04/4.md 0c8f6037628141e899f0c97094e2ec7f
+msgid "Update GC 11.5.0 microcode"
+msgstr ""
+
+#: ../../24.04/4.md 20f40a5b8f9c4df3b6813f24cf71c0ec
+#: 30f9d92728324b9db11b83a6ced6bee7 e512a5c9c5d94fd7ae6c1b461ee90e0c
+msgid "nvidia-graphics-drivers-570"
+msgstr ""
+
+#: ../../24.04/4.md 22ea61f0debc40f8a32183dcf359a7e1
+#: 82e46b7113ce4d308f94bcfaf808e840
+msgid "[2117176](https://bugs.launchpad.net/bugs/2117176)"
+msgstr ""
+
+#: ../../24.04/4.md 309489df6b74496c861749fc160ced53
+#: f33a48ef7c944f3faeee5db8ccf5eb89
+msgid "New upstream release 570.172.08"
+msgstr ""
+
+#: ../../24.04/4.md 1318ee984dcd4ce0bcc58e800fcf7d2e
+#: c2e20b690bbb493a8315c1aa130b0a17 f278f846977846d0a121783ba462370e
+msgid "nvidia-graphics-drivers-535-server"
+msgstr ""
+
+#: ../../24.04/4.md 32fb26fa871f4817b1eacc770564cb87
+msgid "[2117177](https://bugs.launchpad.net/bugs/2117177)"
+msgstr ""
+
+#: ../../24.04/4.md db6b2ec609e941a19fc8c82f37249131
+msgid "New upstream release 535.261.03"
+msgstr ""
+
+#: ../../24.04/4.md 2ae964bbe4b34e999558488c718e0de3
+#: 5b4d428b732c442791f5c2502b13766c 761b01a39aa64737b5e1de8b1acc9bd4
+#: bfdca8cb073c49399d0e743fda08444c
+msgid "nvidia-graphics-drivers-570-server"
+msgstr ""
+
+#: ../../24.04/4.md 76c7a0c91e9148bfa0ad5a1899172a74
+#: 90af330500b84234abf9eea551370f06 d13819e288ab49ef9838d44df4ada7fd
+msgid "linux-gcp-6.14"
+msgstr ""
+
+#: ../../24.04/4.md 345f76bd7a784914a771bf08b9e4edf7
+#: 4c3d3465d55e4ebea66ffacfef32d709 633763587f8c409380e4265af60dd53e
+#: aa798a558d774dbfaa760518a7ea8174 cd94e769825d45709c87e330d1652409
+msgid "nvidia-graphics-drivers-580"
+msgstr ""
+
+#: ../../24.04/4.md 60ed40d134d54b7eb331bb71036423cb
+msgid "[2118901](https://bugs.launchpad.net/bugs/2118901)"
+msgstr ""
+
+#: ../../24.04/4.md b03a6c8bdaca4beb9cb038a4c83e0938
+#: d667527e5ef943c8814e28571561be8a
+msgid "New upstream release 580.65.06"
+msgstr ""
+
+#: ../../24.04/4.md 1849375335094aeda0120a6f200b007a
+#: 2b119611c15641bd80ccc30fd77e5785 a1df820b01da4f289519c63d60ebb56a
+#: d41cb78493134f8caa1d8bacf5483442
+msgid "nvidia-graphics-drivers-580-server"
+msgstr ""
+
+#: ../../24.04/4.md 41f23097d60c4a5e899434fd5ea94aec
+msgid "[2118389](https://bugs.launchpad.net/bugs/2118389)"
+msgstr ""
+
+#: ../../24.04/4.md 05b40aeee7614c4ebe115b742c518268
+#: 1689576175b3401b9e35cf56028f697f 2c5cde4cbec541f3bad5319ffde1a615
+#: 31e6da3db5ee4a2883267932e0792cb0 35c43d074c494f4fbd59ec16b213e22d
+#: 4280157202284788ae3ede3b05426ba0 4aa9cd2bd9164f23b0781c2d156657bd
+#: 522c82d32ca94e6e95d1268a6b423bb5 55d80370d2a3485c824c19a76812df58
+#: 6406065e02524efc9592a5c841c22458 68984d27d5804c318c29e74aa1d37ec5
+#: 79cd68974edb45d68aed36d724f51745 82e1dd97b0764ee2a0123a323bb1eb81
+#: 8a4dc5592c074d658eff96d3ff5fc6e6 8c69f0e3e2eb46e9aede2bd80b283583
+#: 8f0f769f20a54deca4d2e0e33fe4fcd3 96cbc7e18b4546ea84463e0e7ff21d6a
+#: a425d3ce2e874fb7857b3272656ee4af d4fbee15bf334cfe8de8128e5b23ea4b
+#: e09def915b9e4c07b27cb465487523bd e17c99d88665488589ae1f309a5125da
+#: e89d25a28beb4320bfce3fcaeccb8eec efb135b7c79e46e2a63450cb3c9b89ad
+msgid "[2118499](https://bugs.launchpad.net/bugs/2118499)"
+msgstr ""
+
+#: ../../24.04/4.md 105379e08a054ebea8959829ecc48b05
+#: 108360cd4a0144ffa0bd3b15e09957ea 1dde90b4f4d54b5b85909b969be2571d
+#: 215d189873594b3f95765ff365dc0e70 2bac70f127b3401ba9569aade9214abb
+#: 447eea2d79e548159de9f742d1c58b70 5dbdac079e4a4c168226e0b61a9c06e3
+#: 5f6474eab6c24503bbe7570c1c4d17c2 72152053c89d46b29b394b4e2b600c0b
+#: 7566978a0c2a4571b95b2754daf2b817 7974ac220b544a4f839d491825b15e0b
+#: 7a4571c2840f48db8ae55d96661f8a28 7ad920068bf240648c30c7e9bffaa55e
+#: 88e472896b7f4f0d99954f9ff9329ed7 98e7869230c64cb1b938afd62fc3ccb5
+#: b4ddff85c6a24d398bd17a0b7ecc17b3 b6050bdc5321456fa5537d96d6bcc0aa
+#: bb15f577b78742a089cd94a27787e82b d1fec6d1b1534cb3be11f6a9205ff255
+#: e0943d675ccc49d29558fb7af1564e86 e2daf1b3c054435eb619db9552b5d03b
+#: e479e64184884298ab18166dfe011fe7 e98fea8345444b03bbe944c6fae1247c
+msgid ""
+"minimal kernel lacks modules for blk disk in arm64 openstack environments"
+" where config_drive is required"
+msgstr ""
+
+#: ../../24.04/4.md 20cedbf1dcc04266a5ba4a1dcf0c2f5b
+msgid "linux-meta-oem-6.14"
+msgstr ""
+
+#: ../../24.04/4.md 2b7071c7474b4e5f8358a160c4794cb6
+msgid "[2122009](https://bugs.launchpad.net/bugs/2122009)"
+msgstr ""
+
+#: ../../24.04/4.md 6bf699281e9c4975910b8d6f0ac85fde
+msgid "Migrate oem-6.11 to oem-6.14"
+msgstr ""
+
+#: ../../24.04/4.md 039918afebe54405b7a50946b88118c8
+#: 0418160a6f6a4cd0be2ea69aaf79b4f1 0a2f4eabd45843fc83d811531ed8010c
+#: 0fdf80c0968a41f49dc240a5ba1dcd74 15f92ba590f44f8d863b3b5b08765c57
+#: 26d82b20a6494220af25745c3b0ec58b 2d269116a4da4a33b5819298f69f1755
+#: 2d53d21d81d54a189b17a01583585ec9 2ddaf93b160d44ea99c86ee44911ac17
+#: 33828416223744cc856ff3b7feb2ad43 34badeafd76e49e0b94f3051e02c96e6
+#: 37b64989e5f0491d9f0daeaf114f4e04 3c300fe5731749b9b38f593131f04009
+#: 3e8bbb3e2ff24748871df3ba9121ea0a 52a25ba7c2334a858b1a173025589bd9
+#: 53a867dee7ac4c19ae71a91c53cf2875 59a3e01e9f6843f8b7b23ca3566c3e12
+#: 5c6a6ae7076646b18c0ac61a9ebc2c55 5e19da8f62534eda98de3bcf897e9b13
+#: 688aff9c66404856949e1a9bf5758e70 6de6d59bf04d4fe18aba8f0b840dc0d4
+#: 7a12d1286ac54afb9941d228b64a2918 9349fea8b3ff40b284c4a6580e397ce6
+#: a505072961964efcb2858e24d13f884a aaa8abc16b8048dbafef9a6f91e42421
+#: ad2a87f41aa14114b1a8cd3c1db76fb2 be9198a704854ea9afa4963353cfd1f1
+#: bf204e7e248f48308d53bf808e1c3811 c7982dae6ea345eda5520d3455d95df1
+#: cb80de385ad841e486cc1aaca8da0e80 d13db1a41f3a49208b52b6bb81441c38
+#: e3b1eed1d6fc46a0b14d6b2843dde9d6 e429018377534c1a96b6a99318698cbb
+#: f4759828ee3e442d912a4d5afaafc42b
+msgid "linux"
+msgstr ""
+
+#: ../../24.04/4.md 0d683df5df6b4de093c53dbd51be27bf
+#: 3e4c74dec58641dc8ff26c040ceb0e2b 42f443ed1f784ce2b51e45c202e113b7
+#: 7fd476d2372548ac98683e282b5ca7d5 8bd59412110e47b69a3752a00effee13
+#: 9513ce1e3b3c4deca3e18f31571e54d0 a62d72ab10f84ca2a005b101352ab25e
+#: bf07b57f3451476da5abbda2494957ad d06f7ae4552643c1a006a26ab7bd26b8
+#: d3f0d89b2d084078bf0eff556ac5317c eb9c5def4f79456bb1fd3bf54282cf64
+msgid "[2121671](https://bugs.launchpad.net/bugs/2121671)"
+msgstr ""
+
+#: ../../24.04/4.md 02118911e792482ca26610c952b5ea30
+#: 11bcfca3ffd44e9597a63dacd7d94cd3 17c416b68c584ef7b5416e7032cd103b
+#: 1f2876c04a154222bc1d5796a31783da 3147d7f2cafc4fe7b0227fec8a7045ad
+#: 34315438bd9a4c64b70a7404ef1832f4 5a751046df9644249475d1ab7dc91987
+#: 6d043cc5c0f44c24a0b2bf94ba22f44d 78834837c67646328bc9b0af38da3b69
+#: 7c4a46d5f1774759a7bd38ee722117c8 e0b993134e1f44989b67d44ca1e72315
+msgid "noble/linux: 6.8.0-81.81 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 545bdba406c64229baa5a5e0736f1edd
+#: 61f02ead3e804acf8f0c3e427ed0d676 63efbd583ef5416c80aa221c41806c75
+#: 708fe5f4966947b7a99c4e4c4fc2d2b1 78e591dcb9e04224b35feed127d6215e
+#: 7f4ad7a1bfc04c469af12a486c891ad1 90594b95c8934772aa32e865ede6bb71
+#: c0fde89c2bc6488990cf4d6ef06efece c9bbdee9f5de40dcbec94ba5342784c9
+#: d865f2d798b746e2b07b20b54af8e291 e333a980c0104434a7c0373c5a992abf
+msgid "[2117123](https://bugs.launchpad.net/bugs/2117123)"
+msgstr ""
+
+#: ../../24.04/4.md 138e5e9d0ecb453e9dab5f17d8696837
+#: 2899fa53cb064248ba12f4d028cb7495 438e7a27b86b4a3b9cf116d1aad131c1
+#: 47919bca7ae1487c82dc4d4f9f0a8723 52175b49ec5e4d018dae2d3fe0cbfecf
+#: 7a7768d97ffc4b968a5a44584c0635ce 866d236069b847ab948ffa1f88a7aae6
+#: 9882476266a84dd2aa1ac84d3d1a6631 bdcba52765f244c58b2144e2f03fd3b4
+#: c426938cdc674a6d8983775003706e6b ff2493bea08346348e33d793a86426ed
+msgid "rcu: Eliminate deadlocks involving do_exit() and RCU tasks"
+msgstr ""
+
+#: ../../24.04/4.md 0974b4192aad4acc92517fdda35b0583
+#: 1e94c3dabbf54f51b89bdcc7d45ebba3 3f8de0ca99214e748559ada3cebf4e5f
+#: 443a760f88eb431987180b3c43e79481 53652401f30b42ce8a26ae8385f1f79d
+#: 59a0b9d99555487b9656d9476df234bc 5e1ae04c64ab4c19bd510fe8bd4506a8
+#: 685c9802cc3d45ee9d0b9c5516fc60c3 6b8cce56e010420ab70081c4652dd7d4
+#: a785ddfa1c0644c091b4e120a4531e77 d5c7f5b62dc3488fac52bdf4df9348f8
+msgid "[2117716](https://bugs.launchpad.net/bugs/2117716)"
+msgstr ""
+
+#: ../../24.04/4.md 0359a1bf431b42eb826ab48bf3183bf2
+#: 0a5f056449644141a1861856cfd53ae5 2389df49f4194dcb82397caec93a5d57
+#: 26edcead11a54c5eb0a6898bea39fe8e 27bb7be7a8084faf9b01ef1bb527fe68
+#: 4b270895051342ff83670e5a141ef9bb 56bb67a9c920463ab13cd20609d9b90a
+#: ad665943e4e14d709b6fca9eb411d31e d5f6a1066a254f16b15978372296a470
+#: f35288e857094911aa146364d7cca78e f583add6fc46415993c09c65eabc9c8e
+msgid "i915: support ARL-H gpu"
+msgstr ""
+
+#: ../../24.04/4.md 1b4abf40a7a546ac9c2e8742cce69908
+#: 3aff5f0cc084411294d5c4eeb5adbef3 5e1c0338d8374e4c821a372817217e26
+#: 81bc8d4e55f3436eba1350fd1ac67292 9358223be3934a478bd2a892a962d3ce
+#: 992cb9618fb04082a716068453e85b16 9d70e0eda0df44b69868d6953f44d70b
+#: c622c4f3de2e4588be7d095b21f7cba2 d4ffe55964184e6486015ed88bd5dd05
+#: f0121f6c32b0458b905c611c497d6c59 f715884cbad4449d92e07ca8458612a8
+msgid "[2115447](https://bugs.launchpad.net/bugs/2115447)"
+msgstr ""
+
+#: ../../24.04/4.md 257dd136948e4a2cb0649970f88b1959
+#: 43d9fa01810a46c395ce7a733c8bb776 61722a1529c54703b3d74f34a7c67df1
+#: 9429d9730c7a4a498b77c5fca2eed1ac ae0001fbf9224bcf99e34aa0248b4d0a
+#: b31543cddb2741949b968e3d37838aed b81222401d0c442dba7396e157f40dec
+#: b90df8daf64a4ae18c33bdaa98f0826b c69bb68972324a848af4512f32b406c7
+#: dcd479ee1e5e48488924c1d733fa8ac0 e394afb5071e4425b127f94cffbbfd8c
+msgid "Ubuntu 24.04.2: NULL pointer dereference with Ceph and selinux"
+msgstr ""
+
+#: ../../24.04/4.md 0b477260b874482386b18bf515f90a19
+#: 10139291ee664b1ca91314f7842cd830 434bea72b3eb4cb9b2613501c789ce78
+#: 5d5f019ded03427b94449dbe36d41309 785352b379184fc09a502497c7d0d443
+#: 7f7d5eb226354492b69a198cec8d2896 7fc7ee60e6e5441da58f64c6e1456803
+#: 8a02d525bd4c4436850bf48443db536e 955dd949d1f54685ae60e25144b69c5d
+#: a5427943d8e04872a55362868b366f0b fdf1b267b0ce4c3b9a31558a1053a21d
+msgid "[2119458](https://bugs.launchpad.net/bugs/2119458)"
+msgstr ""
+
+#: ../../24.04/4.md 02639b3c965e4081ac1805ec9b13e5f0
+#: 33e68ae6e7014c7487fcb15f85f98e1e 381c2f7792644422b942e07ba1b7d44a
+#: 50b98a782d75446da4c404218202f0b5 5fda9e0cd5964b18a20f006512c7cf33
+#: 81c418da95a14f65b476e2eb930fff29 8411db278e70442bb4a4e9680b0ce65f
+#: 9f7fcbf86692410fa9b51bb1bf2206c4 aaa678b9b8274c399d4ea3021efb0984
+#: ac1d36a49bcd4350850d684996d03aee b9849107c7d344d688cebaf5679b8f8e
+msgid "Noble update: upstream stable patchset 2025-08-04"
+msgstr ""
+
+#: ../../24.04/4.md 09106feed52b4fd1a750148f526f338b
+#: 2fca0d7bf8c146fdbfeee5373bf11d98 30699e9d2178497e886183a2af7dbdca
+#: 4b0976fda5274feca72bbb6edbd86ed8 7114f613fdf04d8ca28246c6130be79e
+#: 7d799743ebfd4f36805c0c29e7355611 82086ee260b24fa19216019a80d94970
+#: a94d6144c22d47c78fe7c9914416560b a9619cbea6ee4a1dbd18d24200197180
+#: b194a566fcc24a44a2489345c452bc15 ee8f8b3437c642d48614d6ee1f4a0336
+msgid "[2118927](https://bugs.launchpad.net/bugs/2118927)"
+msgstr ""
+
+#: ../../24.04/4.md 16182c7e46514941a8b1af7b1eddb15c
+#: 1fcc2ad19e1945a19d839168b32b0f76 34c949e80700437eb8891f8f4f30eeec
+#: 3be19737d5c24282937678144ec30bfa 5dbb5990941f4914a77ccdc433767e0b
+#: 832f6f2052a443638d678091a93dd81c bb92d25dce254f519c9fe2e2ab797270
+#: c5475a00fe6f4536b636ba037164251a d52689c592ce4b48894f6d2c647a51fb
+#: e57a0bfcd5eb49afb377cb7fbbf7a320 ea66295cefae4aedbcf51fd737465fbe
+msgid "Noble update: upstream stable patchset 2025-07-28"
+msgstr ""
+
+#: ../../24.04/4.md 1288dc2523b243be9d04401097d8c953
+#: 37dad9f9fc7c4df7922d64c1c2ad7a66 49a0458e750e46aaaf4c64be036b793d
+#: 56a1e21598674f35a14ed0321ea531e9 872508b04b374e5eb90c0497e491c9de
+#: a31b8760eb86400884044f1290f5b391 a9f2b201a868410d90477f5d1c03e78f
+#: af6e1b41b4d240198d55ae6582801e93 d8a68d67b2eb4a1481e3bd8829f652af
+#: e2c2c7e4fca4413e80692741f1c8acc6 f5f82dd8e2444be8be3f5a8f930c8142
+msgid "[2117533](https://bugs.launchpad.net/bugs/2117533)"
+msgstr ""
+
+#: ../../24.04/4.md 061b4df343604ff088d3b732e3c2be80
+#: 073cd6f60a514bdaaaac952a08c78853 0a6eb1e8f6884f2d800e7e3780667192
+#: 320d044ea6d14440942f0424872f92ad 4c8ac2c002764d0f964d9d39dd5e344f
+#: 56177db4e82d4164b5047f10b003d93b c2acce1aeb8a41ee869af497171b1de8
+#: c5366c967fa144c9b10aa21a20dfac8a e5560a42876d4d0798124072d9a94669
+#: e6802395a3d74261a3cf5bb306f484ad f327e9db912a4461a793ce0ec8f91a97
+msgid "Noble update: upstream stable patchset 2025-07-22"
+msgstr ""
+
+#: ../../24.04/4.md 2284c3b9a10a4c32bc54c7dcf674471f
+#: 3b455aaba7ad4016ab0f709708b4e4a3 618efbff207a4ab98a25c8dd9342126f
+#: 6d74a6c85b4643ac90330edac3628a22 75b3a144884246a3a6f8778873013be7
+#: 77097039100246ec9c0316fa8c6e3e87 8804d755b9d740cc937219478213a1dc
+#: 9b6c6f8161a14777bbb02581aef54efb 9bd8722c55c14775bcac83bee14231c1
+#: f2ce994fa8844b609d12ef6665d33c1e f2ed3adca88b4cef87579b1e6cef6d14
+msgid "[2116878](https://bugs.launchpad.net/bugs/2116878)"
+msgstr ""
+
+#: ../../24.04/4.md 2b2b8bb689ad4cbbbe8f0ab6dffff701
+#: 3bf652504d584d6585fd53f38ae887a8 6b2bd6c073464a4081983d10b87e938c
+#: 855edc60570540e9928b5022650c821a bcf88b2e91ed4549900bf6b6eee549f6
+#: c0a10ea54f7a4f49af7ee5f5c2c2032d c30c42181e184a6cadc8840e7bc31112
+#: d069bbc2212347d6b7b1a58c4bee5bef d5c8c353da994ac29bf3444cf2dffa95
+#: d8c48d9a918c4924820a8ec6e9e68aaf dd26d36751374d12a45cde785e27c086
+msgid "Noble update: upstream stable patchset 2025-07-14"
+msgstr ""
+
+#: ../../24.04/4.md b799f91d71f74089af6b61f26fa26160
+msgid "[2120002](https://bugs.launchpad.net/bugs/2120002)"
+msgstr ""
+
+#: ../../24.04/4.md be65b6a7acc542ca862280f16723cd02
+msgid "noble/linux-aws: 6.8.0-1037.39 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 06d07949cc1348ee80073be30ad6d5a0
+#: 0a2f37f1d837477da0485d44ebc2fdec 2f33f98bfcdf422ea2ddd921507b3428
+#: 3fc850f72dd74fcca6d7e962b746d25f 57170e902a4540f793bb3b423876d8b7
+#: 8ee9f0d34702460db03737f2d61478c9 bbbd887bbbb34df8b2ef67f21e68ca75
+#: ce1af0de094b4f95ba6fdcc8afd18407 e1a5732e724e4ecdbc1494a875a12fe7
+#: e88e96b8dea94a4083da5cf8b958a3d9
+msgid "linux-gcp"
+msgstr ""
+
+#: ../../24.04/4.md f8f8ff93aab946b2b41a3d07c5a4c561
+msgid "[2120013](https://bugs.launchpad.net/bugs/2120013)"
+msgstr ""
+
+#: ../../24.04/4.md ed8fef0caa554b7298638f21a4b3993e
+msgid "noble/linux-gcp: 6.8.0-1038.40 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 1665f0b18f6642b588f73321a21c9cf4
+msgid "[2120014](https://bugs.launchpad.net/bugs/2120014)"
+msgstr ""
+
+#: ../../24.04/4.md bff784e5ec9a4cdab85a22b5dbe1c0ce
+msgid "noble/linux-gke: 6.8.0-1034.38 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 1c28395847fb4ebc8224efe46f64b4f4
+#: 3e28c1dce75e443088392d152ad86b3e
+msgid "[2117098](https://bugs.launchpad.net/bugs/2117098)"
+msgstr ""
+
+#: ../../24.04/4.md 3a3105da69834027a901bb3cf3bba94b
+msgid "Add NVIDIA Grace platform support and 64k page size flavor for noble:gke"
+msgstr ""
+
+#: ../../24.04/4.md 0d5253fe391c4e62b273860094016c44
+msgid "backport arm64 THP improvements from 6.9"
+msgstr ""
+
+#: ../../24.04/4.md 6308f5762d674f34bdf7f3206fef8f97
+msgid "[2120015](https://bugs.launchpad.net/bugs/2120015)"
+msgstr ""
+
+#: ../../24.04/4.md 97412f4bdc064cbbb09bfbbe93978e51
+msgid "noble/linux-gkeop: 6.8.0-1021.23 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 21f3dafebd8b4db4915ff543c473e922
+#: 26a6c11320a64fc48673ca279e017268 41723b7822cd449cac273f3b290bb173
+#: 47d09e48d2c848fbbd9b097d85b2f2f9 7ad6ba8bbf5141f7901cf4b86545bdd3
+#: 80c39d0944154042885f549a313319cc 93e79b8be9b746c784deb88b4c89b836
+#: a8626fb6708449b181914acb3223e36d d8e1c4d5f0f847078b400b27b604a30c
+#: f0a1c95d289b486599b838f18accf679
+msgid "linux-lowlatency"
+msgstr ""
+
+#: ../../24.04/4.md 3fed59b6c72242a5ba8c9fd6eb102d68
+msgid "[2120021](https://bugs.launchpad.net/bugs/2120021)"
+msgstr ""
+
+#: ../../24.04/4.md c053e5fc9f9345a6952263ef612e6fc0
+msgid "noble/linux-lowlatency: 6.8.0-81.81.1 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 10f62dfd73064dfa8649b998f84c1ae5
+#: 14ef7b2b53934c0cbadeac6aeadf558b 359ca83c9e66491e90cbf48ddc0c6f40
+#: 558a5b5920734007921c86d58311792d 5e90faf643c84107bd881308c3b6bf75
+#: 62b2b7ac332141f9bc0654ddf25fd4b5 91047a16899f4b1e86cd600ccf63ae0c
+#: b783415036f0447f9759c98e88ab3ad8 d74faf33d1e94f5a9604b68b5b52f6af
+#: e7fbbc2a940946a080b66ea9f2a3466b
+msgid "linux-nvidia"
+msgstr ""
+
+#: ../../24.04/4.md 586a099f5aa745d78ce3216ae9be5515
+#: 5ff1b3d04f7c4eb69ee962ae8709cb5b
+msgid "[2120024](https://bugs.launchpad.net/bugs/2120024)"
+msgstr ""
+
+#: ../../24.04/4.md 26e0c167eab542648aa6077f5f40355e
+#: fc44a527423743a8a907aa08b27184ea
+msgid "noble/linux-nvidia: 6.8.0-1037.40 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 21d4a6865f4a42318dd0db08f3e7d1e9
+#: 3f50cba045be41fe87b93ae87e04ccfb 3f832984288f4e4bbd12e030aa73c749
+#: 4dc2e47fb9944cd890a16c0a66c23317 59cb66816b8441ada70681bbbbf39059
+#: 625f05c9b1c449ef8a67d4a2d5813f2c 78f9822ce30449c2a3a854090bede281
+#: 8ebb8d1ed3b345dcad98707256520e26 f7a3e0d50c254085ba0c136b1cd1f635
+#: f92c05a2efe64cbc9a37b4d96acd7874 f93c4b19b3864e90adb40643c3bdc7db
+msgid "linux-nvidia-lowlatency"
+msgstr ""
+
+#: ../../24.04/4.md dd7483c3cd4d4d4695ea3cd571d79963
+msgid "[2120022](https://bugs.launchpad.net/bugs/2120022)"
+msgstr ""
+
+#: ../../24.04/4.md 02c8e5e1823a4a978af5e25aa8015036
+msgid "noble/linux-nvidia-lowlatency: 6.8.0-1037.40.1 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 290e708ebcf048f8888c30d5a94c1d2c
+#: 48bd8eabdc204ee0985a50482917c847
+msgid "firmware-sof"
+msgstr ""
+
+#: ../../24.04/4.md ff49223524cc4ef085a7b45fdb4c13fa
+msgid "[2121849](https://bugs.launchpad.net/bugs/2121849)"
+msgstr ""
+
+#: ../../24.04/4.md 1530a61cec274bf1bb302753ea612434
+msgid "Update the signed ipc4 lib for the Intel LNL platform"
+msgstr ""
+
+#: ../../24.04/4.md 535eaed7e3b5434785fc05aefb050bff
+msgid "[2119516](https://bugs.launchpad.net/bugs/2119516)"
+msgstr ""
+
+#: ../../24.04/4.md 298992dfdd5c431986b0641653a45eb6
+msgid "Add support for Intel Panther Lake sof audio"
+msgstr ""
+
+#: ../../24.04/4.md 3a3f2eb680354d6b95dcfbc5986155ee
+msgid "linux-aws-6.14"
+msgstr ""
+
+#: ../../24.04/4.md 960a65f6eafa4dcba3560c0b639b0268
+msgid "linux-hwe-6.14"
+msgstr ""
+
+#: ../../24.04/4.md 00a7bbf030904d389bd27c54a1a1fa03
+#: 40c5367db9774c60a2126a1c6b0608a8 4250be51f8204a6481ae7b2a53f0950a
+#: 77f68e7ae03c4337bc6ad93843aa5485 83e6153239ea4fc59c7b3c2cbead9f98
+#: 9b79750a4a28447a93c5f1a46d63f639 bdf8b84bf5f6469f97fd3b8109189e56
+#: c3b31762dbc1496aa8ba2c2578e1940b ea10396c4ba94688a83c028ca9a7b593
+#: fe8885b4391047bd8aab7a8edadde7bf
+msgid "linux-ibm"
+msgstr ""
+
+#: ../../24.04/4.md 3bf0a9afc4ae438aa7ba94e6ea1d31c5
+msgid "[2120017](https://bugs.launchpad.net/bugs/2120017)"
+msgstr ""
+
+#: ../../24.04/4.md 86bc2c89dc484e2e9f2b001db87fe2bb
+msgid "noble/linux-ibm: 6.8.0-1035.35 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md c8d0eb5844ac4513b7d5573625f30f11
+msgid "oem-somerville-deerling-meta"
+msgstr ""
+
+#: ../../24.04/4.md c45bd4458248415b84e238316a7ac386
+msgid "[2089078](https://bugs.launchpad.net/bugs/2089078)"
+msgstr ""
+
+#: ../../24.04/4.md 7a4c41f94c1047fc87ae21fe3ecc6e0a
+msgid "Meta package for Somerville Deerling"
+msgstr ""
+
+#: ../../24.04/4.md 92d03a39ea7e4777aded484881ef2178
+msgid "oem-somerville-tauros-meta"
+msgstr ""
+
+#: ../../24.04/4.md 961370a9c7174bd3bc6616e9cd38a97c
+msgid "[2089087](https://bugs.launchpad.net/bugs/2089087)"
+msgstr ""
+
+#: ../../24.04/4.md be080d40471444078cb18d5afe2c5428
+msgid "Meta package for Somerville Tauros"
+msgstr ""
+
+#: ../../24.04/4.md 5247b351a3ee43918ad3886caa89ab3e
+msgid "oem-somerville-tyrogue-meta"
+msgstr ""
+
+#: ../../24.04/4.md 29b40ca6c6084515a589d47799ce98e1
+msgid "[2089090](https://bugs.launchpad.net/bugs/2089090)"
+msgstr ""
+
+#: ../../24.04/4.md adf4aaf517c346808dfdc7f4c9ac02b9
+msgid "Meta package for Somerville Tyrogue"
+msgstr ""
+
+#: ../../24.04/4.md 3a28947c7684457eb2ab7aa3be37ee63
+msgid "oem-somerville-wooper-meta"
+msgstr ""
+
+#: ../../24.04/4.md bd97b191bf1e4066b7a90560a90a7452
+msgid "[2089091](https://bugs.launchpad.net/bugs/2089091)"
+msgstr ""
+
+#: ../../24.04/4.md 50b317e87444418a81e919a5409a253c
+msgid "Meta package for Somerville Wooper"
+msgstr ""
+
+#: ../../24.04/4.md 34773af2a86b460b8568320355c9b5ec
+msgid "linux-oracle-6.14"
+msgstr ""
+
+#: ../../24.04/4.md 1e67fabe251a47a38ec3acc37d613e5e
+msgid "linux-azure-fde-6.14"
+msgstr ""
+
+#: ../../24.04/4.md e519dc923d1b45a68bfef80c2b304020
+msgid "linux-azure-6.14"
+msgstr ""
+
+#: ../../24.04/4.md bb74a18d8c724007bd66281614813332
+msgid "linux-signed-azure-6.14"
+msgstr ""
+
+#: ../../24.04/4.md 2eea1fd06fbc41fe98144c696c73a49b
+#: 669a424c168f4eda83e7ec690043dc08
+msgid "[2027818](https://bugs.launchpad.net/bugs/2027818)"
+msgstr ""
+
+#: ../../24.04/4.md 75d961c202604911bab492b13c31ba97
+#: b1e9899039e140a4a6cadea62caff08a
+msgid ""
+"SIGNEDv5: add ubuntu-core-initrd support to the linux-generate ancillary "
+"package"
+msgstr ""
+
+#: ../../24.04/4.md 06c7c3998bab45caa7ddf51eb22c8b34
+#: 10809fe26394404e86e3124aeb222ede 1c20f3df25064c128dd592f507eb4d4d
+#: 237084eb1ff842b881384b1064d0f282 247671a74b644b14b13c28c99d52451b
+#: 2526a95dcc0f4910b0890e41592747d1 2ff7e483144046ef87f290ed60f5da7c
+#: 46eec96e02574a05bcc4da0d6333772c 4e9115627d3c4f1e9abe4877fe5fb763
+#: 516e2ca119b04cf393743ad55d0a8876 524bf5428af044e79d16fb443d478b9c
+#: 52ccd4c066c54573acc5a7396f6f9aac 697412f65f944312b72f1abdd1dc403c
+#: 724dfce50b834b5586f026f1e7ced27f 7520269de33b4bb9bf45c5dfe377212d
+#: 77cb1c886c0a40f89c0661542c0658d0 78d3ad9024334eefbeffb11e0b9f7a42
+#: 827f5ad5c7e449519297dc24b1db2d71 82f519694a9049a1b88bde7bf71741ed
+#: 83d4158fa9d04e05aed1abb9c03bcdf9 9d79d1e73b5643ffb2755ca9da0eb7a4
+#: b086fbd052e24addb2f026e43459132a b5bb35102db343e9ad83011ea5ac86aa
+#: c35503684afa435599ca37fd7f6d49f9 c7a564fb80804d6b946993aa7882931e
+#: c7ffcf27020f47cab72437e20614c570 d55734f08efb4e8899aa1e202f8b3dd4
+#: e2447cddd48f452da2d92ce90aa6711e e30693bf009f4e7aafe3f4d12bb537e0
+#: e6b9c426ea664a94bfa89bdee9189bea e730b7ca09774f05a52d4747579c35e6
+#: edfd8f8d679c4536b568ad2c02bc474b f68ef8cea8ef4171989ede9f70905132
+#: fa4e1957e3b042898cc20108980c78e6 fd63915d4dc047aca5b7cf3722e8ac31
+#: ff6e95a42ef54eb1b568bf038345d239
+msgid "linux-raspi"
+msgstr ""
+
+#: ../../24.04/4.md dc30762478fa47c4970897ab62dc544b
+msgid "[2120029](https://bugs.launchpad.net/bugs/2120029)"
+msgstr ""
+
+#: ../../24.04/4.md 786efa4f973745069bca2f23d7c1a8bb
+msgid "noble/linux-raspi: 6.8.0-1037.41 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 22bd800996a947ce86eaf22e34818f64
+#: 29821444952440269bf10d71cb4560ed 41c3518a13954478b975143cd0c805fa
+#: 59346f5f822342189976dc19fab1978f 99f0e7525ca147bf9b141e85bbfb7bc1
+#: ab286c1da11e4aa881f64ef9b9dc63a8 bdc291564cb146268eafb14ab99dbda7
+#: d925cdb234d84d5183ad48f19b3c7c3f f7ff90c027a54bc78804446da9adc5b1
+msgid "linux-azure"
+msgstr ""
+
+#: ../../24.04/4.md 51fdd80d88894b248469a39762969df5
+msgid "[2121207](https://bugs.launchpad.net/bugs/2121207)"
+msgstr ""
+
+#: ../../24.04/4.md 02e49f51fa014a9db8cf037e8f8367a7
+msgid "AMD Krackan point system freeze at black screen while booting up"
+msgstr ""
+
+#: ../../24.04/4.md d44745a0e7d54830852ba1cbb934d80d
+msgid "[2116108](https://bugs.launchpad.net/bugs/2116108)"
+msgstr ""
+
+#: ../../24.04/4.md a7bbdf29a103403d8c9d5200b9813e96
+msgid "[SRU] Add GuC/HuC firmware support for Panther lake"
+msgstr ""
+
+#: ../../24.04/4.md 80234ba41a8c4c748be8f9580be6f89d
+msgid "[2119494](https://bugs.launchpad.net/bugs/2119494)"
+msgstr ""
+
+#: ../../24.04/4.md a5cb841b63d244e79bcfe401dfe6c45c
+msgid "Fix low volume issue on left speaker on Dell Oasis series"
+msgstr ""
+
+#: ../../24.04/4.md 9139d1b6d3704f02bbd6c7bf0107fef0
+msgid "[2121645](https://bugs.launchpad.net/bugs/2121645)"
+msgstr ""
+
+#: ../../24.04/4.md 8f5539cf36b64b0884ae41d8eddc7ba7
+msgid ""
+"Fix incorrect volume issue on left/right channels on Dell Renegade "
+"platform"
+msgstr ""
+
+#: ../../24.04/4.md bb9d396dfd344ad08614c37e04525541
+msgid "[2123814](https://bugs.launchpad.net/bugs/2123814)"
+msgstr ""
+
+#: ../../24.04/4.md 4009d69211774d78b5dc2484bc5a1360
+msgid "[SRU] multiple functions in GUI unusable, stall with AMD Krackan 2"
+msgstr ""
+
+#: ../../24.04/4.md 8a108d1167de4bae83223dc7fe41efb1
+#: c9b8cc3225ea4a278f4d6e8a0837d476
+msgid "[2125755](https://bugs.launchpad.net/bugs/2125755)"
+msgstr ""
+
+#: ../../24.04/4.md 984ddf36815b47ad9f03d9e283aea54f
+#: fa5d1fe46bec4b05826ba08b371b6b5f
+msgid "New upstream release 570.195.03"
+msgstr ""
+
+#: ../../24.04/4.md 003d5cdabb3d47fd97b90b51e74d1e8d
+#: c7e4e05346254a98ba908421d27ab8ae
+msgid "[2125754](https://bugs.launchpad.net/bugs/2125754)"
+msgstr ""
+
+#: ../../24.04/4.md f0d582f81bde4ef2bd3e3267bdd4307c
+#: f25de7dc9b724b0e8d5795802047ae44
+msgid "New upstream release 580.95.05"
+msgstr ""
+
+#: ../../24.04/4.md 5e76a8dc86f1403cb570a32770c54028
+msgid "[1876632](https://bugs.launchpad.net/bugs/1876632)"
+msgstr ""
+
+#: ../../24.04/4.md d8cb18f419bd423882dcef7142f87bec
+msgid "Preserve video memory on suspend/resume"
+msgstr ""
+
+#: ../../24.04/4.md dccd245372524e56972d7d154654e588
+msgid "[2125765](https://bugs.launchpad.net/bugs/2125765)"
+msgstr ""
+
+#: ../../24.04/4.md 9a19d52c675149eba3eda77c3b7ae816
+msgid "New upstream release 535.274.02"
+msgstr ""
+
+#: ../../24.04/4.md e8368b5faba64c808a544cfcb5ae457f
+msgid "nvidia-graphics-drivers-550"
+msgstr ""
+
+#: ../../24.04/4.md 3f216602ff374d38a50aea69bea4be41
+msgid "[2125411](https://bugs.launchpad.net/bugs/2125411)"
+msgstr ""
+
+#: ../../24.04/4.md 6285a679ae5c4f45a4f06c5680da60cc
+msgid "Release transitionals to 580"
+msgstr ""
+
+#: ../../24.04/4.md 682a26a05cc443f0b4436af44fcc85e6
+msgid "[2122382](https://bugs.launchpad.net/bugs/2122382)"
+msgstr ""
+
+#: ../../24.04/4.md 215246d2732b4eadb14ff4b408b3b91b
+msgid ""
+"Improve audio profiles compatibility: d/patches: audio-upgrade-versions-"
+"to-latest-possible-to-qualify.patch d/patches: cleanup-endpoints-when-"
+"devices-been-removed.patch d/patches: profiles-avdtp-Fix-reply-for-bad-"
+"media-transport-for.patch"
+msgstr ""
+
+#: ../../24.04/4.md 35f5693b598c4a6bb159167b6d6f44c3
+#: 3652e4405ea3481c935eaf4b07055fed 4c5989b31e474b668dd2d78de62d65e8
+#: 4e31c5e7680348d0aab893e2c6b0d7db 518d5d49f1e34b6c8d7f6610962d2d0c
+#: 53e9930fa7f7439491cf3ca06d6ee399 5c45efb88ff5499db118fbb6f0122928
+#: 6d74ba06cbcc4350bc651d10149dae46 6e421d9b1f2841d4b59218e337f40bde
+#: 9f0904d8d3e34227a163393ff765a323 bbfd88951adc48dc9ee297738dcf4ecf
+#: bc29aa3528ee45bba22c13fc4af56a4b bc7855f11ab340f8a42fef241be09673
+#: c24aef191d7a46f0b04984106411b586 c5a645c22dab4433ade9569a6a98db26
+#: c867da6b820e4a6fad060f1682bf27c1 de69a50a677b4cdcb3f5d50842d569a5
+#: e3b80ca5bc3448268205085d51de0de7 e7c3d16e979f4cbcbb8be9ac6ab4899e
+#: f30f774e18b34e1b8f4fbb97e950071e
+msgid "linux-oem-6.17"
+msgstr ""
+
+#: ../../24.04/4.md 1332aea6a9824d22bbb9100606445fbc
+msgid "[2127747](https://bugs.launchpad.net/bugs/2127747)"
+msgstr ""
+
+#: ../../24.04/4.md 9c41cf99b5c24faeaa3d5df8e7913fda
+msgid "noble/linux-oem-6.17: 6.17.0-1005.5 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 11fa7e62ceec4007b91e0db884639e01
+#: 5a22ba226169458999a56ed43176179c 8bd3039bd9ce4e57acc83caa4c57e2c0
+msgid "[2126040](https://bugs.launchpad.net/bugs/2126040)"
+msgstr ""
+
+#: ../../24.04/4.md 07221e0f084147b0b76e708fc07385e0
+#: 76d3f555613c40d9918b7c309c88c3ff ad66bbe54bb44c40a88f6069a4926684
+msgid "questing/linux: 6.17.0-6.6 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 84999cd83f0c49eab6df88152d04cfc1
+#: af78bff02bbf4ff1bce7f77b21df92ef ce79192be2064c4c857a67fc145f0116
+msgid "[2126948](https://bugs.launchpad.net/bugs/2126948)"
+msgstr ""
+
+#: ../../24.04/4.md 9cba87afb5834309a0dc90c16e6929b3
+#: e8b7aa3330104ab2b259b822f48be5ab ff1afeb2014f4e77b23886e7419c7ba6
+msgid "Questing update: v6.17.1 upstream stable release"
+msgstr ""
+
+#: ../../24.04/4.md 2b8cfbd738404afea8ae255902e8d27f
+#: ab9d78dc473d4e3485f3cda06c225ead c4d8c259c55b4c9985f8c448c746f5d9
+msgid "[1981437](https://bugs.launchpad.net/bugs/1981437)"
+msgstr ""
+
+#: ../../24.04/4.md 99e856fc682a4826b360befb053f6d83
+#: d5f80383b3dc482fb6f424ed84651318 dbb96fb3e7714381b3e979537a53b45c
+msgid "RISC-V kernel config is out of sync with other archs"
+msgstr ""
+
+#: ../../24.04/4.md 9c305857c9414e89b46b404902dc1cb6
+msgid "oem-somerville-jellicent-meta"
+msgstr ""
+
+#: ../../24.04/4.md e2b7fadfff264ada9cb123fa0ef46816
+msgid "[2090856](https://bugs.launchpad.net/bugs/2090856)"
+msgstr ""
+
+#: ../../24.04/4.md f84ce58086a7479aa4344f7520867f3c
+msgid "Meta package for Somerville Jellicent"
+msgstr ""
+
+#: ../../24.04/4.md 7a615d9b2c06481f8b62dcc1f72a6e25
+msgid "oem-somerville-seaking-meta"
+msgstr ""
+
+#: ../../24.04/4.md 44943024a2c349c8869000866d340ea3
+msgid "[2102066](https://bugs.launchpad.net/bugs/2102066)"
+msgstr ""
+
+#: ../../24.04/4.md a0aee28fb6e84677a5e358c4923d69a0
+msgid "Meta package for Somerville Seaking"
+msgstr ""
+
+#: ../../24.04/4.md 80235427fee6488787523a11842046c1
+msgid "oem-somerville-woobat-meta"
+msgstr ""
+
+#: ../../24.04/4.md 2fa2048712ba486db89023aef0eb484a
+msgid "[2089675](https://bugs.launchpad.net/bugs/2089675)"
+msgstr ""
+
+#: ../../24.04/4.md 2edf143a7c9c40f884758367641c99c9
+msgid "Meta package for Somerville Woobat"
+msgstr ""
+
+#: ../../24.04/4.md 049d4a7bbf10492e98e60f107c8d5218
+msgid "egl-wayland"
+msgstr ""
+
+#: ../../24.04/4.md 43165bf91ed444cabdd9c1be8692143b
+msgid "[2117339](https://bugs.launchpad.net/bugs/2117339)"
+msgstr ""
+
+#: ../../24.04/4.md bdbc94116804475bbcab119436109b31
+msgid ""
+"Add d/p/Fix-the-ABI-version-check.patch. Fix OpenGL in NVIDIA Wayland "
+"sessions"
+msgstr ""
+
+#: ../../24.04/4.md 770d0bd60f524020871219c81fcbffc8
+msgid "[2129011](https://bugs.launchpad.net/bugs/2129011)"
+msgstr ""
+
+#: ../../24.04/4.md 498ccb7c11be49b1806314533b4cc834
+msgid "[SRU] eDP showing garbage on GPT1 platforms"
+msgstr ""
+
+#: ../../24.04/4.md 04defda17a23481b8d5a4e3f3934b4fa
+msgid "[2129150](https://bugs.launchpad.net/bugs/2129150)"
+msgstr ""
+
+#: ../../24.04/4.md c7f3fb8777e043c2adde594ab89bc071
+msgid "[SRU] Update GC 11.5.1 firmware to enable MES WA on Strix Halo"
+msgstr ""
+
+#: ../../24.04/4.md cc946f07df284367b8c5a1886026a060
+msgid "[2129172](https://bugs.launchpad.net/bugs/2129172)"
+msgstr ""
+
+#: ../../24.04/4.md 9e664d41d3044281b0bd58f572c42232
+msgid "[SRU] Fix eDP showing garbage on GPT2 platforms"
+msgstr ""
+
+#: ../../24.04/4.md 584a453712d04cbab2d4fd726cbc7cd5
+msgid "[2122659](https://bugs.launchpad.net/bugs/2122659)"
+msgstr ""
+
+#: ../../24.04/4.md 6961f6eae02c4298ae41cfa82c0c2e4a
+msgid "Fix power state transition on navi4x"
+msgstr ""
+
+#: ../../24.04/4.md 0d03ae4a865444abb7c822ce814b2224
+msgid "[2094768](https://bugs.launchpad.net/bugs/2094768)"
+msgstr ""
+
+#: ../../24.04/4.md 226a7c4c73df445a83a34ba10221a859
+msgid "Missing vendor/product/sku specific ISH firmware for Dell laptops"
+msgstr ""
+
+#: ../../24.04/4.md d0431e37b02e4b689e75151d496b269b
+msgid "[2125139](https://bugs.launchpad.net/bugs/2125139)"
+msgstr ""
+
+#: ../../24.04/4.md 624ce3e7108c41bf8eb66b4396ffc18d
+msgid "[SRU] Fix amdgpu loading errors on Navi3x systems"
+msgstr ""
+
+#: ../../24.04/4.md 41d31624a07b4c67bfa51522106ab486
+msgid "[2129976](https://bugs.launchpad.net/bugs/2129976)"
+msgstr ""
+
+#: ../../24.04/4.md 639ab46f72ad43cfbf03af75aa0ea7d7
+msgid "amdtee firmware disappeared in noble"
+msgstr ""
+
+#: ../../24.04/4.md 5d8e56caf35d4dc59535b2abe019091a
+msgid "[2127958](https://bugs.launchpad.net/bugs/2127958)"
+msgstr ""
+
+#: ../../24.04/4.md 77311d751047438985f9d6da34fc4edc
+msgid "To support MT7922 BT and WiFi"
+msgstr ""
+
+#: ../../24.04/4.md f95ad00c98d04ffca15db44711a9cb68
+msgid "[2101850](https://bugs.launchpad.net/bugs/2101850)"
+msgstr ""
+
+#: ../../24.04/4.md 1288594210ae47828061a31c798a3d60
+msgid "Intel IPU7x enablement on PTL"
+msgstr ""
+
+#: ../../24.04/4.md 087439d33b0c435c9869c907110f75ef
+msgid "oem-stella-animalhunters-meta"
+msgstr ""
+
+#: ../../24.04/4.md 4524ce82a38e4ee38151b6c8ed64d76f
+msgid "[2089092](https://bugs.launchpad.net/bugs/2089092)"
+msgstr ""
+
+#: ../../24.04/4.md 062a3f2000d14954a26628b2c234054c
+msgid "Meta package for Stella Animalhunters"
+msgstr ""
+
+#: ../../24.04/4.md 96c61499c36444f99138f1d3bb492497
+msgid "oem-stella-aron-meta"
+msgstr ""
+
+#: ../../24.04/4.md b4321fc3719842fc8abfb147c574d80d
+msgid "[2089093](https://bugs.launchpad.net/bugs/2089093)"
+msgstr ""
+
+#: ../../24.04/4.md 4a2942caa07343738052a492d6c53557
+msgid "Meta package for Stella Aron"
+msgstr ""
+
+#: ../../24.04/4.md 0d5aa11380fb4e8798199e3924773c4e
+msgid "oem-stella-asobo-meta"
+msgstr ""
+
+#: ../../24.04/4.md 22af1e43728a45239829459e069cb16f
+msgid "[2089094](https://bugs.launchpad.net/bugs/2089094)"
+msgstr ""
+
+#: ../../24.04/4.md 860e574dcf4043c792ef5ec76d837be1
+msgid "Meta package for Stella Asobo"
+msgstr ""
+
+#: ../../24.04/4.md 755b35a296104e518e7327212e687769
+msgid "oem-stella-brus-meta"
+msgstr ""
+
+#: ../../24.04/4.md 41a27bf0f8b940cbb31d76cc06a93fa5
+msgid "[2089096](https://bugs.launchpad.net/bugs/2089096)"
+msgstr ""
+
+#: ../../24.04/4.md 21dbb9d2fa1c4792b8eff24f2e1703db
+msgid "Meta package for Stella Brus"
+msgstr ""
+
+#: ../../24.04/4.md fc3316f8776341f5aced454b72e911eb
+msgid "oem-stella-bergmite-meta"
+msgstr ""
+
+#: ../../24.04/4.md 1a185ec3fcad44d29de8ca093d33d2ab
+msgid "[2089095](https://bugs.launchpad.net/bugs/2089095)"
+msgstr ""
+
+#: ../../24.04/4.md d3731234c8d34297806674aa811e234f
+msgid "Meta package for Stella Bergmite"
+msgstr ""
+
+#: ../../24.04/4.md e03787fb6c2c4a9a8556e3df1671921a
+msgid "oem-stella-chippo-meta"
+msgstr ""
+
+#: ../../24.04/4.md 3d09fbf734c54d509285d66c0cff827e
+msgid "[2089549](https://bugs.launchpad.net/bugs/2089549)"
+msgstr ""
+
+#: ../../24.04/4.md 93e87250cb7a4994ae7239f269d75f98
+msgid "Meta package for Stella Chippo"
+msgstr ""
+
+#: ../../24.04/4.md 3033f07a51464d9ca8fb618a09de674f
+msgid "oem-stella-demaon-meta"
+msgstr ""
+
+#: ../../24.04/4.md f6f519db2e9f41d9a99795954438324a
+msgid "[2101005](https://bugs.launchpad.net/bugs/2101005)"
+msgstr ""
+
+#: ../../24.04/4.md 7baf7310c70e4293a354679e6a575604
+msgid "Meta package for Stella Demaon"
+msgstr ""
+
+#: ../../24.04/4.md 26aa564c7fac440293d4822ee668aa8e
+msgid "oem-stella-graveler-meta"
+msgstr ""
+
+#: ../../24.04/4.md d67d7791f29f4a15afbff7803b7463fe
+msgid "[2089097](https://bugs.launchpad.net/bugs/2089097)"
+msgstr ""
+
+#: ../../24.04/4.md e1e5d6b6e56c45c5b792586e64e6793e
+msgid "Meta package for Stella Graveler"
+msgstr ""
+
+#: ../../24.04/4.md b72cbadf3367484294204d359bd59977
+msgid "oem-stella-jaiko-meta"
+msgstr ""
+
+#: ../../24.04/4.md 45a5623a19d84b0f9f74d146530afabf
+msgid "[2089098](https://bugs.launchpad.net/bugs/2089098)"
+msgstr ""
+
+#: ../../24.04/4.md 77e88c15907947cf9ca57fe843dcf162
+msgid "Meta package for Stella Jaiko"
+msgstr ""
+
+#: ../../24.04/4.md c490b730e7074f709022049de0f8c0d1
+msgid "oem-stella-wakuburger-meta"
+msgstr ""
+
+#: ../../24.04/4.md 5ce043a1c95244bf8ef795f37eb7d6a3
+msgid "[2101014](https://bugs.launchpad.net/bugs/2101014)"
+msgstr ""
+
+#: ../../24.04/4.md 71a149e945cf45a4ae83da0024a520b3
+msgid "Meta package for Stella Wakuburger"
+msgstr ""
+
+#: ../../24.04/4.md 9464ba896e4e4f18891a5e4bf25ad2ed
+msgid "oem-stella-wakuwaku-meta"
+msgstr ""
+
+#: ../../24.04/4.md afa0736b18654cf496163388c296c12b
+msgid "[2093798](https://bugs.launchpad.net/bugs/2093798)"
+msgstr ""
+
+#: ../../24.04/4.md f30cc66f4f7b486ebe3f366aa9ce28ae
+msgid "Meta package for Stella Wakuwaku"
+msgstr ""
+
+#: ../../24.04/4.md dfedeb4e0f4e42ad829191a9911b4642
+msgid "oem-stella-yoshio-meta"
+msgstr ""
+
+#: ../../24.04/4.md 0e177e26709641d2b4fb421fa6c644f1
+msgid "[2089102](https://bugs.launchpad.net/bugs/2089102)"
+msgstr ""
+
+#: ../../24.04/4.md d0e60a5a39b3413daaebf5d1904a9e18
+msgid "Meta package for Stella Yoshio"
+msgstr ""
+
+#: ../../24.04/4.md 884ab177b2834af5981a66f45e69764a
+msgid "oem-stella-mangetsu-meta"
+msgstr ""
+
+#: ../../24.04/4.md 3b6b2c42d7dd4217bc1242fd14af3042
+msgid "[2101007](https://bugs.launchpad.net/bugs/2101007)"
+msgstr ""
+
+#: ../../24.04/4.md a9edef07b9244f2ebdd87345db7f55ff
+msgid "Meta package for Stella Mangetsu"
+msgstr ""
+
+#: ../../24.04/4.md e07c6c4d88124e638fd1456a3bb38b86
+msgid "oem-stella-mejina-meta"
+msgstr ""
+
+#: ../../24.04/4.md d587949ca5de4313a86faf2545237f41
+msgid "[2101008](https://bugs.launchpad.net/bugs/2101008)"
+msgstr ""
+
+#: ../../24.04/4.md 24e07f01ceb3488993c92a961f9d9721
+msgid "Meta package for Stella Mejina"
+msgstr ""
+
+#: ../../24.04/4.md 4a30dbe6108345f29c35ff4dc999cf53
+msgid "oem-stella-mii-meta"
+msgstr ""
+
+#: ../../24.04/4.md f348707e880340cab3881415a4546289
+msgid "[2089099](https://bugs.launchpad.net/bugs/2089099)"
+msgstr ""
+
+#: ../../24.04/4.md 2b0ca107703c4263a3903d144b6ab0f8
+msgid "Meta package for Stella Mii"
+msgstr ""
+
+#: ../../24.04/4.md 4c1e6da79f41453da7d23bff90b8f770
+msgid "oem-stella-milk-meta"
+msgstr ""
+
+#: ../../24.04/4.md b97a4505bc3244c0a0a981be768df33e
+msgid "[2090809](https://bugs.launchpad.net/bugs/2090809)"
+msgstr ""
+
+#: ../../24.04/4.md 85ebf1fc8fae4233a2a3beb7eea9fcca
+msgid "Meta package for Stella Milk"
+msgstr ""
+
+#: ../../24.04/4.md f43ddc7a84ef40b18e56bd5d2e9ff325
+msgid "oem-stella-miyoko-meta"
+msgstr ""
+
+#: ../../24.04/4.md 7215d88665dc4388a7faa0569db8248c
+msgid "[2101010](https://bugs.launchpad.net/bugs/2101010)"
+msgstr ""
+
+#: ../../24.04/4.md 7644f65f17e64f8282e803ae861a24b9
+msgid "Meta package for Stella Miyoko"
+msgstr ""
+
+#: ../../24.04/4.md eadbf84a9c9a45b98a1d65553b33a746
+msgid "oem-stella-moa-meta"
+msgstr ""
+
+#: ../../24.04/4.md 81c514df7916439fb103e76930c96fde
+msgid "[2089551](https://bugs.launchpad.net/bugs/2089551)"
+msgstr ""
+
+#: ../../24.04/4.md 6f604fc3d74043138dd424ef2f0b1bc2
+msgid "Meta package for Stella Moa"
+msgstr ""
+
+#: ../../24.04/4.md a574b18d684342a38a2fbcfda93a3ff8
+msgid "oem-stella-morina-meta"
+msgstr ""
+
+#: ../../24.04/4.md 8df49fc253ff4e2097645cb359c8492c
+msgid "[2089100](https://bugs.launchpad.net/bugs/2089100)"
+msgstr ""
+
+#: ../../24.04/4.md 19f008bbc10d4468aff5d8380aee2d44
+msgid "Meta package for Stella Morina"
+msgstr ""
+
+#: ../../24.04/4.md 0a4da0fb80894016a88c03191eca3bb5
+msgid "oem-stella-sensei-meta"
+msgstr ""
+
+#: ../../24.04/4.md fff661573017412cb44061cf88c6b383
+msgid "[2089101](https://bugs.launchpad.net/bugs/2089101)"
+msgstr ""
+
+#: ../../24.04/4.md ad711167ebe54aefa788f4019a416124
+msgid "Meta package for Stella Sensei"
+msgstr ""
+
+#: ../../24.04/4.md dd0ffc5f539a43319c0a1e4558a48181
+msgid "oem-stella-sharmee-meta"
+msgstr ""
+
+#: ../../24.04/4.md d3a56ba76e4446c5a18386dcc868c5b2
+msgid "[2092160](https://bugs.launchpad.net/bugs/2092160)"
+msgstr ""
+
+#: ../../24.04/4.md f2a888a49a0c42efa9ddab754aa53da2
+msgid "Meta package for Stella Sharmee"
+msgstr ""
+
+#: ../../24.04/4.md 9a9a90d7dd414112ac0e80ddb9df4a1a
+msgid "oem-stella-spiana-meta"
+msgstr ""
+
+#: ../../24.04/4.md c2d0aa2f449140c788b50bec6c299ae6
+msgid "[2101012](https://bugs.launchpad.net/bugs/2101012)"
+msgstr ""
+
+#: ../../24.04/4.md fb5b0c91fd0f4a15b3a86528520ace9c
+msgid "Meta package for Stella Spiana"
+msgstr ""
+
+#: ../../24.04/4.md 41fab922a6c84f03a198d708208fd603
+msgid "oem-stella-temujin-meta"
+msgstr ""
+
+#: ../../24.04/4.md a5b378f54b5b430c967f1fe11b8b7b6e
+msgid "[2092786](https://bugs.launchpad.net/bugs/2092786)"
+msgstr ""
+
+#: ../../24.04/4.md 6acaa121ab0d4d458d6196a3bb612ccd
+msgid "Meta package for Stella Temujin"
+msgstr ""
+
+#: ../../24.04/4.md 071c792eec1f4184a96777460898feb1
+msgid "oem-stella-tamako-meta"
+msgstr ""
+
+#: ../../24.04/4.md 5f44ffc2ec854e2681f00c0a508df01b
+msgid "[2102193](https://bugs.launchpad.net/bugs/2102193)"
+msgstr ""
+
+#: ../../24.04/4.md 38edbf1213ef48319abbc1f883f56591
+msgid "Meta package for Stella Tamako"
+msgstr ""
+
+#: ../../24.04/4.md bab628c44f934db3b10a86b29ce11262
+msgid "oem-stella-tragis-meta"
+msgstr ""
+
+#: ../../24.04/4.md 5934614348ed485bae70ca8fec2aaa04
+msgid "[2101013](https://bugs.launchpad.net/bugs/2101013)"
+msgstr ""
+
+#: ../../24.04/4.md 197b00ae236943c38771c97893f5e19c
+msgid "Meta package for Stella Tragis"
+msgstr ""
+
+#: ../../24.04/4.md 426b1ca1390443c1ab50e7da771068a5
+msgid "wireless-regdb"
+msgstr ""
+
+#: ../../24.04/4.md bce584e3413042af8ee53ed0d4eef8a5
+msgid "[2119591](https://bugs.launchpad.net/bugs/2119591)"
+msgstr ""
+
+#: ../../24.04/4.md cf7a82f0c7994a6296f39a6b50a6dc45
+msgid "[2129985](https://bugs.launchpad.net/bugs/2129985)"
+msgstr ""
+
+#: ../../24.04/4.md 666746dc2458486d8e8f2cb426da5b4b
+msgid "noble/linux-oem-6.17: 6.17.0-1006.6 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md c21e67b76cb14b7ebe6ba8e17f9818f2
+msgid "[2116169](https://bugs.launchpad.net/bugs/2116169)"
+msgstr ""
+
+#: ../../24.04/4.md da7035230d4042f690b44a13bf16ea89
+msgid "Support Intel Scorpius Peak, Whale Peak WiFi/Bluetooth"
+msgstr ""
+
+#: ../../24.04/4.md b8a2d4c93d164808beed0525cafec778
+msgid "[2127833](https://bugs.launchpad.net/bugs/2127833)"
+msgstr ""
+
+#: ../../24.04/4.md e4ae6606c1e444d89eb82f9d4d59750d
+msgid "Add support for  WNC WWAN OMAR-H R15 5G module"
+msgstr ""
+
+#: ../../24.04/4.md 111d89a325844c3086d090ecb129f00d
+#: 43a1b197181442cb980ca7fc6a392a54 577d72b38c3041e1aac89c8d7dac4645
+msgid "[2128695](https://bugs.launchpad.net/bugs/2128695)"
+msgstr ""
+
+#: ../../24.04/4.md 5915178fe9b04a7c8f78b75c2b8804ee
+#: 8d7460d9b3bf48728a08161639419275 939b7e8dfeb34ee3820397b970872f1b
+msgid "questing/linux: 6.17.0-7.7 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 5422db2b96bc4f60a80e34c2f4436d27
+#: 75fe61e9bf5c4fceabb14fe27c887b69 ec3195f23203497aad7e230bf456f725
+msgid "[2106681](https://bugs.launchpad.net/bugs/2106681)"
+msgstr ""
+
+#: ../../24.04/4.md 0cdf5f907f6840a2bb804ec0e2489ab8
+#: 89afbdffdd424f0fb9ebafc9466bae95 e1d0368c47584ac59f66ca6351fe1f4e
+msgid ""
+"Plucky preinstalled server fails to boot on rb3gen2: // Questing "
+"preinstalled server fails to boot on sa8775p boards"
+msgstr ""
+
+#: ../../24.04/4.md c1fb369dd51e4e558d2b0389ebeeba1d
+#: fa22427ea93b4a12abd79c119477ea6d faa5640dcfb7477091ab381e21825f5d
+msgid "[2121347](https://bugs.launchpad.net/bugs/2121347)"
+msgstr ""
+
+#: ../../24.04/4.md 23d621dce28d4741a64b68c2fccd1135
+#: 3916e78bc0d64fddb68bfe9dc17ab08a 41c63e18d29340dc966297796e5379b1
+msgid "Plucky preinstalled server fails to boot on rb3gen2"
+msgstr ""
+
+#: ../../24.04/4.md 3bfe7acb2b13444d91cadfa5b61e4f5e
+msgid "linux-gcp-6.17"
+msgstr ""
+
+#: ../../24.04/4.md f9114cf5055a4c4cbbb19def0517cb4b
+msgid "[2131275](https://bugs.launchpad.net/bugs/2131275)"
+msgstr ""
+
+#: ../../24.04/4.md dce9ff3600ba4b83a190435943fc0397
+msgid "noble/linux-gcp-6.17: 6.17.0-1004.4~24.04.3 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 9f12d139be4145fd970dc5221c759deb
+msgid "linux-signed-gcp-6.17"
+msgstr ""
+
+#: ../../24.04/4.md 0e2a9f762fd34e819f036363ff78e6c6
+#: 107e7e13fbce44ab9e3d7318e93922a5 22713e88c79d429e970da338b62b7aa2
+#: 2816fa1cd3cf4f83b14881fbc38ada32 2cab515c72b64940956c22d58828d367
+#: 43bb52513a0041049637406839998d3c 615cfdf7075f4302b62efc657f52d91f
+#: 61b546ee38f746e6af201db0c25b9f96 74c3a329a00f41f5bb8e7cccb8480bfb
+#: 7d6eea184b9e47db923788eb842b4372 9d821cbf02644c7d9950014c90509403
+#: abd04f51295640e380410cc7c0524b76 c74584edf69c4f3c9896baf0cabedb01
+#: e8440d64b73542778e3472c453b03f20 ef70ecaa8a424fa4a08cb640460c812c
+msgid "linux-nvidia-6.17"
+msgstr ""
+
+#: ../../24.04/4.md 346af7762fb948e9914dfd804de36798
+msgid "[2131581](https://bugs.launchpad.net/bugs/2131581)"
+msgstr ""
+
+#: ../../24.04/4.md f8590a74f5144ead945c527d774b6df6
+msgid "noble/linux-nvidia-6.17: 6.17.0-1003.3 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 0d3d81c9c18b413997c24387808d2c18
+#: 665483f7783747018cac7bd2548ca80f a952d093d51544ac812e1ae16c4579cf
+#: df3bd65d4b7f414caed13d45477be0f2
+msgid "[2131154](https://bugs.launchpad.net/bugs/2131154)"
+msgstr ""
+
+#: ../../24.04/4.md 2ad30a2d7d6b437a8fc420b9c09e4f78
+#: 6dfbb9f5ad534c0f9d716fd77f1fe705 b9a0a491fe3d404bb0f7f40a7f141765
+#: bb884bd7e95847c3adb245794847c7e0
+msgid "kexec reports it cannot determine the file type of arm64 kernel images"
+msgstr ""
+
+#: ../../24.04/4.md 67833e7e884e48bdb458bb130ab899cd
+msgid "[2130289](https://bugs.launchpad.net/bugs/2130289)"
+msgstr ""
+
+#: ../../24.04/4.md 4b2c2624db654d85a6617a64df273cdb
+msgid "KVM initialization hitting exception at boot time with kernel 6.17"
+msgstr ""
+
+#: ../../24.04/4.md d564a45c4423465da15d8430a7eb5863
+msgid "[2131047](https://bugs.launchpad.net/bugs/2131047)"
+msgstr ""
+
+#: ../../24.04/4.md b6045263388d4b66b87d280fd21b1855
+msgid "Backport arm64: cpufeature: Add Olympus MIDR to BBML2 allow list"
+msgstr ""
+
+#: ../../24.04/4.md 94e3f836a0a2414aa960b497f5bffe57
+msgid "[2127212](https://bugs.launchpad.net/bugs/2127212)"
+msgstr ""
+
+#: ../../24.04/4.md 833e16b6dcb34a29bc9182854eb34037
+msgid "noble/linux-nvidia-6.17: 6.17.0-1001.1 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md e58763e1c97d4152a9f49a828ddc0be5
+msgid "[2061930](https://bugs.launchpad.net/bugs/2061930)"
+msgstr ""
+
+#: ../../24.04/4.md a28c39d59b624eef9943019c68beb6b6
+msgid ""
+"linux-nvidia-6.5_6.5.0-1014.14 breaks with earlier BIOS release, and "
+"modeset/resolutions are wrong: // Blocklist coresight_etm4x"
+msgstr ""
+
+#: ../../24.04/4.md b9302015e9364a01b8083656d3bf15c7
+msgid "[2060327](https://bugs.launchpad.net/bugs/2060327)"
+msgstr ""
+
+#: ../../24.04/4.md 6a03bc98d0d643d99fdb50c37d757b29
+msgid ""
+"Reapply the linux-nvidia kernel config options from the 5.15 and 6.5 "
+"kernels"
+msgstr ""
+
+#: ../../24.04/4.md 47f4911c640f43c8b9235857bb8f5bb7
+#: 93853fbe77ae4ea0a5cd7a2b6aa706ea 9eb6873335bf45b0aecbb52e40c15839
+msgid "linux-meta"
+msgstr ""
+
+#: ../../24.04/4.md d98530e209e243b4be6e0840578e3fed
+#: ec759b0d72984a188c0dc0743532ae5c f2638da77a5f48cd9ed0016bdc9e4055
+msgid "[2128721](https://bugs.launchpad.net/bugs/2128721)"
+msgstr ""
+
+#: ../../24.04/4.md 4297200eddcf4a6f9154717d97cf3769
+#: 762c7288224a4fe2b3e5cb7cef6d719e 77f3aef0272c46ecaf9c6819da06074d
+msgid "missing transitionals for intel-iotg kernels"
+msgstr ""
+
+#: ../../24.04/4.md 4db624cd42fb4d2cb2cd2088096ea7e8
+msgid "[2134520](https://bugs.launchpad.net/bugs/2134520)"
+msgstr ""
+
+#: ../../24.04/4.md 496904f4d91c406ea02a72023bf22f5e
+msgid "noble/linux-oem-6.14: 6.14.0-1018.18 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md a8b4c06fe8a94c40bddb05ad36127d4d
+#: f402f9efded6495c8fa4b0bbc3cd7936
+msgid "[2134491](https://bugs.launchpad.net/bugs/2134491)"
+msgstr ""
+
+#: ../../24.04/4.md 45cb429bf1ee4402b4205cdcbe68832e
+#: c62c71ceeee345b4b7007c9057f21f06
+msgid "Export CWSR size to userspace"
+msgstr ""
+
+#: ../../24.04/4.md 96618542b00943468bfd85e37368b9f5
+#: b8517bd6b8234ee99801ebdc4c585648
+msgid "[2134488](https://bugs.launchpad.net/bugs/2134488)"
+msgstr ""
+
+#: ../../24.04/4.md 0667a1b4a10f47e6857b312f292cdcb2
+#: fbaf74d3bb9945b8928e91acf02e859f
+msgid "Seamless boot doesn't work on Strix or Strix Halo"
+msgstr ""
+
+#: ../../24.04/4.md 0a6dbdb20d7845a481b0bb1713c722bf
+#: 8546d595b1a84841a501b7246b19f81a
+msgid "[2133922](https://bugs.launchpad.net/bugs/2133922)"
+msgstr ""
+
+#: ../../24.04/4.md 4a9be8d81f7a4f6b9fbad095c39f56d1
+#: 94ca13eef0c84428ab4fd202bad37629
+msgid "Fix speaker mute and mic mute leds on more HP 200 G2a platforms"
+msgstr ""
+
+#: ../../24.04/4.md 2f6c38d42a1a4efb85290e2d186fa5f5
+#: c3ef8019ae1e4ce18f7d93be508907b4
+msgid "[2133144](https://bugs.launchpad.net/bugs/2133144)"
+msgstr ""
+
+#: ../../24.04/4.md 7919cdb3f1fc4ed696a99b0b0f62bcd2
+#: 83776805b2f543b2a0576492bb15ff37
+msgid "Enable RTL ASPM for more new Dell platforms"
+msgstr ""
+
+#: ../../24.04/4.md 26d0afc6096a4f1280fa21b5bf2c0bb3
+#: 5705cc8ff6214d53bf03294e17442f9f
+msgid "[2133143](https://bugs.launchpad.net/bugs/2133143)"
+msgstr ""
+
+#: ../../24.04/4.md ab2fc3f9ac314dd695fe97165932bf48
+#: fd2a8660eec54278a9c839a9709550a1
+msgid "Could not output video from type-c to VGA adapter"
+msgstr ""
+
+#: ../../24.04/4.md 32257a7325fd40b7bcb22f08f5124c38
+msgid "[2134511](https://bugs.launchpad.net/bugs/2134511)"
+msgstr ""
+
+#: ../../24.04/4.md c44513ce191a41d7925996d639e6ee14
+msgid "noble/linux-oem-6.17: 6.17.0-1008.8 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md f8afb82a7c0c44698d25a14f3f1f42f2
+msgid "[2133476](https://bugs.launchpad.net/bugs/2133476)"
+msgstr ""
+
+#: ../../24.04/4.md f20264607dc6439b969d9a07f4180a2a
+msgid "Fix speaker mute and mic mute leds on new HP ZBook platforms"
+msgstr ""
+
+#: ../../24.04/4.md 62746708d609496db9bf5dfd76414549
+#: ae112b6f40654334bf7c41e5cf643259 ccde239683484988b2857ca89ce73a40
+msgid "[2129682](https://bugs.launchpad.net/bugs/2129682)"
+msgstr ""
+
+#: ../../24.04/4.md 066f9df2f5f4403a88075951caeeceb5
+#: 39b61792185e4247a44ce97025b124c1 adf5e48047d94e1486e95c2009246011
+msgid "Fix dependencies between packages"
+msgstr ""
+
+#: ../../24.04/4.md 7fedea73f3e740b5b7c860ea476fe22e
+msgid "[2127969](https://bugs.launchpad.net/bugs/2127969)"
+msgstr ""
+
+#: ../../24.04/4.md b39c1b8f01ca4ac4af16acffd0e73039
+msgid "[SRU] Upgrade Intel xe GUC to v70.49.4 for Intel Panther Lake"
+msgstr ""
+
+#: ../../24.04/4.md bee00fc4a977483c966a301a25d8eccd
+msgid "[2130381](https://bugs.launchpad.net/bugs/2130381)"
+msgstr ""
+
+#: ../../24.04/4.md 8910cb38ac9248018689a57074f11be6
+msgid "[SRU][R/Q/N] mt7925: Support 802.11d and CQM events for roaming"
+msgstr ""
+
+#: ../../24.04/4.md 3f9e517cc74e4c77a2a1a18a09d08c20
+msgid "[2131725](https://bugs.launchpad.net/bugs/2131725)"
+msgstr ""
+
+#: ../../24.04/4.md 36b5539a232b4fb0a3301794cb9d445a
+msgid ""
+"Support for Cirrus Logic audio solution CS42L43 with amplifiers  on new "
+"Dell PTL platform"
+msgstr ""
+
+#: ../../24.04/4.md d0534e96135d43bfb912ad7817ddf122
+msgid "[2133664](https://bugs.launchpad.net/bugs/2133664)"
+msgstr ""
+
+#: ../../24.04/4.md 67132c3bd28847e0b298927f78678bbb
+msgid "Add TI tas2781 support for HP platforms"
+msgstr ""
+
+#: ../../24.04/4.md 7eabe8f0837a418e93177be844bed898
+msgid "[2131936](https://bugs.launchpad.net/bugs/2131936)"
+msgstr ""
+
+#: ../../24.04/4.md fc0248f2256042659fb8983b8ee32e04
+msgid "Update aic100 fw for power issues"
+msgstr ""
+
+#: ../../24.04/4.md 66204d5051f241499feec95545f87313
+msgid "[2133787](https://bugs.launchpad.net/bugs/2133787)"
+msgstr ""
+
+#: ../../24.04/4.md 62e61ee804514d3daf6ae3e96e6fc556
+msgid "Support Qualcomm RB4 graphics firmware"
+msgstr ""
+
+#: ../../24.04/4.md 384b12d558424e218605d6a9947f681a
+msgid "[2133923](https://bugs.launchpad.net/bugs/2133923)"
+msgstr ""
+
+#: ../../24.04/4.md e495b8d5eac1447c89becd851b9883a0
+msgid "Linux-firmware: Add qualcomm serial engine firmware qupv3fw.elf"
+msgstr ""
+
+#: ../../24.04/4.md fbd54c22e3e440d99e5b98c860752535
+msgid "[2136790](https://bugs.launchpad.net/bugs/2136790)"
+msgstr ""
+
+#: ../../24.04/4.md 0cf847742ce14481a0dc3753b74ccf5d
+msgid "noble/linux-oem-6.14: 6.14.0-1019.19 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 2a3ee1b410e6425da702eb04625443fd
+msgid "alsa-ucm-conf"
+msgstr ""
+
+#: ../../24.04/4.md c26aea7da2f84051821f68f80e3ba6c7
+msgid "[2126737](https://bugs.launchpad.net/bugs/2126737)"
+msgstr ""
+
+#: ../../24.04/4.md 9d7fec38737c4cdd9795cd326b73451e
+msgid ""
+"Fix missing audio support for MediaTek Genio EVK platforms: by creating "
+"the following patches based on upstream commits:"
+msgstr ""
+
+#: ../../24.04/4.md 77818a4f27e5424abd0508ceb6f71475
+msgid "[2136788](https://bugs.launchpad.net/bugs/2136788)"
+msgstr ""
+
+#: ../../24.04/4.md ab518f4cabba41bb856461db86de5ac0
+msgid "noble/linux-oem-6.17: 6.17.0-1009.9 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 0023ace1f29c44a5bb681d8f0b79f577
+msgid "[2134584](https://bugs.launchpad.net/bugs/2134584)"
+msgstr ""
+
+#: ../../24.04/4.md 441e01701b104296a0ad350686a4d754
+msgid "[SRU] Fix system crash of intel ice ethernet on E810"
+msgstr ""
+
+#: ../../24.04/4.md 22ffc3a175d34a2a98320f796d0b7849
+msgid "[2133482](https://bugs.launchpad.net/bugs/2133482)"
+msgstr ""
+
+#: ../../24.04/4.md 44fb59ed3ad5424189284f96124426b9
+msgid "Enable wireless protocol 802.11d for MTK WiFi mt7925"
+msgstr ""
+
+#: ../../24.04/4.md b058298cebba4ea38a820c23d5a37844
+msgid "linux-aws-6.17"
+msgstr ""
+
+#: ../../24.04/4.md 2049bc0248fc42be80118b15d6e82f25
+msgid "thermald"
+msgstr ""
+
+#: ../../24.04/4.md 72598948cc0942e6949800e0caff7e9a
+msgid "[2122576](https://bugs.launchpad.net/bugs/2122576)"
+msgstr ""
+
+#: ../../24.04/4.md 227e909f9527410bbf52820be3b5198f
+msgid "Add support for Intel Panther Lake platforms"
+msgstr ""
+
+#: ../../24.04/4.md bda205ac5d794246934a7b30bd43fb2e
+msgid "b43-fwcutter"
+msgstr ""
+
+#: ../../24.04/4.md 9ac776e7a84047328c53088ab50a15ef
+msgid "[2138509](https://bugs.launchpad.net/bugs/2138509)"
+msgstr ""
+
+#: ../../24.04/4.md 972934ee452b47ddb8123b305b0d4d4e
+msgid "debian/firmware-b43-installer.postinst: Fix download url to github"
+msgstr ""
+
+#: ../../24.04/4.md f0d343909da3494f963d5e4a397fd3f3
+msgid "nvidia-graphics-drivers-535"
+msgstr ""
+
+#: ../../24.04/4.md 5800d7f963d44a73a90f53ac59c34b30
+#: 70548afc6e994143b37516e80d4c3b06
+msgid "[2138271](https://bugs.launchpad.net/bugs/2138271)"
+msgstr ""
+
+#: ../../24.04/4.md 5829a66538a345fbb92fb1490dfbf172
+msgid "New upstream release 535.288.01"
+msgstr ""
+
+#: ../../24.04/4.md 25de51c33dee48e9820a6f5401e52066
+#: 69664987d4004795bd485c949d198026
+msgid "[2137576](https://bugs.launchpad.net/bugs/2137576)"
+msgstr ""
+
+#: ../../24.04/4.md 791b4483cfdd434f8e73565702c8a741
+msgid "New upstream release 570.211.01 UDA"
+msgstr ""
+
+#: ../../24.04/4.md 43ebbb0c7cdd48968c611f99dfb55604
+#: d6ecd2af606441629982740b214ad743
+msgid "[2138245](https://bugs.launchpad.net/bugs/2138245)"
+msgstr ""
+
+#: ../../24.04/4.md 00d53d38ab884d3a872a0a8add20a615
+msgid "New upstream release 580.126.09"
+msgstr ""
+
+#: ../../24.04/4.md dedd58643c614d2a89842a5b7a6d2ffc
+msgid "New upstream release 535.288.01 ERD17"
+msgstr ""
+
+#: ../../24.04/4.md 0e0d029e7f7945c68e8c7771b349706b
+msgid "New upstream release 570.211.01 ERD"
+msgstr ""
+
+#: ../../24.04/4.md ce2ef97d61bb4632a216b09bb69bc023
+msgid "New upstream release 580.126.09 ERD5"
+msgstr ""
+
+#: ../../24.04/4.md b22957025fa34cab99e881870e640664
+msgid "nvidia-graphics-drivers-590"
+msgstr ""
+
+#: ../../24.04/4.md 97c1f13adf2949169bd32c3b7bf8a724
+#: bad5387295114cc9994b9ff373db5af5
+msgid "[2137575](https://bugs.launchpad.net/bugs/2137575)"
+msgstr ""
+
+#: ../../24.04/4.md 0abccef67287443487d5f6291254d606
+#: ce1524d2978f4ab1b9efe91294bd1420
+msgid "New upstream release 590.48.01"
+msgstr ""
+
+#: ../../24.04/4.md 6f76b2929b2a44c98522f42e940172b3
+msgid "nvidia-graphics-drivers-590-server"
+msgstr ""
+
+#: ../../24.04/4.md dd88146adf91465ea9be63eed69d4e2f
+msgid "[2135079](https://bugs.launchpad.net/bugs/2135079)"
+msgstr ""
+
+#: ../../24.04/4.md 688603a2b35c47808613791223b48e08
+msgid "tas2781: Add more symbol links on SPI devices on HP platforms"
+msgstr ""
+
+#: ../../24.04/4.md 41aee629cd92449a804d66f454c3f4a3
+msgid "[2136743](https://bugs.launchpad.net/bugs/2136743)"
+msgstr ""
+
+#: ../../24.04/4.md ce72ee8864e94f799d96d022263fd891
+msgid "Update Intel IPU7 product signed firmware binary"
+msgstr ""
+
+#: ../../24.04/4.md e9dcdbbf5cd9489e8c77594d6ba06ba4
+msgid "[2136987](https://bugs.launchpad.net/bugs/2136987)"
+msgstr ""
+
+#: ../../24.04/4.md f2c6e9905333490a8ee5aa8c957b7bfe
+msgid "Firmware updates for Intel WIFI core98 software release"
+msgstr ""
+
+#: ../../24.04/4.md f86deaf885a14fdca85ca738fdfd695a
+msgid "[2136991](https://bugs.launchpad.net/bugs/2136991)"
+msgstr ""
+
+#: ../../24.04/4.md 7f550e5f3a24440695826c499e800f93
+msgid "Upgrade Intel xe GUC to v70.55.3 for Intel Panther Lake"
+msgstr ""
+
+#: ../../24.04/4.md 4240cf091b0941d988444f6d4ecd9c98
+msgid "[2137522](https://bugs.launchpad.net/bugs/2137522)"
+msgstr ""
+
+#: ../../24.04/4.md 3eff0349c16f4e12aceade1c06a1c0bd
+msgid "[SRU] iwlwifi: add new fw versions to satisfy 6.17 kernel requirement"
+msgstr ""
+
+#: ../../24.04/4.md 819bbae9b4b843a39259d41243fd6e70
+msgid "[2137181](https://bugs.launchpad.net/bugs/2137181)"
+msgstr ""
+
+#: ../../24.04/4.md fc17d51aaa8e40ceb76af19ce63b34b6
+msgid "Update last Intel VPU fw support for Jammy"
+msgstr ""
+
+#: ../../24.04/4.md 01ea6816eb61440ab72c24d988991c8c
+msgid "[2136894](https://bugs.launchpad.net/bugs/2136894)"
+msgstr ""
+
+#: ../../24.04/4.md 870182f0253f4affb4c14bd82d636b6b
+msgid ""
+"[SRU][R/Q/N] mt7925: Fix invalid reporting of support for EMLSR on MLO "
+"link and add support for Indonesia 6GHz"
+msgstr ""
+
+#: ../../24.04/4.md 2b70c70bac8f44c4bbf5e535a2f3f295
+msgid "[2128240](https://bugs.launchpad.net/bugs/2128240)"
+msgstr ""
+
+#: ../../24.04/4.md c5a76abe926b49f1889ddf7989cefab4
+msgid "Missing firmware for Intel NPU for Intel Panther Lake"
+msgstr ""
+
+#: ../../24.04/4.md 12fbae6b2c5a46cf8a9525b8fba3bbe9
+#: 1a9d72ab53ff428f95fc2f2430ef356c 1c8406d2e9cd45d1b60d09d0d8cc051c
+#: 32e6085d79c34e5ba992d96d0d0cb54c 334fd2f328484d98957c5afedb4eb4ac
+#: 3f8848feb4134536a96d640371569b19 4064915a7a3b4625983905979abb9526
+#: 461c49074a48419a8b757fc683066fa3 4cdaae3876e449c2bee694c936414c70
+#: 553cde7456604a069762b4cfb7431027 588b9cca27a94fb1a3283f69e0f6d414
+#: 5d400fe300be456ea9d3f2977141a4f8 67b519eb28494ef18bed79a61117317a
+#: 6f719c78f539430c9fbf1bee47e25f67 700d7a7756424daebff336f864ac697a
+#: 7af8332d8cdd47ec8209d1e39102fe4d 8e2496fbba3b4796aea032d033727171
+#: 96cfeac3c9be4384afb56e85dd6c3daa 9f569eff82c94780acc3a67d5be40605
+#: abe4f5b08a2b40f5bec96bc44bce9d8c acb0e9e450e74a05935529e8e8149112
+#: afb50edb176141f9924faea84e98c70c b0276b383fb245e2a9bc94785b58c5a0
+#: b44147b5298a4ed094f897494b31a42c d018bf7ef8fc43fea51d1e0de980d094
+#: d2685514fc014dc2b189f7ca13a96c2e e44c2f8635484de7815d87bb76c29888
+#: f05c0a64823e416fa9f90554e1dae02d f6e1763d4d7e4e7f8830a77575d3d910
+#: fe168b950cee4ccca68986e3831bc459
+msgid "linux-oracle-6.17"
+msgstr ""
+
+#: ../../24.04/4.md 4806ece2cbe34092a1793ab6a5c7f06c
+msgid "[2133191](https://bugs.launchpad.net/bugs/2133191)"
+msgstr ""
+
+#: ../../24.04/4.md aa3f9f106e5847209aa81530a893529c
+msgid "noble/linux-oracle-6.17: 6.17.0-1004.4~24.04.2 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 4ddf4e871bd342c2814e9c7b4d1677ce
+msgid "[2126043](https://bugs.launchpad.net/bugs/2126043)"
+msgstr ""
+
+#: ../../24.04/4.md 09889a994d3c4cfca7116012e163a8da
+msgid "questing/linux-oracle: 6.17.0-1003.3 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md e743d0c2f2f549f080c97f005689425d
+msgid "[2125323](https://bugs.launchpad.net/bugs/2125323)"
+msgstr ""
+
+#: ../../24.04/4.md cae5cb3037e24331a6e4ad4d66dc7629
+msgid "questing/linux-oracle: 6.17.0-1002.2 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 1173d063f36c4b72b2c89abe3ae03641
+msgid "[2125319](https://bugs.launchpad.net/bugs/2125319)"
+msgstr ""
+
+#: ../../24.04/4.md b2f911c8eba446b19bdfb77480d791e3
+msgid "questing/linux: 6.17.0-5.5 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 29fb529d8501488cbb8c6fdb9898859e
+msgid "[2122310](https://bugs.launchpad.net/bugs/2122310)"
+msgstr ""
+
+#: ../../24.04/4.md e908ed1810c54e7d8f4e3f101284ee21
+msgid ""
+"[SRU] Failed to create source package: Unmet build dependencies: "
+"bpftool:native"
+msgstr ""
+
+#: ../../24.04/4.md 1379f565d9e04df2aa248b088df8031f
+msgid "[2124257](https://bugs.launchpad.net/bugs/2124257)"
+msgstr ""
+
+#: ../../24.04/4.md f6dc6567fc434543b952246a792a0eae
+msgid ""
+"iproute2 breaking netplan DEP-8 tests in Questing, unexpected \"fan-map\""
+" in JSON output"
+msgstr ""
+
+#: ../../24.04/4.md 0220fd6f751b49959b5f4b5b6eacf7d8
+msgid "[2110092](https://bugs.launchpad.net/bugs/2110092)"
+msgstr ""
+
+#: ../../24.04/4.md a4f19085ee544deab3f087fbbac74828
+msgid "Support AMD Image Signal Processing (ISP) unit V4.0"
+msgstr ""
+
+#: ../../24.04/4.md 6cb23de4bd3f42c1bca76917ad75200d
+msgid "[2121477](https://bugs.launchpad.net/bugs/2121477)"
+msgstr ""
+
+#: ../../24.04/4.md 8d6055f00bd240419bc06b76418f391f
+msgid "25.10 Snapdragon X Elite: Sync concept kernel changes"
+msgstr ""
+
+#: ../../24.04/4.md 6c3dabf0b9ca404296925d4747b38efc
+msgid "[2122647](https://bugs.launchpad.net/bugs/2122647)"
+msgstr ""
+
+#: ../../24.04/4.md f745a52ec3674633b3eaebdade957cd6
+msgid "questing/linux-oracle: 6.17.0-1001.1 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 9ea509d39325482fa8dfdcadeaf9323e
+msgid "[2122321](https://bugs.launchpad.net/bugs/2122321)"
+msgstr ""
+
+#: ../../24.04/4.md 404dde4b61a74674b10394905859caff
+msgid "questing/linux: 6.17.0-4.4 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md c244d4cf2ae744bfb4ab8438be953857
+msgid "[2115758](https://bugs.launchpad.net/bugs/2115758)"
+msgstr ""
+
+#: ../../24.04/4.md 414c2ec25fc3481b973ec24e5e314e55
+msgid ""
+"initramfs-tools: autopkgtest fails on arm64 with Possible missing "
+"firmware /lib/firmware/apple/dfrmtfw-*.bin for built-in driver apple_z2"
+msgstr ""
+
+#: ../../24.04/4.md 4087ccfffb09483798058c85dedf0d31
+msgid "[2121873](https://bugs.launchpad.net/bugs/2121873)"
+msgstr ""
+
+#: ../../24.04/4.md 31b14ae356dc4b09ac48c39b658f1f85
+msgid "Support TDX host in questing"
+msgstr ""
+
+#: ../../24.04/4.md b9ff88dc5bab4a538ad614216b2ac61e
+msgid "[2121512](https://bugs.launchpad.net/bugs/2121512)"
+msgstr ""
+
+#: ../../24.04/4.md 81806b95ae504759bcb938bf306d7628
+msgid "questing/linux: 6.17.0-3.3 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 635a970e9e3b4f1980d0c059f6b10199
+msgid "Plucky/Questing fails to boot on (older) Macs"
+msgstr ""
+
+#: ../../24.04/4.md f294bb3ec3c04362b001dac8928be957
+msgid "[2121374](https://bugs.launchpad.net/bugs/2121374)"
+msgstr ""
+
+#: ../../24.04/4.md 4792e48c4d3d4601a05df606731c84ec
+msgid "questing/linux: 6.17.0-2.2 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 5ad4add124334b08a7d8599ff63c518f
+msgid "[2116138](https://bugs.launchpad.net/bugs/2116138)"
+msgstr ""
+
+#: ../../24.04/4.md 13994fac26cb494587e5492a6ce777fd
+msgid "enable Mediatek media platform drivers on arm64"
+msgstr ""
+
+#: ../../24.04/4.md 6d95b443c8f44d9f89080846ca03083d
+#: de8d119599304a26bc9d064df97d5f4e
+msgid "[2028253](https://bugs.launchpad.net/bugs/2028253)"
+msgstr ""
+
+#: ../../24.04/4.md 4d4c69647e2e49699ae4619267374c7c
+#: 53ecbe17d9e24ccd8bb7dca785a2c44e
+msgid "update apparmor and LSM stacking patch set"
+msgstr ""
+
+#: ../../24.04/4.md 07073ce79f6548e89d9e8a426f34f47e
+msgid "[2102680](https://bugs.launchpad.net/bugs/2102680)"
+msgstr ""
+
+#: ../../24.04/4.md aa2e482623724fa3b96f1b824b7e4969
+msgid ""
+"Installation of AppArmor on a 6.14 kernel produces error message "
+"\"Illegal number: yes\""
+msgstr ""
+
+#: ../../24.04/4.md b0019eca673c4b05ae0d8fce48569f0c
+msgid ""
+"update apparmor and LSM stacking patch set: // [FFe] "
+"apparmor-4.0.0-alpha2 for unprivileged user namespace restrictions in "
+"mantic"
+msgstr ""
+
+#: ../../24.04/4.md 9a8d1e7282904f42b5bb3815182beba8
+msgid "[2032602](https://bugs.launchpad.net/bugs/2032602)"
+msgstr ""
+
+#: ../../24.04/4.md 3568aed4471246638686fa1c5bec49fc
+msgid "[2121054](https://bugs.launchpad.net/bugs/2121054)"
+msgstr ""
+
+#: ../../24.04/4.md 3fdc08f516894e59abd852d60383a1ec
+msgid "questing/linux-unstable: 6.17.0-1.1 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md bbbbcf189883450eb14d09a33841198b
+msgid "[1728366](https://bugs.launchpad.net/bugs/1728366)"
+msgstr ""
+
+#: ../../24.04/4.md 081f8eb2205f41ffaf4c167cbecc96af
+msgid "Enable CONFIG_IPV6_OPTIMISTIC_DAD"
+msgstr ""
+
+#: ../../24.04/4.md 08562c3cc3ef45ba965c9a0b49f59f06
+msgid "[2138288](https://bugs.launchpad.net/bugs/2138288)"
+msgstr ""
+
+#: ../../24.04/4.md 6e6018d3e4d2467c81759670ba1336bb
+msgid "noble/linux-oem-6.14: 6.14.0-1020.20 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 327ef46b10fb4fd2b5ee91680f756472
+msgid "oem-somerville-remoraid-meta"
+msgstr ""
+
+#: ../../24.04/4.md e953cf69ae1c473285619201c75367d7
+msgid "[2089548](https://bugs.launchpad.net/bugs/2089548)"
+msgstr ""
+
+#: ../../24.04/4.md 69db6806c1a64a03b552cee6c52cd607
+msgid "Meta package for Somerville Remoraid"
+msgstr ""
+
+#: ../../24.04/4.md bf5293db5e394704ad02f1bd33563e0c
+msgid "crash"
+msgstr ""
+
+#: ../../24.04/4.md 4fea2fa8adac4e63882b29586f38f228
+msgid "[2125145](https://bugs.launchpad.net/bugs/2125145)"
+msgstr ""
+
+#: ../../24.04/4.md 7c2dbe1c27a446679f903524dcc329cf
+msgid "Enable crash to open coredumps generated on 6.14 HWE kernels"
+msgstr ""
+
+#: ../../24.04/4.md 125eab8a0c4c4a8a912f8b730d00a97d
+#: 1c0be6310c734ed0a72b53dfcac4489d
+msgid "linux-hwe-6.17"
+msgstr ""
+
+#: ../../24.04/4.md ff8a817bcf8e49ebaab4c1f78faad6b0
+msgid "[2132312](https://bugs.launchpad.net/bugs/2132312)"
+msgstr ""
+
+#: ../../24.04/4.md 4f80de09639445edb7608335ddb6501a
+msgid "noble/linux-hwe-6.17: 6.17.0-9.9~24.04.2 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 07967e367f3f4e6cbe0500731cadd30b
+#: 725c4514bdc34e2f91f6c87f2d917194
+msgid "linux-riscv-6.17"
+msgstr ""
+
+#: ../../24.04/4.md ad6c51491c5d43e4bc7851fe98156864
+msgid "[2137844](https://bugs.launchpad.net/bugs/2137844)"
+msgstr ""
+
+#: ../../24.04/4.md 3ee520a49d1b4da0b67f0d1f536a4109
+msgid "noble/linux-riscv-6.17: 6.17.0-14.14.1~24.04.1 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 7d0ffb2e9aec4836b6999f24cb0e37de
+msgid "[2013232](https://bugs.launchpad.net/bugs/2013232)"
+msgstr ""
+
+#: ../../24.04/4.md b32d165d52b144bfa87744cddc54f42f
+msgid "Enable StarFive VisionFive 2 board"
+msgstr ""
+
+#: ../../24.04/4.md 05462f2b10314d53ad11fd898cb601f9
+#: 16c5318a00024ed8a8b586d98ce63ddf
+msgid "[2138307](https://bugs.launchpad.net/bugs/2138307)"
+msgstr ""
+
+#: ../../24.04/4.md 18d9719c71164da7a9bfe8f870598604
+#: 9eff73a772ea49c892a165f72485d9c9
+msgid "noble/linux: 6.8.0-100.100 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md c51251cacc4049e48e0aeebfd1ead031
+#: ee7278fbbdb14f809ec18a08219aff07
+msgid "[2122531](https://bugs.launchpad.net/bugs/2122531)"
+msgstr ""
+
+#: ../../24.04/4.md dbe4e995dd3d4fb7a89fc2124b9920de
+#: fabe1599235044958011e8ad9b0067db
+msgid "Turbo boost stuck disabled on Clevo PD5x_7xSNC_SND_SNE"
+msgstr ""
+
+#: ../../24.04/4.md 5c0a52d2f4234a9a8919e6dc14059301
+#: c7316a6f69db4b10b249d8ac4698ba9b
+msgid "[2138244](https://bugs.launchpad.net/bugs/2138244)"
+msgstr ""
+
+#: ../../24.04/4.md 2cfd98bce7bb442fba486f0bcf974439
+#: 888e3356832a4da69931a14badd8bb1c
+msgid "[noble] write-sealed memfd mappings fail to map read-only"
+msgstr ""
+
+#: ../../24.04/4.md 1fe1c2f7225440948275562421cdb93c
+#: b522e37e3f954bce8995ca6fc0646f70
+msgid "[2137901](https://bugs.launchpad.net/bugs/2137901)"
+msgstr ""
+
+#: ../../24.04/4.md 9fa4bbecb33644b096f643bcb6d50f04
+#: a7fa6df6fb474a449bc17329f832bb70
+msgid "noble/linux: 6.8.0-98.98 -proposed tracker"
+msgstr ""
+
+#: ../../24.04/4.md 18187588db554f128ebbf1b88c3081d7
+#: c12dc8fdeff04bdabc80f193171fa4a5
+msgid "[2137528](https://bugs.launchpad.net/bugs/2137528)"
+msgstr ""
+
+#: ../../24.04/4.md 80f7868d6ef64e79af9be461b998affa
+#: 89c0a420b51142b4bdac805605e37df4
+msgid "TPM timeouts occur on some Infineon TPMs"
+msgstr ""
+
+#: ../../24.04/4.md 04912fb4789045d4996f1a05d178ecf1
+#: dd97cbaca3394efeac5d381eb913232b
+msgid "[2130244](https://bugs.launchpad.net/bugs/2130244)"
+msgstr ""
+
+#: ../../24.04/4.md a85f27b1b45d4ee784e71b8b3025b740
+#: c9f9318266534c2d9e7773e34a37a4fa
+msgid "power: intel_pstate: Fix unchecked MSR"
+msgstr ""
+
+#: ../../24.04/4.md 352f3248d94d44cbae9e4c376f997a2a
+#: d91965b40455447fa9606ee79da646db
+msgid "[2131265](https://bugs.launchpad.net/bugs/2131265)"
+msgstr ""
+
+#: ../../24.04/4.md b6ce4cd0a88e4c0e9a098df7033e3189
+#: f5dff4c76dea4f8f866f992626c02875
+msgid "[SRU] ixgbe: Add support for E610 in Noble"
+msgstr ""
+
+#: ../../24.04/4.md 3811e0c84c7540cfa1aeb31daf38071d
+#: 5c3677f3b63c4e55a49faac6dbc80a10
+msgid "[2135716](https://bugs.launchpad.net/bugs/2135716)"
+msgstr ""
+
+#: ../../24.04/4.md 02321e8a8853400eb390c4276534ba5b
+#: fd59a68fcf3243a6a29b15725e511de8
+msgid "Enabling crypto selftests causes boot stall on 6.8"
+msgstr ""
+
+#: ../../24.04/4.md 6eab76767f6d4ec28e045ffb8843028d
+#: a2bc847e5d344fdda0a5cacefb24c51a
+msgid "[2135261](https://bugs.launchpad.net/bugs/2135261)"
+msgstr ""
+
+#: ../../24.04/4.md ab47e03318284740a53667e86e6a752f
+#: f5d7f4a2b23d4e4bba49dfbc8affeb37
+msgid "Noble update: upstream stable patchset 2025-12-12"
+msgstr ""
+
+#: ../../24.04/4.md 63bd7d6770694588938d176bc3f59246
+#: 6892ec9a655b42069776d3a2bfcd740a
+msgid "[1928890](https://bugs.launchpad.net/bugs/1928890)"
+msgstr ""
+
+#: ../../24.04/4.md 4c3013d2126b46b6a7d53dcc4fb31f19
+#: 55c0f8f150a94dcfa2a77d8c2c430fbf
+msgid ""
+"vrf_route_leaking.sh in net from ubuntu_kernel_selftests linux ADT test "
+"failure with linux/5.11.0-18.19 (Ping received ICMP Packet too big)"
+msgstr ""
+
+#: ../../24.04/4.md 3533dddb83f44f69ad5f131b2bc5b0e0
+#: 93ff8b47fc014d2a896a0ab49ec0fe01
+msgid "[2112357](https://bugs.launchpad.net/bugs/2112357)"
+msgstr ""
+
+#: ../../24.04/4.md 97707721ea63407d9fe9a9f39ceaaa11
+#: ec31e21ba58648cbb2e5f1aa4606d69d
+msgid ""
+"ubuntu_bpf failed to build on Noble ( error: ‘struct prog_test_def’ has "
+"no member named ‘should_tmon’)"
+msgstr ""
+
+#: ../../24.04/4.md 9204fa113de342ce96cf577ca603948c
+#: e87f97406de04b83a4e86cdb8ac9648d
+msgid "[2012859](https://bugs.launchpad.net/bugs/2012859)"
+msgstr ""
+
+#: ../../24.04/4.md 215a9ea69aa34502a2a81ea3ada011a9
+#: e96ce0dcf8664ecc8e96c4927038c02d
+msgid ""
+"fib_tests.sh in ubuntu_kernel_selftests failed with IPv4 mangling tests "
+"Connection check - server side"
+msgstr ""
+
+#: ../../24.04/4.md 5b0d37551fa44647b190324ba85369db
+#: 86b3ecbbec474576b07f8bd5226305bd
+msgid "[2031531](https://bugs.launchpad.net/bugs/2031531)"
+msgstr ""
+
+#: ../../24.04/4.md 8d3e65589ece4b9498132f13ca997f3c
+#: e45c85e658854b8fbf7d536e27ffaa99
+msgid ""
+"net:rtnetlink.sh in ubuntu_kernel_selftests failed with FAIL: address "
+"proto IPv4 / IPv6"
+msgstr ""
+
+#: ../../24.04/4.md a6f2b571a6dd49729c5ddc9ab6158d7b
+#: b310a0f0890244d1a7b384dd546af12f
+msgid "[2136740](https://bugs.launchpad.net/bugs/2136740)"
+msgstr ""
+
+#: ../../24.04/4.md 87ae265e60384a3884ab33d6b3994f39
+#: cb223798ca4040db9c39f335f8869dbb
+msgid "Noble update: upstream stable patchset 2025-12-17"
+msgstr ""
+
+#: ../../24.04/4.md 0e39c1d1b46740408561e4b06f7fe890
+#: 66825268a0574136988eccb7846cc0bd
+msgid "[2136361](https://bugs.launchpad.net/bugs/2136361)"
+msgstr ""
+
+#: ../../24.04/4.md 0abf8b3a06124f2d8ef14fca72c5f85f
+#: 2d4c60e86c484272b829a99fd4245e92
+msgid "Noble update: upstream stable patchset 2025-12-16"
+msgstr ""
+
+#: ../../24.04/4.md 27ceebb39f7c471e8bd468656bc4a400
+#: f5b330c15296401c9e5e30de07b27e59
+msgid "[2136221](https://bugs.launchpad.net/bugs/2136221)"
+msgstr ""
+
+#: ../../24.04/4.md 78c88c5cb86b4434a53ea6dc4d89403a
+#: 7bb7b4c35af642aea71906237670a5f8
+msgid "Noble update: upstream stable patchset 2025-12-15"
+msgstr ""
+
+#: ../../24.04/4.md 2524ebdf7a9f46b2a3d1545572054c26
+#: a297554f1316423a9a33c5c9cfe40a40
+msgid "[2134382](https://bugs.launchpad.net/bugs/2134382)"
+msgstr ""
+
+#: ../../24.04/4.md c8d9abf2413c42e1a1443ac2f843b785
+#: cb472d0d56134fb394aa09fc264841d7
+msgid "Noble update: upstream stable patchset 2025-12-08"
+msgstr ""
+
+#: ../../24.04/4.md 74d06276cfef419190e64a4ab427e8de
+#: 9bd5c46895ac416ea06026ec9b280d6b
+msgid "[2071861](https://bugs.launchpad.net/bugs/2071861)"
+msgstr ""
+
+#: ../../24.04/4.md 30f0ab0216564e4d8838b123c9faf9b3
+#: 8d4f350acdeb479485b9ba963596b4a0
+msgid "ftrace:test.d--event--subsystem-enable.tc fails on some instances"
+msgstr ""
+
+#: ../../24.04/4.md 764fe565827544c9800bb439d417b232
+#: 777f50d18364413c8ba2399e5c1831c0
+msgid "[2134640](https://bugs.launchpad.net/bugs/2134640)"
+msgstr ""
+
+#: ../../24.04/4.md 2e696e5dcb954a99b11816c051d7d12d
+#: a85731494f354bc5a44150c88b74f9c6
+msgid "Noble update: upstream stable patchset 2025-12-11"
+msgstr ""
+
+#: ../../24.04/4.md 8cd78bdef7c54099baf613b85ec95f57
+#: e1d3668402674ed383fad0c5628eac34
+msgid "[2134499](https://bugs.launchpad.net/bugs/2134499)"
+msgstr ""
+
+#: ../../24.04/4.md 1598e7c9026248348b5ea2aa9dda45ea
+#: a182643d1e5945cb804c25c7cd14f88c
+msgid "Noble update: upstream stable patchset 2025-12-09"
+msgstr ""
+
+#: ../../24.04/4.md 7886bf0e2ac543839b1c33de3906d5ab
+#: ca2eb1ebfa234e9b840f0558891e9415
+msgid "[2133786](https://bugs.launchpad.net/bugs/2133786)"
+msgstr ""
+
+#: ../../24.04/4.md 561f5a40cac9483ea85b4d9f7587c378
+#: ba8dd9e8d93e467ebfb9268ed0cf216c
+msgid "Noble update: upstream stable patchset 2025-12-03"
+msgstr ""
+
+#: ../../24.04/4.md 1192ce3602764ef099978a935bb5dd60
+#: 1debbf3febf94e35bd9c23675c3da5ba
+msgid "[2133301](https://bugs.launchpad.net/bugs/2133301)"
+msgstr ""
+
+#: ../../24.04/4.md 9059a8b6b7f44a57b56688432a8f2d72
+#: a5a5c5ac294b4faba3f34b4021d40041
+msgid "Noble update: upstream stable patchset 2025-11-28"
+msgstr ""
+
+#: ../../24.04/4.md 17a0b3cff37b45e0be776de2b5ef2b5a
+#: c9441177e51744b3bcc33dba98cfe516
+msgid "[2127971](https://bugs.launchpad.net/bugs/2127971)"
+msgstr ""
+
+#: ../../24.04/4.md 24d019828fee44f09976a31c06ea9b95
+#: 93a6118e21ed452a8df830de1e7f913c
+msgid ""
+"Ubuntu x86_64 6.8 kernels won't build if CONFIG_FB_HYPERV config option "
+"is enabled"
+msgstr ""
+
+#: ../../24.04/4.md 10391baf52594bf38c1279f93dc91832
+#: 6195fa133e7444e6b920330ade73bd2e
+msgid "[2130344](https://bugs.launchpad.net/bugs/2130344)"
+msgstr ""
+
+#: ../../24.04/4.md c0145f2e3e894f99bda69af213520c7a
+#: ec7b0bdf64d24479ab24b270fbf3e57d
+msgid "Noble update: upstream stable patchset 2025-10-30"
+msgstr ""
+
+#: ../../24.04/4.md 2062b9be25d84e4296b15ca422ea2dba
+#: 4e795eb92f7e4885b5d22503e8999e86
+msgid "[2129559](https://bugs.launchpad.net/bugs/2129559)"
+msgstr ""
+
+#: ../../24.04/4.md 204d446eda3d4c2d877b55146157a2d0
+#: 3008e62c9db548b0b5f7f9d12a15e8fe
+msgid "Noble update: upstream stable patchset 2025-10-22"
+msgstr ""
+
+#: ../../24.04/4.md 441118de9c0d4688b16187f2dcfb8fba
+msgid "linux-firmware-nvidia-tegra"
+msgstr ""
+
+#: ../../24.04/4.md 0c31a43fdbf24161a3b53b849d20a264
+msgid "[2127473](https://bugs.launchpad.net/bugs/2127473)"
+msgstr ""
+
+#: ../../24.04/4.md c12b06ea75e14376a275d7f549ed2bf2
+msgid "Add firmware files for Thor, notably display and bluetooth"
+msgstr ""
+
+#: ../../24.04/4.md 301331c4cadc4e019a1978e296b89230
+msgid "[2059814](https://bugs.launchpad.net/bugs/2059814)"
+msgstr ""
+
+#: ../../24.04/4.md de1d8e6348d4486c889007d23fc63813
+msgid "Enable GDS in the 6.8 based linux-nvidia kernel"
+msgstr ""
+
+#: ../../24.04/4.md cda530fdebcf4da2b1845d179fca4145
+msgid "[2138269](https://bugs.launchpad.net/bugs/2138269)"
+msgstr ""
+
+#: ../../24.04/4.md f86fd9318ef74f94a48ebc3133ebf133
+msgid "Add PCIe Hotplug Driver for CX7 on DGX Spark"
+msgstr ""
+
+#: ../../24.04/4.md:548 d16189fdd94047a2be7d756639d7d775
+msgid "Base platform fixes"
+msgstr ""
+
+#: ../../24.04/4.md:550 a9f8d93b8a49479b92cb57aa0cb9bad6
+msgid ""
+"These changes affect the core fundamental components of all the Ubuntu "
+"flavors."
+msgstr ""
+
+#: ../../24.04/4.md 043b5a3909e94a4ab209683a7aa161d8
+#: 377e3cd1039f41718d597ca8f551deb1 5efa133847324d4d86de4e6563ed2975
+#: 9ea45128f0ad414983412992bb4ff9e9
+msgid "dotnet8"
+msgstr ""
+
+#: ../../24.04/4.md 569fedcdefa14b4eba19d10a213b21ff
+msgid "[2119537](https://bugs.launchpad.net/bugs/2119537)"
+msgstr ""
+
+#: ../../24.04/4.md 1909c8693a8e47c7a2fbcd32063bddd3
+#: 63e3151e1fdb42b6b668a1a6f0d65511 7dda7968705444358526b117d8151e59
+#: 8535bd9350f448f19868abe0f9950d1b abdcaae3398c47d08e42961024ba99b8
+#: dc3e8b814150407dacfffc3a211b6592 fe036d2261a749738d79dd99ab51b3b5
+msgid "New upstream release"
+msgstr ""
+
+#: ../../24.04/4.md 4303ac6d3b32443b9c94b1d156e96991
+#: cc22c8072cad4df79667b21dc0ab6897
+msgid "malcontent"
+msgstr ""
+
+#: ../../24.04/4.md 8c6e3db1cac54903810b9da8bf13b9b4
+msgid "[2116954](https://bugs.launchpad.net/bugs/2116954)"
+msgstr ""
+
+#: ../../24.04/4.md 0010cf7f04c14c7eb8a316d2ea2440cf
+msgid "Fix wrong a11y role in button"
+msgstr ""
+
+#: ../../24.04/4.md 2c0fd767e146413f87a34eecb9cb81c0
+#: e203078408464f258ad7dc28f1c8890f
+msgid "powermgmt-base"
+msgstr ""
+
+#: ../../24.04/4.md 011fe80def15491d80194f1ef92b49a4
+#: e53a078d2ec04856ac798599e742d890
+msgid "[1980991](https://bugs.launchpad.net/bugs/1980991)"
+msgstr ""
+
+#: ../../24.04/4.md 08e929f326b242daa154dbdbefd1dbb0
+msgid ""
+"Fix on_ac_power incorrectly reporting AC state on some machines with USB "
+"type-C ports: ."
+msgstr ""
+
+#: ../../24.04/4.md 471e3044523440c2beeab32ff43bea3b
+msgid "on_ac_power: improve reporting of AC power status in more scenarios"
+msgstr ""
+
+#: ../../24.04/4.md c01702ec39664a178274089adb7a7e87
+msgid "tecla"
+msgstr ""
+
+#: ../../24.04/4.md e7d531113d04418eb7a8f6023103cc84
+msgid "[2116166](https://bugs.launchpad.net/bugs/2116166)"
+msgstr ""
+
+#: ../../24.04/4.md 65c551dfb961404ab2f2ad57f50f1015
+msgid ""
+"a11y: Add accessibility to the keyboard layout by using "
+"`gtk_accessible_announce()` to read the popup with the key combinations"
+msgstr ""
+
+#: ../../24.04/4.md 14d0ff9edb73493ca44616ffdf0f8f06
+msgid "screen-resolution-extra"
+msgstr ""
+
+#: ../../24.04/4.md 6397fae35f394d89a3c584fe89c7a19d
+msgid "[2090974](https://bugs.launchpad.net/bugs/2090974)"
+msgstr ""
+
+#: ../../24.04/4.md b4fb9c300fb445fea47e195a77c555ed
+msgid "Make nvidia-polkit executable"
+msgstr ""
+
+#: ../../24.04/4.md 0971a5c28b9348e1900e32b04111b841
+#: 1f460eb7fef3426094abde814db88860 2e6f3452a38b4f488fe959af445604d1
+#: 6013fdf75cd742ecbf878d2052015466 d0f22aa6595845f6bb9a2ef0f2b2d507
+#: f508272212c548deb636ea84f7e6adf2
+msgid "gtk4"
+msgstr ""
+
+#: ../../24.04/4.md 95c9403c5a85416380e416e0d867b6cb
+msgid "[2105946](https://bugs.launchpad.net/bugs/2105946)"
+msgstr ""
+
+#: ../../24.04/4.md 6aaf98e1ca7b43c4aa6218391324dfc7
+msgid ""
+"d/p/lp2105946-gtklistbase-Do-not-select-invalid-positions.patch: cherry-"
+"pick fix from upstream to fix a crash when pressing the arrow keys in an "
+"empty directory: ."
+msgstr ""
+
+#: ../../24.04/4.md 39633629b34244c18dbd1cee92816d7a
+#: b2449b08133744ee89c429908c4f7102
+msgid "xserver-xorg-video-vesa"
+msgstr ""
+
+#: ../../24.04/4.md e733a15bd72948eeb9f1a7a01b2c0765
+msgid "[2062159](https://bugs.launchpad.net/bugs/2062159)"
+msgstr ""
+
+#: ../../24.04/4.md bfcdd50304b1472c952db02382c4f072
+msgid ""
+"d/p/fix-implicit-declarations.patch: patching the file to fix FTBFS on "
+"multiple platforms: ."
+msgstr ""
+
+#: ../../24.04/4.md 79e11a26b46946918d157bfff7172fcb
+msgid "[2083867](https://bugs.launchpad.net/bugs/2083867)"
+msgstr ""
+
+#: ../../24.04/4.md 9c77bc650e0b4e00972f248bd57a1cbb
+msgid "Rebuild to pick-up debhelper frame-pointer flags: ."
+msgstr ""
+
+#: ../../24.04/4.md 9b3949ae59724b52b1c7053e2effb2ee
+#: db654bde4d00421daa882b54b0b9168a
+msgid "xserver-xorg-video-nouveau"
+msgstr ""
+
+#: ../../24.04/4.md 7435ce988b1a458085c07c4451a2f088
+msgid "[2062144](https://bugs.launchpad.net/bugs/2062144)"
+msgstr ""
+
+#: ../../24.04/4.md ad5e356a9cfa4d53bb84161705a5c956
+msgid ""
+"d/p/nouveau-fixup-driver-for-new-macro-gating.patch: fix implicit "
+"declarations: ."
+msgstr ""
+
+#: ../../24.04/4.md 20c1499796ea488086586f3b88b91130
+msgid "[2083855](https://bugs.launchpad.net/bugs/2083855)"
+msgstr ""
+
+#: ../../24.04/4.md 2a16bfdcaee24440a8f2f535dc707cd5
+msgid "Rebuild to pick-up frame-pointer flags: ."
+msgstr ""
+
+#: ../../24.04/4.md 6204a78245ff425a8ef85eb9c17cfafd
+#: 703ad2d574a5443cb441e03a14f433d8
+msgid "fwupd"
+msgstr ""
+
+#: ../../24.04/4.md 8fac1fd71b5f491fbb769acdda2cfd29
+msgid "[2116567](https://bugs.launchpad.net/bugs/2116567)"
+msgstr ""
+
+#: ../../24.04/4.md fc503c0f57404f66b1aabb52ee8941d2
+msgid "Add Dell SD25TB5 and AIO system MTK scalar IC firmware update"
+msgstr ""
+
+#: ../../24.04/4.md 2b5ddb315f254eccbd6602692f05bb79
+#: c61dc34fc2974f09985e7fae9a6e9359
+msgid "mesa"
+msgstr ""
+
+#: ../../24.04/4.md 2221a1fde140413b8efb3c654def64df
+msgid "[2111265](https://bugs.launchpad.net/bugs/2111265)"
+msgstr ""
+
+#: ../../24.04/4.md f29346a2363f49dbaeaaba5ef82379da
+msgid "Migrate to llvm-20"
+msgstr ""
+
+#: ../../24.04/4.md cf8260c60f074b2586d28f9813ae8db6
+msgid "coreutils"
+msgstr ""
+
+#: ../../24.04/4.md 3c137a111f3e42a2a88ee64298dac1fd
+msgid "[2115274](https://bugs.launchpad.net/bugs/2115274)"
+msgstr ""
+
+#: ../../24.04/4.md 6a818a86e82849478361758fd2bf635b
+msgid ""
+"Avoid returning permission denied errors when running ls -l when reading "
+"file attributes"
+msgstr ""
+
+#: ../../24.04/4.md 1dc28cba55d74fc38199c9d5787670af
+#: 695264deec114614a297ba6e60b7fde1 733d332339824c92b639148ccea5912d
+#: e1ddce6ee84a471ba32f9475385fe71d
+msgid "s390-tools"
+msgstr ""
+
+#: ../../24.04/4.md 2de1e8826c0d43ce8db359e543b99712
+#: 3e57f8a613784635829e53e4009c52f0 4b3b9be30873444a86fcd064ea227c42
+#: a6743f8cfe7a4f2a9789893830e3146f
+msgid "[2103414](https://bugs.launchpad.net/bugs/2103414)"
+msgstr ""
+
+#: ../../24.04/4.md ec18f555b781496a810d46686f7f06d1
+msgid ""
+"Add missing commit/patch d/p/lp-2103414-cpumf-lscpumf-Add-support-for-"
+"IBM-z17-counter-sets.patch that caused a failed verification of "
+"2.31.0-0ubuntu5.2: ."
+msgstr ""
+
+#: ../../24.04/4.md e3a8c4e11ee34e76afe6ff74fbad42c0
+msgid ""
+"Add d/p/lp-2103414-s390-tools-libutil-Add-machine-type-3932.patch and "
+"d/p/lp-2103414-libutil-Add-machine-type-definition-for-z17.patch to "
+"achieve support for IBM z17 (and z16 GA2) hw specific CPU-MF counters: ."
+msgstr ""
+
+#: ../../24.04/4.md 68861528feae4194aab8b19822f88821
+#: fe46abf8dda54342b311511ebdc74880
+msgid "[2078347](https://bugs.launchpad.net/bugs/2078347)"
+msgstr ""
+
+#: ../../24.04/4.md b077feb1004048feb486bc8e1ce3760d
+msgid ""
+"Add d/p/lp-2078347-udev-Introduce-rule-to-set-newly-hotplugged-CPUs.patch"
+" that fixes CPUs from staying offline: ."
+msgstr ""
+
+#: ../../24.04/4.md 6000918e06274ef7bfdbf23081c3cf8f
+#: 88efaeb3a7444e908500baf25629f4f7 9c822e16dff348a3932a8ae8f5465abe
+msgid "[2044104](https://bugs.launchpad.net/bugs/2044104)"
+msgstr ""
+
+#: ../../24.04/4.md 6408ee68f0cb4351b30df0c53ba29bb6
+msgid ""
+"Add d/p/lp-2044104-zdev-option-to-identify-files-created-by-zdev.patch to"
+" avoid rebuild initramfs by chzdev -e if zdev:early=0 set: ."
+msgstr ""
+
+#: ../../24.04/4.md 346d1531328a4149b7e4e2183d23cbec
+#: 466ed94daa7545098c60287d24819469 926e7578eefa41c5a612f4dac711edb8
+#: fd239035d5f54e56af1e448a4ef965cc
+msgid "s390-tools-signed"
+msgstr ""
+
+#: ../../24.04/4.md 1c58f25d8a134f2eb116ddd0ed67240d
+msgid "Rebuild against 2.31.0-0ubuntu5.3"
+msgstr ""
+
+#: ../../24.04/4.md 64c5a17005304a40a5abefa439ac4019
+#: b9473593641c46d3969de89d7448afcd ccd03ede2f53486d9ef050e858d67534
+msgid "Rebuild against 2.31.0-0ubuntu5.2"
+msgstr ""
+
+#: ../../24.04/4.md 4a2d949bad40402ea8bdd948410743a3
+#: cdaea1e3617a49908493782ce60bdfa2
+msgid "systemd-hwe"
+msgstr ""
+
+#: ../../24.04/4.md b0859e35cc4544a6bcc9d233d708e9a8
+msgid "[2121006](https://bugs.launchpad.net/bugs/2121006)"
+msgstr ""
+
+#: ../../24.04/4.md f680d92e188248aea76713d19db21428
+msgid "Fix hardware name for Intel Wireless-AC 9560 on Jasper Lake"
+msgstr ""
+
+#: ../../24.04/4.md d9197441f4d64d66a4a3c02050c385c0
+msgid "dconf"
+msgstr ""
+
+#: ../../24.04/4.md f291a0031bd8485983cf5cf2e5ca12d9
+msgid "[2072586](https://bugs.launchpad.net/bugs/2072586)"
+msgstr ""
+
+#: ../../24.04/4.md f6d1b4dab08343a7becb1e27dfc3a7b3
+msgid ""
+"Restore permissions on database write to prevent restrictive umask from "
+"rendering the db inaccessible"
+msgstr ""
+
+#: ../../24.04/4.md 122e5a75965a4fd4a530979b881216b8
+#: 5f470cafaa7446fb8a2ed6a52e4b9d55 7068b1b623eb492f9213976fde5b8c37
+#: 95065ede856b459e9a5fa194df4cd6ce
+msgid "landscape-client"
+msgstr ""
+
+#: ../../24.04/4.md 86295072a894487a8d5d4a3b7a1b0369
+#: ff7a4db1dd7c4ddf8a016d169eb531d2
+msgid "[2087852](https://bugs.launchpad.net/bugs/2087852)"
+msgstr ""
+
+#: ../../24.04/4.md a8389532551241db868efc13dec80924
+msgid ""
+"d/p/fix-apt-source-file-management.patch: restore .list and .sources "
+"files when a repo profile is disassociated"
+msgstr ""
+
+#: ../../24.04/4.md 92d9e64bb45944c68483c997aac37dae
+msgid "[2099283](https://bugs.launchpad.net/bugs/2099283)"
+msgstr ""
+
+#: ../../24.04/4.md 185c20a75ad84bee82525a25396a419f
+msgid ""
+"d/p/package-reporter-high-cpu.patch: backport fix to reduce CPU usage of "
+"package-reporter by avoiding creating Origin objects from the Python apt "
+"package"
+msgstr ""
+
+#: ../../24.04/4.md 7cd18489e83249939a7b8f024416d734
+msgid ""
+"d/p/2087852-feat-manage-ubuntu-sources-glob.patch: include DEB822 "
+"formatted sources when managing apt sources by regex matching .sources "
+"files"
+msgstr ""
+
+#: ../../24.04/4.md 3941a0dbf6ea4679a62f99bc67a537c0
+msgid "dpkg"
+msgstr ""
+
+#: ../../24.04/4.md 5f1414b681ec4a13915f7c075f71c0aa
+msgid "[2082636](https://bugs.launchpad.net/bugs/2082636)"
+msgstr ""
+
+#: ../../24.04/4.md 4aabd2fb62734d9e840d58408aad5204
+msgid "Add RUSTFLAGS to define frame pointers for Rust toolchain: ."
+msgstr ""
+
+#: ../../24.04/4.md e20c21a8026c435e93a7f9bd50acbb12
+msgid "lftp"
+msgstr ""
+
+#: ../../24.04/4.md 7ffc002e6b2a4a7396a8fbe9822b09c6
+msgid "[2091440](https://bugs.launchpad.net/bugs/2091440)"
+msgstr ""
+
+#: ../../24.04/4.md c19e030cee6e4f569c90bb1dff3f0332
+msgid "d/p/cd-zVM-segfault-fix.patch: fix segfault on z/VM cd"
+msgstr ""
+
+#: ../../24.04/4.md cd7bb7a93fe54ba7a104e6a0fcb73202
+msgid "[2122356](https://bugs.launchpad.net/bugs/2122356)"
+msgstr ""
+
+#: ../../24.04/4.md 0b48a661682b44339a1d4fd82afd3784
+#: 820aa82f68584b93b4f7d7851fc8483f f52f1786aa51444ebd9204f6872f5f45
+msgid "network-manager"
+msgstr ""
+
+#: ../../24.04/4.md 07fd413589d94c4e8c5f93d0a489b22d
+msgid "[2116940](https://bugs.launchpad.net/bugs/2116940)"
+msgstr ""
+
+#: ../../24.04/4.md 591134a1be0242acb739efa13922a566
+msgid "fix nmcli that could not report 6ghz wifi channels correctly"
+msgstr ""
+
+#: ../../24.04/4.md a6b31ef98bd64dbb8f41e1c02a22d267
+msgid "wpa"
+msgstr ""
+
+#: ../../24.04/4.md 71ef17623eb9489ca4a09ccfb829b8ef
+msgid "[2117180](https://bugs.launchpad.net/bugs/2117180)"
+msgstr ""
+
+#: ../../24.04/4.md b4ce4b201ec441acb6c9bcd3d5a7cf41
+msgid "Bump DEFAULT_BSS_MAX_COUNT to 1000"
+msgstr ""
+
+#: ../../24.04/4.md 0d97a1399f7447229daa35f90fd23e1a
+#: 2693a37109db4b3aa9ee6338ebcb47bd 52d2293d2731493a8e0b33ea5a39f0eb
+#: 55ab9e7c33f84227a2e112961ff11984 598e09c5d66b44d3a3344ee613e4428d
+#: 64ee21c6be834c05b60a167ecfe30a5f 65ed20748b5545158e564e2e3d0aa237
+#: 6ab190b95c0b407ca3799487d2dbb2e2 6c12badad81a498aaac8408db010ebe0
+#: 6e74336a356149caaf7398afabd4b9ed 74f7674d50524a529d90742ce8b6697d
+#: 87a77f1fb9a642ca9e40418d6c35bcf4 8ce1ba9069b54cf0a47129d80709d71f
+#: 94658550e6944b6e869da63d44d88d00 97ef6305257840e8829ee754f7597c7e
+#: 9bea3eb017ba44368966f4c67922a516 a0fd0ca698a94f29b654fe1287ede551
+#: a5eed0e46bf84ebabfc12571207b1c1e a8584f07139a4c5c8428b2fd2c686ce8
+#: ab079989f56240b3b46abb26d947ee7b ab44ac30335f414a853b8d317462f57c
+#: aee4bf4644334379b914556af52ea65d b2239cc54faa4b6a9e7c69b2f1768651
+#: bf06b4a1738f4f919eafe39efd67537d c8311ad59f074300920736da7b015f19
+#: cf6628c098da488d82b44fede4e3b84a d2e893e65bc640fd82b3764dd081c921
+#: d90195e9e504407e92752a0f9741f4f5 d91fe34c434b4daf9ac2ca329dfcd9ad
+#: f814ac14d08b498d8b80ca540e97a67c
+msgid "snapd"
+msgstr ""
+
+#: ../../24.04/4.md f8f2e830f45b4fd589b567ea84c68aa0
+msgid "[2118396](https://bugs.launchpad.net/bugs/2118396)"
+msgstr ""
+
+#: ../../24.04/4.md c157ca781dc6467db4d992e5736d7579
+msgid "[2114923](https://bugs.launchpad.net/bugs/2114923)"
+msgstr ""
+
+#: ../../24.04/4.md b5ef16540bad4c778ff644aef6997fa7
+msgid ""
+"snap-confine: add support for host policy for limiting users able to run "
+"snaps: Reject system key mismatch advise when not yet seeded"
+msgstr ""
+
+#: ../../24.04/4.md 8c47ae47105e4f34a276bf5d1d57f115
+msgid "[2112551](https://bugs.launchpad.net/bugs/2112551)"
+msgstr ""
+
+#: ../../24.04/4.md fbcfe0ca754a4c518d7bbaca58a65ce6
+msgid ""
+"Fix bug preventing remodel from core18 to core18 when snapd snap is "
+"unchanged: Make removal of last active revision of a snap equal to snap "
+"remove"
+msgstr ""
+
+#: ../../24.04/4.md 1d7b76788fc944d79831b8c05c874f01
+msgid "[2114779](https://bugs.launchpad.net/bugs/2114779)"
+msgstr ""
+
+#: ../../24.04/4.md 10c4b28cf61c45e4b3c6b3b689614fd8
+msgid ""
+"Fix bug preventing remodel from core18 to core18 when snapd snap is "
+"unchanged: Allow non-gpt in fallback mode to support RPi"
+msgstr ""
+
+#: ../../24.04/4.md 75620e7294494755a926728cb8de5c31
+msgid "[2112544](https://bugs.launchpad.net/bugs/2112544)"
+msgstr ""
+
+#: ../../24.04/4.md a99583c5e8644c4eb27d9131b0dcd4b6
+msgid ""
+"Switch from using core to snapd snap for snap debug connectivity: Fix "
+"offline remodel case where we switched to a channel without an actual "
+"refresh"
+msgstr ""
+
+#: ../../24.04/4.md da61b1e354634c7e8c89eaa561554a1e
+msgid "[2112332](https://bugs.launchpad.net/bugs/2112332)"
+msgstr ""
+
+#: ../../24.04/4.md 32c934f322a74b32a658b07637255f89
+msgid ""
+"Switch from using core to snapd snap for snap debug connectivity: Exclude"
+" snap/snapd/preseeding when generating preseed tarball"
+msgstr ""
+
+#: ../../24.04/4.md f6e5217796514029b79c073235eafa26
+msgid "[1952500](https://bugs.launchpad.net/bugs/1952500)"
+msgstr ""
+
+#: ../../24.04/4.md 6a6871a930534f139a74076d3d313ec1
+msgid ""
+"Switch from using core to snapd snap for snap debug connectivity: Fix "
+"snap command progress reporting"
+msgstr ""
+
+#: ../../24.04/4.md f6f98da8f6a148b6bb51e47eec0b1973
+msgid "[1849346](https://bugs.launchpad.net/bugs/1849346)"
+msgstr ""
+
+#: ../../24.04/4.md 237d597852d44d3a890ff65c6fe581e4
+msgid ""
+"Switch from using core to snapd snap for snap debug connectivity: "
+"Interfaces: kerberos-tickets"
+msgstr ""
+
+#: ../../24.04/4.md 3cfeb65c32cd4a8fb0005ba9000ca242
+msgid "[2098780](https://bugs.launchpad.net/bugs/2098780)"
+msgstr ""
+
+#: ../../24.04/4.md 83945955725e47e6bb9d39c1b1cd227c
+msgid "Interfaces: posix-mq"
+msgstr ""
+
+#: ../../24.04/4.md 7deb32ccc1164a75ae5038ea83cef0cc
+msgid "[2033883](https://bugs.launchpad.net/bugs/2033883)"
+msgstr ""
+
+#: ../../24.04/4.md 27c66d15d3384f6487d39be154bcac84
+msgid "Interfaces: block-devices"
+msgstr ""
+
+#: ../../24.04/4.md e02fd63d7993437e93e3bc482cdd0bc9
+msgid "[2107443](https://bugs.launchpad.net/bugs/2107443)"
+msgstr ""
+
+#: ../../24.04/4.md fac4ec385cce40b39ce1775497abd5f8
+msgid ""
+"Fix a regression during seeding when using early-config: reset SHELL to "
+"/bin/bash in non-classic snaps"
+msgstr ""
+
+#: ../../24.04/4.md 86e61e3f74ba40cd9a9fabe90fd55cb7
+msgid "[2104066](https://bugs.launchpad.net/bugs/2104066)"
+msgstr ""
+
+#: ../../24.04/4.md 4745d99e86c54d42a92b84c2dac1b075
+msgid ""
+"Fix potential validation set deadlock due to bases waiting on snaps: Only"
+" cancel notices requests on stop/shutdown"
+msgstr ""
+
+#: ../../24.04/4.md fc73be5e02fa4f31bf029318d9f105aa
+msgid "[2102456](https://bugs.launchpad.net/bugs/2102456)"
+msgstr ""
+
+#: ../../24.04/4.md a16a7e30c86b43b89b51c3348021ae99
+msgid ""
+"Modify snap-confine AppArmor template to allow all glibc HWCAPS "
+"subdirectories to prevent launch errors: update secboot to bf2f40ea35c4 "
+"and modify snap- bootstrap to remove usage of go templates to reduce size"
+" by 4MB"
+msgstr ""
+
+#: ../../24.04/4.md 85267efb403e45ee9286319f300a5e0a
+msgid "[2106121](https://bugs.launchpad.net/bugs/2106121)"
+msgstr ""
+
+#: ../../24.04/4.md cc55d581290c42bba205c35cf0540379
+msgid ""
+"Fix snap-bootstrap to mount kernel snap from /sysroot/writable/system-"
+"data: fix snap-bootstrap busy loop"
+msgstr ""
+
+#: ../../24.04/4.md 4513b9894ebc4f7f9c98332a1f4b6fcc
+msgid "[2088456](https://bugs.launchpad.net/bugs/2088456)"
+msgstr ""
+
+#: ../../24.04/4.md b2363d082014413499e5699693584bdc
+msgid "Interfaces: opengl"
+msgstr ""
+
+#: ../../24.04/4.md 0a3c7cf9ac8b4aad87dadbc38ff4e4f1
+#: 26990dd8e03c4ac1b7f89cd0bad02467 2dc7801454ce42b1be2ea013d40ffa0f
+#: 4e6c1fe76d864196a1d35a66e3ff9265 79656025d1a1434691b8a2cbc9daa2d9
+#: 8708780f954f443ab9d38b20eeb14dff b8a16d1a48a64a2f9561067dcc58b91f
+#: bbc4a49decc04df7a74291913a6f63cb d4883903056349eaa58e66ed7ac26ec7
+msgid "systemd"
+msgstr ""
+
+#: ../../24.04/4.md d0e1315ab73f4e32b3bcee5db62c3728
+msgid "[2112237](https://bugs.launchpad.net/bugs/2112237)"
+msgstr ""
+
+#: ../../24.04/4.md 94d54f2b1b93497b9783c0fd00963b48
+msgid "initramfs-tools: copy hwdb.bin to initramfs"
+msgstr ""
+
+#: ../../24.04/4.md 3fc4f51d9e534e45a581260ddf2b6e11
+msgid "[2115263](https://bugs.launchpad.net/bugs/2115263)"
+msgstr ""
+
+#: ../../24.04/4.md 3f54c3c978d6446e89968804781fcee5
+msgid "d/t/`tests-in-lxd`: drop patching workaround"
+msgstr ""
+
+#: ../../24.04/4.md 6c5b8d9d59e6482ba92de0a17a473aa9
+msgid ""
+"initramfs-tools: filter out zdev rules in the initramfs hook: Backport "
+"the logic from plucky onward, but adjust the version string for noble."
+msgstr ""
+
+#: ../../24.04/4.md 8de3d25d98f5417893dda9fd4db2e7a7
+msgid "[2115391](https://bugs.launchpad.net/bugs/2115391)"
+msgstr ""
+
+#: ../../24.04/4.md f81cc19432ad4c17b9ced8d060497169
+msgid ""
+"pcrlock: handle measurement logs where hash algs in header. Fix pcrlock "
+"log to function correctly reading the TPM eventlog on hyper-v VMs"
+msgstr ""
+
+#: ../../24.04/4.md 34eaf3c1af804bed9e5a6a40f8fadcdd
+msgid "[2115418](https://bugs.launchpad.net/bugs/2115418)"
+msgstr ""
+
+#: ../../24.04/4.md a8f5b421430d49b387295ab12f462dcd
+msgid ""
+"network/dhcp6: consider the DHCPv6 protocol as finished when conflict "
+"addresses exist"
+msgstr ""
+
+#: ../../24.04/4.md 42da1e5fa2bc46a1b41b813518b156c2
+msgid "[2110585](https://bugs.launchpad.net/bugs/2110585)"
+msgstr ""
+
+#: ../../24.04/4.md ff1fd7eab50a4d79829616a34a0b2d79
+msgid "Drop support for using actual brightness"
+msgstr ""
+
+#: ../../24.04/4.md 216da79c80394d6b893fb0ea3f3638ea
+msgid "tcpdump"
+msgstr ""
+
+#: ../../24.04/4.md d176398c0d674812b3b4db3ea9fde6ff
+msgid "[2071891](https://bugs.launchpad.net/bugs/2071891)"
+msgstr ""
+
+#: ../../24.04/4.md 9dc37d5fa21245748582ee2068169b22
+msgid "Fixes segfault when running as the root user"
+msgstr ""
+
+#: ../../24.04/4.md 6079ec3307b64b5ca01121ccc9189685
+msgid "[2126468](https://bugs.launchpad.net/bugs/2126468)"
+msgstr ""
+
+#: ../../24.04/4.md 0bb3cc3192bb40cfaeff0ec005a8b224
+msgid "hwdb: enable autosuspend for Dell DW5826e WWAN modem"
+msgstr ""
+
+#: ../../24.04/4.md a9c2af12def44e11a1dbb8f8a84d95fe
+msgid "libgtop2"
+msgstr ""
+
+#: ../../24.04/4.md 2439d7971e1047cd828d270efbfeea60
+msgid "[2116763](https://bugs.launchpad.net/bugs/2116763)"
+msgstr ""
+
+#: ../../24.04/4.md 7284a46eda9b4b61ae77fc624c81aefc
+msgid "Expand fields with data from lscpu"
+msgstr ""
+
+#: ../../24.04/4.md f8ed143630a54e8c878de50e96170cdf
+msgid "distro-info-data"
+msgstr ""
+
+#: ../../24.04/4.md 37dfd18412e64b41937da18b468add23
+msgid "[2126961](https://bugs.launchpad.net/bugs/2126961)"
+msgstr ""
+
+#: ../../24.04/4.md 84bd332e40694e4686c54c366fad8f0d
+msgid "Add Ubuntu 26.04 LTS \"Resolute Raccoon\""
+msgstr ""
+
+#: ../../24.04/4.md 9c73b5a0bfa94859a5981520653bcea5
+msgid "nullboot"
+msgstr ""
+
+#: ../../24.04/4.md 77278bd5df294396b37fc540d019045f
+msgid "[2110302](https://bugs.launchpad.net/bugs/2110302)"
+msgstr ""
+
+#: ../../24.04/4.md 5ec164b09240464f8d5f356f5760f5d0
+msgid "New upstream release 0.5.3"
+msgstr ""
+
+#: ../../24.04/4.md c1bfd6e87d7b422fb4bbc40083ccfb77
+msgid "sosreport"
+msgstr ""
+
+#: ../../24.04/4.md 05e18dbbfad145aba6ab0950cf5f5671
+msgid "[2114840](https://bugs.launchpad.net/bugs/2114840)"
+msgstr ""
+
+#: ../../24.04/4.md 82f6821fe5e94a85ab86cf7d35e9a23e
+msgid "New 4.9.2 upstream release"
+msgstr ""
+
+#: ../../24.04/4.md d526ec062e06475ea13a0ca4f6d7fd1a
+msgid "lintian"
+msgstr ""
+
+#: ../../24.04/4.md d56be8e94d814a1396d3fe8260947d67
+msgid "[2127769](https://bugs.launchpad.net/bugs/2127769)"
+msgstr ""
+
+#: ../../24.04/4.md e2264aaaca3c49249b2113e7c2b2c5bc
+msgid "Add 'resolute' to known distro series"
+msgstr ""
+
+#: ../../24.04/4.md 846db53a34f44e84a1345d75e64e5cc2
+msgid "[2124239](https://bugs.launchpad.net/bugs/2124239)"
+msgstr ""
+
+#: ../../24.04/4.md 03286b48822c42e192b553d9d07f6d0c
+msgid "[2122054](https://bugs.launchpad.net/bugs/2122054)"
+msgstr ""
+
+#: ../../24.04/4.md 92d161b55c1a4e80bbf1d6e25f0e965a
+msgid ""
+"Packaging: modify Makefile.am to fix out-of-tree use of 'make hack': Snap"
+" installation: skip snap icon download when running in a cloud or using a"
+" proxy store"
+msgstr ""
+
+#: ../../24.04/4.md 5365144d819a4f1db4ebaf7a0462d815
+msgid "[2117558](https://bugs.launchpad.net/bugs/2117558)"
+msgstr ""
+
+#: ../../24.04/4.md 4085dd90914c41069bb36db3d1daeaf7
+msgid ""
+"Snap installation: use http(s) proxy for icon downloads: snap-confine: "
+"fix error message with /root/snap not accessible"
+msgstr ""
+
+#: ../../24.04/4.md 1ab95f7141e348968f5c19d908f391b1
+msgid "[1916244](https://bugs.launchpad.net/bugs/1916244)"
+msgstr ""
+
+#: ../../24.04/4.md 5e7fe695e0134eefae0390fd4d919bc5
+msgid "core-initrd: remove debian folder: Interfaces: gpio-chardev"
+msgstr ""
+
+#: ../../24.04/4.md ddea3fbde43948e69ad09b3f1aedcbcb
+msgid "[2121238](https://bugs.launchpad.net/bugs/2121238)"
+msgstr ""
+
+#: ../../24.04/4.md 7914eea1c9ba4636ac1521d2d0686e8d
+msgid "Interfaces: content"
+msgstr ""
+
+#: ../../24.04/4.md c12ad97f263d4e09a22d8348071c2370
+msgid "[2117121](https://bugs.launchpad.net/bugs/2117121)"
+msgstr ""
+
+#: ../../24.04/4.md 43ff095f5e7846e3badc6b4a5971cca5
+msgid ""
+"Unhide 'snap help' sign and export-key under Development category: "
+"Cleanly support socket activation for classic snap"
+msgstr ""
+
+#: ../../24.04/4.md 7fa6e587b2d641268a8da3e55f134eaa
+msgid "[2112626](https://bugs.launchpad.net/bugs/2112626)"
+msgstr ""
+
+#: ../../24.04/4.md 09564578de39437bb39cc68ac43034d1
+msgid ""
+"Support 'snap debug api' queries to user session agents: Improve progress"
+" reporting for snap install/refresh"
+msgstr ""
+
+#: ../../24.04/4.md 54dbf26a467646008ca6f654df9819ab
+msgid "[2114704](https://bugs.launchpad.net/bugs/2114704)"
+msgstr ""
+
+#: ../../24.04/4.md d06c79e508904e0fa9bc3dc48b1d77fa
+msgid ""
+"Fix /v2/apps error for root user when user services are present: Extend "
+"output to indicate when snap data snapshot was created during remove"
+msgstr ""
+
+#: ../../24.04/4.md c528d31a3b1e45c9b5c72a4055bc36b2
+msgid "python3-defaults"
+msgstr ""
+
+#: ../../24.04/4.md df487bd26db1416a90897fc830c44463
+msgid "[2127093](https://bugs.launchpad.net/bugs/2127093)"
+msgstr ""
+
+#: ../../24.04/4.md 5aef274a4b524d2e8c93796965e426b9
+msgid "No-change rebuild into -security to fix dep issues"
+msgstr ""
+
+#: ../../24.04/4.md e7ba5b74cc754dd4ad490d2e66b3af81
+msgid "[2128350](https://bugs.launchpad.net/bugs/2128350)"
+msgstr ""
+
+#: ../../24.04/4.md 512a9ccd02da481d9bd2466168599ddf
+msgid "d/p: Fix filtering snaps after snapd 2.72"
+msgstr ""
+
+#: ../../24.04/4.md 2ece634fc04e483198e2a682f33ea8df
+#: 607d586bba8e43829b75eb407387bf3b
+msgid "libdrm"
+msgstr ""
+
+#: ../../24.04/4.md 5a82ff6668e04629a025b58b10e09b8d
+msgid "[2127944](https://bugs.launchpad.net/bugs/2127944)"
+msgstr ""
+
+#: ../../24.04/4.md 188c3140def4470da603664245c488c2
+msgid "patches: Identify APUs from hardware"
+msgstr ""
+
+#: ../../24.04/4.md 01f5fbf177c84aacb70fab4b411dda83
+#: 7ba009f760b14d5882df7614cf48ab1e
+msgid "packagekit"
+msgstr ""
+
+#: ../../24.04/4.md d4660e9ea84f43f493416e1a0d9ad55f
+#: fa5e82f7b74548d491ba44eb3f4a8445
+msgid "[2060730](https://bugs.launchpad.net/bugs/2060730)"
+msgstr ""
+
+#: ../../24.04/4.md 4330bbbfa0c54e6bb8352d94e9c94483
+msgid ""
+"d/p/apt-Handle-gstreamer-64bit-suffix-on-any-architecture.patch: Fix "
+"matching GStreamer capabilities on ARM64 and other architectures"
+msgstr ""
+
+#: ../../24.04/4.md ecbbb121c97141da87ec02e0db33744e
+msgid ""
+"d/p/apt-Fix-matching-gstreamer-pkgs-where-the-only-modifier-i.patch: Fix "
+"matching GStreamer capabilities, which would find no results in some "
+"specific but common edge-cases: ."
+msgstr ""
+
+#: ../../24.04/4.md 4c908195404c4eb4a9b7561fc4dbf6cc
+msgid "[2127925](https://bugs.launchpad.net/bugs/2127925)"
+msgstr ""
+
+#: ../../24.04/4.md 41d4d069c59647d78d3cc4c8fde7dc20
+msgid ""
+"d/p/lp2127925-fix-autoreconnect-blocker.patch: unblock autoreconnect when"
+" a previously failed connection is now successful"
+msgstr ""
+
+#: ../../24.04/4.md 0909db976a3142efbc859164281a988e
+msgid "xdg-dbus-proxy"
+msgstr ""
+
+#: ../../24.04/4.md e64a2ac5d44c4e2db20636f67d6fe553
+msgid "[2083258](https://bugs.launchpad.net/bugs/2083258)"
+msgstr ""
+
+#: ../../24.04/4.md 4f25fe31fa524c8196603de432f1a07a
+msgid "d/p/0001-Fix-GVariant-reference-leaks.patch: Fix GVariant memory leaks"
+msgstr ""
+
+#: ../../24.04/4.md 3631fbcac15242d88c122c77efa8f1b4
+msgid "[2122598](https://bugs.launchpad.net/bugs/2122598)"
+msgstr ""
+
+#: ../../24.04/4.md 446bee4ade394fd8945dd7b3220f1e95
+msgid "Default to the Cairo renderer on s390x"
+msgstr ""
+
+#: ../../24.04/4.md 17d6c53cd2794915988101c4c9f7e82a
+#: 92c58d710aef43c9a071d76640d35b0e c7ea76cecec2465999c8378a5a5cb103
+msgid "gce-compute-image-packages"
+msgstr ""
+
+#: ../../24.04/4.md 5494aa1eb18f4fe8bfd33541cd91658f
+#: fd82006d763743878416331102872c54
+msgid "[2113788](https://bugs.launchpad.net/bugs/2113788)"
+msgstr ""
+
+#: ../../24.04/4.md 420cb93a9bab466b994ac2a45693dd88
+msgid "No change rebuild for Noble: ."
+msgstr ""
+
+#: ../../24.04/4.md 7d482319be774290b84ecaa54685a5a3
+msgid "New upstream version for upstream tag 20250501.00"
+msgstr ""
+
+#: ../../24.04/4.md 42cece44aae944fd8980f122b33df9e4
+msgid "[2112595](https://bugs.launchpad.net/bugs/2112595)"
+msgstr ""
+
+#: ../../24.04/4.md 1281e612975f493bae2dbff52d29a44f
+msgid ""
+"This version fixes: (`Domains=local` is appending `.local` to the FQDN) "
+"as well."
+msgstr ""
+
+#: ../../24.04/4.md 6955e217faad432da7c659fca2d5ba1a
+#: d9e43c5520df49c0a4bf906ef17fe496
+msgid "libinput"
+msgstr ""
+
+#: ../../24.04/4.md 965f915e0b974df99bff37949e4d4a09
+msgid "[2127963](https://bugs.launchpad.net/bugs/2127963)"
+msgstr ""
+
+#: ../../24.04/4.md 05da662ae04c4d79b3334e1375275040
+msgid ""
+"Fix built-in volume button could not change the volume on Dell Pro Rugged"
+" tablet: d/p/0001-quirks-add-quirks-for-Dell-Pro-Rugged-tablets-for-"
+"vo.patch"
+msgstr ""
+
+#: ../../24.04/4.md e20458c2d51c4c8ca15fb0f45018455e
+msgid "[2130298](https://bugs.launchpad.net/bugs/2130298)"
+msgstr ""
+
+#: ../../24.04/4.md 13bbd3c083874477a4dfaefee086d4e2
+msgid ""
+"Add Dell laptop touchpad quirks: d/p/0006-quirks-add-Dell-laptop-"
+"touchpad-quirks.patch d/p/0007-quirks-add-quirks-for-Dell-laptop-with-"
+"Sensel-Touchp.patch"
+msgstr ""
+
+#: ../../24.04/4.md 06b0db97e15545e6800666d1681b0615
+msgid "xserver-xorg-video-amdgpu"
+msgstr ""
+
+#: ../../24.04/4.md 86f17700ac884c0ca06f0525ffbb5cef
+msgid "[2130348](https://bugs.launchpad.net/bugs/2130348)"
+msgstr ""
+
+#: ../../24.04/4.md d3c40fc0f7e743f5b9c57ecce3e8935b
+msgid "Crashes with certain DRM properties"
+msgstr ""
+
+#: ../../24.04/4.md afa1a58cd4684f97a2db3dd1bba18a21
+msgid "glib2.0"
+msgstr ""
+
+#: ../../24.04/4.md 8165311e138f4f289bdea16f3d03d59e
+msgid "[2119581](https://bugs.launchpad.net/bugs/2119581)"
+msgstr ""
+
+#: ../../24.04/4.md 149a2389b3cb4e889fbc9f545966c996
+msgid ""
+"debian/patches: Fix a crash on arg0 matching. This is causing a crash in "
+"tracker if the battery charging state changes while tracker is indexing "
+"files, as tracker-extract-3 will try to emit property changes with a NULL"
+" arg0"
+msgstr ""
+
+#: ../../24.04/4.md 7175682f658c466ba9659a0d3778faee
+msgid "[2120978](https://bugs.launchpad.net/bugs/2120978)"
+msgstr ""
+
+#: ../../24.04/4.md 622be0efdf7e4bb280641723a0a6ff88
+msgid ""
+"Extend `landscape-config`, registration, and computer info messages for "
+"UP4W integration"
+msgstr ""
+
+#: ../../24.04/4.md 660938ee347042a08198fd9d316dc2ff
+msgid "[2051886](https://bugs.launchpad.net/bugs/2051886)"
+msgstr ""
+
+#: ../../24.04/4.md eeb4817f679d4282b983117ffaf75788
+msgid "Fix touchscreen issues on Xorg: , #2119066, #2119065, #2125309)"
+msgstr ""
+
+#: ../../24.04/4.md 1b98d4bca12a42a498b5d6d4384f5f18
+msgid "[2119066](https://bugs.launchpad.net/bugs/2119066)"
+msgstr ""
+
+#: ../../24.04/4.md 6533f5ff2237472a8aee29a230f7ab1e
+#: 9cae5fdbc57e48b491d1bf8a9273c00d a20f889439934b2d91444f07037b52a4
+msgid "Fix touchscreen issues on Xorg"
+msgstr ""
+
+#: ../../24.04/4.md a60b5ed21bbd4d90b6bfc48373120f8e
+msgid "[2119065](https://bugs.launchpad.net/bugs/2119065)"
+msgstr ""
+
+#: ../../24.04/4.md 80faf043e36e4217b12b5b84b24e8d8a
+msgid "[2125309](https://bugs.launchpad.net/bugs/2125309)"
+msgstr ""
+
+#: ../../24.04/4.md a3cf40646a1b4e4f8e5d0ba1c8e9994e
+msgid "apparmor"
+msgstr ""
+
+#: ../../24.04/4.md acfa4dba7d0d4c5994a4f6f25ceb949f
+msgid "[2115234](https://bugs.launchpad.net/bugs/2115234)"
+msgstr ""
+
+#: ../../24.04/4.md 5a9bdcbe03e141e898401301b249312f
+msgid "profiles: make /sys/devices PCI paths hex-aware"
+msgstr ""
+
+#: ../../24.04/4.md f1a4d556388d4bb280a7d46d785b6cf2
+msgid "[2130895](https://bugs.launchpad.net/bugs/2130895)"
+msgstr ""
+
+#: ../../24.04/4.md a792e3ea9ac24fb797106fc613acfefb
+msgid "whoopsie"
+msgstr ""
+
+#: ../../24.04/4.md ee36918fed294ccca032d15c3d2b5e6a
+msgid "[2130649](https://bugs.launchpad.net/bugs/2130649)"
+msgstr ""
+
+#: ../../24.04/4.md d3aabb55942a439fb141ae8b096ffbfe
+msgid "Enable `ShellJournal` and `JournalAll` fields"
+msgstr ""
+
+#: ../../24.04/4.md 76ec7d55d6414c0a923a9f1dd9de613b
+msgid "dhcpcd"
+msgstr ""
+
+#: ../../24.04/4.md e2fc413678d84984a3b140c44a24e5bd
+msgid "[2131252](https://bugs.launchpad.net/bugs/2131252)"
+msgstr ""
+
+#: ../../24.04/4.md 2ea2d16f6a3d40469a3823cbe03e1bda
+msgid "Fix intermittent dumplease failures when parsing stdin"
+msgstr ""
+
+#: ../../24.04/4.md 88f1b49d26d741aa9d3dddb2f4579d2e
+msgid "libmbim"
+msgstr ""
+
+#: ../../24.04/4.md 8beec2232d12452db38c6243131677dc
+msgid "[2121842](https://bugs.launchpad.net/bugs/2121842)"
+msgstr ""
+
+#: ../../24.04/4.md 78e603725c4741e5817dc28a8944d068
+msgid "Add Intel mbim service to send AT command"
+msgstr ""
+
+#: ../../24.04/4.md 36c8ca9f798b41208c50c2018a17ff7e
+msgid "util-linux"
+msgstr ""
+
+#: ../../24.04/4.md d578352ac08d4a399f7196894e878882
+msgid "[2123886](https://bugs.launchpad.net/bugs/2123886)"
+msgstr ""
+
+#: ../../24.04/4.md e65a7afa7fa24cff9bd38f2482023c52
+msgid "Add ARM core support for Vera systems"
+msgstr ""
+
+#: ../../24.04/4.md 43acc0e6ea884fca90d3749e5e0ee8dd
+msgid "opensbi"
+msgstr ""
+
+#: ../../24.04/4.md 2a5bf6f659e04520b75938a03a8e95e0
+msgid "[2121785](https://bugs.launchpad.net/bugs/2121785)"
+msgstr ""
+
+#: ../../24.04/4.md 207260e5a57542a1922c85cb79d54632
+msgid "Backport of 1.7-1 to support StarFive VisionFive 2 Lite"
+msgstr ""
+
+#: ../../24.04/4.md 447a69e7af16457f9f5030436b6f233e
+msgid "[2125405](https://bugs.launchpad.net/bugs/2125405)"
+msgstr ""
+
+#: ../../24.04/4.md 0581851c830d4b6498e74f14af64f813
+msgid "basic: validate timezones in get_timezones()"
+msgstr ""
+
+#: ../../24.04/4.md f63285395ac54210beb26ad274b878b2
+msgid "[2132666](https://bugs.launchpad.net/bugs/2132666)"
+msgstr ""
+
+#: ../../24.04/4.md e7dd906377bd4faeb2609c1bd7353d45
+msgid "ukify: fix insertion of padding in merged sections"
+msgstr ""
+
+#: ../../24.04/4.md 665b0d9688094b28bf52d1808fdfa27e
+msgid "[2130554](https://bugs.launchpad.net/bugs/2130554)"
+msgstr ""
+
+#: ../../24.04/4.md 8521ae53a0aa45e68bf25c286000481a
+msgid "core: downgrade a log message from warning to debug"
+msgstr ""
+
+#: ../../24.04/4.md 469688d8326146e48d962435832272eb
+msgid "[2132084](https://bugs.launchpad.net/bugs/2132084)"
+msgstr ""
+
+#: ../../24.04/4.md 21b31c48af824a1f91215b47adf921ba
+msgid "[2127189](https://bugs.launchpad.net/bugs/2127189)"
+msgstr ""
+
+#: ../../24.04/4.md fbdba8d5f5cf4b238425f2e67f57e528
+msgid ""
+"Prompting: remove polkit authentication when modifying/deleting prompting"
+" rules: Prompting: do not record notices for unchanged rules on snapd "
+"startup"
+msgstr ""
+
+#: ../../24.04/4.md 768cff66cd37496c856b3b3ec7bd51f8
+msgid "[1851490](https://bugs.launchpad.net/bugs/1851490)"
+msgstr ""
+
+#: ../../24.04/4.md 756fc6f8d2c6415da812a42d6574e15b
+msgid ""
+"Avoid race between store download stream and cache cleanup executing in "
+"parallel when invoked by snap download task: Use \"current\" instead of "
+"revision number for icons"
+msgstr ""
+
+#: ../../24.04/4.md 27f84de383a54f088306f402cd244522
+msgid "[2121853](https://bugs.launchpad.net/bugs/2121853)"
+msgstr ""
+
+#: ../../24.04/4.md 1d7529ddd4d242779276db7ddb91deec
+msgid ""
+"Avoid race between store download stream and cache cleanup executing in "
+"parallel when invoked by snap download task: Add snapctl version command"
+msgstr ""
+
+#: ../../24.04/4.md effb03d01d244bd1ac8c928fe233e3bd
+msgid "[2127214](https://bugs.launchpad.net/bugs/2127214)"
+msgstr ""
+
+#: ../../24.04/4.md dc871c1dce42474d964ac81f968adcf6
+msgid ""
+"Avoid race between store download stream and cache cleanup executing in "
+"parallel when invoked by snap download task: Ensure no more than one "
+"partition on disk can match a gadget partition"
+msgstr ""
+
+#: ../../24.04/4.md b36250fc40604d3a88cbb0f4dac257d9
+msgid "[2127244](https://bugs.launchpad.net/bugs/2127244)"
+msgstr ""
+
+#: ../../24.04/4.md e043dedc687146359f1e73e55cbf7e38
+msgid ""
+"Avoid race between store download stream and cache cleanup executing in "
+"parallel when invoked by snap download task: snap-confine: update "
+"AppArmor profile to allow read/write to journal as workaround for snap-"
+"confine fd inheritance prevented by newer AppArmor"
+msgstr ""
+
+#: ../../24.04/4.md c030d17e3af2424d8bfe89874f8594b2
+msgid "[2127766](https://bugs.launchpad.net/bugs/2127766)"
+msgstr ""
+
+#: ../../24.04/4.md 0bbb52906a0b41c5a818403965652954
+msgid ""
+"Avoid race between store download stream and cache cleanup executing in "
+"parallel when invoked by snap download task: Add new tracing mechanism "
+"with independently running strace and shim synchronization"
+msgstr ""
+
+#: ../../24.04/4.md b7335e5e0c114701a9a9673ed0ece134
+msgid "[2128668](https://bugs.launchpad.net/bugs/2128668)"
+msgstr ""
+
+#: ../../24.04/4.md a5047193c5e14f22af30db57c1e2ef29
+msgid "Use iptables instead of nftables as firewall backend, to match UFW"
+msgstr ""
+
+#: ../../24.04/4.md 987e97b0a88a493cad3443c9ad120d03
+msgid "sl-modem"
+msgstr ""
+
+#: ../../24.04/4.md 7adfb74417294777ad7cfc1ae3437f76
+msgid "[2134844](https://bugs.launchpad.net/bugs/2134844)"
+msgstr ""
+
+#: ../../24.04/4.md 1c77fad820cc439bb1e8fdcfc20a980e
+msgid "Support 6.17 kernel"
+msgstr ""
+
+#: ../../24.04/4.md 3a95ddc6220e4512bd0e79b7945d1174
+#: 81156ba0151d4c6cb5edd031853a7b05
+msgid "u-boot"
+msgstr ""
+
+#: ../../24.04/4.md 8c50fa0df353434e96d8ce5699757460
+msgid "[2121690](https://bugs.launchpad.net/bugs/2121690)"
+msgstr ""
+
+#: ../../24.04/4.md 9bf92d7b52d94eb1952b3d2b7fc51d1d
+msgid ""
+"Added patches to support for StarFive VisionFive Lite and Milk-V Mars CM:"
+" :"
+msgstr ""
+
+#: ../../24.04/4.md 6d253493431548dca3222e3aaaa375d7
+msgid "[2091618](https://bugs.launchpad.net/bugs/2091618)"
+msgstr ""
+
+#: ../../24.04/4.md 3ce62eea8a5748df83e9c8def79906ba
+msgid ""
+"d/p/rpi-squashfs.patch: Enable squashfs support on rpi and amd64/arm64 "
+"QEMU builds for internal image testing"
+msgstr ""
+
+#: ../../24.04/4.md 3560e16621eb4a85882079aba86c3177
+msgid "[2131001](https://bugs.launchpad.net/bugs/2131001)"
+msgstr ""
+
+#: ../../24.04/4.md c616228ec07d46c0bd972c14eec1f287
+msgid "Add PS5512 usb firmware update"
+msgstr ""
+
+#: ../../24.04/4.md 3fe3d9320f1447f6ad8368b0611a49c9
+#: 9f484fb58c264bc89bd34b8b3646cc0c
+msgid "qpdf"
+msgstr ""
+
+#: ../../24.04/4.md b587bb71ca1648e4b4ea568efd3b2e04
+msgid "[2129676](https://bugs.launchpad.net/bugs/2129676)"
+msgstr ""
+
+#: ../../24.04/4.md 867ba710eae842bc8876bc77fd433f82
+msgid ""
+"d/p/lp2129676-relax-fips-for-pdfs.patch: Utilize the GNUTLS_FIPS140_LAX "
+"around MD5 initialization"
+msgstr ""
+
+#: ../../24.04/4.md 25c2b74da90045aa848e9131ec8b78cf
+msgid "[2131944](https://bugs.launchpad.net/bugs/2131944)"
+msgstr ""
+
+#: ../../24.04/4.md dba7c972de7b4675aecf6a51845778ca
+msgid ""
+"d/p/lp2131944-fix-failing-tests-on-s390x.patch: Fix failing tests on "
+"s390x due to different error output"
+msgstr ""
+
+#: ../../24.04/4.md 2f4365d737e849eeaa46709c185dfc8a
+msgid "xwayland"
+msgstr ""
+
+#: ../../24.04/4.md f7b2059e1c3a45aa9092e479b7125444
+msgid "xwayland-glamor-gbm-make-wl_drm-optional.diff: Fix glamor with mesa 25.2+"
+msgstr ""
+
+#: ../../24.04/4.md 302e3d8f8aa449b982c7704d452b4a75
+#: 7537f57c2a6e43c2b3d70f09bc8b40be
+msgid "flash-kernel"
+msgstr ""
+
+#: ../../24.04/4.md 9ec244dc2b5448e58a33303cb4200105
+msgid "[2132298](https://bugs.launchpad.net/bugs/2132298)"
+msgstr ""
+
+#: ../../24.04/4.md a9f2711c30cd49b59667755b04e01765
+msgid ""
+"Add StarFive VisionFive 2 Lite, Milk-V Mars CM and Milk-V Mars CM Lite to"
+" database"
+msgstr ""
+
+#: ../../24.04/4.md 84334dc242a243a8b99a585a5713f93b
+msgid "[2134398](https://bugs.launchpad.net/bugs/2134398)"
+msgstr ""
+
+#: ../../24.04/4.md 97674d48e3244869adfd01f982181a7c
+msgid "db/all.db: Removed duplicated entry for Lenovo ThinkPad X13s"
+msgstr ""
+
+#: ../../24.04/4.md e6ecd821000f427aaefb1e47ac7f46fd
+msgid "python-apt"
+msgstr ""
+
+#: ../../24.04/4.md 56c3bab15ace4a2eb7f049cbf788b040
+msgid "[2138617](https://bugs.launchpad.net/bugs/2138617)"
+msgstr ""
+
+#: ../../24.04/4.md 4b278c4e2aa344c5a7650ea60b3f98c7
+msgid "Mirror list update for 24.04.4"
+msgstr ""
+
+#: ../../24.04/4.md 18914a0fd9374f508941bba3cf1eda55
+msgid "[2138326](https://bugs.launchpad.net/bugs/2138326)"
+msgstr ""
+
+#: ../../24.04/4.md 07ec825d8cc4478bb62f58e835d91b01
+msgid "boost1.83"
+msgstr ""
+
+#: ../../24.04/4.md d8d5890d522046f5b6eaa7c101dadf81
+msgid "[2122352](https://bugs.launchpad.net/bugs/2122352)"
+msgstr ""
+
+#: ../../24.04/4.md eb6693ca5a5745cdab5d63bf97ed4ade
+msgid ""
+"Cherry-pick two changes from upstream (#565, #737) to fix a "
+"multiprecision bug"
+msgstr ""
+
+#: ../../24.04/4.md 39bbb8cc3a9e4ab98001c5ec761bce3f
+msgid "devscripts"
+msgstr ""
+
+#: ../../24.04/4.md 49443f73e7b74037b7b558a7141c1e1c
+msgid "[2061609](https://bugs.launchpad.net/bugs/2061609)"
+msgstr ""
+
+#: ../../24.04/4.md e6193a813aca42898dad95290964ce9a
+msgid "Fix Perl warnings in chdist and debcheckout"
+msgstr ""
+
+#: ../../24.04/4.md 5443760380144d7b8037ef5b00bebef7
+msgid "linux-firmware-raspi"
+msgstr ""
+
+#: ../../24.04/4.md 1f2820df64e14b5abd4c788a25972c99
+msgid "[2139343](https://bugs.launchpad.net/bugs/2139343)"
+msgstr ""
+
+#: ../../24.04/4.md 29a552c5a5094fff88ef73ffa0aa3d8a
+msgid "Add missing links for Raspberry Pi 500 wifi firmwares"
+msgstr ""
+
+#: ../../24.04/4.md 931a5cd09d1943988793ec58d77a3315
+msgid "base-files"
+msgstr ""
+
+#: ../../24.04/4.md 1eab586cf590442eb664f1d44f6370de
+msgid "[2140756](https://bugs.launchpad.net/bugs/2140756)"
+msgstr ""
+
+#: ../../24.04/4.md 7bb644e8914547eda7213c35ae238f0d
+#, python-brace-format
+msgid "/etc/issue{,.net}, /etc/{lsb,os}-release: bump version to 24.04.4"
+msgstr ""
+
+#: ../../24.04/4.md 50d6a994dc7b4e43afaa22074a0c9e01
+msgid "initramfs-tools"
+msgstr ""
+
+#: ../../24.04/4.md 96c4381ba9ba4190a3d8412cd75a6eac
+msgid "[2140344](https://bugs.launchpad.net/bugs/2140344)"
+msgstr ""
+
+#: ../../24.04/4.md 637b17c8870848bc8cd3f839059c8cea
+msgid "Add missing USB drivers for StarFive JH7110 SoC"
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/24.04/index.po
+++ b/docs/locale/ja/LC_MESSAGES/24.04/index.po
@@ -1,0 +1,3975 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../24.04/index.md:12
+msgid "24.04.4"
+msgstr ""
+
+#: ../../24.04/index.md:12
+msgid "24.04.3"
+msgstr ""
+
+#: ../../24.04/index.md:12
+msgid "24.04.2"
+msgstr ""
+
+#: ../../24.04/index.md:12
+msgid "24.04.1"
+msgstr ""
+
+#: ../../24.04/index.md:23
+msgid "Release schedule"
+msgstr ""
+
+#: ../../24.04/index.md:6 94e4bc89a0d94ab7b47f1b7d15b989e5
+msgid "Ubuntu 24.04 LTS release notes"
+msgstr ""
+
+#: ../../24.04/index.md:8 fc7de63e7acc49c0aa8b3f110c074f8b
+msgid ""
+"These release notes for **Ubuntu 24.04 LTS** (Noble Numbat) provide an "
+"overview of the release and document the known issues with Ubuntu and its"
+" flavors."
+msgstr ""
+
+#: ../../24.04/index.md:10 972c12b1ab31445eb8d1db1e4c5f6b5a
+msgid ""
+"For details of the changes applied since 24.04, refer to the following "
+"changelogs:"
+msgstr ""
+
+#: ../../24.04/index.md:21 16f172f4d9914ecab3da5df486b523bc
+msgid ""
+"For the release schedule of Ubuntu 24.04 LTS and its point releases, "
+"refer to:"
+msgstr ""
+
+#: ../../24.04/index.md:29 47b1f4d68d7f4f1cb9afe7b1e1b37d82
+msgid "Support lifespan"
+msgstr ""
+
+#: ../../24.04/index.md:31 4a46556afc9e4035aed9dc5a00e86b75
+msgid ""
+"Ubuntu 24.04 LTS will be security maintained for 5 years until 31 May "
+"2029. Users can choose to extend this to 10 years with [Ubuntu "
+"Pro](https://ubuntu.com/pro) or 12 years with the [Legacy add-"
+"on](https://ubuntu.com/blog/canonical-expands-long-term-support-to-12"
+"-years-starting-with-ubuntu-14-04-lts)."
+msgstr ""
+
+#: ../../24.04/index.md:33 fb2690eb0240465f8df6120462f6ca92
+msgid "Upgrades"
+msgstr ""
+
+#: ../../24.04/index.md:35 bbe422096bbf4c06a757b0e351acae87
+msgid ""
+"Users of Ubuntu 23.10 have been offered an automatic upgrade to 24.04 "
+"since shortly after the release. Users of 22.04 LTS will also start being"
+" offered the automatic upgrade now that 24.04.1 LTS has been released."
+msgstr ""
+
+#: ../../24.04/index.md:38 48b1e24b5f274c0fa1b5ddc165e85ecd
+msgid "Changes since 22.04 LTS"
+msgstr ""
+
+#: ../../24.04/index.md:40 1c0b98b7cd7d465db9a68c93cae1ff36
+msgid ""
+"If you’re upgrading from Ubuntu 22.04 LTS to 24.04 LTS, you get all the "
+"changes that happened in the six months since Ubuntu 23.10, as well as "
+"the changes in all the interim releases between 22.04 LTS and 24.04 LTS."
+msgstr ""
+
+#: ../../24.04/index.md:42 a56c61667c9043b0b93d5f599ca6a2a7
+msgid ""
+"For details, see the complete interim release notes: "
+"[22.10](https://discourse.ubuntu.com/t/kinetic-kudu-release-notes/27976),"
+" [23.04](https://discourse.ubuntu.com/t/lunar-lobster-release-"
+"notes/31910) and [23.10](https://discourse.ubuntu.com/t/mantic-minotaur-"
+"release-notes/35534). Finally, review the following changes since Ubuntu "
+"23.10."
+msgstr ""
+
+#: ../../24.04/index.md:46 bda49b26e9814271b625679562e3abc4
+msgid "New features in 24.04 LTS"
+msgstr ""
+
+#: ../../24.04/index.md:48 ff2222d583ac47dd88665cc7fa12dc4e
+msgid "Year 2038 support for the armhf architecture"
+msgstr ""
+
+#: ../../24.04/index.md:50 c48dbe4f6ef94cd8a2140cc964fd5b31
+msgid ""
+"Ubuntu 24.04 LTS solves the [Year 2038 "
+"problem](https://en.wikipedia.org/wiki/Year_2038_problem) that existed on"
+" armhf. More than a thousand packages have been updated to handle time "
+"using a 64-bit value rather than a 32-bit one, making it possible to "
+"handle times up to 292 billion years in the future."
+msgstr ""
+
+#: ../../24.04/index.md:52 4e184030a6d2490f9310862fffa5f544
+msgid "Updated Packages"
+msgstr ""
+
+#: ../../24.04/index.md:54 2e1e1e9b132a4538af2fd1a15814496b
+msgid "Linux kernel 🐧"
+msgstr ""
+
+#: ../../24.04/index.md:56 1ad37e3dfde047bdae31313429f7dc4f
+msgid ""
+"Ubuntu 24.04 LTS includes the new 6.8 Linux kernel that brings many new "
+"features."
+msgstr ""
+
+#: ../../24.04/index.md:58 99aef721d4fc4cefb023b174f5f2d7aa
+msgid ""
+"Detailed changes are reported in the [Noble Kernel Release "
+"Notes](https://discourse.ubuntu.com/t/introducing-kernel-6-8-for-"
+"the-24-04-noble-numbat-release) post."
+msgstr ""
+
+#: ../../24.04/index.md:60 60d6ff797c2b41d29f812cccce76d83d
+msgid "systemd v255.4"
+msgstr ""
+
+#: ../../24.04/index.md:62 3807b60359ae4fcd80249d2582373722
+msgid ""
+"The init system was updated to systemd v255.4. See the [upstream "
+"changelog](https://github.com/systemd/systemd/releases/tag/v255) for more"
+" information about individual features."
+msgstr ""
+
+#: ../../24.04/index.md:64 cbcc848df00a4fa1b4eddc5de239255f
+msgid "Netplan v1.0 🌐"
+msgstr ""
+
+#: ../../24.04/index.md:66 7d8be01205ad4ca28427d4382e073678
+msgid ""
+"The network stack was updated to [Netplan version "
+"1.0](https://github.com/canonical/netplan/releases/tag/1.0). Supporting "
+"simultaneous WPA2 & WPA3, Mellanox VF-LAG for high-performance SR-IOV "
+"networking and VXLAN improvements. It also provides a [stable libnetplan1"
+" API](https://netplan.readthedocs.io/en/stable/apidoc/) and a new "
+"`netplan status --diff` sub-command to find differences between "
+"configuration and system state. For more information please see the "
+"[Introducing Netplan v1.0](https://ubuntu.com/blog/introducing-"
+"netplan-v1) blog post."
+msgstr ""
+
+#: ../../24.04/index.md:68 15f13061d9e141b09ff4fb8d7d5a40e0
+msgid "Toolchain Upgrades 🛠️"
+msgstr ""
+
+#: ../../24.04/index.md:70 e11fdff617cf4b4cac7604648d06e075
+msgid "GCC 🐄 is updated to the 14, binutils to 2.42, and glibc to 2.39."
+msgstr ""
+
+#: ../../24.04/index.md:71 634be3761a0d492db4d819c607711fdb
+msgid "Python 🐍 now defaults to version 3.12"
+msgstr ""
+
+#: ../../24.04/index.md:72 488c12c74af44aea857e6172992df46a
+msgid "OpenJDK ☕ now defaults to LTS version 21"
+msgstr ""
+
+#: ../../24.04/index.md:73 68f7af24db744fe18c4ce715b15bf62b
+msgid "LLVM 🐉 now defaults to version 18"
+msgstr ""
+
+#: ../../24.04/index.md:74 bffbb6e3e3264adc9f40b841dd520b25
+msgid "Rust 🦀 toolchain defaults to version 1.75"
+msgstr ""
+
+#: ../../24.04/index.md:75 d399f9d8a74c44de8e521b40db5ad81b
+msgid "Golang 🐀 is updated to 1.22"
+msgstr ""
+
+#: ../../24.04/index.md:76 6fb6dd757cd14f7092d6b3ae8fa4f8e2
+msgid ".NET 8 is now default"
+msgstr ""
+
+#: ../../24.04/index.md:78 9c56b421cc4947aab97fe22da20bb742
+msgid "OpenJDK"
+msgstr ""
+
+#: ../../24.04/index.md:80 5f95c5c01bb44b84a775ffbc58f6833e
+msgid ""
+"OpenJDK LTS 21 is the default in Ubuntu 24.04 LTS while maintaining "
+"support for versions 17, 11, and 8. OpenJDK 17 and 21 are also TCK "
+"certified, which means they adhere to Java standards and ensure "
+"interoperability with other Java platforms. A special FIPS-compliant "
+"OpenJDK 11 package is also available for Ubuntu Pro users."
+msgstr ""
+
+#: ../../24.04/index.md:82 a891a38181ee48d0aa391fcda49601f7
+msgid ".NET"
+msgstr ""
+
+#: ../../24.04/index.md:84 25fbf99a36394b9a88581ef6328a2515
+msgid ""
+"With the introduction of .NET 8, Ubuntu is taking a significant step "
+"forward in supporting the .NET community. .NET 8 will be fully supported "
+"on Ubuntu 24.04 LTS and 22.04 LTS for the entire lifecycle of both "
+"releases. This enables developers to upgrade their applications to newer "
+".NET versions before upgrading their Ubuntu release. Starting with 24.04 "
+"LTS the .NET support has also been extended to the IBM System Z platform."
+msgstr ""
+
+#: ../../24.04/index.md:86 acb18baf2ec84dbe84ea164fb1e984e8
+msgid ""
+".NET 6 and .NET 7 packages with limited support are available via a "
+"[PPA](https://launchpad.net/~dotnet/+archive/ubuntu/backports)."
+msgstr ""
+
+#: ../../24.04/index.md:88 e7251033abca43a78986ac286766e05b
+msgid "Apport"
+msgstr ""
+
+#: ../../24.04/index.md:90 41440560463948b282c33042ae9ba995
+msgid ""
+"Apport added integration with systemd-coredump to handle crashes. "
+"Developers on Ubuntu can co-install systemd-coredump now and use "
+"coredumpctl to analyze crash data. Apport will continue to collect crash "
+"information and submit it to the Ubuntu Error Tracker and Launchpad."
+msgstr ""
+
+#: ../../24.04/index.md:92 a4f123598fd9494fb23fc52f795814c4
+msgid "Security Improvements 🔒"
+msgstr ""
+
+#: ../../24.04/index.md:94 d600eccbbb934f40b2420e8c63c3b1da
+msgid "Unprivileged user namespace restrictions"
+msgstr ""
+
+#: ../../24.04/index.md:96 1ea9526da1424063b8c836d31685a806
+msgid ""
+"In combination with the `apparmor` package, the Ubuntu kernel now "
+"restricts the use of unprivileged user namespaces. This affects all "
+"programs on the system that are unprivileged and unconfined. A default "
+"AppArmor profile is provided that allows the use of user namespaces for "
+"unprivileged and unconfined applications but will deny the subsequent use"
+" of any capabilities within the user namespace. A common use-case for "
+"unprivileged user namespaces is applications that construct their own "
+"sandboxes or work with styles of container workloads. As such, AppArmor "
+"profiles that allow the use of unprivileged user namespaces are also "
+"provided for common applications and frameworks that come from the Ubuntu"
+" archive, as well as popular third party applications like Google Chrome,"
+" Discord and others. This is a subsequent step towards trying to mitigate"
+" the larger attack surface presented by unprivileged user namespaces (the"
+" first being the introduction of this feature in Ubuntu 23.10 where it "
+"was not enabled by default)."
+msgstr ""
+
+#: ../../24.04/index.md:98 c3f5a4d9f20d4c8ba1cccfdc9c2bddc2
+msgid ""
+"Whilst significant effort has been expended to try and identify all "
+"applications that may require such profiles, it is expected that there "
+"may be cases where additional profiles are required."
+msgstr ""
+
+#: ../../24.04/index.md:100 3985cb49668b4e1dadb518038e379f4d
+msgid "In this case, there are several options if you run into problems:"
+msgstr ""
+
+#: ../../24.04/index.md:102 5e67d261bb0c41bc9baff662606401f4
+msgid ""
+"Confine your applications with an AppArmor profile. Because this can be "
+"potentially onerous, a new `unconfined` profile mode/flag has been added "
+"to AppArmor. This designates the profile to essentially act like the "
+"unconfined mode for AppArmor where an application is not restricted, and "
+"it allows additional permissions to be added, such as the `userns,` "
+"permission. Such profile for, e.g. [Google "
+"Chrome](https://www.google.com/chrome/?platform=linux), would look like "
+"the following, and it would be located within the "
+"`/etc/apparmor.d/chrome` file:"
+msgstr ""
+
+#: ../../24.04/index.md:115 8c777752e12f4bb3b986ba4f92570cb2
+msgid ""
+"Alternatively, a complete AppArmor profile for the application can be "
+"created (see the [AppArmor](https://ubuntu.com/server/docs/security-"
+"apparmor) documentation)."
+msgstr ""
+
+#: ../../24.04/index.md:117 d91c2355b81541edab77d7b0bca85ca4
+msgid ""
+"Launch your application in a way that doesn't use unprivileged user "
+"namespaces, e.g. `google-chrome-stable --no-sandbox`. However, since this"
+" disables the use of an internal security feature within the application,"
+" this is not recommended. Instead, use the `unconfined` profile mode "
+"described above instead."
+msgstr ""
+
+#: ../../24.04/index.md:119 19fb9ab46e274c39b6e0c20c4cefdb2f
+msgid ""
+"Disable this restriction on the entire system for one boot by executing "
+"`echo 0 | sudo tee "
+"/proc/sys/kernel/apparmor_restrict_unprivileged_userns`. This setting is "
+"lost on reboot. This similar to the previous behaviour, but it does not "
+"mitigate against kernel exploits that abuse the unprivileged user "
+"namespaces feature."
+msgstr ""
+
+#: ../../24.04/index.md:121 89c6e7ac371c4e25b85dda85d9941093
+msgid ""
+"Disable this restriction using a persistent setting by adding a new file "
+"(`/etc/sysctl.d/60-apparmor-namespace.conf`) with the following contents:"
+msgstr ""
+
+#: ../../24.04/index.md:125 e5f0e6e228b94e2fb553665ad94dd017
+msgid ""
+"Reboot. This is similar to the previous behaviour, but it does not "
+"mitigate against kernel exploits that abuse the unprivileged user "
+"namespaces feature."
+msgstr ""
+
+#: ../../24.04/index.md:127 6c093103ef194a1d8fdd6c22e3bd1a70
+msgid "TLS 1.0, 1.1 and DTLS 1.0 are forcefully disabled"
+msgstr ""
+
+#: ../../24.04/index.md:129 954ca23d4a7b4557ace76bed5d6446de
+msgid "for software using openssl this was the case since 20.04"
+msgstr ""
+
+#: ../../24.04/index.md:130 66f584323a864415819f69186ec0327b
+msgid ""
+"for software using gnutls, this is now enforced (with openconnect being a"
+" notable exception)"
+msgstr ""
+
+#: ../../24.04/index.md:132 9dc444c2e2be46458b2746dc2b78b06d
+msgid "More consistent application of openssl and gnutls system configurations"
+msgstr ""
+
+#: ../../24.04/index.md:134 d316edf4dd2d42129a1aed29e697bbaf
+msgid ""
+"Some libraries do not raise errors when their configuration is not "
+"accessible; this could happen when AppArmor does not allow access to the "
+"configuration files. Due to how widespread openssl and gnutls are, the "
+"AppArmor rules now grant access to their configuration files by default. "
+"Their system-wide configuration will therefore be followed better."
+msgstr ""
+
+#: ../../24.04/index.md:136 ca8fe4f8bf5b4aef8136060e3eccf6c0
+msgid "Deprecation and disablement of 1024-bit RSA APT repository signing keys"
+msgstr ""
+
+#: ../../24.04/index.md:138 ded3456f8b8442939c74250c1ffc3784
+msgid ""
+"APT in 24.04 requires repositories to be signed with the RSA keys no "
+"smaller than 2048 bits, Ed25519, or Ed448. As work to resign old "
+"Launchpad PPAs with a stronger keys is still ongoing for some weeks, this"
+" is initially only a warning."
+msgstr ""
+
+#: ../../24.04/index.md:140 553408f049a041ce9e6038d929f16bbe
+msgid ""
+"Once Launchpad PPAs have been resigned, you will need to manually migrate"
+" any affected PPAs to new signing keys by removing and re-adding them to "
+"quiesce the warning."
+msgstr ""
+
+#: ../../24.04/index.md:142 b9b12c5ce26745408c82ad688ed35efa
+msgid ""
+"The final APT 2.8.0 release that converts the warning to an error should "
+"be published as a stable release update some time after the resigning is "
+"complete."
+msgstr ""
+
+#: ../../24.04/index.md:144 1db000d4608249fbbd3a58e03776fa5e
+msgid "pptpd removed"
+msgstr ""
+
+#: ../../24.04/index.md:146 c77d5859c38d49938c74d13af3fd0fb8
+msgid ""
+"[`pptpd` and `bcrelay` have been "
+"removed](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2041751)"
+msgstr ""
+
+#: ../../24.04/index.md:148 52485a9a98324142bbf640905dc80546
+msgid "OpenSSH with reduced dependencies"
+msgstr ""
+
+#: ../../24.04/index.md:150 e4e00a15b4e947aabc420855b9fe79ab
+msgid ""
+"As per the XZ-utils backdoor, `openssh` in Ubuntu does not depend anymore"
+" on libsystemd, reducing the number of dependencies and making it less "
+"prone to future security issues."
+msgstr ""
+
+#: ../../24.04/index.md:152 a6b5ebbfb3d34149afd39e6d22d7a9f4
+msgid "Package security-hardening improvements"
+msgstr ""
+
+#: ../../24.04/index.md:154 c110fe2b47004e7d8b36bb841026cdef
+msgid ""
+"Packages are now built with security-hardening features which stop many "
+"undiscovered security vulnerabilities, rendering them unexploitable."
+msgstr ""
+
+#: ../../24.04/index.md:156 8153292c4a4d49eeb12cf44d2eddb69f
+msgid ""
+"The [gcc compiler](https://wiki.ubuntu.com/ToolChain/CompilerFlags) and "
+"dpkg now defaults to `-D_FORTIFY_SOURCE=3` instead of "
+"`-D_FORTIFY_SOURCE=2` which greatly increases buffer overflow detection "
+"and mitigation."
+msgstr ""
+
+#: ../../24.04/index.md:158 b124fa76dae24823ba02e26ad18fa5d6
+msgid ""
+"dpkg now defaults to use `-mbranch-protection=standard` which mitigates "
+"code reuse attacks on arm64."
+msgstr ""
+
+#: ../../24.04/index.md:160 3bdfa9b2e0a142dfbe0e4e21ad31d611
+msgid "Performance ⚡"
+msgstr ""
+
+#: ../../24.04/index.md:162 b91f42117f48450587257a5d6a551847
+msgid "Performance Engineering tools"
+msgstr ""
+
+#: ../../24.04/index.md:163 9883a564a78f49909cc6127f4edef656
+msgid ""
+"A set of performance engineering tools is installed by default on "
+"relevant Ubuntu systems. Additionally, a performance-tools metapackage "
+"has been created to assist in debugging performance and reliability "
+"issues. See [specification](https://discourse.ubuntu.com/t/spec-include-"
+"performance-tooling-in-ubuntu/43134) for more details."
+msgstr ""
+
+#: ../../24.04/index.md:165 658cdd4de57d402dbc2d15a094d86e45
+msgid "Default configuration changes ⚙️"
+msgstr ""
+
+#: ../../24.04/index.md:167 1ca1451bebbb460790ce0e557c92ce60
+msgid ""
+"As always there are many changes to defaults, mostly by newer versions of"
+" packages. But a few are worth spelling out if your former automation, "
+"configuration and tuning relied on those settings being one or the other "
+"way."
+msgstr ""
+
+#: ../../24.04/index.md:171 e8c1d280e2634df998d4f75483da2493
+msgid "Apt priority of the proposed pocket"
+msgstr ""
+
+#: ../../24.04/index.md:173 24cdb4da64f54c0f9f6d1106bdc70892
+msgid ""
+"The proposed pocket is used as a staging area for software updates. These"
+" updates land in the proposed pocket before they are released to the "
+"wider public userbase."
+msgstr ""
+
+#: ../../24.04/index.md:177 b9f489671a354f3a865c8a839336d464
+msgid ""
+"But in the past, if someone enabled the proposed pocket for testing they "
+"often got into trouble by getting their system flooded with everything "
+"that is in the proposed pocket. If just one of the packages in there was "
+"weirdly broken you'd have been broken by that as well - and it might have"
+" been unrelated to what you really care about and made your regular "
+"testing consume more effort and thereby less attractive."
+msgstr ""
+
+#: ../../24.04/index.md:184 3f445698a4e44b4aacddc2670e384577
+msgid ""
+"By changing the default priority, users are less likely to install "
+"potentially unstable updates unintentionally. Therefore the default apt "
+"priority of the proposed pocket was reduced from 500 to 100. This change "
+"already happened in Ubuntu Lunar, but Noble is the first Ubuntu LTS to "
+"pick it up and therefore there is much more time of consumption from the "
+"proposed pocket in front of it."
+msgstr ""
+
+#: ../../24.04/index.md:190 e3a6b62eeefd4293a46f71328568535e
+msgid ""
+"With the change, users can now selectively install packages from the "
+"proposed pocket. This allows for more conscious selection and testing of "
+"updates. You can always see the new versions of the packages e.g. via "
+"`apt-cache policy` but they will no more auto-install. To install a "
+"package from proposed you'd now need to select from which pocket you want"
+" to install like `apt install <package>/<release>-proposed`"
+msgstr ""
+
+#: ../../24.04/index.md:197 a7a88f26c82442a5aeda1f4b969a3a6d
+msgid ""
+"The above helps a lot for the conscious testing of changes. But on the "
+"other hand having automation and people testing (almost) all new package "
+"versions regularly can provide great signal. Especially in canary setup "
+"with their very own workload it can prevent breaking these specific setup"
+" unintentionally as it might be different from what is tested elsewhere."
+msgstr ""
+
+#: ../../24.04/index.md:203 59d900a056fb4a9580d268bda6ca88d0
+msgid ""
+"Therefore in those situations if you want to go back to the old behavior "
+"of just getting everything from proposed all the time, you'd need to bump"
+" the apt pin priority back up to 500 so the versions from the proposed "
+"pocket compete on the same level with the rest of the Ubuntu Archive. To "
+"do that you could put the following in a file like "
+"`/etc/apt/preferences.d/bump-proposed-prio`:"
+msgstr ""
+
+#: ../../24.04/index.md:216 6b7f65f4c72d4593857925799565f349
+msgid "deb822 sources management"
+msgstr ""
+
+#: ../../24.04/index.md:218 365d86abca2b4071ac6b50fbf4c5a7a4
+msgid ""
+"The sources configuration for Ubuntu has moved from "
+"`/etc/apt/sources.list` to `/etc/apt/sources.list.d/ubuntu.sources` in "
+"the more featureful deb822 format, aligning with PPAs that already "
+"migrated to deb822 last year. See [the "
+"specification](https://discourse.ubuntu.com/t/spec-apt-deb822-sources-by-"
+"default/29333/19) for more details."
+msgstr ""
+
+#: ../../24.04/index.md:220 8b0c8362b6f441f494046f64976d915b
+msgid "Services restart on unattended-upgrade"
+msgstr ""
+
+#: ../../24.04/index.md:222 62bcab4c06be49c4b81e62ca5874d0d9
+msgid ""
+"The `needrestart` package has been modified to systematically restart "
+"services if affected by a library upgrade, including in non-interactive "
+"scenarios such as `unattended-upgrade`. The reason for this change is "
+"that `unattended-upgrade` defaults to security updates only, and failing "
+"to restarting services means that those running daemons will still be "
+"exposed to the security issues fixed by the update."
+msgstr ""
+
+#: ../../24.04/index.md:229 463bb4f78f9a4b2683cd51acbf0582fc
+msgid ""
+"It is possible to exclude specific services from automatic restart by "
+"adding them to the `override_rc` section of "
+"`/etc/needrestart/needrestart.conf`."
+msgstr ""
+
+#: ../../24.04/index.md:232 4c48e55b67e2481b811c20ad2b64cd7d
+msgid ""
+"See [this Discourse post](https://discourse.ubuntu.com/t/needrestart-"
+"changes-in-ubuntu-24-04-service-restarts/44671/1) for more details."
+msgstr ""
+
+#: ../../24.04/index.md:234 ce28e83d96304d7a985bf8ce48e92a34
+msgid "irqbalance no more installed and enabled by default"
+msgstr ""
+
+#: ../../24.04/index.md:236 5cab56454ee449deb5346a16f876a0c5
+msgid ""
+"The `irqbalance` service is designed to distribute hardware interrupts "
+"across processors on a multiprocessor system to increase performance. "
+"This is particularly useful in server configurations where multiple "
+"devices will be competing for the CPU’s attention. And in doing so it has"
+" served Ubuntu well being default enabled since 14 years based on [a "
+"discussion](https://lists.ubuntu.com/archives/ubuntu-"
+"devel/2010-January/029939.html) and related to the [kernel actively "
+"delegating this to "
+"userspace](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8b8e8c1bf7275eca859fe551dfa484134eaf013b)."
+msgstr ""
+
+#: ../../24.04/index.md:243 b14839d1a45143e8a99bf59cedace89b
+msgid ""
+"But evolution of the wider ecosystem has outpaced irqbalance in most "
+"situations. `Irqbalance` can still be useful, but unless the admin "
+"configures it, the policy it provides is not a discernible improvement "
+"over the in-kernel default policy."
+msgstr ""
+
+#: ../../24.04/index.md:247 89b54e1431bd4a87815c3accc8b8187b
+msgid ""
+"At the same time a few cases have been reported where `irqbalance` causes"
+" issues, [hence discussions have been ongoing for quite a "
+"while](https://bugs.launchpad.net/ubuntu/+source/ubuntu-"
+"meta/+bug/1833322). It does usually not make as much sense for virtual "
+"guests, it might conflict with manual tuning and other power consumption "
+"or latency targets. Furthermore the kernel and in particular many device "
+"drivers evolved since then and often do an equal or better job now."
+msgstr ""
+
+#: ../../24.04/index.md:253 0430aaf8e8c24fcc97679c12a6873bc2
+msgid ""
+"This change is just not installing it by default, `irqbalance` will stay "
+"available and anyone that benefits or even just want to experiment with "
+"it can use it as before."
+msgstr ""
+
+#: ../../24.04/index.md:257 7d0acfa8f93e4bd5aa506bbd84430f59
+msgid ""
+"Some specific scenarios, like particular cloud images, already had "
+"`irqbalance` disabled by default before. In a similar fashion some have "
+"been (and more might be) identified which will keep it enabled by default"
+" as there has been evidence that on this platform it is more helpful."
+msgstr ""
+
+#: ../../24.04/index.md:262 21006e43f025419d951e95bbf3e71111
+msgid "tzdata package split"
+msgstr ""
+
+#: ../../24.04/index.md:264 fddcc946496241bdad19a7867c446935
+msgid ""
+"The tzdata package was split into tzdata, tzdata-icu, and tzdata-legacy. "
+"The tzdata package ships only timezones that follow the current rules of "
+"geographical region (continent or ocean) and city name. All legacy "
+"timezone symlinks (old or merged timezones mentioned in the upstream "
+"backward file) were moved to tzdata-legacy. This includes the US/* "
+"timezones."
+msgstr ""
+
+#: ../../24.04/index.md:266 a27b4578303244ddaf30a5dbe0afede1
+msgid ""
+"Please install tzdata-legacy in case you need the legacy timezones or to "
+"restore the previous behavior. This might be needed in case the system "
+"provides timezone-aware data over the network (e. g. SQL databases)."
+msgstr ""
+
+#: ../../24.04/index.md:268 ../../24.04/index.md:1091
+#: 07c5a5e336b1420f990fec237de65d84 df62ed50a66e4413b5fffc6296e81881
+msgid "Ubuntu Desktop"
+msgstr ""
+
+#: ../../24.04/index.md:270 07896f6e8af644a7a4bbdac06d77f903
+msgid "Installer and Upgrades"
+msgstr ""
+
+#: ../../24.04/index.md:272 ca0ef1bcf59b4f12b153580204903a6f
+msgid ""
+"We've taken the first steps towards a more general \"provisioning\" "
+"approach that encompasses a \"device bootstrap\" stage followed by a "
+"\"first boot initialization\" and a \"desktop welcome\" step."
+msgstr ""
+
+#: ../../24.04/index.md:273 80dc25ff6ef94268b56b29c05aeaa531
+msgid ""
+"This means the ubuntu-desktop-installer is now part of the larger ubuntu-"
+"desktop-provision project and has been renamed to ubuntu-desktop-"
+"bootstrap."
+msgstr ""
+
+#: ../../24.04/index.md:274 069b04eab83b4cb9ace717fb5617b863
+msgid ""
+"It comes with an improved UI design that is customizable via a central "
+"configuration file. Default image assets automatically follow the "
+"customized accent color, or can be swapped out entirely according to the "
+"needs of flavors or OEM providers."
+msgstr ""
+
+#: ../../24.04/index.md:276 7797a5c9dbdb477b878546c640ece5c7
+msgid ""
+"In order to enable advanced users to benefit from subiuity's/cloud-init's"
+" autoinstall capabilities, we've added a dedicated page that allows side-"
+"loading an autoinstall.yaml from a network URL during the installation."
+msgstr ""
+
+#: ../../24.04/index.md:278 606f415983434f478478212a3e4173f4
+msgid ""
+"We are reintroducing support for **ZFS guided installations**, enhancing "
+"the flexibility and choices available for your storage management needs. "
+"This is a new implementation in the Subiquity-based installers, and is "
+"without encryption by default. The encrypted ZFS guided option will be "
+"developed in a future release."
+msgstr ""
+
+#: ../../24.04/index.md:280 9a8dc373522e445d9c4a6037c32cd5f2
+msgid ""
+"Starting with Ubuntu 23.10, **TPM-backed full-disk encryption** (FDE) is "
+"introduced as an experimental feature, building on years of experience "
+"with Ubuntu Core. On supported platforms, you no longer need to enter "
+"passphrases at boot manually. Instead, the TPM securely manages the "
+"decryption key, providing enhanced security against physical attacks. "
+"This new feature streamlines the user experience and offers additional "
+"layers of security, especially in enterprise environments. However, the "
+"traditional passphrase-backed FDE is still available for those who prefer"
+" it. We invite users to experiment with this new feature, although "
+"caution is advised as it's still experimental. More details in the [TPM-"
+"backed Full Disk Encryption is coming to Ubuntu](https://ubuntu.com/blog"
+"/tpm-backed-full-disk-encryption-is-coming-to-ubuntu) blog post. Do not "
+"hesitate to [report bugs in Launchpad against the ubuntu-desktop-"
+"provision project](https://bugs.launchpad.net/ubuntu-desktop-"
+"provision/+filebug)."
+msgstr ""
+
+#: ../../24.04/index.md:282 637fc4f2e2db4d3dbb35ba1dc4ceea5b
+msgid "Known limitations:"
+msgstr ""
+
+#: ../../24.04/index.md:284 8954cf70cf11440c9ba1136169ed9951
+msgid "Requires TPM 2.0."
+msgstr ""
+
+#: ../../24.04/index.md:285 540b35f495da4beaa3abaee31112f656
+msgid "Only a limited set of hardware is supported."
+msgstr ""
+
+#: ../../24.04/index.md:286 b1e73922f7c4491db39f2a2481fe80a4
+msgid ""
+"No external kernel-modules support. For example, no support of NVIDIA "
+"graphics cards."
+msgstr ""
+
+#: ../../24.04/index.md:287 53d2facfe2d7433098fc009efc1dc8ca
+msgid ""
+"Firmware updates and upgrades to future releases of Ubuntu are not "
+"currently supported."
+msgstr ""
+
+#: ../../24.04/index.md:289 3e7f870d5a2d4b29bf9a9f57372291f6
+msgid ""
+"Common issues: The 2 most common bugs experienced by users when testing "
+"the experimental TPM backed FDE option are:"
+msgstr ""
+
+#: ../../24.04/index.md:292 85b680e99cc646fd832ec7a39355e0c3
+msgid ""
+"The installation fails to complete and logs contain an error message that"
+" references an operation not being able to complete successfully because "
+"of \"DA lockout mode\". In this case, the TPM must be cleared using one "
+"of two mechanisms. Note that this will result in the loss of all keys "
+"previously protected by this TPM, such as Windows BitLocker keys."
+msgstr ""
+
+#: ../../24.04/index.md:294 02dfabe94cd54ccbbe936bd2d5aac2ae
+msgid ""
+"Reboot into the firmware settings UI and select the option to clear the "
+"TPM. The experience of this will differ between vendors."
+msgstr ""
+
+#: ../../24.04/index.md:295 ebd3783c5abc42f7902b0b3d2bf14a49
+msgid ""
+"Request that the firmware clear the TPM on the next reboot from userspace"
+" by running \"echo 5 | sudo tee /sys/class/tpm/tpm0/ppi/request > "
+"/dev/null\" and then rebooting the device."
+msgstr ""
+
+#: ../../24.04/index.md:297 8d7478a0f9424b4c809589e14b2f71fa
+msgid ""
+"The installation completes, but the user is prompted for a recovery key "
+"on the first boot. Many modern laptops contain a piece of endpoint "
+"management software called Absolute that is built into the firmware and "
+"runs before the operating system loads. This currently causes us to mis-"
+"predict PCR values. The existing workaround is to disable Absolute, which"
+" can be done using one of two mechanisms."
+msgstr ""
+
+#: ../../24.04/index.md:298 e7a69563011b47b8a74edb8af1a6d9fd
+msgid ""
+"On Dell devices, Absolute can be disabled from userspace by running "
+"\"echo DisableAbsolute | sudo tee /sys/devices/virtual/firmware-"
+"attributes/dell-wmi-sysman/attributes/Absolute/current_value > "
+"/dev/null\" and then rebooting."
+msgstr ""
+
+#: ../../24.04/index.md:299 dc80e45a71474159a3a0c437483dc4b0
+msgid ""
+"On other devices, it may be possible to disable Absolute from the "
+"firmware UI. The experience of this will differ between vendors."
+msgstr ""
+
+#: ../../24.04/index.md:301 8582a9573e7c4399b8856bebd5fbdafd
+msgid ""
+"Future updates to the installer will provide additional tools to provide "
+"richer error messaging and support for these use-cases."
+msgstr ""
+
+#: ../../24.04/index.md:303 b86d994776ce4f948c97b550f6b7ebed
+msgid ""
+"The configuration file, `/etc/netplan/01-network-manager-all.yaml` (which"
+" specifies Network Manager as the Netplan renderer), has been moved to "
+"`/lib/netplan/00-network-manager-all.yaml` to reflect that it should not "
+"be edited. Also, it is now owned by the `ubuntu-settings` package. For "
+"upgraders, the move is be performed automatically and the old file "
+"removed if it was unchanged. If it was changed, the move still takes "
+"place, but a copy of the old file is left in `/etc/netplan/01-network-"
+"manager-all.yaml.dpkg-backup` ([LP: "
+"#2020110](https://bugs.launchpad.net/ubuntu/+source/ubuntu-"
+"settings/+bug/2020110))."
+msgstr ""
+
+#: ../../24.04/index.md:305 c4ed41b390104f998706f5e65f0988b9
+msgid ""
+"**NetworkManager now uses Netplan** as its default settings-storage "
+"backend. On upgrade, all connection profiles from `/etc/NetworkManager"
+"/system-connections/` are transparently migrated to "
+"`/etc/netplan/90-NM-*.yaml` and become ephemeral, Netplan-rendered "
+"connection profiles in `/run/NetworkManager/system-connections/`. Backups"
+" of the original profiles are automatically created in "
+"`/var/lib/NetworkManager/backups/` (read more at [NetworkManager YAML "
+"settings backend](https://netplan.readthedocs.io/en/stable/netplan-"
+"everywhere) and [LP: "
+"#1985994](https://bugs.launchpad.net/netplan/+bug/1985994))."
+msgstr ""
+
+#: ../../24.04/index.md:307 b7f47f48b33245beaeb8e52ff36b947b
+msgid ""
+"**ADSys Active Directory Certificates auto-enrollment:** Windows Server "
+"offers a solution for auto-enrolling certificates using Group Policies. "
+"This interacts with Certificate Enrollment Services by Microsoft and "
+"works seamlessly with Windows clients."
+msgstr ""
+
+#: ../../24.04/index.md:309 37ea7e50411a472ca44ca05561e94459
+msgid ""
+"ADSys introduces AD certificates auto-enrollment to streamline connecting"
+" to corporate Wi-Fi and VPN networks. Automated enrollment eliminates the"
+" need for manual interactions with the certificate authority, such as "
+"pre-creating certificates. This simplifies IT administration and "
+"minimises security risks associated with managing sensitive data."
+msgstr ""
+
+#: ../../24.04/index.md:311 f262ce52a04147fb90794cdda8e55e46
+msgid ""
+"The **installer** is now able to update itself and will prompt the user "
+"to update in the very early stages of the installation if a newer version"
+" is available."
+msgstr ""
+
+#: ../../24.04/index.md:313 2ece19bd411e49a1ae8f31d72c77586e
+msgid ""
+"**Power Profiles Manager** [has been improved and "
+"optimized](https://gitlab.freedesktop.org/upower/power-profiles-"
+"daemon/-/releases/#0.21) to support better newer hardware features "
+"(especially AMD), can now support multiple optimization drivers and is "
+"now battery-aware to automatically increase the optimization levels when "
+"running on battery only."
+msgstr ""
+
+#: ../../24.04/index.md:315 46e350abfcb34673bb6a881c58da7bef
+msgid ""
+"**fprintd** has been updated and [**libfprint** supports now many other "
+"fingerprint drivers and "
+"devices](https://gitlab.freedesktop.org/libfprint/libfprint/-/releases#v1.94.7)."
+msgstr ""
+
+#: ../../24.04/index.md:317 68314ed00aec4e0cae02f085923f7807
+msgid "New Store"
+msgstr ""
+
+#: ../../24.04/index.md:319 948ad61e43914c3daeb74c6d2a890a2b
+msgid ""
+"There is a brand new **Ubuntu App Center** that replaces the previous "
+"Snap Store. The application has been written from scratch using the "
+"Flutter toolkit."
+msgstr ""
+
+#: ../../24.04/index.md:320 e8c87c14854e4d8787bcc1b446034887
+msgid "New since 23.10, a Games page has been added to the Ubuntu App Center"
+msgstr ""
+
+#: ../../24.04/index.md:322 371ba5755be14d32abaabd731b14bc6f
+msgid ""
+"There is also a new standalone **Firmware Updater** application available"
+" for both amd64 and arm64. This provides the possibility to update "
+"firmware without needing to have a full app store running continuously in"
+" the background."
+msgstr ""
+
+#: ../../24.04/index.md:324 4ebf64fed9ab40f59875e340231dcbbf
+msgid "GNOME 👣"
+msgstr ""
+
+#: ../../24.04/index.md:326 d82965f1e3f34146a34cb3508d4ea5cf
+msgid ""
+"GNOME has been updated to include new features and fixes from the latest "
+"GNOME release, [GNOME 46](https://release.gnome.org/46/)"
+msgstr ""
+
+#: ../../24.04/index.md:328 2f8a363225b844899b84396e97a64879
+msgid "Default app changes"
+msgstr ""
+
+#: ../../24.04/index.md:330 fb45ee6c35ab4f4ea1c75a66a483c687
+msgid ""
+"The default Ubuntu Desktop installation is now **minimal**. There is "
+"still an “extended selection” option for those who prefer to have "
+"applications like LibreOffice and Thunderbird installed for the first "
+"boot."
+msgstr ""
+
+#: ../../24.04/index.md:332 007b0d01da0d4807a52e6733cb0a587a
+msgid ""
+"In the extended install, the webcam app is now provided by GNOME Snapshot"
+" instead of Cheese"
+msgstr ""
+
+#: ../../24.04/index.md:334 80c3d8d7a11a4bb4b59b8dab592feaee
+msgid "Games are no longer installed by default"
+msgstr ""
+
+#: ../../24.04/index.md:336 ec8b77e303e14cfaa7046da6882b7f1e
+msgid "Updated Ubuntu font"
+msgstr ""
+
+#: ../../24.04/index.md:338 8d29e5b84dc34d54a7f5e6008500c98a
+msgid ""
+"A more modern slimmer version of the Ubuntu font family is now shipped as"
+" standard. Anyone wishing to return to the older Ubuntu font used in "
+"22.04 can do so by installing the `fonts-ubuntu-classic` package."
+msgstr ""
+
+#: ../../24.04/index.md:340 6302ee82f8a949dbb7abab09bf24dff7
+msgid "Updated Applications"
+msgstr ""
+
+#: ../../24.04/index.md:342 158ae8ff43f343bea1e8c779915b0820
+msgid "[Firefox](https://mozilla.org/firefox/releases/) 124 🔥🦊"
+msgstr ""
+
+#: ../../24.04/index.md:343 43851f5e2dba4d71b18fc724fa0704aa
+msgid ""
+"Firefox is a native [Wayland application](https://discourse.ubuntu.com/t"
+"/firefox-snap-with-wayland-enabled-by-default-in-ubuntu-23-10-mantic-"
+"minotaur/38660) for this Ubuntu release"
+msgstr ""
+
+#: ../../24.04/index.md:344 bb4e75be18c74c86be8928a83a85bdea
+msgid ""
+"[LibreOffice 24.2](https://wiki.documentfoundation.org/ReleaseNotes/24.2)"
+" 📚"
+msgstr ""
+
+#: ../../24.04/index.md:345 d283324aa0a648cc98cb904317979b98
+msgid ""
+"[Thunderbird 115 \"Supernova\"](https://blog.thunderbird.net/2023/07/our-"
+"fastest-most-beautiful-release-ever-thunderbird-XY-supernova-is-here/) "
+"🌩️🐦"
+msgstr ""
+
+#: ../../24.04/index.md:346 ef89e3a1ced742b38bf3cb89937a8e49
+msgid "Thunderbird is now provided as a Snap package only"
+msgstr ""
+
+#: ../../24.04/index.md:348 d3d0432ba24d4978aa417358c0f412a3
+msgid "Updated Subsystems"
+msgstr ""
+
+#: ../../24.04/index.md:350 30e251abcc5f40cd9a0b43ab68ba5594
+msgid ""
+"[BlueZ "
+"5.72](https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/ChangeLog?id=5.72)"
+msgstr ""
+
+#: ../../24.04/index.md:351 0ac5f2a029a3437f9e1c15e6eae222e7
+msgid "[Cairo 1.18](https://cairographics.org/news/cairo-1.18.0/)"
+msgstr ""
+
+#: ../../24.04/index.md:352 adbbba35deb743a2adc681339cd21121
+msgid ""
+"[NetworkManager "
+"1.46](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/nm-1-46/NEWS)"
+msgstr ""
+
+#: ../../24.04/index.md:353 ff06f610a53a443c96ffaa74e483a4ee
+msgid ""
+"[Pipewire "
+"1.0.4](https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/1.0.4/NEWS)"
+msgstr ""
+
+#: ../../24.04/index.md:354 eb045bd6b8a44ffba585d9dfa5dddded
+msgid ""
+"[Poppler "
+"24.02](https://gitlab.freedesktop.org/poppler/poppler/-/blob/poppler-24.02.0/NEWS)"
+msgstr ""
+
+#: ../../24.04/index.md:355 518d6f641e054a62a5a45f958c48aa55
+msgid ""
+"[xdg-desktop-portal 1.18](https://github.com/flatpak/xdg-desktop-"
+"portal/blob/1.18.2/NEWS)"
+msgstr ""
+
+#: ../../24.04/index.md:357 6c8ee66eaadd462e8e08f7922b1ff9f8
+msgid "Ubuntu WSL"
+msgstr ""
+
+#: ../../24.04/index.md:359 b9ecfbec2a7648ca849d72bb12c44d8d
+msgid "Cloud-init support"
+msgstr ""
+
+#: ../../24.04/index.md:361 1fecff4faa814ccea83c9895233598a1
+msgid ""
+"`cloud-init`  is the *industry standard* multi-distribution method for "
+"cross-platform cloud instance initialisation. It is supported across all "
+"major public cloud providers, provisioning systems for private cloud "
+"infrastructure, and bare-metal installations."
+msgstr ""
+
+#: ../../24.04/index.md:363 dcfb16f2b6cf416a823bb4ba4d73dbbd
+msgid ""
+"With `cloud-init` on WSL you can now automatically and reproducibly "
+"configure your WSL instances on first boot. Make the first steps with "
+"[this tutorial](https://canonical-ubuntu-wsl.readthedocs-"
+"hosted.com/en/latest/tutorials/cloud-init/)."
+msgstr ""
+
+#: ../../24.04/index.md:365 1f86d42302e84db9a208b760fe6b79be
+msgid "New documentation"
+msgstr ""
+
+#: ../../24.04/index.md:367 6f5702c1f3884715b575ffa8869c78a1
+msgid ""
+"The documentation specific to [Ubuntu on WSL is available on Read the "
+"Docs](https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/). "
+"This evolving project is regularly updated with new content about "
+"Ubuntu's specifics on WSL."
+msgstr ""
+
+#: ../../24.04/index.md:369 d07cd87a74094fec9af6fb7fdd871ac5
+msgid "Enhancements"
+msgstr ""
+
+#: ../../24.04/index.md:371 eadb4e308901460e8cef7660723fc8d4
+msgid ""
+"**Reduced footprint** Experience faster download and installation times "
+"with 24.04, with a 200MB reduction in image size."
+msgstr ""
+
+#: ../../24.04/index.md:374 7c8f7a5ccf2b447ea93a2e3efd1057f0
+msgid ""
+"**systemd by default everywhere** `systemd` is now enabled by default "
+"even when the instance is launched directly from a terminal with the "
+"`wsl.exe` command or from an imported root files system."
+msgstr ""
+
+#: ../../24.04/index.md:377 ../../24.04/index.md:1109
+#: 0f5bfd6ec031434f8bed6fbb58f85f48 f9b8045f301f4012a96c87659b28c1c9
+msgid "Ubuntu Server"
+msgstr ""
+
+#: ../../24.04/index.md:379 99e8f0dd6390409388a392a2fdb53687
+msgid "Apache2"
+msgstr ""
+
+#: ../../24.04/index.md:381 fe0c8e38859c48a687445c93068f7f8e
+msgid ""
+"The Apache2 package has been updated to version 2.4.58.  Here are the "
+"major changes since Ubuntu Jammy:"
+msgstr ""
+
+#: ../../24.04/index.md:384 74e8d3b3a46c4988a68ef6c9120bc8ea
+msgid ""
+"mod_http2 has a partial rewrite of how connections and streams are "
+"handled. APR pollset and pipes do the monitoring instead of stuttered "
+"timed waits. Resource handling for misbehaving clients is improved. It "
+"also gains new directives `H2ProxyRequests`, `H2MaxDataFrameLen`, "
+"`H2WebSockets` and `H2EarlyHint`."
+msgstr ""
+
+#: ../../24.04/index.md:385 d675f846ea6a4e45a219414d055c2a97
+msgid ""
+"Add an auto status to mod_md using a format similar to "
+"mod_proxy_balancer, and supports managing certificates via the tailscale "
+"secure networking service."
+msgstr ""
+
+#: ../../24.04/index.md:386 360e00253f99491f933803fc75232163
+msgid ""
+"mod_md fixes certificate renewal issues in certain situations, and gains "
+"a new directive `MDCertificateAuthority` for failover of renewals, along "
+"with configurational directives `MDRetryDelay` and `MDRetryFailover` to "
+"control its behavior."
+msgstr ""
+
+#: ../../24.04/index.md:387 a585a95ab6af4ab8a8c4b2e139c31845
+msgid ""
+"mod_md also gains new directives MDMatchNames and MDChallengeDns01Version"
+" to give more configurational control over MDomains and challenges."
+msgstr ""
+
+#: ../../24.04/index.md:388 41d4a0d45ffd48acb43e8694bc530c28
+msgid "Support for managing mod_md configurations via local tailscale daemon"
+msgstr ""
+
+#: ../../24.04/index.md:389 d62ad600496d4702baad61989dc9d68f
+msgid ""
+"Support pcre2 (10.x) library in place of the now end-of-life pcre (8.x) "
+"for regular expression evaluation."
+msgstr ""
+
+#: ../../24.04/index.md:390 5d7fecd8c51340d498da50f34b85f327
+msgid ""
+"mod_proxy gains various backend refinements and fixes, including "
+"detecting AJP/CPING support correctly now."
+msgstr ""
+
+#: ../../24.04/index.md:391 af390867a4484f07be7a055a2635665d
+msgid "MPM event fix issues during restart and idle maintenance."
+msgstr ""
+
+#: ../../24.04/index.md:392 112a7048738347fbbfb3dff4c6285001
+msgid ""
+"Add the BCTLS and BNE RewriteRule flags to mod_rewrite and fixes   "
+"security issues and several bugs."
+msgstr ""
+
+#: ../../24.04/index.md:394 2bdedae364a94a38b5256ae97e9a461a
+msgid ""
+"More information on the changes in Apache2 2.4.53 through 2.4.58, now "
+"included in Ubuntu can be found at: "
+"https://www.apachelounge.com/changelog-2.4.html"
+msgstr ""
+
+#: ../../24.04/index.md:397 3d11fce5d0014844ad900cba4f39b3ef
+msgid "Clamav"
+msgstr ""
+
+#: ../../24.04/index.md:399 6eee236e38734751ab2324a15daf738b
+msgid ""
+"The clamav anti-virus toolkit saw a 1.0.0 release between Ubuntu 22.04 "
+"LTS and now.  Some of the major changes since Ubuntu Jammy include:"
+msgstr ""
+
+#: ../../24.04/index.md:400 aee8d5c75a1047148c8ae22fcb295b8e
+msgid ""
+"Support for decrypting read-only OLE2-based XLS files that are encrypted "
+"with the default password."
+msgstr ""
+
+#: ../../24.04/index.md:401 46a7841ed1b34b51a4a9b038c1c1d8c3
+msgid "Overhauled the implementation of the all-match feature. The newer code"
+msgstr ""
+
+#: ../../24.04/index.md:402 436c75cbe1894effb782904200f2ddb0
+msgid ""
+"Added a new callback, cl_engine_set_clcb_file_inspection(), for "
+"inspecting file content during a scan at each layer of archive "
+"extraction."
+msgstr ""
+
+#: ../../24.04/index.md:403 b6e99eff83c34a75ba92a49cf4ba5fc4
+msgid "Added a new API function unpacking CVD signature archives, cl_cvdunpack()."
+msgstr ""
+
+#: ../../24.04/index.md:405 b49f90f74c3246388418278b3d6a1725
+msgid ""
+"The full list of changes for the ClamAV 1.0.0 LTS release can be found at"
+" https://blog.clamav.net/2022/11/clamav-100-lts-released.html.  For "
+"details on subsequent bugfix releases in the 1.0 branch, including 1.0.5,"
+" see Clamav's blog at https://blog.clamav.net/."
+msgstr ""
+
+#: ../../24.04/index.md:408 e64ae1de84514c6784ad009e1b2876f5
+msgid "Chrony"
+msgstr ""
+
+#: ../../24.04/index.md:410 6cc48d0b58bf4699bcb6828de734c5f1
+msgid ""
+"Chrony is updated to 4.5, which adds support for systemd socket "
+"activation, multiple refclocks on one PHC, corrections from PTP "
+"transparent clocks, AES-GCM-SIV in GnuTLS, and AES-GCM-SIV with Nettle >="
+" 3.9 to shorten NTScookies to avoid some length-specific blocking of NTP."
+"  DSCP is set for IPv6 packets.  New options include maxpoll for the "
+"hwtimestamp directive to improve PHC tracking with low packet rates, "
+"maxdelayquant for adding long-term quantile-based filtering to the "
+"server/pool/peer directive, and a local option to the refclock directive "
+"to stabilise system clock with more stable free-running clock (e.g. TCXO,"
+" OCXO).  A new hwtstimeout directive has been added to configure timeout "
+"for late timestamps, and a selectopts command to modify source-specific "
+"selection options."
+msgstr ""
+
+#: ../../24.04/index.md:412 d38aa0ebfbed464bbd026b09ecf338c8
+msgid ""
+"More information about the 4.5 and other releases can be found at "
+"Chrony's news page, at https://chrony-project.org/news.html."
+msgstr ""
+
+#: ../../24.04/index.md:414 cdde331f85434f2581bcc657f7775bc6
+msgid "cloud-init v.24.1.3"
+msgstr ""
+
+#: ../../24.04/index.md:415 a80862de7f014d7cb31cd0f795314a76
+msgid "Notable features:"
+msgstr ""
+
+#: ../../24.04/index.md:416 87923b77413c48c1ae5369b6729ebdad
+msgid "Windows Subsystem for Linux(WSL) datasource support"
+msgstr ""
+
+#: ../../24.04/index.md:417 c57aabfb8c3244b8874e7dab86d8a368
+msgid ""
+"azure: improved handling and retires of DHCP during pre-provisioning "
+"stage (PPS)"
+msgstr ""
+
+#: ../../24.04/index.md:418 3d0f702b77314cfb9cebc07c4479a96b
+msgid "ec2: support for multi-NIC/IP instances"
+msgstr ""
+
+#: ../../24.04/index.md:419 6d567e66cdb94855bc88ca1ef7f79402
+msgid "oracle: add resilience to early network issues"
+msgstr ""
+
+#: ../../24.04/index.md:420 57c02f4f5f9f48c69e1b8c323bfd9fa3
+msgid "network: dhcpcd support as primary DHCP client (successor to isc-dhclient)"
+msgstr ""
+
+#: ../../24.04/index.md:421 04a5dd8a7a8349b8aee75b1442037c9a
+msgid "APT deb822 support for default sources"
+msgstr ""
+
+#: ../../24.04/index.md:422 a901f5fca7ab43e893b9c427e462cc15
+msgid "cloud-init status improved recoverable_error(warning) visibility"
+msgstr ""
+
+#: ../../24.04/index.md:424 d450189fcb494e369b448ec599dc5d48
+msgid "Breaking changes:"
+msgstr ""
+
+#: ../../24.04/index.md:425 a4b69cfe9185404abc3d89589ed76b96
+msgid "cloud-init status exist 2 on warnings and exits 1 on error."
+msgstr ""
+
+#: ../../24.04/index.md:426 f31bbba50393433586559f0a23708fee
+msgid "SSH dropped support for DSA host keys"
+msgstr ""
+
+#: ../../24.04/index.md:427 a02e4bd2dbe14670abb8ed49b5e5ac33
+msgid "boot optimization: removed systemd ordering dependency on snapd.seeded"
+msgstr ""
+
+#: ../../24.04/index.md:428 ebd31880c7254bc2a65e626f6cdf1742
+msgid "stopped adding network v2 DNS to global DNS"
+msgstr ""
+
+#: ../../24.04/index.md:429 b8ad6814358e4784977d7dc7d1af8784
+msgid "mandate use of a single datasource when specified in datasource_list"
+msgstr ""
+
+#: ../../24.04/index.md:431 adbb69a4677d40358b9066a84205e7ed
+msgid ""
+"Features since Ubuntu Jammy: (details in [cloud-init's Github releases "
+"page](https://github.com/canonical/cloud-init/releases/))"
+msgstr ""
+
+#: ../../24.04/index.md:433 7838d8dbbf084f4394d678f6017a42b9
+msgid "Clouds: added NWCS and Akamai(Linode)"
+msgstr ""
+
+#: ../../24.04/index.md:434 785bf4190beb4de6b8ef5a992799ecde
+msgid ""
+"Config Modules: added ansible and wireguard modules, sodoers doas and "
+"opendoas support"
+msgstr ""
+
+#: ../../24.04/index.md:435 11dab5927d5848459decd91241f59eec
+msgid ""
+"Ephemeral network IPv4/IPv6 dual-stack support setup, support ucdhcp "
+"client"
+msgstr ""
+
+#: ../../24.04/index.md:436 b382d2009ff24c7bbb2a07b4437fd395
+msgid "Netplan schema validation and config passthrough"
+msgstr ""
+
+#: ../../24.04/index.md:437 cb4f80fce0ab4455be01fd70fe965244
+msgid "NetworkManager and networkd renderer support"
+msgstr ""
+
+#: ../../24.04/index.md:438 0094efbd1ed14938bcfe0adf039ffa32
+msgid "jinja template support of /etc/cloud/cloud.cfg.d"
+msgstr ""
+
+#: ../../24.04/index.md:439 02e7c9d071ca440cb6039b2b6a3daf61
+msgid "cloud-init schema: validation of user-data, vendor-data and network-config"
+msgstr ""
+
+#: ../../24.04/index.md:440 7bf04499ea6c4267bbe36c75f11967b5
+msgid "cloud-init clean: /etc/machine-id support for golden images"
+msgstr ""
+
+#: ../../24.04/index.md:442 171e5cc8b4854b4685b2fd8baba3d2d1
+msgid "Containerd"
+msgstr ""
+
+#: ../../24.04/index.md:444 7fa5bcc831ff4aa299bfc76184b378b6
+msgid ""
+"The containerd package was updated to version 1.7.12. It contains a bunch"
+" of bug fixes, adding support to newer Golang version, updating "
+"dependencies and so on. The two features below are new in this version "
+"since the last Ubuntu release:"
+msgstr ""
+
+#: ../../24.04/index.md:446 e3cef4ef32724708a00945bc08fbc8bf
+msgid "Add blockfile snapshotter."
+msgstr ""
+
+#: ../../24.04/index.md:447 e95364dca348463f802adc81e8fa5f4f
+msgid "Add remote/proxy differ."
+msgstr ""
+
+#: ../../24.04/index.md:449 531b5adb2f454e4caa8adb3e55730b48
+msgid ""
+"Some features were marked as deprecated, please try to not use them "
+"anymore. Deprecation warnings:"
+msgstr ""
+
+#: ../../24.04/index.md:451 fe85549ca1d14c0d89430be0d2da3d07
+msgid "Emit deprecation warning for `containerd.io/restart.logpath` label usage."
+msgstr ""
+
+#: ../../24.04/index.md:452 e4766ff208dd4ef9820a3432937b2702
+msgid "Emit deprecation warning for AUFS snapshotter."
+msgstr ""
+
+#: ../../24.04/index.md:453 8f2119b0a53a4bc19cb293d62d3f22a1
+msgid "Emit deprecation warning for v1 runtime."
+msgstr ""
+
+#: ../../24.04/index.md:454 7b82b238497842708146cd9251319efd
+msgid "Emit deprecation warning for deprecated CRI configs."
+msgstr ""
+
+#: ../../24.04/index.md:455 7cd82c3ccd0e403eaabbdadc1a93de30
+msgid "Emit deprecation warning for CRI v1alpha1 usage."
+msgstr ""
+
+#: ../../24.04/index.md:456 ec8b2ca4971b41ccbe745e7730e3e370
+msgid "Emit deprecation warning for CRIU config in CRI."
+msgstr ""
+
+#: ../../24.04/index.md:458 6bc94550f3b447a8b72299ba01547a15
+msgid ""
+"For more information, please see [the upstream "
+"changelog](https://github.com/containerd/containerd/releases)."
+msgstr ""
+
+#: ../../24.04/index.md:460 273d3fe2e5fa4ade83a523502ad08f32
+msgid "Django"
+msgstr ""
+
+#: ../../24.04/index.md:462 fe1cc1edc5d1494fa8f755de44345985
+msgid ""
+"Django was updated to version 4.2.11, providing the latest LTS bug and "
+"security fixes. For more information see the upstream changelogs for "
+"[4.2.5](https://docs.djangoproject.com/en/4.2/releases/4.2.5/)-[4.2.11](https://docs.djangoproject.com/en/4.2/releases/4.2.11/)."
+msgstr ""
+
+#: ../../24.04/index.md:464 339ad285118d4d589d852582ae109fb0
+msgid "Docker"
+msgstr ""
+
+#: ../../24.04/index.md:466 0bd8fe1151844fb9aab3c4b25a005d3b
+msgid ""
+"The docker.io package was updated to version 24.0.7. It contains many bug"
+" fixes and dependencies update. Some highlights are the fix of data "
+"corruption with zstd output and many improvements to the containerd "
+"storage backend. For more information, please see [the upstream "
+"changelog](https://docs.docker.com/engine/release-notes/24.0/)."
+msgstr ""
+
+#: ../../24.04/index.md:469 63269f2f142d4896ac1ff55f38955480
+msgid ""
+"There is a AppArmor related bug where containers cannot be promptly "
+"stopped due to the recently added AppArmor profile for `runc`. The "
+"containers are always killed with `SIGKILL` due to the denials when "
+"trying to receive a signal. More details about this bug can be found "
+"[here](https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/2063099),"
+" and a workaround is described "
+"[here](https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/2063099/comments/4)."
+msgstr ""
+
+#: ../../24.04/index.md:472 32f0287109364bb1a5b52f5d7da2642c
+msgid "Dovecot"
+msgstr ""
+
+#: ../../24.04/index.md:473 9a206d43061b472cbf309c77924d062e
+msgid ""
+"Dovecot received several micro-point updates from 2.3.16 in Ubuntu Jammy,"
+" to 2.3.21 in this new LTS."
+msgstr ""
+
+#: ../../24.04/index.md:475 a1e72469235d49c09704fa5a16a9d571
+msgid ""
+"There is also a new dsync_features=no-header-hashes setting, which "
+"enables an optimization that assumes identical IMAP UIDs contain the same"
+" mail contents. This is useful on IMAP servers that don’t cache the Date"
+"/Message-ID headers."
+msgstr ""
+
+#: ../../24.04/index.md:477 7697df4cc0a643e885a935a004332722
+msgid ""
+"[New events](https://doc.dovecot.org/admin_manual/list_of_events/) are "
+"added."
+msgstr ""
+
+#: ../../24.04/index.md:478 3375838b27ca47ce8aee74f5a1b6a28d
+msgid "New Lua HTTP client settings and a new doveadm replicator status command."
+msgstr ""
+
+#: ../../24.04/index.md:479 fe54be50579f4b95adc390d5241f29f5
+msgid ""
+"fts: [Don't index inline base64 encoded "
+"content](https://doc.dovecot.org/configuration_manual/fts/tokenization) "
+"in FTS indexes using the generic tokenizer. This reduces the FTS index "
+"sizes by removing input that is very unlikely to be searched for. Only "
+"applies when using libfts."
+msgstr ""
+
+#: ../../24.04/index.md:480 b36b05cfbe0342a2a261c847094e3a24
+msgid ""
+"stats: If metric has fields specified, all these fields are [exported as "
+"counters](https://doc.dovecot.org/configuration_manual/stats/openmetrics/.)"
+" to prometheus exposition."
+msgstr ""
+
+#: ../../24.04/index.md:481 8744dbf97cdb4f2d9c5a3ea9e6d102df
+msgid ""
+"lua: [HTTP client has more "
+"settings](https://doc.dovecot.org/admin_manual/lua/#dovecot.http.client) "
+"now."
+msgstr ""
+
+#: ../../24.04/index.md:482 e77dd2d0eb5c4527898ae49540e4e752
+msgid ""
+"Added [mail_user_session_finished "
+"event](https://doc.dovecot.org/admin_manual/list_of_events/), which is "
+"emitted when the mail user session is finished (e.g. imap, pop3, lmtp). "
+"It also includes fields with some process statistics information."
+msgstr ""
+
+#: ../../24.04/index.md:483 0f90976b048445e1903c868a0baddc79
+msgid ""
+"auth: Add [a cache hit "
+"indicator](https://doc.dovecot.org/admin_manual/list_of_events/) to auth "
+"passdb/userdb finished events."
+msgstr ""
+
+#: ../../24.04/index.md:484 b83daa44b0db458dbafcadd62125faa5
+msgid ""
+"lib-lua: Add [a Lua interface](https://doc.dovecot.org/admin_manual/lua/)"
+" to Dovecot's HTTP client library."
+msgstr ""
+
+#: ../../24.04/index.md:485 ac9e8b6cb4704af3ad58f63b480a4bcf
+msgid ""
+"[Events now have a \"reason_code\" "
+"field](https://doc.dovecot.org/admin_manual/event_reasons/), which can "
+"provide a list of reasons why the event is happening."
+msgstr ""
+
+#: ../../24.04/index.md:486 206220ab73f84412a759d568c77fd20d
+msgid ""
+"fts: Added [fts_header_excludes and fts_header_includes "
+"settings](https://doc.dovecot.org/settings/plugin/fts-plugin#plugin-fts-"
+"setting-fts-header-excludes) to specify which headers to index."
+msgstr ""
+
+#: ../../24.04/index.md:488 78414bb26eb9468aae2b740c3b5d5193
+msgid ""
+"For more detailed information on the changes since Ubuntu Jammy, see "
+"Dovecot's release announcements for "
+"[2.3.17](https://dovecot.org/pipermail/dovecot-"
+"news/2021-October/000465.html), [2.3.18](https://dovecot.org/pipermail"
+"/dovecot-news/2021-December/000468.html), "
+"[2.3.19](https://dovecot.org/list/dovecot-news/2022-May/000473.html), "
+"[2.3.20](https://dovecot.org/pipermail/dovecot-"
+"news/2022-December/000479.html), and "
+"[2.3.21](https://dovecot.org/mailman3/archives/list/dovecot-"
+"news@dovecot.org/thread/KYDR7WWPEQOBZA3IA4NL5XDSLODZLG6N/)."
+msgstr ""
+
+#: ../../24.04/index.md:491 1ec2ea297baf4295a45798a7f8bed845
+msgid "Exim4"
+msgstr ""
+
+#: ../../24.04/index.md:493 300a13df408c4b7d9b35f0e05bcb67e0
+#, python-brace-format
+msgid ""
+"The exim4 mail transport agent was updated to version 4.97.  This brings "
+"numerous fixes to syntax parsing including ${run...}, ${if} and ${filter "
+"} constructions.  Query-style lookups are now checked for quoting; for "
+"now issues are just logged but will be treated as errors in a future "
+"release. An expansion operator for wrapping long header lines has been "
+"added."
+msgstr ""
+
+#: ../../24.04/index.md:495 ../../24.04/index.md:806
+#: a0c8a6531b5549e8a858538bdb82566e d0e43775eaa84b64afc8c57b1fb1a1ba
+msgid "Other notable changes include:"
+msgstr ""
+
+#: ../../24.04/index.md:497 1791720a98fd4446910f47f5ce8355b7
+msgid "Queue runners for several queues can now be started from one daemon."
+msgstr ""
+
+#: ../../24.04/index.md:498 5fa28d8a60bd402aa037ae077381f2be
+msgid "A new ACL condition: seen. Records/tests a timestamp against a key."
+msgstr ""
+
+#: ../../24.04/index.md:499 58ed69d2021445afaa4572970c0b44ca
+msgid ""
+"Events on a failing SMTP AUTH, for both client and server operations, and"
+" for failing TLS connects to the daemon."
+msgstr ""
+
+#: ../../24.04/index.md:500 1df108552bba46c189afe1cd0a2ef716
+msgid ""
+"Variable $sender_helo_verified with the result of an ACL \"verify = "
+"helo\"."
+msgstr ""
+
+#: ../../24.04/index.md:501 81ef52dc5af24dd293a6d9e3ada199c8
+msgid "The smtp transport option \"max_rcpt\" is now expanded before use."
+msgstr ""
+
+#: ../../24.04/index.md:502 8795d83ed94c49c7b517e7c4fe6170d5
+msgid "The expansion-test facility (exim -be) can set variables."
+msgstr ""
+
+#: ../../24.04/index.md:503 9812f28d8f1c4ad2831c5297d5dc9400
+msgid ""
+"The \"allow_insecure_tainted_data\" main config option and the \"taint\" "
+"log_selector have been removed.  These were deprecated in the 4.95 "
+"release."
+msgstr ""
+
+#: ../../24.04/index.md:505 283abe70c89d4ab69aefe63b86632d30
+msgid ""
+"Please note that the default configuration (/etc/default/exim4) generated"
+" for fresh installations differs from past practices, and a number of "
+"settings (QFLAGS, QUEUEINTERVAL, COMMONOPTIONS, QUEUERUNNEROPTIONS and "
+"SMTPLISTENEROPTIONS) have been replaced.  As well, the `update-"
+"exim4defaults` script is no longer used for setting run parameters for "
+"the Exim daemon; users are encouraged to edit /etc/default/exim4 directly"
+" to customize.  Also, the internal (but exposed in logs, Received: "
+"headers and Message-ID: headers) identifier used for messages is longer "
+"than in the previous release."
+msgstr ""
+
+#: ../../24.04/index.md:507 51097abe83e94fceab62ccaf2dba307f
+msgid ""
+"For more information on the changes introduced in Exim4 4.96 and 4.97, "
+"please see the [Exim4 project's "
+"ChangeLog](https://github.com/Exim/exim/blob/master/doc/doc-"
+"txt/ChangeLog)."
+msgstr ""
+
+#: ../../24.04/index.md:509 b0b78250edeb4b7599c7da9090b5e025
+msgid "GlusterFS"
+msgstr ""
+
+#: ../../24.04/index.md:511 94888057d23e48c8bf9917cfd6f4e570
+msgid ""
+"The GlusterFS clustering filesystem package was updated to version "
+"[11.1](https://lists.gluster.org/pipermail/gluster-"
+"devel/2023-February/058414.html). Following this update, some changes "
+"were made to the packaging layout of GlusterFS and dependent packages:"
+msgstr ""
+
+#: ../../24.04/index.md:513 e7112dab12d54bc7aa1df320b7a44b54
+msgid ""
+"GlusterFS upstream no longer supports 32 bit architectures (see [LP: "
+"#2052734](https://bugs.launchpad.net/ubuntu/+source/glusterfs/+bug/2052734))."
+" Therefore, there are no armhf packages for GlusterFS in Ubuntu Noble. As"
+" a further consequence, other packages that linked or relied on GlusterFS"
+" also no longer have that support on the armhf architecture."
+msgstr ""
+
+#: ../../24.04/index.md:514 50a727b1ab6c4e6b8fd894133824087a
+msgid ""
+"GlusterFS has been demoted to Universe ([LP: "
+"#2045063](https://bugs.launchpad.net/ubuntu/+source/glusterfs/+bug/2045063))."
+msgstr ""
+
+#: ../../24.04/index.md:515 df9df5bca71d44c4a033330618a1087e
+msgid ""
+"Since there cannot be packages in Main depending on Universe, packages in"
+" main that had a dependency on GlusterFS were modified to ship that "
+"dependency also in Universe."
+msgstr ""
+
+#: ../../24.04/index.md:517 7d4b9932cfe8475ab18081e95169d69f
+msgid "The following packages were changed:"
+msgstr ""
+
+#: ../../24.04/index.md:519 1b9e5f35052d4f25875ccbae3573ecfd
+msgid ""
+"qemu: The binary `qemu-block-extra` package had a dependency on GlusterFS"
+" due to the gluster storage module it shipped. That module is now being "
+"shipped in the new `qemu-block-supplemental` binary package."
+msgstr ""
+
+#: ../../24.04/index.md:521 afc3459cefb94b5ab042d761a0243b42
+msgid ""
+"samba: The binary `samba-vfs-modules` package had a dependency on "
+"GlusterFS due to a VFS module. All GlusterFS VFS modules were moved to "
+"the new `samba-vfs-modules-extra` package."
+msgstr ""
+
+#: ../../24.04/index.md:523 65faa5c50bd3445aa7d2a810364a8fa8
+msgid ""
+"Note that since GlusterFS is no longer available for 32 bit architectures"
+" (see [LP: "
+"#2052734](https://bugs.launchpad.net/ubuntu/+source/glusterfs/+bug/2052734)),"
+" the two new packages mentioned above do not exist on armhf."
+msgstr ""
+
+#: ../../24.04/index.md:525 f0ba2270a4bd42cfa2d55dcd638a7a69
+msgid "Upgrade considerations for qemu and samba"
+msgstr ""
+
+#: ../../24.04/index.md:526 e6f267b852eb447d82f5cbeb5426c35e
+msgid ""
+"If you have a deployment of qemu or samba that used the glusterfs storage"
+" or VFS modules, then there are considerations to be made. In other "
+"words, if you:"
+msgstr ""
+
+#: ../../24.04/index.md:527 228aa15eee6d46c5b3f993a3cca8ec4b
+msgid ""
+"had `qemu-block-extra` installed, and were using the `block-gluster.so` "
+"module"
+msgstr ""
+
+#: ../../24.04/index.md:528 8eca9731c35c45dfb2f1a4128b133d97
+msgid ""
+"had `samba-vfs-modules` installed and were using either `glusterfs.so` or"
+" `glusterfs_fuse.so` VFS modules"
+msgstr ""
+
+#: ../../24.04/index.md:530 b30fe991188f41edb048ff320763145e
+msgid ""
+"Then the release upgrade to Ubuntu Noble will replace those packages with"
+" the new versions that DO NOT have the glusterfs modules. In such cases, "
+"you will have to install the new packages manually after the release "
+"upgrade is completed:"
+msgstr ""
+
+#: ../../24.04/index.md:531 fa0e758ca83e43738b5809973e404881
+msgid "`sudo apt install qemu-block-supplemental`, or"
+msgstr ""
+
+#: ../../24.04/index.md:532 894dae547a5a4f4da651492274bd24a2
+msgid "`sudo apt install samba-vfs-modules-extra`"
+msgstr ""
+
+#: ../../24.04/index.md:534 6947161af6ea47099479246773e3d31d
+msgid ""
+"Considerations were made ([ubuntu-devel mailing list "
+"thread](https://lists.ubuntu.com/archives/ubuntu-"
+"devel/2024-January/042872.html)) to perhaps include this logic in the "
+"Ubuntu release upgrade tool, but it was decided to not increase the "
+"complexity of the upgrader at this time. If you have a different scenario"
+" where this will have a big impact on your deployments, then please "
+"comment on the [LP: "
+"#2045063](https://bugs.launchpad.net/ubuntu/+source/glusterfs/+bug/2045063)"
+" bug."
+msgstr ""
+
+#: ../../24.04/index.md:537 dd18fa923c5d42c48041d288e6421eb6
+msgid "HAProxy"
+msgstr ""
+
+#: ../../24.04/index.md:539 15573de1d28b43e7b3c29bfb0a83eeca
+msgid ""
+"The [HAProxy](https://www.haproxy.org) package was updated to version "
+"2.8.5. This new version includes several improvements and bug fixes. For "
+"more information, please see [the upstream "
+"changelog](https://www.haproxy.org/download/2.8/src/CHANGELOG)."
+msgstr ""
+
+#: ../../24.04/index.md:541 4cb5393cdcc041728533b7d58ecf0342
+msgid "Kea"
+msgstr ""
+
+#: ../../24.04/index.md:543 4db8e75da6174e8c84de604fe71aca5d
+msgid ""
+"The [Kea](https://www.isc.org/kea/) package was updated to version 2.4.1."
+" This is now the supported DHCP server in Ubuntu, replacing ISC DHCP, "
+"which has been discontinued by ISC."
+msgstr ""
+
+#: ../../24.04/index.md:545 fa97438b30e94568a7d7d3efad4e3ac1
+msgid ""
+"`keama` a new binary package to aid migrating ISC DHCP configuration "
+"files to Kea was also made available in noble."
+msgstr ""
+
+#: ../../24.04/index.md:547 2b368cffe04d4c3bad61e4e91c8a7762
+msgid "Here are some of the major changes in Kea since Ubuntu Jammy."
+msgstr ""
+
+#: ../../24.04/index.md:549 d2ff17a1b69f43ad805f9b253a909264
+msgid "Native TLS support."
+msgstr ""
+
+#: ../../24.04/index.md:550 d8bbe95277a24b43ae68601387665468
+msgid "PostgreSQL configuration backend."
+msgstr ""
+
+#: ../../24.04/index.md:551 74cba8d8c0024f449922bc3f8feedd17
+msgid "Support password-files to store HTTP API credentials."
+msgstr ""
+
+#: ../../24.04/index.md:552 a0c9c8f695514fe894ece6955a46fac7
+msgid "Multi-threading is now enabled by default."
+msgstr ""
+
+#: ../../24.04/index.md:553 7225159639914ce7b1fec640ab7b41a2
+msgid ""
+"Affinity for released leases. Kea now keeps leases for a configurable "
+"period after they are released. This is useful for devices that send "
+"RELEASE when rebooting so they have more chances of obtaining the same "
+"lease when the reboot process is complete."
+msgstr ""
+
+#: ../../24.04/index.md:555 b4652bf3b2c449c9942972ce46501b0c
+msgid ""
+"For more details, please see the upstream release notes for [version "
+"2.4](https://downloads.isc.org/isc/kea/2.4.0/Kea-2.4.0-ReleaseNotes.txt) "
+"and for [version "
+"2.2](https://downloads.isc.org/isc/kea/2.2.0/Kea-2.2.0-ReleaseNotes.txt)"
+msgstr ""
+
+#: ../../24.04/index.md:557 f66c5edc888e42a3925ecfa9655eeeb5
+msgid "libvirt"
+msgstr ""
+
+#: ../../24.04/index.md:559 13c38d72be9542fdae79ab4b048e40f2
+msgid ""
+"The [libvirt](https://libvirt.org) package was updated to version 10.0.0."
+"  Here are the changes since Ubuntu Jammy."
+msgstr ""
+
+#: ../../24.04/index.md:561 a9c631ad27fb4f6c8a6aa2cff7f14a61
+msgid "Support mode option for `dirtyrate` calculation."
+msgstr ""
+
+#: ../../24.04/index.md:562 8ddfa61e4efb443eb9f21e9108c022ac
+msgid "Improve domain save/restore throughput"
+msgstr ""
+
+#: ../../24.04/index.md:563 d99381b3df094de2b5c77737c597517b
+msgid "Introduce manual disk snapshot mode to coordinate outside libvirt."
+msgstr ""
+
+#: ../../24.04/index.md:564 aa7e88981faa40b4ba704c301e049d8d
+msgid ""
+"Introduce memory allocation threads (handy for guests with large amounts "
+"of memory)."
+msgstr ""
+
+#: ../../24.04/index.md:565 8305cc74ca8146648b24ab69c1cd9fd0
+msgid "Introduce support for `virtio-iommu`."
+msgstr ""
+
+#: ../../24.04/index.md:566 bba9940120584e0dab2ed3e4f2b03464
+msgid "PPC64 Power10 processor support."
+msgstr ""
+
+#: ../../24.04/index.md:567 5e79583c511e4dce8296615bbd3077cb
+msgid "Introduce absolute clock offset."
+msgstr ""
+
+#: ../../24.04/index.md:568 bd4ae1059aa448288c848b8f33d5ebef
+msgid "Add support for post-copy migration recovery."
+msgstr ""
+
+#: ../../24.04/index.md:569 f97440cf2d0242f98588a8feb7be9050
+msgid "qemu: Add support for zero-copy migration"
+msgstr ""
+
+#: ../../24.04/index.md:570 e1ddaba538fa469e9d7db189f0fd2655
+msgid "qemu: Add support for specifying vCPU physical address size in bits"
+msgstr ""
+
+#: ../../24.04/index.md:571 ec12c1ce45494934acf2bbf18b6145fb
+msgid "qemu: Add flags to keep or remove TPM state for virDomainUndefineFlags"
+msgstr ""
+
+#: ../../24.04/index.md:572 d1d9821a57934cceb44a93295da22d19
+msgid "QEMU: Core Scheduling support (not enabled by default)."
+msgstr ""
+
+#: ../../24.04/index.md:573 29bbd5dad7094de6b908660e89dc21fc
+msgid "External snapshot deletion."
+msgstr ""
+
+#: ../../24.04/index.md:574 9e1520c8395848e08ec953a5e6288485
+msgid "External backend for swtpm."
+msgstr ""
+
+#: ../../24.04/index.md:575 86c86d4a24544ecbada09b49cce1b366
+msgid "Passing file descriptors instead of opening files for `<disk>`."
+msgstr ""
+
+#: ../../24.04/index.md:576 74c09b17d91a4afdbb2c11fdc93f1fe2
+msgid "Allow multiple nodes for preferred policy."
+msgstr ""
+
+#: ../../24.04/index.md:577 f4107e57fc314a269c1533ea210ff622
+msgid "Report Hyper-V Enlightenments in `domcapabilities`."
+msgstr ""
+
+#: ../../24.04/index.md:578 2b90fecdff934acfb92c6f378d3c389f
+msgid "Support for SGX EPC (enclave page cache)."
+msgstr ""
+
+#: ../../24.04/index.md:579 7789c3e9503d4e2a88bf03da4a3e9124
+msgid "Support migration of vTPM state of QEMU VMs on shared storage."
+msgstr ""
+
+#: ../../24.04/index.md:580 b6e418126adb47188a6b94581c187f0a
+msgid "Introduce support for `igb` network interface model."
+msgstr ""
+
+#: ../../24.04/index.md:581 21bac0f5bce540709ba338f336f69340
+msgid "Support compression for parallel migration."
+msgstr ""
+
+#: ../../24.04/index.md:582 f829b3ddf2bc4ff2a4ff1a7e9ca6f618
+msgid "AppArmor: All profiles and abstractions now support local overrides"
+msgstr ""
+
+#: ../../24.04/index.md:583 31ec9f6f158d429190bc51f2b43491d9
+msgid "Add Sapphire Rapids CPU model."
+msgstr ""
+
+#: ../../24.04/index.md:584 cc831927f49c4a7a81506a57b34bf683
+msgid "Support removable attribute for SCSI disk."
+msgstr ""
+
+#: ../../24.04/index.md:585 1e33359942de4d088db63b2793252797
+msgid "qemu: Change default machine type for ARM and RISC-V to 'virt'"
+msgstr ""
+
+#: ../../24.04/index.md:586 05d5b2c87a1d4af99cef71a7f877a562
+msgid "QEMU: Enable `postcopy-preempt` migration capability."
+msgstr ""
+
+#: ../../24.04/index.md:587 59c59083de6945d1901db8f5baa9bafb
+msgid ""
+"QEMU: Add support for mapping iothreads to virtqueues of `virtio-blk` "
+"devices."
+msgstr ""
+
+#: ../../24.04/index.md:588 4ae47cf5e0584b5dabebc449181a8731
+msgid ""
+"QEMU: Allow automatic resize of block-device-backed disk to full size of "
+"the device."
+msgstr ""
+
+#: ../../24.04/index.md:589 9b803320ff644835b9e92c09c092841c
+msgid "QEMU: Automatic selection/binding of VFIO variant drivers."
+msgstr ""
+
+#: ../../24.04/index.md:590 1cfe0eeb94254973ad5398501f437560
+msgid "qemu: Add support for vDPA block devices"
+msgstr ""
+
+#: ../../24.04/index.md:591 5dd3a82f412e495eb78f92266ef29ad0
+msgid "QEMU: Add runtime configuration option for nbdkit."
+msgstr ""
+
+#: ../../24.04/index.md:592 a7237b1bfe334f0588be6b47b7178eac
+msgid "QEMU: Add ID mapping support for `virtiofsd`."
+msgstr ""
+
+#: ../../24.04/index.md:593 886fa35f4cce4672b435e96a945e1c51
+msgid "QEMU: Improve migration XML use when persisting VM on destination."
+msgstr ""
+
+#: ../../24.04/index.md:594 5d4868e94e9f4971895b031ddad80522
+msgid "QEMU: Simplify non-shared storage migration to raw block devices."
+msgstr ""
+
+#: ../../24.04/index.md:595 09fb65c5fdfe4df9bd63ddfe7c85c2c6
+msgid "QEMU: Allow `virtiofsd` to run unprivileged."
+msgstr ""
+
+#: ../../24.04/index.md:596 26e4f9be520749b6a881b898e9ba1ad8
+msgid ""
+"The RBD/Ceph storage driver (`libvirt-daemon-driver-storage-rbd`) is now "
+"available only on 64-bit architectures."
+msgstr ""
+
+#: ../../24.04/index.md:598 94eefb04c5244b3b9bf3746c1e4b0681
+msgid ""
+"For more details, please see [the upstream "
+"changelog](https://www.libvirt.org/news.html)."
+msgstr ""
+
+#: ../../24.04/index.md:600 53132fed782e471bafbdd4e198bcb8d5
+msgid "LXD"
+msgstr ""
+
+#: ../../24.04/index.md:602 f093cadb0128432b8c1accf5c6586025
+msgid ""
+"Keeping with the theme of further streamlining Ubuntu, starting with this"
+" release, LXD snap won’t be pre-installed in the Ubuntu server by "
+"default. Instead, we will be applying the same logic as with the ubuntu-"
+"minimal images, where we use a small script (`lxd-installer`) to install "
+"LXD on first use."
+msgstr ""
+
+#: ../../24.04/index.md:604 8b4ad06dec734b14ab2c83dd91244ddc
+msgid ""
+"LXD 5.21.0 LTS has been released with a number of useful features and a "
+"few other operational changes. For more information, please read [the "
+"full release announcement](https://discourse.ubuntu.com/t/lxd-5-21-0-lts-"
+"has-been-released/42476/1)."
+msgstr ""
+
+#: ../../24.04/index.md:606 70640116e03448579e496ec43c521597
+msgid "Monitoring Plugins"
+msgstr ""
+
+#: ../../24.04/index.md:608 193481bf73bf4e7f866069b675822ea2
+msgid ""
+"Four micro-version release updates to monitor-plugins brings it to "
+"version 2.3.5 in this Ubuntu LTS release, providing a number of fixes and"
+" enhancements.  A few items of note:"
+msgstr ""
+
+#: ../../24.04/index.md:612 fedccace38a44564b91acba3c3a589e4
+msgid "check_dhcp: Add dhcp rogue detection"
+msgstr ""
+
+#: ../../24.04/index.md:613 3f326deb66c34e97b1bc3d79942cb3b4
+msgid "check_icmp: Add support to Jitter, MOS and Score"
+msgstr ""
+
+#: ../../24.04/index.md:614 a574beacb95a497f8daa94eaeb29ce6f
+msgid "check_smtp: Add support for SMTP over TLS"
+msgstr ""
+
+#: ../../24.04/index.md:615 960adb051f3c4bb5b7e5d8b74ead36b1
+msgid "check_smtp: Add support for SNI"
+msgstr ""
+
+#: ../../24.04/index.md:616 ba791ff8d06a4bd5b4d7714ad23309b4
+msgid "check_http: Implement chunked encoding decoding"
+msgstr ""
+
+#: ../../24.04/index.md:617 4d129ab480df4cc98bd4d805614417a5
+msgid "check_curl: detect ipv6"
+msgstr ""
+
+#: ../../24.04/index.md:618 c5f8e4bb870549f99a8f29f8cddbbb15
+msgid ""
+"check_by_ssh: Let ssh decide if a host is valid, enables usage of ssh "
+".config file"
+msgstr ""
+
+#: ../../24.04/index.md:620 5aa8f67fbcc34e1ca939465ef73b0d03
+msgid ""
+"check_curl: Add an option to check_curl to verify the peer certificate & "
+"host using the system CA's"
+msgstr ""
+
+#: ../../24.04/index.md:622 62b63bc5e8af42daa5b9f011f60a8aa9
+msgid "check_fping: Implements 'host-alive' mode"
+msgstr ""
+
+#: ../../24.04/index.md:623 889d5730734442c0be10f6683185cdb9
+msgid "check_http: Support http redirect"
+msgstr ""
+
+#: ../../24.04/index.md:624 eecb283523e544979a0638bad5f8393c
+msgid "check_ping: understand ping6"
+msgstr ""
+
+#: ../../24.04/index.md:625 0c8d0ee993b24fd0bda271121dcc95ac
+msgid "check_smtp: add -L flag to support LMTP (LHLO instead of HELO/EHLO)."
+msgstr ""
+
+#: ../../24.04/index.md:627 2d368f920a434e439a28a70eb1b0a658
+msgid "check_snmp: Added option for null zero length string exit codes"
+msgstr ""
+
+#: ../../24.04/index.md:629 cc1fa110a8b94c87b1450ee40c070d16
+msgid ""
+"For more detail, see the release announcements for [2.3.2](https://www"
+".monitoring-plugins.org/news/release-2-3-2.html), [2.3.3](https://www"
+".monitoring-plugins.org/news/release-2-3-3.html), [2.3.4](https://www"
+".monitoring-plugins.org/news/release-2-3-4.html), and [2.3.5](https://www"
+".monitoring-plugins.org/news/release-2-3-5.html)."
+msgstr ""
+
+#: ../../24.04/index.md:632 a8e554a7b3344669940fae965300526b
+msgid "Net SNMP"
+msgstr ""
+
+#: ../../24.04/index.md:634 621aeca8bd8b482eabfd23142e1c7535
+msgid ""
+"The [Net SNMP](http://www.net-snmp.org/) package was updated to version "
+"5.9.4."
+msgstr ""
+
+#: ../../24.04/index.md:636 eb4a6f199c9a4340bd34c26b5408be86
+msgid ""
+"In addition to a few security and stability fixes, support is now "
+"included for recognizing Docker's overlay filesystem such as when running"
+" `snmpwalk` against a Docker container."
+msgstr ""
+
+#: ../../24.04/index.md:638 30ee53d693044988ac52fbf59cbc2c63
+msgid ""
+"For more details, please see [the upstream changelog](https://github.com"
+"/net-snmp/net-snmp/blob/v5.9.4/CHANGES)."
+msgstr ""
+
+#: ../../24.04/index.md:640 44dedeb12507459687bedf9efc740ef0
+msgid "Nginx"
+msgstr ""
+
+#: ../../24.04/index.md:642 c5b648a85e52451f9dd1c42d9512df27
+msgid ""
+"The Nginx web server has been updated to version 1.24 in Ubuntu 24.04 "
+"LTS, marking a major jump from version 1.18 in the previous LTS.  This "
+"brings OpenSSL 3.0 compatibility, support for the PCRE2 library, protocol"
+" TLSv1.3 enabled by default, Application-Layer Protocol Negotiation "
+"(ALPN) support for the stream module, Online Certificate Status Protocol "
+"(OCSP) validation of client SSL certificates, and improved HTTP/2 support"
+" among other things."
+msgstr ""
+
+#: ../../24.04/index.md:644 bc7b243894024dc0b6a72f3742f19467
+msgid ""
+"For a complete listing of changes, please see the release notices for "
+"Nginx [1.20](https://nginx.org/en/CHANGES-1.20), "
+"[1.22](https://nginx.org/en/CHANGES-1.22), and "
+"[1.24](https://nginx.org/en/CHANGES-1.24)."
+msgstr ""
+
+#: ../../24.04/index.md:647 e40f233b0e684c48a3c3b313510f10a0
+msgid "OpenLDAP"
+msgstr ""
+
+#: ../../24.04/index.md:649 c32e8d23a12142bd9e872ef6365f473f
+msgid ""
+"The [OpenLDAP ](https://openldap.org) package was updated to version "
+"2.6.7, which brings several bug fixes. For more details, please see [the "
+"upstream changelog "
+"](https://www.openldap.org/software/release/changes.html)."
+msgstr ""
+
+#: ../../24.04/index.md:651 0c043465685f4cd685428cbdcde23712
+msgid "OpenVmTools"
+msgstr ""
+
+#: ../../24.04/index.md:653 d2e37659f9984b56b6708361088dfedd
+msgid ""
+"open-vm-tools moves to 12.3.5 in Ubuntu 24.04 LTS.  Intermediate versions"
+" resolved a few critical problems, vulnerabilities, and Coverity issues. "
+"In addition, it brings support for managing Salt Minion, and for "
+"gathering and publishing lists of containers running inside Linux guests."
+"  A tools.conf configuration setting is also available to temporarily "
+"direct Linux quiesced snapshots to restore pre open-vm-tools 12.2.0 "
+"behavior of ignoring file systems already frozen."
+msgstr ""
+
+#: ../../24.04/index.md:655 fd30b43fd74b4c43b0cc8cfecfdd6ce8
+msgid ""
+"The announcements for 12.3.5 and other releases since 11.3.5 can be found"
+" on the [open-vm-tools Github releases page](https://github.com/vmware"
+"/open-vm-tools/releases)."
+msgstr ""
+
+#: ../../24.04/index.md:657 fd39e2bb6a274a01b1303c37e4d86e62
+msgid "PAM"
+msgstr ""
+
+#: ../../24.04/index.md:659 63cbc6cbefb54c0fb2cda2b2e9ff26d8
+msgid ""
+"`pam_lastlog.so` has [been "
+"removed](https://bugs.launchpad.net/ubuntu/+source/shadow/+bug/2060676) "
+"because it was not Year 2038 compliant."
+msgstr ""
+
+#: ../../24.04/index.md:661 603b607984cf4dff92d97d3d2d17acaa
+msgid "Percona Xtrabackup"
+msgstr ""
+
+#: ../../24.04/index.md:663 1f4c1d943bf646c880a57f8fadd6aafd
+msgid ""
+"Percona Xtrabackup has been added as a new package, working alongside "
+"MySQL 8.0.x. It is a tool for creating and restoring backups of MySQL "
+"databases while maintaining availability. For more information see "
+"Percona Xtrabackup's [upstream documentation](https://docs.percona.com"
+"/percona-xtrabackup/8.0/)."
+msgstr ""
+
+#: ../../24.04/index.md:665 16b58f5ee3d345dc9176617f8f44691f
+msgid "PHP"
+msgstr ""
+
+#: ../../24.04/index.md:667 b5aa989401cb4ef4b2d629adfb9aa4de
+msgid ""
+"The [PHP](https://php.net) package was updated to version 8.3.6. Here are"
+" the major changes since Ubuntu Jammy."
+msgstr ""
+
+#: ../../24.04/index.md:669 94b2ce3ecf35404098296e2f286f99a3
+msgid ""
+"Upon updates, PHP will re-start apache2 to ensure any bugs in your PHP "
+"powered web server gets addressed as soon as an upgrade is performed."
+msgstr ""
+
+#: ../../24.04/index.md:670 c0f7eb1b204d48e19ca4cd34720c2f1f
+msgid "Read only classes"
+msgstr ""
+
+#: ../../24.04/index.md:671 7af666b8e449433398ee25b0b3f5cee8
+msgid ""
+"Disjunctive Normal Form (DNF) types to allow the combination of union and"
+" intersection types"
+msgstr ""
+
+#: ../../24.04/index.md:672 0f4d68019e7c4fa385154d397a65850f
+msgid "`null`, `false`, and `true` are now allowed as stand-alone types"
+msgstr ""
+
+#: ../../24.04/index.md:673 5792869455d748ef9b1435f2b512d956
+msgid ""
+"A new \"random\" extension was introduced. It provides an object-oriented"
+" API for random for random number generation."
+msgstr ""
+
+#: ../../24.04/index.md:674 a95bcd7c3b834bcc89e679baeecad8c4
+msgid ""
+"Constants can now be declared in traits. They can then be accessed by "
+"classes which use the trait."
+msgstr ""
+
+#: ../../24.04/index.md:675 334aff6fea7f4b1cb0907574582e7911
+msgid ""
+"Creation of dynamic properties are now deprecated to avoid mistakes and "
+"typos."
+msgstr ""
+
+#: ../../24.04/index.md:676 d0d12e7d72434041bb6b6e7b34637980
+msgid "Typed class constants"
+msgstr ""
+
+#: ../../24.04/index.md:677 9d2721b8a96e429ab334629d6985c914
+msgid "Class constants can now be fetched dynamically"
+msgstr ""
+
+#: ../../24.04/index.md:678 f4d7f8c5ddc74877ae96494d4e33b3e2
+msgid ""
+"A new `#[\\Override]` attribute was introduced. It ensures that a method "
+"of the same name exists in the parent class or implemented interface."
+msgstr ""
+
+#: ../../24.04/index.md:679 b286d4c875634f519bf0be8d51da9369
+msgid "Deep-cloning of readonly properties is now allowed."
+msgstr ""
+
+#: ../../24.04/index.md:680 d3e61bcecf264c7bb5fe5a4a0caf6978
+msgid ""
+"A now `json_validate()` function was introduced to check if a string is "
+"syntactically valid JSON."
+msgstr ""
+
+#: ../../24.04/index.md:681 6b6feff7735c44b9b040abcc75161f26
+msgid "The command line linter now supports parsing multiple files at once."
+msgstr ""
+
+#: ../../24.04/index.md:683 645c04426c1f48aeaae276d1bfe0c97d
+msgid ""
+"Moreover, an apache2 change now ensures that the apache2 service will "
+"restart after the PHP package is upgraded. This is a change in the "
+"package behavior. Before, needrestart would inform the user of the need "
+"to restart the service, but the service would not restart automatically. "
+"Please see [LP: "
+"#2038912](https://bugs.launchpad.net/ubuntu/+source/apache2/+bug/2038912)"
+" for additional context on this change."
+msgstr ""
+
+#: ../../24.04/index.md:685 9a70e100dbeb4ac39c61ac7d27ac66b0
+msgid ""
+"For more details, please see the [upstream "
+"changelog](https://www.php.net/ChangeLog-8.php#PHP_8_3)"
+msgstr ""
+
+#: ../../24.04/index.md:687 6c03d51c2dd6411bbb52bd3ca6a3fbdc
+msgid "PostgreSQL"
+msgstr ""
+
+#: ../../24.04/index.md:689 e935f411d27f4dcab92835fd9e9e736b
+msgid ""
+"The [PostgreSQL](https://www.postgresql.org) package was updated to "
+"version 16.2. The new version includes several performance improvements. "
+"Here are some of the major changes included since Ubuntu Jammy."
+msgstr ""
+
+#: ../../24.04/index.md:691 cba7e4684a2b41e0a0ebceea60e31a3a
+msgid ""
+"The SQL standard `MERGE` command is now available. it lets you write "
+"conditional SQL statements including `INSERT`, `DELETE`, and `UPDATE` "
+"actions in a single statement."
+msgstr ""
+
+#: ../../24.04/index.md:692 e923b80cd0ce40179ee0df82c2c6839f
+msgid "New regular expressions related functions."
+msgstr ""
+
+#: ../../24.04/index.md:693 c35edd39f2624bc3858368fc24592c06
+msgid "New `jsonlog` format to output logs using a defined JSON structure."
+msgstr ""
+
+#: ../../24.04/index.md:694 f3cef69b637045c2b1d77149daad4e00
+msgid "Users can now perform logical replication from standby instance"
+msgstr ""
+
+#: ../../24.04/index.md:695 149cbb2d4d20489a83c24bead56accf2
+msgid ""
+"More syntax from `SQL/JSON` was added, such as `JSON_ARRAY()`, "
+"`JSON_ARRAYAGG()`, and `IS JSON`."
+msgstr ""
+
+#: ../../24.04/index.md:696 8f7954caec3644cb94e573bce02c8531
+msgid ""
+"Users can now express thousands using `_` as a separator (e.g., "
+"`5_100_042`)"
+msgstr ""
+
+#: ../../24.04/index.md:697 d4954677ed654014b1c127b43fecfa40
+msgid ""
+"Added support for non-decimal integer literals, such as `0x1234A`, "
+"`0o777`, and `0b0101011`"
+msgstr ""
+
+#: ../../24.04/index.md:698 c10067a0ae934b5c82e8a8a346237594
+msgid ""
+"Several security-oriented client connection parameters were added, "
+"including `require_auth` to specify accepted authentication parameters, "
+"and `sslrootcert=\"system\"` to use the trusted certificate authority "
+"(CA) store provided by the client's operating system."
+msgstr ""
+
+#: ../../24.04/index.md:700 0c72073c4f814a62aa61a71b7cda2df6
+msgid ""
+"For details on the above changes or to get a complete list of changes "
+"introduced in PostgreSQL 16, please refer to the [upstream release "
+"notes](https://www.postgresql.org/docs/16/release-16.html)."
+msgstr ""
+
+#: ../../24.04/index.md:702 b167d8cc1c984cb993991b8f3a941e68
+msgid "QEMU"
+msgstr ""
+
+#: ../../24.04/index.md:704 1839cf6c7e3c436592cf8c0a287ed10d
+msgid ""
+"The [QEMU](https://qemu.org) package was updated to version 8.2.1.  Here "
+"are the changes since Ubuntu Jammy."
+msgstr ""
+
+#: ../../24.04/index.md:706 59c90daf456843bda6f2eea831a9a046
+msgid ""
+"User-mode emulation (`linux-user`, `bsd-user`) will enforce guest "
+"alignment constraints and raise `SIGBUS` to the guest program as "
+"appropriate."
+msgstr ""
+
+#: ../../24.04/index.md:708 d603b19d7c904d6a91c4f8c79feb8602
+msgid ""
+"The `qemu-nbd` program has gained a new `--tls-hostname` parameter to "
+"allow TLS validation against a different hostname, such as when setting "
+"up TLS through a TCP tunnel, and now supports TLS over UNIX sockets."
+msgstr ""
+
+#: ../../24.04/index.md:709 18896adc6c9645be80f3b450d828c2dc
+msgid "ARM"
+msgstr ""
+
+#: ../../24.04/index.md:710 ea01dce95deb40acb4489e7ffe736495
+msgid ""
+"Emulation of ARM Cortex-A76, Cortex-A35, Cortex-A710, Neoverse-N1, "
+"Neoverse-N2 CPUs."
+msgstr ""
+
+#: ../../24.04/index.md:711 eb47700ea47b4bde921e8a06933d39dc
+msgid "The virt board now supports emulation of the GICv4.0."
+msgstr ""
+
+#: ../../24.04/index.md:712 f5cbe0cace3e40a29528fb5b4bb3381e
+msgid "Several new PCPU architecture features are now emulated as well."
+msgstr ""
+
+#: ../../24.04/index.md:713 b7e79990292f494d892674ed9315270b
+msgid ""
+"KVM VMs on a host which supports MTE (the Memory Tagging Extension) can "
+"now use MTE in the guest"
+msgstr ""
+
+#: ../../24.04/index.md:714 ../../24.04/index.md:1056
+#: 24b3862fc56543f9bfe5453d04140fd1 57ac632541524b46bf6a2de57bdd8ed2
+msgid "RISC-V"
+msgstr ""
+
+#: ../../24.04/index.md:715 74618e9865cf40aa8e3ecb1351f1b057
+msgid "Add support for privileged spec version 1.12.0."
+msgstr ""
+
+#: ../../24.04/index.md:716 224d56416eb84d99be481bfa895a48f3
+msgid ""
+"Add support for the `Zbkb`, `Zbkc`, `Zbkx`, `Zknd`/`Zkne`, `Zknh`, "
+"`Zksed`/`Zksh` and `Zkr` extensions."
+msgstr ""
+
+#: ../../24.04/index.md:717 f3cb25ee573849d0bd2047227b27cf5d
+msgid "Add support for `Zmmul` extension."
+msgstr ""
+
+#: ../../24.04/index.md:718 b5727bde232e46b29c9235f7cb76758f
+msgid "Add TPM support to the virt board."
+msgstr ""
+
+#: ../../24.04/index.md:719 134eb6342beb4b2ba1cfc329575c2e37
+msgid "virt machine device tree improvements."
+msgstr ""
+
+#: ../../24.04/index.md:720 f92be8b5512d4c758d74ad9edf49ba61
+msgid ""
+"Support for various further RISC-V extensions, among them the hypervisor "
+"extension is no more marked experimental and now enabled by default."
+msgstr ""
+
+#: ../../24.04/index.md:721 998409f6222b4f679c58853e7293c4a1
+msgid "Add RISC-V vector cryptographic instruction set support."
+msgstr ""
+
+#: ../../24.04/index.md:722 1c8674b5868e4218b848b4ea1472a895
+msgid "Update RISC-V vector crypto to ratified v1.0.0."
+msgstr ""
+
+#: ../../24.04/index.md:723 78d37e7872c441a0bb9e71c5cf7fe21f
+msgid "s390x"
+msgstr ""
+
+#: ../../24.04/index.md:724 e38740a9bfad43babd1cd040c9454b97
+msgid "Emulate the s390x Vector-Enhancements Facility 2 with TCG."
+msgstr ""
+
+#: ../../24.04/index.md:725 32ee94fbbb2044aeb3f15cdde9dbe39a
+msgid ""
+"The `s390-ccw` bios has been fixed to also boot from drives with non-512 "
+"sector sizes that have a different geometry than the typical DASD drives."
+msgstr ""
+
+#: ../../24.04/index.md:726 e963d9e57c4a43f98c56da6c9e63bc4c
+msgid "Fix emulation of `LZRF`, `VISTR`, `SACF` instructions."
+msgstr ""
+
+#: ../../24.04/index.md:727 140ebbb9d2fb44bc887e184abc3f3cd9
+msgid "Enhanced zPCI interpretation support for KVM guests."
+msgstr ""
+
+#: ../../24.04/index.md:728 b4135c5d177b428ba65e86eb4984c7b2
+msgid ""
+"Implement Message-Security-Assist Extension 5 (random number generation "
+"via `PRNO` instruction)."
+msgstr ""
+
+#: ../../24.04/index.md:729 73ddf6575e7f40d0b474d5807ae41677
+msgid ""
+"Support s390x CPU topology (books and drawers, `STSI` 15.1.x instruction,"
+" `PTF` instruction) with KVM."
+msgstr ""
+
+#: ../../24.04/index.md:730 be81412ec64d49d08922d162e6026fc3
+msgid "More"
+msgstr ""
+
+#: ../../24.04/index.md:731 39fd9908f1d14de89997e4f4d9e85ea3
+msgid ""
+"Support for zero-copy-send on Linux, which reduces CPU usage on the "
+"source host. Note that locked memory is needed to support this."
+msgstr ""
+
+#: ../../24.04/index.md:732 631c3838bc32434a9961775ff195b8bc
+msgid "Added support for Intel AMX."
+msgstr ""
+
+#: ../../24.04/index.md:733 94e4b05013724a1b955de665eabc004f
+msgid "TCG performance improvements in full-system emulation."
+msgstr ""
+
+#: ../../24.04/index.md:734 cc7d231e0e304793a5a1fc66d871b131
+msgid "TCG support for `AVX`, `AVX2`, `F16C`, `FMA3` and `VAES` instructions."
+msgstr ""
+
+#: ../../24.04/index.md:735 7b6e8539c429452280b2bcfb09fbe363
+msgid "Support for the Sapphire Rapids and Granite Rapids CPU models."
+msgstr ""
+
+#: ../../24.04/index.md:736 955e3f558c1648a9a644225145991db8
+msgid ""
+"System emulation on 32-bit x86 hosts has been deprecated. The QEMU "
+"project no longer considers 32-bit x86 host support for system emulation "
+"to be an effective use of its limited resources, and thus intends to "
+"discontinue. User mode emulation continues to be supported on 32-bit "
+"hosts."
+msgstr ""
+
+#: ../../24.04/index.md:737 9ca97cc0a5054c5896292cd9cd4194b5
+msgid "Support for `igb` device emulation."
+msgstr ""
+
+#: ../../24.04/index.md:738 acb4c3f63bce4a93b3a30e1f4a766bf9
+msgid ""
+"Support virtual machines with up to 1024 vCPUs (for more details, see "
+"[here](https://ubuntu.com/server/docs/create-qemu-vms-with-up-"
+"to-1024-vcpus))"
+msgstr ""
+
+#: ../../24.04/index.md:739 bec9590e6fdf44719d2fe3b167b5deb3
+msgid ""
+"Due to the GlusterFS demotion (see [LP: "
+"#2045063](https://bugs.launchpad.net/ubuntu/+source/glusterfs/+bug/2045063)),"
+" the GlusterFS block storage module was moved out of the `qemu-block-"
+"extra` package and into the new `qemu-block-supplemental` package. Please"
+" see the GlusterFS section of these Release Notes for upgrade "
+"considerations if you are using qemu with the GlusterFS block storage "
+"module."
+msgstr ""
+
+#: ../../24.04/index.md:740 ad909f3729244ff3b619efb18a18944c
+msgid ""
+"Since GlusterFS is no longer available for 32 bit architectures (see [LP:"
+" "
+"#2052734](https://bugs.launchpad.net/ubuntu/+source/glusterfs/+bug/2052734)),"
+" the `block-gluster` storage module (now shipped in `qemu-block-"
+"supplemental`) is no longer available in armhf."
+msgstr ""
+
+#: ../../24.04/index.md:742 42e8ace06f6a49fa81dd2b11cfd2ce59
+msgid "For more details, please see related upstream changelogs:"
+msgstr ""
+
+#: ../../24.04/index.md:743 1ac16757acee442cb43b14f1a80cdd88
+msgid "[8.2](https://wiki.qemu.org/ChangeLog/8.2)"
+msgstr ""
+
+#: ../../24.04/index.md:744 5dbe46021a9549d7a2510e37bb641123
+msgid "[8.1](https://wiki.qemu.org/ChangeLog/8.1)"
+msgstr ""
+
+#: ../../24.04/index.md:745 da91553454734016a95257275a057365
+msgid "[8.0](https://wiki.qemu.org/ChangeLog/8.0) [Mantic]"
+msgstr ""
+
+#: ../../24.04/index.md:746 b59cdfe7ec5f47ffa331dace1f16d52e
+msgid "[7.2](https://wiki.qemu.org/ChangeLog/7.2)"
+msgstr ""
+
+#: ../../24.04/index.md:747 356037199df14843acbc083fa9a590ae
+msgid "[7.1](https://wiki.qemu.org/ChangeLog/7.1)"
+msgstr ""
+
+#: ../../24.04/index.md:748 fe50329d624d4bcba74dd1672e166f7d
+msgid "[7.0](https://wiki.qemu.org/ChangeLog/7.0)"
+msgstr ""
+
+#: ../../24.04/index.md:749 464876405ed840d7b57b4d69932be4a4
+msgid "[6.2](https://wiki.qemu.org/ChangeLog/6.2) [Jammy]"
+msgstr ""
+
+#: ../../24.04/index.md:752 bc545e9902144bc29e3b89cf0080e3e4
+msgid "Ruby 3.2"
+msgstr ""
+
+#: ../../24.04/index.md:754 323e5ab6e58647879dddaab3870bcf25
+msgid ""
+"The default ruby interpreter was updated to version 3.2.3. There are many"
+" new features and bug fixes, some highlights are:"
+msgstr ""
+
+#: ../../24.04/index.md:756 ed2ca0cf0d504cd59ba3d858882806ee
+msgid "YJIT is now production ready (JIT compiler for Ruby)."
+msgstr ""
+
+#: ../../24.04/index.md:757 b611d12e705646149ad62f96707b4493
+msgid "Immutable objects with `Data.define` (new `Data` class)."
+msgstr ""
+
+#: ../../24.04/index.md:758 cf6792968d9c4e1193ccf71713edc125
+msgid "WebAssembly support."
+msgstr ""
+
+#: ../../24.04/index.md:759 0e65e5a90a814f12b1498ce8a6db46c5
+msgid ""
+"`bundle gem` now supports `--ext=rust` to allow building gems with rust "
+"extensions."
+msgstr ""
+
+#: ../../24.04/index.md:761 b6186e30e94949e586935cdf83fc9ee1
+msgid ""
+"There are some constants and methods that were already deprecated and now"
+" they are removed, when migrating to this ruby version be careful with "
+"the following:"
+msgstr ""
+
+#: ../../24.04/index.md:763 de3d48b307664e11864f2d8e3f91f48d
+msgid "`Fixnum` and `Bignum`"
+msgstr ""
+
+#: ../../24.04/index.md:764 6a5ddac2fb524842ae7dae832d159af8
+msgid "`Random::DEFAULT`"
+msgstr ""
+
+#: ../../24.04/index.md:765 dbec36efdf2049658bf1c4692ae86422
+msgid "`Struct::Group`"
+msgstr ""
+
+#: ../../24.04/index.md:766 c653057db65144a0a7f2541f18150c97
+msgid "`Struct::Passwd`"
+msgstr ""
+
+#: ../../24.04/index.md:767 7aec4f817cd14d38910f7f52780bdaa5
+msgid "`Dir.exists?`"
+msgstr ""
+
+#: ../../24.04/index.md:768 cbb155a1874e4c7d9227afa638e883ba
+msgid "`File.exists?`"
+msgstr ""
+
+#: ../../24.04/index.md:769 5088cc361b1c4c5cb201c172b3d48df7
+msgid "`Kernel#=~`"
+msgstr ""
+
+#: ../../24.04/index.md:770 1b520cc96f7448c99394cfa8081d1ca5
+msgid "`Kernel#taint`, `Kernel#untaint`, `Kernel#tainted?`"
+msgstr ""
+
+#: ../../24.04/index.md:771 2cc13aa2177b4bc1ba11200ecff4453b
+msgid "`Kernel#trust`, `Kernel#untrust`, `Kernel#untrusted?`"
+msgstr ""
+
+#: ../../24.04/index.md:773 5a45b8288f284b34b72495511934584e
+msgid ""
+"All the above was removed from Ruby 3.2 and cannot be used anymore. For "
+"more information, please see [the upstream release "
+"announcement](https://www.ruby-"
+"lang.org/en/news/2022/12/25/ruby-3-2-0-released/)."
+msgstr ""
+
+#: ../../24.04/index.md:775 9a15575fad2d46adb5e435f2f34f51ec
+msgid "`runc`"
+msgstr ""
+
+#: ../../24.04/index.md:777 83362e18becc4d44a160db6563db6f39
+msgid ""
+"The runc package was updated to version 1.1.12. It contains bug fixes "
+"specially related to the cgroup v2 support, and most importantly, it adds"
+" support for riscv64. For more information, please see [the upstream "
+"changelog](https://github.com/opencontainers/runc/releases)."
+msgstr ""
+
+#: ../../24.04/index.md:779 dff6cb0236114e04a9d344a8f5d32c34
+msgid ""
+"For users/developers willing to customize the runc package, the source "
+"package is now split into `runc` (library package) and `runc-app` "
+"(application package). This was done to follow what was done in "
+"containerd and docker.io, and therefore, ease the future maintenance, "
+"including backports to stable releases."
+msgstr ""
+
+#: ../../24.04/index.md:781 2b7768c5f07446e6bfcde99ad924ae09
+msgid "Samba"
+msgstr ""
+
+#: ../../24.04/index.md:782 626407a1e1a149ed88de7b4fef7fff2e
+msgid ""
+"The Samba package has been updated to the 4.19.x series. Here are the "
+"upstream release notes for 4.19.0: "
+"https://www.samba.org/samba/history/samba-4.19.0.html"
+msgstr ""
+
+#: ../../24.04/index.md:784 5a10d47dbaf5405cb5fb7910f518edf3
+msgid ""
+"Due to the GlusterFS demotion (see [LP: "
+"#2045063](https://bugs.launchpad.net/ubuntu/+source/glusterfs/+bug/2045063)"
+" and the GlusterFS section of these release notes), the samba packaging "
+"had to be changed a bit to accommodate this change."
+msgstr ""
+
+#: ../../24.04/index.md:786 e02ff10fd9d942f8a75b6451ef35efe7
+msgid ""
+"The GlusterFS VFS modules which were previously shipped in the binary "
+"`samba-vfs-modules` package, are now shipped in the new binary package "
+"called `samba-vfs-modules-extra`. Specifically, these modules (and their "
+"respective manual pages) were moved to `samba-vfs-modules-extra`:"
+msgstr ""
+
+#: ../../24.04/index.md:787 561b33585aa0486aab545d2db70aa83c
+msgid "`glusterfs.so`"
+msgstr ""
+
+#: ../../24.04/index.md:788 40c5608fe67d41bc859142a4d7fc809b
+msgid "`glusterfs_fuse.so`"
+msgstr ""
+
+#: ../../24.04/index.md:790 10295b5fabfd4c3893ae51e5a76d5cff
+msgid ""
+"The `fuse` module does not depend on the gluster libraries, but was moved"
+" together with `glusterfs.so` for consistency."
+msgstr ""
+
+#: ../../24.04/index.md:792 74af9fc56d61410ba7490e68a38603bc
+msgid ""
+"If you are upgrading from an Ubuntu release that used either of those two"
+" VFS modules, you should install `samba-vfs-modules-extra` after the "
+"upgrade:"
+msgstr ""
+
+#: ../../24.04/index.md:796 5247312159574ddab979077b97d775e7
+msgid ""
+"If you are doing a fresh install of Ubuntu Noble, and want to use the "
+"glusterfs VFS modules with samba, you should also install `samba-vfs-"
+"modules-extra`."
+msgstr ""
+
+#: ../../24.04/index.md:798 155d7bbb605b4827b83dd34d1daac981
+msgid "Spamassassin"
+msgstr ""
+
+#: ../../24.04/index.md:800 19d66c319f99470d9443cd68c2bfb751
+msgid ""
+"Apache SpamAssassin 4.0.0 contains numerous tweaks and bug fixes over the"
+" past releases. In particular, it includes major changes that "
+"significantly improve the handling of text in international language."
+msgstr ""
+
+#: ../../24.04/index.md:802 c3430c66fa794709a72c333025ed4fc7
+msgid ""
+"As with any major release, there are countless functional patches and "
+"improvements to upgrade to 4.0.0. Apache SpamAssassin 4.0.0 includes "
+"several years of fixes that significantly improve classification and "
+"performance."
+msgstr ""
+
+#: ../../24.04/index.md:804 d51fada3ba854c5aa141b95ff0a98910
+msgid ""
+"New plugins include ExtractText, DMARC, and DecodeShortURLs. The HashCash"
+" module, which had been deprecated previously, is now fully removed.  "
+"Mail::SPF::Query use is deprecated, along with settings "
+"do_not_use_mail_spf, do_not_use_mail_spf_query.  Mail::SPF is now the "
+"only supported module used by the SPF plugin."
+msgstr ""
+
+#: ../../24.04/index.md:808 d7fb967eb1b24c949582a8b6d153ac5d
+msgid ""
+"Bayes plugin has been improved to skip common words aka noise words "
+"written in languages other than English"
+msgstr ""
+
+#: ../../24.04/index.md:809 b6d208cd521c48718f73274b5856b326
+msgid ""
+"You can now use Captured Tags to use tags \"captured\" in one rule inside"
+" other rules"
+msgstr ""
+
+#: ../../24.04/index.md:810 ad809783a6be474ba6e1893062326ce4
+msgid ""
+"sa-update has been improved with three new options: forcemirror, score-"
+"multiplier, and score-limit."
+msgstr ""
+
+#: ../../24.04/index.md:811 c8a55ef54fde4494adca7b6d839d9157
+msgid "DKIM plugin can now detect ARC signatures"
+msgstr ""
+
+#: ../../24.04/index.md:812 4fcc091290924f029b156af8be389e53
+msgid "The normalize_charset option is now enabled by default."
+msgstr ""
+
+#: ../../24.04/index.md:813 0e31dd39a305435999d586c639ec8811
+msgid "SPF lookups are not done asynchronously"
+msgstr ""
+
+#: ../../24.04/index.md:814 63331c6791a34a3aaec330427af83c25
+msgid ""
+"The default sa-update ruleset doesn't make ASN lookups or header "
+"additions anymore."
+msgstr ""
+
+#: ../../24.04/index.md:816 099a12b7b4bb46e2a8d0b60cd78c0cbd
+msgid ""
+"The [SpamAssassin 4.0.0 release "
+"announcement](https://svn.apache.org/repos/asf/spamassassin/trunk/build/announcements/4.0.0.txt)"
+" provides more details about these changes."
+msgstr ""
+
+#: ../../24.04/index.md:818 d8e088efc3ed4b4e829ca21cb9356fcb
+msgid "Squid"
+msgstr ""
+
+#: ../../24.04/index.md:820 cdc5abf11e2d460a91929870f0eaaedd
+msgid ""
+"The [Squid](http://www.squid-cache.org) package was updated to version "
+"6.6. Here are some of the major changes since Ubuntu Jammy."
+msgstr ""
+
+#: ../../24.04/index.md:822 33ce302181fd40a995a5ffe81143cdf5
+msgid ""
+"Squid is now more tolerant on `tls-cert=` misconfiguration. It will try "
+"to sort the CA chain and send certificates in the required order."
+msgstr ""
+
+#: ../../24.04/index.md:823 d5298ce08f8943a9adccce1e336ef9bf
+msgid ""
+"Squid now logs communication details for TLS connections it accepts or "
+"establishes."
+msgstr ""
+
+#: ../../24.04/index.md:824 a8835164a19a4c8a92b8f411a8bf4b2e
+msgid ""
+"A new `to_linklocal` ACL was introduced as pre-defined to match requests "
+"from 169.254.0.0/16 and fe80::/10."
+msgstr ""
+
+#: ../../24.04/index.md:825 ae69bc1d1d9540028a2d1a7d24d5e065
+msgid ""
+"The `X-Cache` and the `X-Cache-Lookup` HTTP headers were replaced with "
+"the new `Cache-Status` HTTP header, as per RFC 9211. Tools and systems "
+"relying on the `X-` headers should be upgraded to use the new header."
+msgstr ""
+
+#: ../../24.04/index.md:826 65b3ab7df51148ce8d6e25ff70f1749e
+msgid "The Gopher protocol support was removed."
+msgstr ""
+
+#: ../../24.04/index.md:828 e5943631aa7c436d9591d302cad8a9ea
+msgid ""
+"For more details, please see [the upstream release notes](http://www"
+".squid-cache.org/Versions/v6/squid-6.6-RELEASENOTES.html)."
+msgstr ""
+
+#: ../../24.04/index.md:830 2cc81668af80419d899831c7aa326dfe
+msgid "SSSD"
+msgstr ""
+
+#: ../../24.04/index.md:832 cc6b5715149f4a7c85e09a9f8b5dbc69
+msgid ""
+"The [SSSD](https://sssd.io) package was updated to version 2.9.4.  Here "
+"are the changes since Ubuntu Jammy."
+msgstr ""
+
+#: ../../24.04/index.md:834 8b74e605b50e45f19406ed701e93b8ec
+msgid ""
+"All SSSD client libraries (`nss`, `pam`, etc.) won’t serialize requests "
+"anymore by default, i.e. requests from multiple threads can be executed "
+"in parallel. The old behavior (serialization) can still be enabled by "
+"setting the environment variable `SSS_LOCKFREE` to `NO`."
+msgstr ""
+
+#: ../../24.04/index.md:835 29bab582a5e14514a2efaffd326272ff
+msgid ""
+"Added a new krb5 plugin `idp` and a new binary `oidc_child` which "
+"performs **OAuth2** authentication against FreeIPA. This, however, cannot"
+" be tested yet because this feature is still under development on the "
+"FreeIPA server side."
+msgstr ""
+
+#: ../../24.04/index.md:836 f02b729254924fe8ad9b7dd94b48d2d4
+msgid ""
+"`sss_simpleifp` library is deprecated and might be removed in further "
+"releases."
+msgstr ""
+
+#: ../../24.04/index.md:837 72664fb1473349ae95b8e938803e6b1b
+msgid ""
+"“Files provider” (i.e. `id_provider = files`) is deprecated and might be "
+"removed in further releases. Consider using “Proxy provider” with "
+"`proxy_lib_name = files` instead."
+msgstr ""
+
+#: ../../24.04/index.md:838 b82b276fdb14460583781d3c100ccb91
+msgid ""
+"Add support for `ldapi://` URLs to allow connections to local LDAP "
+"servers."
+msgstr ""
+
+#: ../../24.04/index.md:839 c532ed4cf0434d36842a1795fd4bb2e8
+msgid ""
+"The `proxy` provider is now able to handle certificate mapping and "
+"matching rules and users handled by the proxy provider can be configured "
+"for local Smartcard authentication. Besides the mapping rule local "
+"Smartcard authentication should be enabled with the `local_auth_policy` "
+"option in the backend and with `pam_cert_auth` in the PAM responder."
+msgstr ""
+
+#: ../../24.04/index.md:841 d7d0df4a4c634432b5a1f343a8eb72cd
+msgid "Intel® QuickAssist Technology (Intel® QAT)"
+msgstr ""
+
+#: ../../24.04/index.md:843 89d10000b44041a6a56f7eb7a5b3ed4e
+msgid ""
+"Intel® QAT is a built-in accelerator on 4th Gen and newer Intel® Xeon® "
+"Scalable Processors that offloads critical data compression and "
+"decompression, encryption and decryption, and public key data encryption "
+"tasks from the CPU cores and accelerates those operations to help improve"
+" performance and save valuable compute resources."
+msgstr ""
+
+#: ../../24.04/index.md:845 599997d9a49546c2906a8cdacecba1d6
+msgid "The components enabled on Ubuntu 24.04 LTS are:"
+msgstr ""
+
+#: ../../24.04/index.md:846 6a0c1aa1d6b9487eb0d3dab4805b4720
+msgid ""
+"qatlib 24.02.0 This package provides user space libraries that allow "
+"access to Intel® QAT devices and expose the Intel® QAT APIs and sample "
+"codes. For more information, visit the project’s "
+"[repo](https://github.com/intel/qatlib?tab=readme-ov-file#features)."
+msgstr ""
+
+#: ../../24.04/index.md:849 7a74adf1fd5f4f2991599c4fe9b48238
+msgid ""
+"qatengine 1.5.0 This package provides the Intel® QAT OpenSSL Engine Plug-"
+"in as a shared library that sits between OpenSSL and the QAT library. The"
+" engine can be configured to use Intel optimized libraries (ipp-crypto "
+"and intel-ipsec-mb) and/or offload those operations to the QAT device. "
+"For more information, visit the project’s "
+"[repo](https://github.com/intel/QAT_Engine/blob/master/docs/features.md)."
+msgstr ""
+
+#: ../../24.04/index.md:852 f43b8b4a17eb418fb5aee1eefde1235a
+msgid ""
+"qatzip 1.2.0 This package provides a user space library offering "
+"accelerated compression and decompression services by offloading the work"
+" to the Intel QAT device, which uses the deflate* and lz4* algorithms. "
+"For more information, visit the project’s "
+"[repo](https://github.com/intel/QATzip?tab=readme-ov-file#features)."
+msgstr ""
+
+#: ../../24.04/index.md:855 c3e469ef06224e8a9de212ddf233e2a5
+msgid ""
+"ipp-crypto 2021.10.0 Intel® Integrated Performance Primitives "
+"Cryptography (Intel® IPP Cryptography) is a secure, fast and lightweight "
+"library of building blocks for cryptography, highly-optimized for various"
+" Intel® CPUs. For more information, visit the project’s "
+"[repo](https://github.com/intel/ipp-crypto)."
+msgstr ""
+
+#: ../../24.04/index.md:858 dc5e9c80d49d426dbac25c67c86590e7
+msgid ""
+"intel-ipsec-mb 1.5-1 Intel® Multi-Buffer Crypto for IPsec Library "
+"provides software crypto acceleration that primarily focuses on symmetric"
+" cryptography applications. For more information, visit the project’s "
+"[repo](https://github.com/intel/intel-ipsec-mb)."
+msgstr ""
+
+#: ../../24.04/index.md:862 089a7509ebc846edbdd32e1e112f5f75
+msgid "Subiquity"
+msgstr ""
+
+#: ../../24.04/index.md:864 3cdcd28046644b5887636ff979221fbf
+msgid ""
+"A new version of the Subiquity server installer has been released. Please"
+" read the full [release notes for "
+"24.04.1](https://github.com/canonical/subiquity/releases/tag/24.04.1) on "
+"GitHub."
+msgstr ""
+
+#: ../../24.04/index.md:866 2c8796ef53614493a043ee69bfbd64e7
+msgid "OpenSSH"
+msgstr ""
+
+#: ../../24.04/index.md:868 ad2594d7eca74d5db0213be2ae44b243
+msgid ""
+"Since Ubuntu 22.10, `openssh-server` is configured to use systemd socket "
+"activation by default. In Ubuntu 24.04 LTS, the implementation changed so"
+" that settings from `/etc/ssh/sshd_config` (and snippets from "
+"`/etc/ssh/sshd_config.d/`) are read by a systemd generator to configure "
+"the `ssh.socket` unit accordingly.  See the [original discourse "
+"post](https://discourse.ubuntu.com/t/sshd-now-uses-socket-based-"
+"activation-ubuntu-22-10-and-later/30189/1) for more details."
+msgstr ""
+
+#: ../../24.04/index.md:870 76b57cfcd2d646229f1a81b813b1cb9d
+msgid "Ubuntu HA/Clustering"
+msgstr ""
+
+#: ../../24.04/index.md:872 28f4055fcf0343b2b895e4d73c73a3e2
+msgid "Pacemaker"
+msgstr ""
+
+#: ../../24.04/index.md:874 b392ecfad84748198f05b08e2a062fa0
+msgid ""
+"The [Pacemaker](https://clusterlabs.org/pacemaker/) package was updated "
+"to version 2.1.6. There are several fixes, API changes and new features "
+"introduced since jammy. For more details, please see [the upstream "
+"changelog](https://github.com/ClusterLabs/pacemaker/releases)."
+msgstr ""
+
+#: ../../24.04/index.md:876 7ca63924266d40d7941c2d8f0f00160e
+msgid "Resource Agents"
+msgstr ""
+
+#: ../../24.04/index.md:878 5cf72d6cfeda4874b49addad60a59413
+msgid ""
+"The [Resource Agents](https://github.com/ClusterLabs/resource-agents) "
+"package was updated to version 4.13.0."
+msgstr ""
+
+#: ../../24.04/index.md:880 46bbd36dafb048bd87178fa604c13e70
+msgid ""
+"A noteworthy change is the upstream improvements on PostgreSQL support. "
+"The pgsql agent was moved to the resource-agents-base package and is now "
+"part of our curated set of resource agents."
+msgstr ""
+
+#: ../../24.04/index.md:882 7442c3c2754d4f0c9fb46e2b444c5997
+msgid ""
+"Moreover, the transitional resource-agents package was removed. You "
+"should now install resource agents through the resource-agents-base "
+"package or through the resource-agents-extra package. The agents "
+"available in each of these packages are listed in the package "
+"descriptions."
+msgstr ""
+
+#: ../../24.04/index.md:884 11c74804b077498c968c65c29b8547ee
+msgid ""
+"For further information, please refer to [the upstream "
+"changelog](https://github.com/ClusterLabs/resource-"
+"agents/blob/main/ChangeLog)."
+msgstr ""
+
+#: ../../24.04/index.md:886 26e3f0f9f5e84e848a08b37909c90a6f
+msgid "OpenStack"
+msgstr ""
+
+#: ../../24.04/index.md:888 7864a30845d94f129d4d275481245183
+msgid ""
+"OpenStack has been updated to the [2024.1 (Caracal) "
+"release](https://releases.openstack.org/caracal/).  This includes "
+"packages for Aodh, Barbican, Ceilometer, Designate, Glance, Heat, "
+"Horizon, Ironic, Keystone, Magnum, Manila, Masakari, Mistral, Neutron, "
+"Nova, Octavia, Swift, Watcher and Zaqar."
+msgstr ""
+
+#: ../../24.04/index.md:890 9a0ff23ea694405aa7bfd922aab0b3e8
+msgid ""
+"Murano, Senlin, Sahara, Freezer and Solum where all [declared "
+"inactive](https://governance.openstack.org/tc/reference/emerging-"
+"technology-and-inactive-projects.html#current-inactive-projects) as of "
+"the 2024.1 cycle and have been removed from Ubuntu."
+msgstr ""
+
+#: ../../24.04/index.md:892 ../../24.04/index.md:898
+#: ae0bf6e8be6a43c6b0a5fe70fae1296d fde84d0ae392462aab90a1c5fafc7d39
+msgid ""
+"This release is also provided for Ubuntu 22.04 LTS via the Ubuntu Cloud "
+"Archive."
+msgstr ""
+
+#: ../../24.04/index.md:894 a41a96dc776846d0b9c03fb1ce112581
+msgid "Ceph"
+msgstr ""
+
+#: ../../24.04/index.md:896 a7ccc8b4626d4e3789c48729e03d1d0c
+msgid ""
+"[Ceph](http://ceph.com) has been updated to a snapshot in preparation for"
+" the 19.2.0 (Squid) release which will be provided via a [stable release "
+"update](https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/2065515)."
+msgstr ""
+
+#: ../../24.04/index.md:900 0cfe9ffcea0647da9bd6274c6a77af5e
+msgid "Open vSwitch (OVS) and Open Virtual Network (OVN)"
+msgstr ""
+
+#: ../../24.04/index.md:902 ec76260e3585419e9f677a41578b0534
+msgid ""
+"[Open vSwitch](https://www.openvswitch.org/) has been updated to the "
+"3.3.0 release."
+msgstr ""
+
+#: ../../24.04/index.md:904 829d0498804f48548c27c7765920b0b5
+msgid ""
+"[Open Virtual Network](https://www.ovn.org/) has been updated to the "
+"24.03 release."
+msgstr ""
+
+#: ../../24.04/index.md:906 26abb8185c8f4eb1be0194e747fae32a
+msgid ""
+"These releases are also provided for Ubuntu 22.04 LTS via the Ubuntu "
+"Cloud Archive."
+msgstr ""
+
+#: ../../24.04/index.md:908 ba2d3d1d49e547178f5752dc9f389555
+msgid "Platforms"
+msgstr ""
+
+#: ../../24.04/index.md:910 548fe20f080943e4bd205636c7470c80
+msgid "Public Cloud / Cloud images"
+msgstr ""
+
+#: ../../24.04/index.md:912 a38e55f2f20844e7924f39b36bae5182
+msgid "All"
+msgstr ""
+
+#: ../../24.04/index.md:914 7793c1100488410987651f82c17ce3fa
+msgid ""
+"[23.10 cloud images unexpected UDP listening...” : Bugs : cloud-"
+"images](https://bugs.launchpad.net/cloud-images/+bug/2038894)"
+msgstr ""
+
+#: ../../24.04/index.md:915 2be7cb186eea4ff79b35770439f5c4c6
+msgid "Cloud-init no longer blocks by default when preseeding snaps"
+msgstr ""
+
+#: ../../24.04/index.md:916 de031733b84a41cda53117fd36e1d053
+msgid ""
+"See the [cloud-init "
+"docs](https://cloudinit.readthedocs.io/en/latest/reference/breaking_changes.html"
+"#removed-ubuntu-s-ordering-dependency-on-snapd-seeded) for details on how"
+" to fix user scripts that rely on snaps"
+msgstr ""
+
+#: ../../24.04/index.md:917 75e9bf3e9b4a4cc8a145e861a001346a
+msgid "Cloud images no longer preseed any snaps by default"
+msgstr ""
+
+#: ../../24.04/index.md:918 1ff2892dfc754d5fba573f893cb342b4
+msgid ""
+"With the changes to [LXD detailed above](https://discourse.ubuntu.com/t"
+"/noble-numbat-release-notes/39890#lxd-45), LXD snap is no longer "
+"seeded/installed in the non minimal public cloud images. As a result, "
+"snaps will no longer be seeded/installed in non minimal images."
+msgstr ""
+
+#: ../../24.04/index.md:919 dbb9106cf88546ac96c612b1da5a1c79
+msgid ""
+"The decision remove LXD snap seeding was made @ "
+"https://bugs.launchpad.net/ubuntu/+source/ubuntu-meta/+bug/2051346 and "
+"the decision to stop seeding any snaps was made @ "
+"https://bugs.launchpad.net/ubuntu/+source/ubuntu-meta/+bug/2051572"
+msgstr ""
+
+#: ../../24.04/index.md:920 89a7ba8aea394282a92bba7c00acfc48
+msgid "The exceptions are AWS and GCE, which have cloud specific snaps preseeded."
+msgstr ""
+
+#: ../../24.04/index.md:921 17c61ee522d9412788e522348879fd4f
+msgid "Upgrading from previous releases"
+msgstr ""
+
+#: ../../24.04/index.md:922 6bb1bc9cb7304fb2ac68062067797223
+msgid ""
+"Upgrading to Ubuntu 24.04 LTS using do-release-upgrade will result in one"
+" of more interactive prompts. One for grub-pc, which will request you "
+"choose the boot device, and if chrony is installed you will also be "
+"prompted to choose “on disk config” or “packaged config”. These are "
+"expected and do not impact the ability to upgrade."
+msgstr ""
+
+#: ../../24.04/index.md:923 588764bb8ded4571b473c1384890b234
+msgid "The footprint of minimal images has been reduced"
+msgstr ""
+
+#: ../../24.04/index.md:924 0aedfa9b9ba14a10aeb31e134fde907a
+msgid ""
+"[Introduced in the 23.10 cycle](https://discourse.ubuntu.com/t/mantic-"
+"minotaur-release-notes/35534#minimal-downloadqcow2-cloud-images-42), "
+"minimal cloud images now are smaller than the Ubuntu 22.04 LTS minimal "
+"images. The package count has dropped from 426 to 288 (difference: 138) "
+"resulting in a much smaller image size. For example, download qcow2 "
+"images have reduced from 337.19MiB to 226.75MiB (diff: 110.44MiB)."
+msgstr ""
+
+#: ../../24.04/index.md:925 76439f7495154332b7089a3566357a20
+msgid ""
+"This was achieved, in part, by reducing the packages installed to only "
+"those we feel are required for a functional Ubuntu cloud instance and by "
+"removing the installation of ‘Recommends’ packages."
+msgstr ""
+
+#: ../../24.04/index.md:927 91d199cf99384d6bb71ccf77c1599bfd
+msgid "Vagrant"
+msgstr ""
+
+#: ../../24.04/index.md:929 08b8ed08a7584c8bb1331e714ce3a50d
+msgid ""
+"Starting in Ubuntu 24.04 LTS, Ubuntu no longer produces Vagrant images. "
+"Documentation regarding creating an Ubuntu Base Image from scratch is "
+"provided at https://documentation.ubuntu.com/public-images/en/latest"
+"/public-images-how-to/build-vagrant-with-bartender/."
+msgstr ""
+
+#: ../../24.04/index.md:931 bfec788aedd94fe7a7f14134c7143fab
+msgid "Public Images (cloud-images.ubuntu.com) images"
+msgstr ""
+
+#: ../../24.04/index.md:933 8ff5d85583fb4460b565e8bc4ba1cd98
+msgid "Release notes/image diff"
+msgstr ""
+
+#: ../../24.04/index.md:934 393bf142e3184d65a53e69e8af2d7fb8
+msgid ""
+"Since 19th April 2024 we have introduced `.image_changelog.json` files to"
+" accompany published images @ https://cloud-images.ubuntu.com/. This is a"
+" JSON document listing all the package additions, removals and changes as"
+" well as noting the changelog entries for the package changes. It also "
+"highlights any CVEs addressed in those package updates. The tool used to "
+"generate these diffs is `ubuntu-cloud-image-changelog` available @ "
+"[github.com/canonical/ubuntu-cloud-image-"
+"changelog](http://github.com/canonical/ubuntu-cloud-image-changelog)"
+msgstr ""
+
+#: ../../24.04/index.md:935 e910ef4f8cc540beaa1b72eefe2e8770
+msgid ""
+"Diffs are generated between the image being published and the previous "
+"daily image, and also between the image being published and the previous "
+"release image."
+msgstr ""
+
+#: ../../24.04/index.md:936 bc43643a5e164e8aa0cc5def713763b9
+msgid ""
+"These image diffs have been backported to previous published Ubuntu "
+"release too."
+msgstr ""
+
+#: ../../24.04/index.md:938 36e50b282f404577b2f128b778fc3ad2
+msgid ""
+"There are potential issues with OVA images and some versions of Cloud "
+"Director related to the attached serial port. In some cases, this may "
+"lead to a failure to deploy the OVA image. In the event of a failure, "
+"editing the OVF directly in your deployment and removing the serial port "
+"stanza should allow successful deployment. VMware has an associated [KB "
+"article](https://kb.vmware.com/s/article/2128084) regarding these "
+"failures. Cloud Director versions around version 10.4.2.22463311 are "
+"potentially effected. This is currently under investigation: "
+"[LP:2062552](https://bugs.launchpad.net/cloud-images/+bug/2062552)."
+msgstr ""
+
+#: ../../24.04/index.md:940 6927ad22321d46509926bf93ad832e2f
+msgid "AWS EC2"
+msgstr ""
+
+#: ../../24.04/index.md:942 043f00202450459a84d8afc7c52d38bb
+msgid ""
+"Noble instances now launch using "
+"[IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-"
+"instance-metadata-service.html) by default for the instance metadata "
+"service."
+msgstr ""
+
+#: ../../24.04/index.md:943 61b055d04f9b42df8a50455925876c51
+msgid ""
+"Auto configuration of [multi-"
+"NIC](https://documentation.ubuntu.com/aws/en/latest/aws-how-to/instances"
+"/automatically-setup-multiple-nics/) instances is now supported with "
+"source-routing via cloud-init."
+msgstr ""
+
+#: ../../24.04/index.md:944 9b242ecfd5b543c2b464d52093e59ab6
+msgid ""
+"The `awscli` debian package got removed from the archive. The [aws-"
+"cli](https://snapcraft.io/aws-cli) snap should be used instead. That snap"
+" is maintained by AWS itself."
+msgstr ""
+
+#: ../../24.04/index.md:946 ../../24.04/index.md:1190
+#: 09def194fe9247b9b3af5e2c82fc280c 7c1b21c6300641cbbed040b095468375
+msgid "Microsoft Azure"
+msgstr ""
+
+#: ../../24.04/index.md:948 546c05d548e941ad9c4d972952b5117a
+msgid ""
+"Canonical is introducing  a new way of publishing on Azure with Ubuntu "
+"24.04 LTS. All Ubuntu Images for 24.04 LTS will be available under the "
+"same offer: ubuntu-24_04-lts. Derivative images, such as the minimized "
+"version of Ubuntu server or Ubuntu Pro are available as plans under this "
+"main offer."
+msgstr ""
+
+#: ../../24.04/index.md:949 ../../24.04/index.md:1192
+#: 2b47135a7874488fb214c065ae6452bf a50129b349fe49f698a7b34125020f57
+msgid ""
+"We have identified an issue with AppArmor profiles on Confidential VM "
+"images available under the `cvm` plan of the offer `ubuntu-24_04-lts`. "
+"For example, the `rsyslog` service will fail to start on VMs launched "
+"from this plan. This is being investigated and a new image with a fix "
+"will be published shortly."
+msgstr ""
+
+#: ../../24.04/index.md:951 8e04b692f2c14997a97b366972efdf5a
+msgid ""
+"Users with multic-NIC setup on their instances may experience delays in "
+"DNS resolution due to mis-configuration of systemd-resolved. We are "
+"currently implementing a solution on cloud-init "
+"(https://github.com/canonical/cloud-init/pull/5180). Before the solution "
+"lands in cloud-init, users can remedy the misconfiguration by creating "
+"the file `/etc/netplan/91-secondary-nics-azure.yaml` with the content:"
+msgstr ""
+
+#: ../../24.04/index.md:972 9be947e6970f40ed97b060c8e8a3aaeb
+msgid ""
+"Users should then reboot the instance for the netplan configuration to "
+"take effect."
+msgstr ""
+
+#: ../../24.04/index.md:974 eec145a2db6e43fa97ffc7596e236afb
+msgid "Google"
+msgstr ""
+
+#: ../../24.04/index.md:976 b4cdfb72dbb64ea899f648a2ef500839
+msgid ""
+"GCE: Setting a hostname via cloud-init user-data requires the addition of"
+" the create_hostname_file key; see "
+"[here](https://documentation.ubuntu.com/gcp/en/latest/google-how-to/gce"
+"/set-hostname-using-cloudinit/) for more details."
+msgstr ""
+
+#: ../../24.04/index.md:977 d8cf51595efd495691f70ceaec3213da
+msgid ""
+"Boot speed improvements: the I/O scheduler has been changed to `none` "
+"(from `noop`) to improve i/o performance for the most common disk types "
+"([LP: #2045708](https://bugs.launchpad.net/ubuntu/+source/gce-compute-"
+"image-packages/+bug/2045708))"
+msgstr ""
+
+#: ../../24.04/index.md:978 b621c077ad964ba4beac4eb064482dc6
+msgid ""
+"A regression has been discovered with the GCP suspend feature with the "
+"linux-gcp 6.8 kernel that is being investigated in [LP: "
+"#2063315](https://bugs.launchpad.net/ubuntu/+source/linux-"
+"gcp/+bug/2063315)"
+msgstr ""
+
+#: ../../24.04/index.md:979 ../../24.04/index.md:1187
+#: 2515382138424c208f4893cd217bcf07 f583b077c4d54c0585e57fcfb31ba0a1
+#, python-brace-format
+msgid ""
+"Ubuntu 24.04 LTS has introduced a change in the behaviour of the "
+"needrestart package - see notes @ [Services restart on unattended-"
+"upgrade](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890"
+"#services-restart-on-unattended-upgrade-26) for more information. This "
+"results in any google-guest-agent startup scripts being run again on "
+"package upgrade or re-install. This is being investigated but it will "
+"only be triggered when the google-guest-agent package is re-installed. It"
+" can be worked around by setting `NEEDRESTART_SUSPEND=1` prior to any re-"
+"install as per the [`needrestart` man "
+"pages](https://manpages.ubuntu.com/manpages/noble/man1/needrestart.1.html#environment)"
+" or by appending to the `needrestart` configuration `echo "
+"\"\\$nrconf{override_rc}{qr(^google-(shutdown|startup)-scripts\\.service$)}"
+" = 0;\" >> /etc/needrestart/conf.d/google-guest-agent.conf` which will "
+"disable this behaviour for any future `google-guest-agent` upgrade or "
+"reinstall. New GCE images will be built and published shortly after "
+"release to disable this behaviour for the google-guest-agent by default."
+msgstr ""
+
+#: ../../24.04/index.md:981 62de6908628f4726980aa0a2dd15e27b
+msgid "Oracle"
+msgstr ""
+
+#: ../../24.04/index.md:983 513b11d19f904e4a946329eacf84ad21
+msgid ""
+"The uncomplicated Firewall package ufw is no longer installed in Oracle "
+"Cloud Ubuntu 24.04 LTS+ images. Upgrading from an earlier version of "
+"Ubuntu to 24.04 will uninstall ufw. The ufw tool conflicts with system "
+"configuration through iptables-persistent and netfilter-persistent as "
+"documented by Oracle [here](https://docs.oracle.com/en-"
+"us/iaas/Content/Compute/References/bestpracticescompute.htm#Essentia), "
+"illustrated further on this "
+"[blog](https://blogs.oracle.com/developers/post/enabling-network-traffic-"
+"to-ubuntu-images-in-oracle-cloud-infrastructure), and listed as a known "
+"[issue](https://docs.oracle.com/en-us/iaas/Content/Compute/known-"
+"issues.htm#ufw). If ufw is optionally installed on Ubuntu 24.04 LTS+, it "
+"will uninstall iptables-persistent and netfilter-persistent, disabling "
+"default functionality needed to support iSCSI boot and block devices."
+msgstr ""
+
+#: ../../24.04/index.md:985 f4135c0db8584c3c9b15e076215c6bfd
+msgid "How to report any issues resulting from these changes"
+msgstr ""
+
+#: ../../24.04/index.md:987 194057e2e4034199840f2a029907844d
+msgid ""
+"If you notice any unexpected changes or bugs in the minimal images, "
+"create a new bug in [cloud-images](https://bugs.launchpad.net/cloud-"
+"images)."
+msgstr ""
+
+#: ../../24.04/index.md:989 affe037795024b05a35d81b6b2b281d8
+msgid "Raspberry Pi 🍓"
+msgstr ""
+
+#: ../../24.04/index.md:991 6ef160d1cf0d40ff8f81b378e264cc51
+msgid "Pi 5 LTS"
+msgstr ""
+
+#: ../../24.04/index.md:993 33fb217913094009a8eb98b5bdce7692
+msgid ""
+"24.04 (noble) will be the first LTS release supporting the Raspberry Pi 5"
+" with both arm64 server and desktop images."
+msgstr ""
+
+#: ../../24.04/index.md:995 5445d4a303e04f0b861e29d9b23dc775
+msgid "Browser Acceleration"
+msgstr ""
+
+#: ../../24.04/index.md:997 7c092c6177f349e69df77c2c04f1be11
+msgid ""
+"The Firefox browser now supports 3D acceleration after mesa 23.2 was "
+"backported to 22.04 (jammy) which permitted the necessary content snaps "
+"to be regenerated. The classic [aquarium "
+"sample](https://webglsamples.org/aquarium/aquarium.html) can be used to "
+"test the performance of the new graphics stack, which can achieve a "
+"smooth 40+fps full-screen on a Pi 5 at a resolution of 1080p."
+msgstr ""
+
+#: ../../24.04/index.md:999 2ad6307aa4e6434f84c0b802ed77912e
+msgid "Power monitoring"
+msgstr ""
+
+#: ../../24.04/index.md:1001 116d853b4040435b89f70d0d48a37b9b
+msgid ""
+"On the Pi 5, the [pemmican](https://pemmican.readthedocs.io/) package "
+"will now provide monitoring of the power supply."
+msgstr ""
+
+#: ../../24.04/index.md:1003 7c5c6988dcd74e10b10e676023d14e50
+msgid ""
+"On server images, the MOTD on login will indicate if the power supply "
+"failed to negotiate the 5A expected for unlimited operation, or if "
+"brownout was the cause of the last reset. Kernel messages will warn of "
+"undervolt or overcurrent situations."
+msgstr ""
+
+#: ../../24.04/index.md:1005 60b9609416cd4547a32edef3f265649b
+msgid ""
+"On desktop images, a desktop notification will be displayed for these "
+"issues, with options for further information or suppression of future "
+"warnings of this type."
+msgstr ""
+
+#: ../../24.04/index.md:1007 80961c498a214491b90b46d219229fee
+msgid "No 32-bit (armhf) images"
+msgstr ""
+
+#: ../../24.04/index.md:1009 994f85936bab43f38bd6e5d6357e4b38
+msgid ""
+"From 24.04 (noble), we will no longer be producing 32-bit (armhf) images "
+"for the Raspberry Pi. The only images produced will be 64-bit (arm64). "
+"For the avoidance of doubt, this does *not* mean that armhf is no longer "
+"supported as an architecture on Raspberry Pi; it will remain supported as"
+" a foreign architecture in noble (see below)."
+msgstr ""
+
+#: ../../24.04/index.md:1011 ef7f714ed0fd4b1f9e6d77d626232d5a
+msgid ""
+"To add armhf as a foreign architecture to an arm64 image, use the "
+"following commands:"
+msgstr ""
+
+#: ../../24.04/index.md:1018 59c9d891ae1f441c8eef39b1cca32f71
+msgid "Thereafter, to install an armhf package:"
+msgstr ""
+
+#: ../../24.04/index.md:1024 c99a6a87aafd4c979995c335df457e8c
+msgid ""
+"Please note, there will be no armhf kernels (primarily because the Pi 5 "
+"does not support 32-bit kernels), and users who are currently on armhf "
+"images *will not* be able to upgrade directly to noble."
+msgstr ""
+
+#: ../../24.04/index.md:1026 8994d29068eb4225a375c039c3607bad
+msgid "Simpler Bluetooth on server"
+msgstr ""
+
+#: ../../24.04/index.md:1028 a30d7500b0834b5f8c0ae9d915b6514e
+msgid ""
+"There is no longer a need to install the `pi-bluetooth` package in order "
+"to enable Bluetooth functionality on server images. Simply install the "
+"regular `bluez` package and Bluetooth will be configured by the kernel."
+msgstr ""
+
+#: ../../24.04/index.md:1030 4e019b8caa6e4a8395466b987b16d930
+msgid "arm64"
+msgstr ""
+
+#: ../../24.04/index.md:1032 19e4f43571ae497cb6674abce266592e
+msgid ""
+"The new arm64+largemem ISO includes a kernel with 64k page size. A larger"
+" page size can increase throughput, but comes at the cost of increased "
+"memory use, making this option more suitable for servers with plenty of "
+"memory. Typical use cases for this ISO include: machine learning, "
+"databases with many large entries, high performance computing."
+msgstr ""
+
+#: ../../24.04/index.md:1034 876365ade8b54129b33bf06f787bd47a
+msgid "IBM Z and LinuxONE"
+msgstr ""
+
+#: ../../24.04/index.md:1036 dc1881a5b7db48aaa463e9079fb4a315
+msgid ""
+"The key 's390-tools' package was step-by-step upgraded to latest v2.31.0 "
+"([LP: #2049612](https://launchpad.net/bugs/2049612)), which incl. lots of"
+" updates, new tools and features, especially a secure guest tool to bind "
+"and associate APQNs crypto domains ([LP: "
+"#2003672](https://launchpad.net/bugs/2003672))."
+msgstr ""
+
+#: ../../24.04/index.md:1037 ef67ddb8b22b4af6a0561d4d02e6ef39
+msgid ""
+"Like on all other architectures, COMPAT_32BIT_TIME was also disabled on "
+"s390x ([LP: #2038583](https://launchpad.net/bugs/2038583)), and with that"
+" 31/32bit legacy support is removed ([LP: "
+"#2051683](https://launchpad.net/bugs/2051683))."
+msgstr ""
+
+#: ../../24.04/index.md:1038 b49301fc8c5d4c2d8053b325199443b5
+msgid ""
+"With the upgrade to GDB 15, support for IBM z16 was introduced ([LP: "
+"#1982336](https://launchpad.net/bugs/1982336))."
+msgstr ""
+
+#: ../../24.04/index.md:1039 f603d08ed4b84f61900cd1528cc6728d
+msgid ""
+"The Glasgow Haskell Compiler was upgraded to version 9.4.7 that is new "
+"enough to enable the LLVM backend to allow performance improvements ([LP:"
+" #1913302](https://launchpad.net/bugs/1913302))."
+msgstr ""
+
+#: ../../24.04/index.md:1040 264bf777c78848c782e034fec52fc24e
+msgid ""
+"IBM Z specific improvements also landed in the KVM virtualization stack "
+"with the introduction of virtual CPU topology ([LP: "
+"#1983223](https://launchpad.net/bugs/1983223)) and enhancement of the "
+"dynamic CPU topology for KVM guests ([LP: "
+"#2049703](https://launchpad.net/bugs/2049703)), as well as the "
+"implementation for nested guest shadow event counters ([LP: "
+"#2027926](https://launchpad.net/bugs/2027926)). For more details see the "
+"qemu and libvirt sections above."
+msgstr ""
+
+#: ../../24.04/index.md:1041 dcf2ec8dbc054fa3bb0ce904ba79d89e
+msgid ""
+"Another big area of s390x improvements is cryptography, with the upgrade "
+"to opencryptoki v2.23 ([LP: "
+"#2050023](https://launchpad.net/bugs/2050023)), there is now support in "
+"PKCS #11 3.0 for AES_XTS ([LP: "
+"#2025924](https://launchpad.net/bugs/2025924)) and EP11 token support for"
+" FIPS 2021-session bound EP11 keys ([LP: "
+"#2050014](https://launchpad.net/bugs/2050014))."
+msgstr ""
+
+#: ../../24.04/index.md:1042 a2d031fb9cf346e386d3bcc144923b9c
+msgid ""
+"Furthermore libica was updated to v4.3.0 ([LP: "
+"#2050024](https://launchpad.net/bugs/2050024)), the openssl-ibmca package"
+" to v2.4.1 and the openssl-pkcs11-sign-provider package was made "
+"available in v1.0.1 ([LP: 2003668)](https://launchpad.net/bugs/003668),) "
+"including fork support ([LP: "
+"#2050015](https://launchpad.net/bugs/2050015))."
+msgstr ""
+
+#: ../../24.04/index.md:1043 1e98cc9261d34b93b6a8aa4b2f749142
+msgid ""
+"And finally several s390x-specific libraries were bumped to their latest "
+"version, like qclib to 2.4.1 ([LP: "
+"#2050028](https://launchpad.net/bugs/2050028)) and libzpc to v1.2.0 ([LP:"
+" #2050031](https://launchpad.net/bugs/2050031))."
+msgstr ""
+
+#: ../../24.04/index.md:1045 6e3d96e2701d4940b1b609225c109891
+msgid "IBM POWER (ppc64el)"
+msgstr ""
+
+#: ../../24.04/index.md:1047 0edeeb295592457386cb1a98f53217ff
+msgid ""
+"KVM running in IBM PowerVM LPARs: Ubuntu Server 24.04 has now the "
+"required technology enablement and support for running KVM in a PowerVM "
+"LPAR. This technology enables expanded open-source based innovations and "
+"solutions for Ubuntu Server on the IBM Power platform. Below are the "
+"firmware and hardware requirements:"
+msgstr ""
+
+#: ../../24.04/index.md:1051 198d183a52ef4d9c9ba41326aa4e1b0b
+msgid "Firmware: FW1060.10"
+msgstr ""
+
+#: ../../24.04/index.md:1052 ac5536ca17764369a22c40d8f84441d2
+msgid "Hardware: IBM Power10"
+msgstr ""
+
+#: ../../24.04/index.md:1054 c2461ce5375c4e819ee6e01c6179bf1b
+msgid ""
+"Note: KVM virtualization continues to be supported on POWER9 bare-metal /"
+" OPAL based systems."
+msgstr ""
+
+#: ../../24.04/index.md:1058 3ab8ae0b445b413c8f8547c48a4e27a1
+msgid ""
+"Ubuntu 24.04 LTS is the first LTS release for the StarFive VisionFive 2 "
+"board. For an overview of Canonical supported boards see "
+"https://ubuntu.com/download/risc-v/canonical-built."
+msgstr ""
+
+#: ../../24.04/index.md:1061 e3c2fdea171a446b8c13df23167a2dce
+msgid "The RISC-V Ubuntu userland is compatible with all RVA20 hardware."
+msgstr ""
+
+#: ../../24.04/index.md:1064 1993be0a511040ed83a5eb78a2c9f3ba
+msgid "Known Issues"
+msgstr ""
+
+#: ../../24.04/index.md:1066 8ad7242826034f2b9bdffcbba92fab30
+msgid ""
+"As is to be expected with any release, there are some significant known "
+"bugs that users may encounter with this release of Ubuntu. The ones we "
+"know about at this point (and some of the workarounds) are documented "
+"here, so you don't need to spend time reporting these bugs again:"
+msgstr ""
+
+#: ../../24.04/index.md:1068 8595148766634afbafeadcefaf09be19
+msgid "General"
+msgstr ""
+
+#: ../../24.04/index.md:1070 77fa1549ef3e4a5b93a6009925078769
+msgid ""
+"In 24.04.2 HDMI output for Nezha D1 and LicheeRV is broken due to a "
+"missing kernel module."
+msgstr ""
+
+#: ../../24.04/index.md:1073 5e04b75abfab4eebbf249861976c9002
+msgid "sysstat enablement state mismatches intent"
+msgstr ""
+
+#: ../../24.04/index.md:1075 92720186bac84d169d08fc45ce4c9207
+msgid ""
+"In 24.04, we shipped sysstat by default as part of a wider performance "
+"engineering effort. The idea is that relevant performance engineering "
+"tooling is already present and available when a user finds themselves "
+"needing to solve a performance engineering problem."
+msgstr ""
+
+#: ../../24.04/index.md:1077 bc04d757ecb043e5abb03045e89b981a
+msgid ""
+"In some cases the sysstat services are not actually enabled. This will be"
+" fixed in a future update. When the update arrives, sysstat will become "
+"enabled in situations where it wasn't enabled before, to realign with our"
+" intended defaults. If you do not wish sysstat services to ever run, you "
+"may remove the sysstat package in advance."
+msgstr ""
+
+#: ../../24.04/index.md:1079 cc9eb3c3d6b645fd90072e21bb47e88d
+msgid ""
+"See [LP: #2073285](https://launchpad.net/bugs/2073285) and [LP: "
+"#2073284](https://launchpad.net/bugs/2073284) for details."
+msgstr ""
+
+#: ../../24.04/index.md:1081 0ff7817d741c4d8a9240748562e65ca0
+msgid "Linux kernel"
+msgstr ""
+
+#: ../../24.04/index.md:1083 e4e3f0d0c4ee47ffbfee8414f3f9e923
+msgid "In 24.04.4:"
+msgstr ""
+
+#: ../../24.04/index.md:1084 a54c41dece41422083ee14bffbf04828
+msgid "for 6.17.0-14.14 (HWE kernel)"
+msgstr ""
+
+#: ../../24.04/index.md:1085 ce32e5e94a8142cb926e274d0c6b58c7
+msgid ""
+"Kernel crash when connecting multiple displays that are daisy-chained via"
+" USB-C ([LP: #2141225](https://launchpad.net/bugs/2141225)). Still under "
+"investigation."
+msgstr ""
+
+#: ../../24.04/index.md:1086 110c2d6e6c91487e861b1906bb2631ba
+msgid ""
+"Intel MIPI (IPU6/7) cameras are not detected ([LP: "
+"#2140761](https://launchpad.net/bugs/2140761)). Fix is known and "
+"scheduled to be included in the next kernel update."
+msgstr ""
+
+#: ../../24.04/index.md:1087 953fdeca65094554bed8112a50fad544
+msgid ""
+"Some Intel Wifi chips are missing their firmware file ([LP: "
+"#2140975](https://bugs.launchpad.net/ubuntu/+source/linux-"
+"firmware/+bug/2140975)). If you need to install online using Wifi and one"
+" of those chips, make sure to grab the previous point-release image "
+"(24.04.3)."
+msgstr ""
+
+#: ../../24.04/index.md:1088 4d7f284ea2f64890b279b1adb318c423
+msgid "for 6.8.0-100.100"
+msgstr ""
+
+#: ../../24.04/index.md:1089 39c4981fabf240479afa6023b1bb6111
+msgid ""
+"Suspend failures when mt7925* wireless driver is loaded ([LP: "
+"#2141198](https://launchpad.net/bugs/2141198)). Still under "
+"investigation."
+msgstr ""
+
+#: ../../24.04/index.md:1093 ec54cba4f4774e9993d144138062c6b5
+msgid ""
+"Screen reader support is present with the new desktop installer, but is "
+"incomplete ([LP: #2061015](https://launchpad.net/bugs/2061015), [LP: "
+"#2061018](https://launchpad.net/bugs/2061018), [LP: "
+"#2036962](https://launchpad.net/bugs/2036962), [LP: "
+"#2061021](https://launchpad.net/bugs/2061021))"
+msgstr ""
+
+#: ../../24.04/index.md:1095 33198d15903b4d7d826b72315a45251b
+msgid ""
+"OEM installs are not supported yet ([LP: "
+"#2048473](https://launchpad.net/bugs/2048473))"
+msgstr ""
+
+#: ../../24.04/index.md:1097 2563742669f34030baa5b84f955c2308
+msgid ""
+"Application icons don't use the correct High Contrast theme when High "
+"Contrast is enabled [(LP: #2013107](https://launchpad.net/bugs/2013107))"
+msgstr ""
+
+#: ../../24.04/index.md:1099 cf5590756b5a4cf893a7a43187117653
+msgid ""
+"GTK4 apps (including the desktop wallpaper) do not display correctly with"
+" VirtualBox or VMWare with 3D Acceleration ([LP: "
+"#2061118](https://launchpad.net/bugs/2061118))."
+msgstr ""
+
+#: ../../24.04/index.md:1101 58eb7eb35c884aefa24029c34dc64790
+msgid ""
+"Fullscreen graphics performance in Xorg sessions (i.e. with the Nvidia "
+"driver) has temporarily regressed ([LP: "
+"#2052913](https://bugs.launchpad.net/bugs/2052913))."
+msgstr ""
+
+#: ../../24.04/index.md:1103 42f9b5670a9c4c2eb06cbe19d7c3e444
+msgid ""
+"Netbooting the new desktop installer causes the installer to crash on "
+"startup. The issue will be resolved for the 24.04.1  release (or sooner) "
+"and at that time the fix will become available via a manual `snap "
+"refresh` in the live environment on the 24.04 ISOs ([LP: "
+"#2062988](https://launchpad.net/bugs/2062988))."
+msgstr ""
+
+#: ../../24.04/index.md:1105 fcdf9c99a84a4d58bca3103f3a3c2e17
+msgid ""
+"**Incompatibility between TPM-backed Full Disk Encryption and Absolute:**"
+" TPM-backed Full Disk Encryption (FDE) has been introduced to enhance "
+"data security. However, it's important to note that this feature is "
+"incompatible with Absolute (formerly Computrace) security software. If "
+"Absolute is enabled on your system, the machine will not boot post-"
+"installation when TPM-backed FDE is also enabled. Therefore, disabling "
+"Absolute from the BIOS is recommended to avoid booting issues."
+msgstr ""
+
+#: ../../24.04/index.md:1106 b199c7ac76a14e4ab85c18fac1548209
+msgid ""
+"**Hardware-Specific Kernel Module Requirements for TPM-backed Full Disk "
+"Encryption:** TPM-backed Full Disk Encryption (FDE) requires a specific "
+"kernel snap which may not include certain kernel modules necessary for "
+"some hardware functionalities. A notable example is the `vmd` module "
+"required for NVMe RAID configurations. In scenarios where such specific "
+"kernel modules are indispensable, the hardware feature may need to be "
+"disabled in the BIOS (such as RAID) to ensure the continued availability "
+"of the affected hardware post-installation. If disabling in the BIOS is "
+"not an option, the related hardware will not be available post-"
+"installation with TPM-backed FDE enabled."
+msgstr ""
+
+#: ../../24.04/index.md:1107 e80d8609e1ca43a7a0a69c3ba8b02340
+msgid ""
+"[FDE specific bug "
+"reports](https://bugs.launchpad.net/bugs/+bugs?field.searchtext=&orderby=-importance&field.status%3Alist=NEW&field.status%3Alist=CONFIRMED&field.status%3Alist=TRIAGED&field.status%3Alist=INPROGRESS&field.status%3Alist=FIXCOMMITTED&field.status%3Alist=INCOMPLETE_WITH_RESPONSE&field.status%3Alist=INCOMPLETE_WITHOUT_RESPONSE&assignee_option=any&field.assignee=&field.bug_reporter=&field.bug_commenter=&field.subscriber=&field.tag=fde&field.tags_combinator=ANY&field"
+".status_upstream-empty-"
+"marker=1&field.has_cve.used=&field.omit_dupes.used=&field.omit_dupes=on&field.affects_me.used=&field.has_patch.used=&field.has_branches.used=&field.has_branches=on&field.has_no_branches.used=&field.has_no_branches=on&field.has_blueprints.used=&field.has_blueprints=on&field.has_no_blueprints.used=&field.has_no_blueprints=on&search=Search)."
+msgstr ""
+
+#: ../../24.04/index.md:1111 59309151d7744489841522ec1f34de23
+msgid "freeradius"
+msgstr ""
+
+#: ../../24.04/index.md:1112 e163a4d0503040d0af7b639d67301e34
+msgid ""
+"The [freeradius](https://launchpad.net/ubuntu/+source/freeradius) package"
+" will be accidentally removed by the release upgrade tool on upgrades "
+"from Ubuntu 22.04 LTS to Ubuntu 24.04 LTS. The removal is reported in the"
+" upgrade summary before any action is taken, but might be missed. This is"
+" being tracked in [LP: "
+"#2114224](https://bugs.launchpad.net/ubuntu/+source/freeradius/+bug/2114224)."
+msgstr ""
+
+#: ../../24.04/index.md:1115 8164abd3b5e24fb9806c8e969b540f8f
+msgid "Installer"
+msgstr ""
+
+#: ../../24.04/index.md:1117 839d684885074be48c50b05a2f5a3608
+msgid ""
+"In some situations, it is acceptable to proceed with an offline "
+"installation when the mirror is inaccessible. In this scenario, it is "
+"advised to use:"
+msgstr ""
+
+#: ../../24.04/index.md:1124 6f13afba59c44db4816f2a1c7257d5c6
+msgid "samba apparmor profile"
+msgstr ""
+
+#: ../../24.04/index.md:1125 7d3696db0d7d4b23a7a70b12379e30f4
+msgid ""
+"Due to [bug LP: "
+"#2063079](https://bugs.launchpad.net/ubuntu/+source/samba/+bug/2063079), "
+"the samba `smbd.service` unit file is no longer calling out to the helper"
+" script to dynamically create apparmor profile snippets according to the "
+"existing shares."
+msgstr ""
+
+#: ../../24.04/index.md:1127 cecde0cec48547ca987aa0b6d5a69db8
+msgid ""
+"By default, the `smbd` service from samba is not confined. To be affected"
+" by this bug, users have to:"
+msgstr ""
+
+#: ../../24.04/index.md:1128 7a23ebabb5e944ac8b26ba86f1388bbb
+msgid "install the optional `apparmor-profiles` package"
+msgstr ""
+
+#: ../../24.04/index.md:1129 d2b8286e21bc4661b00da4c8e9ee96cc
+msgid "switch the `smbd` profile confinement from `complain` to `enforce`"
+msgstr ""
+
+#: ../../24.04/index.md:1131 cfc33a423c424bb99daf0bb7b39d30f9
+msgid ""
+"Therefore, only users who have taken those steps and upgrade to Noble, "
+"will be affected by this bug. An SRU to fix it will be done shortly after"
+" release."
+msgstr ""
+
+#: ../../24.04/index.md:1133 1edaaeea07f244b19047eba1ede5c06d
+msgid "rrdtool on armhf"
+msgstr ""
+
+#: ../../24.04/index.md:1134 7f6818bdba2242629ed2a2337c462916
+msgid ""
+"`rrdtool` is a very popular package used by monitoring and graphing tools"
+" such as [cacti](https://www.cacti.net/), [munin](https://munin-"
+"monitoring.org/), [mrtg](https://oss.oetiker.ch/mrtg/), and others."
+msgstr ""
+
+#: ../../24.04/index.md:1136 c5097b517a544c7eaafa23758a198847
+msgid ""
+"Due to the Ubuntu 24.04 LTS `time_t` change from 32bits to 64bits in the "
+"armhf architecture, to fix the [Year 2038 "
+"problem](https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-"
+"release-notes/39890#year-2038-support-for-the-armhf-architecture) "
+"mentioned elsewhere in these Release Notes, the `rrd` databases produced "
+"by `rrdtool` in armhf in Ubuntu releases before Noble are not binary "
+"compatible with `rrdtool` in Ubuntu 24.04 LTS and later."
+msgstr ""
+
+#: ../../24.04/index.md:1138 5fb891292b1649cfa7729202a73a0eb4
+msgid ""
+"If such `rrd` files are attempted to be read by `rrdtool` from Ubuntu "
+"24.04 LTS or later, it will fail with an error that can be similar to "
+"this:"
+msgstr ""
+
+#: ../../24.04/index.md:1144 92031170fb4c4e96a61be4027b8fc775
+msgid ""
+"This essentially prevents the database from being opened, read, or "
+"written to."
+msgstr ""
+
+#: ../../24.04/index.md:1146 61d7f2ca0ed1478ea1aecc20066c5a70
+msgid ""
+"To correctly upgrade such systems, each `rrd` database needs to be dumped"
+" into xml using the tool from the system before the upgrade, and restored"
+" into `rrd` from that xml on the upgraded system. This is a manual "
+"process and there is no automated tooling for this available at the "
+"moment."
+msgstr ""
+
+#: ../../24.04/index.md:1148 68698494ea81481e9c0966887f3d1ab1
+msgid "To dump a `rrd` file into xml:"
+msgstr ""
+
+#: ../../24.04/index.md:1154 8385ebd0510c44259daf413d42e34cc9
+msgid "To later restore it on the new upgraded system:"
+msgstr ""
+
+#: ../../24.04/index.md:1160 33d38fb2199b44518b19549e450c58c1
+msgid ""
+"For more details, please see the "
+"[rrddump](https://manpages.ubuntu.com/manpages/noble/man1/rrddump.1.html)"
+" and "
+"[rrdrestore](https://manpages.ubuntu.com/manpages/noble/man1/rrdrestore.1.html)"
+" manpages."
+msgstr ""
+
+#: ../../24.04/index.md:1162 3ff8ad2e8ff84e8a86bc02743c579e1a
+msgid "Raspberry Pi"
+msgstr ""
+
+#: ../../24.04/index.md:1164 260073c4156a4f23abec4d3f3b419177
+msgid ""
+"On Pi 3A+, 3B+, 4B, and 5, when the wifi reconnects to an AP advertising "
+"a regulatory domain, various kernel errors are reported which may "
+"interrupt the console output (particularly on server). While annoying, "
+"this doesn't actually affect wifi connectivity, but may slow down re-"
+"authentication ([LP: #2063365](https://launchpad.net/bugs/2063365))"
+msgstr ""
+
+#: ../../24.04/index.md:1166 5fcfe0e2f3f64f5cb0f253f5961d49d7
+msgid ""
+"The startup sound does not play before the initial setup process, hence "
+"users cannot currently rely on hearing this sound to determine if the "
+"system has booted ([LP: #2060693](https://launchpad.net/bugs/2060693))"
+msgstr ""
+
+#: ../../24.04/index.md:1168 6f80a11fdafe4fbfb25db65fe9e030c6
+msgid ""
+"The seeded totem video player will not prompt users to install missing "
+"codecs when attempting to play a video requiring them ([LP: "
+"#2060730](https://launchpad.net/bugs/2060730))"
+msgstr ""
+
+#: ../../24.04/index.md:1170 2655ea2a8dbf4558bd2f802cf21166e5
+msgid ""
+"With some monitors connected to a Raspberry Pi, it is possible that a "
+"monitor powers off after a period of inactivity but then powers back on "
+"and shows a black screen. Investigation into the types of monitors "
+"affected is ongoing in [LP: "
+"#1998716](https://bugs.launchpad.net/ubuntu/+source/mutter/+bug/1998716)."
+msgstr ""
+
+#: ../../24.04/index.md:1172 bdf02570a5a44c119dc87b9caf412a99
+msgid ""
+"With the removal of the `crda` package in 22.04, the method of setting "
+"the wifi regulatory domain (editing `/etc/default/crda`) no longer "
+"operates. On server images, use the `regulatory-domain` option in the "
+"Netplan configuration. On desktop images, append "
+"`cfg80211.ieee80211_regdom=GB` (substituting `GB` for the relevant "
+"country code) to the kernel command line in the `cmdline.txt` file on the"
+" boot partition  ([LP: #1951586](https://launchpad.net/bugs/1951586))."
+msgstr ""
+
+#: ../../24.04/index.md:1174 a2c105e180e6480b9182f3dc4bf810bc
+msgid ""
+"The power LED on the Raspberry Pi 2B, 3B, 3A+, 3B+, and Zero 2W currently"
+" goes off and stays off once the Ubuntu kernel starts booting ([LP: "
+"#2060942](https://launchpad.net/bugs/2060942))"
+msgstr ""
+
+#: ../../24.04/index.md:1176 a627cd6429174f6e80afa844d423f789
+msgid ""
+"libcamera support is currently broken; this will be a priority for next "
+"cycle and fixes will be SRU'd to noble as and when they become available "
+"([LP: "
+"#2038669](https://bugs.launchpad.net/ubuntu/+source/libcamera/+bug/2038669))"
+msgstr ""
+
+#: ../../24.04/index.md:1178 2b821b5807ca4c8b8d77040c72506bde
+msgid ""
+"Red and blue colours in the Ubuntu software store are reversed ([LP: "
+"#2076919](https://launchpad.net/bugs/2076919))"
+msgstr ""
+
+#: ../../24.04/index.md:1180 d82b0d36c4dd485f82c8423fa59164b0
+msgid "RISC--V"
+msgstr ""
+
+#: ../../24.04/index.md:1182 5b4923a1838649429535cc69a2c6db57
+msgid "SD-card support is missing on the Milk-V Mars CM Lite."
+msgstr ""
+
+#: ../../24.04/index.md:1183 b038c3a2f0b04c6a9110fcccd4013d27
+msgid "PCIe on StarFive JH7110 based boards only supports NVMe."
+msgstr ""
+
+#: ../../24.04/index.md:1185 cc49d9e0d4a64a31b24ff4fbd63867bb
+msgid "Google Compute Platform"
+msgstr ""
+
+#: ../../24.04/index.md:1195 f7eec57b8446457fa487361dd73bda7e
+msgid "Official flavors"
+msgstr ""
+
+#: ../../24.04/index.md:1197 8cdb4be997464f0d9c1f229eb5621581
+msgid "Find the release notes for the official flavors at the following links:"
+msgstr ""
+
+#: ../../24.04/index.md:1199 4f7589c876cb4e5693f5964cfcea3ea8
+msgid ""
+"[Edubuntu Release Notes](https://discourse.ubuntu.com/t/edubuntu-24-04"
+"-lts-released/44455/)"
+msgstr ""
+
+#: ../../24.04/index.md:1200 1d703c975f37400690d773d4f1c1edf0
+msgid ""
+"[Kubuntu Release "
+"Notes](https://wiki.ubuntu.com/NobleNumbat/ReleaseNotes/Kubuntu)"
+msgstr ""
+
+#: ../../24.04/index.md:1201 10bedb5ac2cb42d984edcdfc96dee824
+msgid "[Lubuntu Release Notes](https://lubuntu.me/noble-released/)"
+msgstr ""
+
+#: ../../24.04/index.md:1202 855c8d3f546a445ba44551531f0e07a1
+msgid ""
+"[Ubuntu Budgie Release Notes](https://ubuntubudgie.org/2024/04/ubuntu-"
+"budgie-24-04-release-notes/)"
+msgstr ""
+
+#: ../../24.04/index.md:1203 484a33f295cd48df93be98406a44adca
+msgid ""
+"[Ubuntu MATE Release Notes](https://ubuntu-mate.org/blog/ubuntu-mate-"
+"noble-numbat-release-notes/)"
+msgstr ""
+
+#: ../../24.04/index.md:1204 638f0aec837a416c98ed76cf13d97660
+msgid ""
+"[Ubuntu Studio Release Notes](https://ubuntustudio.org/ubuntu-"
+"studio-24-04-LTS-release-notes/)"
+msgstr ""
+
+#: ../../24.04/index.md:1205 9bf564fb04b34586955583072198e1d8
+msgid ""
+"[Ubuntu Unity Release Notes](https://ubuntuunity.org/posts/ubuntu-"
+"unity-2404-released/)"
+msgstr ""
+
+#: ../../24.04/index.md:1206 0fd74ab411214921bbc03515855917ac
+msgid ""
+"[Xubuntu Release Notes](https://wiki.xubuntu.org/releases/24.04/release-"
+"notes)"
+msgstr ""
+
+#: ../../24.04/index.md:1207 324b98b7cd9a489190cd6e33c347a3bf
+msgid ""
+"[Ubuntu Kylin Release "
+"Notes](https://ubuntukylin.com/news/ubuntukylin2404-en.html)"
+msgstr ""
+
+#: ../../24.04/index.md:1208 1479911fe26045a48196a8e8019d4cd2
+msgid "[Ubuntu Cinnamon Release Notes](https://ubuntucinnamon.org/?p=1310)"
+msgstr ""
+
+#: ../../24.04/index.md:1211 c3ac7d3e7bb445aa871762635be519e0
+msgid "More information"
+msgstr ""
+
+#: ../../24.04/index.md:1213 35f22800d7944c0ab29e01962046b946
+#, python-brace-format
+msgid ""
+"Refer to {ref}`release-policy-and-schedule` and {ref}`project-and-"
+"community`."
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/24.04/schedule.po
+++ b/docs/locale/ja/LC_MESSAGES/24.04/schedule.po
@@ -1,0 +1,724 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../24.04/schedule.md:2 8a63e67c9dca45f68f94d8c7916e560f
+msgid "Ubuntu Noble Numbat Release Schedule"
+msgstr ""
+
+#: ../../24.04/schedule.md 3c6546d679aa4de59ee71829a46cc075
+#: d605a0a75d5f438c89be84c503a40a25
+msgid "Week"
+msgstr ""
+
+#: ../../24.04/schedule.md 4c266aa257dc49d682b02b8a6b1b0664
+#: fa0ad7360b314255a357cfdcc457c553
+msgid "Date (Thursday)"
+msgstr ""
+
+#: ../../24.04/schedule.md d4be1ee40caf41458f8c2bca183d669d
+msgid "24.04 events"
+msgstr ""
+
+#: ../../24.04/schedule.md 19436ee91b7244aeac31fb237526ca99
+#: 53498c2b7ebf40eb9941d19c382d70d4
+msgid "**October 2023**"
+msgstr ""
+
+#: ../../24.04/schedule.md 87882e2d5d124e07bd1d89c70025b049
+#: f41caa87547749ad8495839486ecb5cb
+msgid "1"
+msgstr ""
+
+#: ../../24.04/schedule.md 0b22efd2be284db4824694fddec2dd0f
+#: 6d6eb1f430444ebe84f06a56d50386ad
+msgid "October 26"
+msgstr ""
+
+#: ../../24.04/schedule.md 6d621fc5f54b48d889f53de88b2e23e7
+msgid "Toolchain Uploaded"
+msgstr ""
+
+#: ../../24.04/schedule.md a48d6e903c9a4bf0911e80b93be42bb4
+#: ef0b3112d79541c19cf85a1d2b0d8bf8
+msgid "**November 2023**"
+msgstr ""
+
+#: ../../24.04/schedule.md 7390aab0692c41fdb0bba0d48c5510a1
+#: a69d3d0ad1584bff871b770b86322371
+msgid "2"
+msgstr ""
+
+#: ../../24.04/schedule.md 813470c426b746a4a675a084fcc6ff68
+#: bfbb41c10e5c4c229c5c129d50e2940e
+msgid "November 02"
+msgstr ""
+
+#: ../../24.04/schedule.md 75ebd17c5a144e91b3efeda54fcca6dd
+#: c58e12407c6849d78d1a0b974500670f
+msgid "3"
+msgstr ""
+
+#: ../../24.04/schedule.md 121b15be297341819833e0e2235b2817
+#: b93a0b8087764942b99d10d38a556a2c
+msgid "November 09"
+msgstr ""
+
+#: ../../24.04/schedule.md bae362448c1b4c20ab832831cd06a7fc
+#: cc57afaf052c45a48d33f51f04a00178
+msgid "4"
+msgstr ""
+
+#: ../../24.04/schedule.md ec865def24ee41049bf9f458962f8daa
+#: fc1e7e3d8a644fd896eeb5a887728c95
+msgid "November 16"
+msgstr ""
+
+#: ../../24.04/schedule.md 4d8f65949eee4851892f59297c0e58f8
+#: 714e92c869c544f4b2e115f131062970
+msgid "5"
+msgstr ""
+
+#: ../../24.04/schedule.md 4df2eca7da164d19bff1d7793312401c
+#: 99fddbb56f144d6e910ccd0865844b3e
+msgid "November 23"
+msgstr ""
+
+#: ../../24.04/schedule.md aaca79c0010f43859d3e543ac731ad15
+#: b819fe483fce4a979a58ae968606a660
+msgid "6"
+msgstr ""
+
+#: ../../24.04/schedule.md 233a6afa34f844849855b41c68a0ef20
+#: 5959fabc97174df681b5b89833a11336
+msgid "November 30"
+msgstr ""
+
+#: ../../24.04/schedule.md 3527ab22839e4e1c971b898e383171ea
+#: 53df0100b8d646be994150e5f91177b9
+msgid "**December 2023**"
+msgstr ""
+
+#: ../../24.04/schedule.md 2accb6280a254cbcabf3f3fb3ed72923
+#: 95e8289b05f2468cab10c4c7b8fe5a7e
+msgid "7"
+msgstr ""
+
+#: ../../24.04/schedule.md 28a39f9bf8514e4085160b03cbd117e5
+#: c0aeebdc469946e3a8b8a21d3bb4baa0
+msgid "December 07"
+msgstr ""
+
+#: ../../24.04/schedule.md 02a137f95a214afe9ad1bb928ad9ad3f
+#: 20df25d25dea489a82531d6b48b9b7a8
+msgid "8"
+msgstr ""
+
+#: ../../24.04/schedule.md 5cebb93fdd6e4abeb36499e5ae382b67
+#: 794d4af4d5014ab0b05f678c4a2eba8e
+msgid "December 14"
+msgstr ""
+
+#: ../../24.04/schedule.md cd85c170c3fe4caa8feefe2c1e5cb249
+#: f976ff1aa5974034ac87fab615c8b555
+msgid "9"
+msgstr ""
+
+#: ../../24.04/schedule.md 486c060c56ae4b679c60700705577198
+#: 68d40fa204434a9ea4d3d2b36e186181
+msgid "December 21"
+msgstr ""
+
+#: ../../24.04/schedule.md 3736c32b83524fc991a11d63bb738c0c
+#: b7c4481191454b5fb43f0e2413afea1c
+msgid "10"
+msgstr ""
+
+#: ../../24.04/schedule.md 033daec3fea5481989619566749e9e47
+#: ba68abcaa4404325b733cfb79287f27b
+msgid "December 28"
+msgstr ""
+
+#: ../../24.04/schedule.md 09e98c5110604a409651e89a4b1ba1f6
+#: 1dbba5ba61f444cf9b00aab54ca6351b
+msgid "Ubuntu Testing Week (optional)"
+msgstr ""
+
+#: ../../24.04/schedule.md 44c786c566f442ad9ea864ffff70ed4d
+#: addcac19d26b477488321e8847157698
+msgid "**January 2024**"
+msgstr ""
+
+#: ../../24.04/schedule.md 8b32dc97266b4e029e835c172a41ef16
+#: 8e54e7d90e124e74ab758d02e4efa906
+msgid "11"
+msgstr ""
+
+#: ../../24.04/schedule.md 1cfd4474c73043f7abd7d6cd86b107d4
+#: 5b9e10ac28244480bbbff102b8edbdf9
+msgid "January 04"
+msgstr ""
+
+#: ../../24.04/schedule.md 5f3c38e6a17f422da9b12a02582f74c0
+#: 6107d19cfe124c08b6929ce70b20a74f
+msgid "12"
+msgstr ""
+
+#: ../../24.04/schedule.md 09118c609317431ea45b2fa4abd33d03
+#: 5e79eb17f7664898a25c92447d3b9929
+msgid "January 11"
+msgstr ""
+
+#: ../../24.04/schedule.md 5a9a8245ae5a47f2a6931d9cf478104a
+#: f6039aa7b5894d7b8f491f02db2d807a
+msgid "13"
+msgstr ""
+
+#: ../../24.04/schedule.md 61b1e49930a24a39987b918403755a75
+#: e954622200f546b8b774860cd6210362
+msgid "January 18"
+msgstr ""
+
+#: ../../24.04/schedule.md 04350027c62a489080d65e4885df40f4
+#: 48d7610348bf4db6a2516ce35b5db704
+msgid "14"
+msgstr ""
+
+#: ../../24.04/schedule.md 33d83123f9014bf7a85f5b436ee2fe75
+#: 532d152a302d4b5e91b39110b7a4a253
+msgid "January 25"
+msgstr ""
+
+#: ../../24.04/schedule.md 782c3a746a7f44cdaa2a37a6129f65d1
+#: bb643892ecd549719e7857a303532538
+msgid "**February 2024**"
+msgstr ""
+
+#: ../../24.04/schedule.md 3d4a6a97e7f345469205023a6d5ccfe2
+#: 7f762797e88b441ab3f2e5c68296cb9f
+msgid "15"
+msgstr ""
+
+#: ../../24.04/schedule.md 2b9f683b529f478daf7d6054f0366f58
+#: 5de91a3930714340bffe4927f9896fab
+msgid "February 01"
+msgstr ""
+
+#: ../../24.04/schedule.md 385a5522bfe8426bb437cd4ceb386f0b
+#: bcba8f400ab44dda9c4dd58e06ce17d2
+msgid "16"
+msgstr ""
+
+#: ../../24.04/schedule.md 09a79d482c184ea687d63955e9654b90
+#: 13778dd0b6634be08396b3c9da9ccda1
+msgid "February 08"
+msgstr ""
+
+#: ../../24.04/schedule.md c9dd6d08b07545e0a42115787c8e6de3
+#: f2960c905b064014b47ad832b7c262c7
+msgid "17"
+msgstr ""
+
+#: ../../24.04/schedule.md ca3694b6094549f7bd295ac4f17014e7
+#: ec430edbaf7348f7b43f9cc5a8b47f2c
+msgid "February 15"
+msgstr ""
+
+#: ../../24.04/schedule.md 81b32928cd064effbc7b06f7663132d9
+#: da6ff4acd67744de8eb0a282b2c0ea02
+msgid "18"
+msgstr ""
+
+#: ../../24.04/schedule.md 1ee8795c931f427a93178f93b87b883b
+#: b67c6e795f26481d82ab3a9b1019108f
+msgid "February 22"
+msgstr ""
+
+#: ../../24.04/schedule.md 2e9fccc2d8b94beaaa089438ebc941d0
+msgid "*22.04.4*"
+msgstr ""
+
+#: ../../24.04/schedule.md 7dffdefd523444ed9184c02fbed9af57
+#: eca65219a3bc4f09a7e52d7f57cbeaf8
+msgid "19"
+msgstr ""
+
+#: ../../24.04/schedule.md 3c20ebea5e534871a0f1d4948a6bc624
+#: 4a2442bf43fd4497ace706770187c858
+msgid "February 29"
+msgstr ""
+
+#: ../../24.04/schedule.md b07b7f02590e4ce6a95762bb612aa761
+msgid ""
+"[Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), Debian Import "
+"Freeze"
+msgstr ""
+
+#: ../../24.04/schedule.md 6f6a3f1179744d5199b47a443c5446c1
+#: 8d55fcc1bdd74627a7c2da8b744acad9
+msgid "**March 2024**"
+msgstr ""
+
+#: ../../24.04/schedule.md 34ea7f270d444853a50cc43143303d67
+#: cd567c711c3443eb885f5371b58f9293
+msgid "20"
+msgstr ""
+
+#: ../../24.04/schedule.md 1e2db734b12f435ead556ee501c9a5f1
+#: 45e1373e178f454cab63a922877aef13
+msgid "March 07"
+msgstr ""
+
+#: ../../24.04/schedule.md 076405a68f80463885f28342e585d101
+#: 1de6d938cfea4f6db85bba778135a3df
+msgid "21"
+msgstr ""
+
+#: ../../24.04/schedule.md d5591d62135d4eb7b97dc3a94c13fad0
+#: e4b84a2e80244dd783b85b4fe563968e
+msgid "March 14"
+msgstr ""
+
+#: ../../24.04/schedule.md 907dcc845c084e7f8a776f7f1b6a6380
+#: 9cbb2dc14566481291d8c0a735b8a32c
+msgid "22"
+msgstr ""
+
+#: ../../24.04/schedule.md 24a51f5e681246b4acc4261173914576
+#: c17f1d7869664c4a9acfebe4b861cd15
+msgid "March 21"
+msgstr ""
+
+#: ../../24.04/schedule.md a4ddfe2248db40e5a5a14d387c95a7a3
+msgid "[User Interface Freeze](https://wiki.ubuntu.com/UserInterfaceFreeze)"
+msgstr ""
+
+#: ../../24.04/schedule.md 7835a00138e24618bd0f9d9f1a36ac57
+#: 8a20d20bbf43476d9b00d47406750efe
+msgid "23"
+msgstr ""
+
+#: ../../24.04/schedule.md 39df9f3e36774971b30e0c3478c83143
+#: 80ad8538f1494921b0f75647ab3f54d3
+msgid "March 28"
+msgstr ""
+
+#: ../../24.04/schedule.md e513d7661242488c830ebc1d0d69fab2
+msgid ""
+"[Documentation String "
+"Freeze](https://wiki.ubuntu.com/DocumentationStringFreeze), [Kernel "
+"Feature Freeze](https://wiki.ubuntu.com/KernelFeatureFreeze)"
+msgstr ""
+
+#: ../../24.04/schedule.md 66e5f024b30745da86389988cf486da1
+#: 89250bd22fb94106a6264a0f707861c4
+msgid "**April 2024**"
+msgstr ""
+
+#: ../../24.04/schedule.md 04dbc4bf38e94247a6f2ef5180a94a2b
+#: 86b6c86dd044476ab8d8c3ae949d2b32
+msgid "24"
+msgstr ""
+
+#: ../../24.04/schedule.md f3421a60c58942e6a6ce6a8f81e90ebe
+msgid "April 01 (Monday)"
+msgstr ""
+
+#: ../../24.04/schedule.md f42adcd3628748b5bfafc22ff85884e4
+msgid ""
+"[Hardware Enablement "
+"Freeze](https://wiki.ubuntu.com/HardwareEnablementFreeze)"
+msgstr ""
+
+#: ../../24.04/schedule.md 00e6002c6527476a92a5b0c7d0e64649
+#: c547b91001e94e04abd68f88b70fba62
+msgid "⠀"
+msgstr ""
+
+#: ../../24.04/schedule.md b4a81e9bffd24196a35df9df269ff5c9
+#: bad073aa62f04ac3a3db8bb5c11ffb4e
+msgid "April 04"
+msgstr ""
+
+#: ../../24.04/schedule.md 75ca7977ebd34d63ac4c583a33d24cc1
+#: e18cab84e39b48f994921c961edacc8a
+msgid "25"
+msgstr ""
+
+#: ../../24.04/schedule.md 95044b3fbcae4365b73663e307b7a8b1
+msgid "April 08"
+msgstr ""
+
+#: ../../24.04/schedule.md d0f1d7c0d8ea46d788b5f48e7441e6cd
+msgid "[Beta Freeze](https://wiki.ubuntu.com/BetaFreeze)"
+msgstr ""
+
+#: ../../24.04/schedule.md 12a841438c49489c9b8e8285bc2fa4e5
+#: 2204a44df8964c9d869c77145ffb3f2a
+msgid "April 11"
+msgstr ""
+
+#: ../../24.04/schedule.md a1a3bfd86f5441a99a400170537a900e
+msgid ""
+"Beta (mandatory, delayed), [Kernel "
+"Freeze](https://wiki.ubuntu.com/KernelFreeze), [Non Language Pack "
+"Translation "
+"Deadline](https://wiki.ubuntu.com/NonLanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../24.04/schedule.md 57184930443644a6a0b551b972401706
+#: 75b764fe5f194101906a4d76e44cb066
+msgid "26"
+msgstr ""
+
+#: ../../24.04/schedule.md 869e9b64f3b3495a957db14e2789c07e
+#: d21d6b57287a47aa945bb58db08df2f1
+msgid "April 18"
+msgstr ""
+
+#: ../../24.04/schedule.md 6c780045124c4435b5326935dd5a2a11
+msgid ""
+"[Final Freeze](https://wiki.ubuntu.com/FinalFreeze), [Release "
+"Candidate](https://wiki.ubuntu.com/ReleaseCandidate), [Language Pack "
+"Translation "
+"Deadline](https://wiki.ubuntu.com/LanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../24.04/schedule.md b6b73662c2624740b00e184562903417
+#: df58160a6f184d0caa0cba3c7b231585
+msgid "27"
+msgstr ""
+
+#: ../../24.04/schedule.md 34cceb1781614de196bb9fda4368030b
+#: f397ee737c4d463f8039085ac34f25cb
+msgid "April 25"
+msgstr ""
+
+#: ../../24.04/schedule.md b1d478754e1e4001bccc2743f46dd2f3
+msgid "[Final Release](https://wiki.ubuntu.com/FinalRelease)"
+msgstr ""
+
+#: ../../24.04/schedule.md 1755b1aab7224e7793e881d38f993757
+#: 4ffb832f3d3946adbc22ae1696fb3732 5c9497a6e68f4e3b9c9ba3ac25a4a55f
+#: c6b248cc941e4db69d3da3dbd0234d16 c8a41f8f65924b57a53d09f8c434d68b
+#: f1274d98df024aa1859ec0aeef44e163
+msgid "..."
+msgstr ""
+
+#: ../../24.04/schedule.md 5d4cb8a88fbe40b3b45633978a5409de
+msgid "**August 2024**"
+msgstr ""
+
+#: ../../24.04/schedule.md da82596e3bb74f26b8b8e26890faf8f4
+msgid "41"
+msgstr ""
+
+#: ../../24.04/schedule.md a72fc1b63ae844a8bc11af315a717020
+msgid "August 01"
+msgstr ""
+
+#: ../../24.04/schedule.md bbae6106049b47e1a7766c9628342871
+msgid "42"
+msgstr ""
+
+#: ../../24.04/schedule.md 49d95a2605554092ad478acd28fac659
+msgid "August 08"
+msgstr ""
+
+#: ../../24.04/schedule.md 5ae536f5e7854245b5b8f4a8efa62445
+msgid "43"
+msgstr ""
+
+#: ../../24.04/schedule.md 48e0380d416b442295f7b5c0fc25a86b
+msgid "August 15"
+msgstr ""
+
+#: ../../24.04/schedule.md aed276a6816042a7a87ce1e13e8b6226
+msgid "44"
+msgstr ""
+
+#: ../../24.04/schedule.md 22013b38ca5f47d4b1931fc71773add5
+msgid "August 22"
+msgstr ""
+
+#: ../../24.04/schedule.md 0079f8e72aef44498eacef76374c9a43
+msgid "45"
+msgstr ""
+
+#: ../../24.04/schedule.md 56dbba9a9eb04817b1f4af1b1f329c11
+msgid "August 29"
+msgstr ""
+
+#: ../../24.04/schedule.md ee5f58ff858942c497ce3e7588b8b677
+msgid "[24.04.1 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)"
+msgstr ""
+
+#: ../../24.04/schedule.md 229a538d0d4a4b0395632a2e5ce45970
+msgid "**February 2025**"
+msgstr ""
+
+#: ../../24.04/schedule.md 637489fb68de480d83ad75c28765d217
+msgid "67"
+msgstr ""
+
+#: ../../24.04/schedule.md b27d84fd58fa4cf4a89709cc2a7ecc04
+msgid "February 06"
+msgstr ""
+
+#: ../../24.04/schedule.md d88fe2b3f5f1483fa00e3ba875aa5dbb
+msgid "68"
+msgstr ""
+
+#: ../../24.04/schedule.md 3cbf3c04a2b74902910f204d0ec2eed1
+msgid "February 13"
+msgstr ""
+
+#: ../../24.04/schedule.md 115e6fd7a75e4643ae1390597d795d25
+msgid "[24.04.2 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)"
+msgstr ""
+
+#: ../../24.04/schedule.md 9aa2482bae92413094ff164adab53e6f
+msgid "69"
+msgstr ""
+
+#: ../../24.04/schedule.md a5557760c690423c8cc87a8583a53138
+msgid "February 20"
+msgstr ""
+
+#: ../../24.04/schedule.md f25b6ff4b25c4e80a2586f7f9cefa59f
+msgid "70"
+msgstr ""
+
+#: ../../24.04/schedule.md 606a758a75204324a97ac302c558ab85
+msgid "February 27"
+msgstr ""
+
+#: ../../24.04/schedule.md 4814727b775c42ddb092722f8a9a0df4
+msgid "**August 2025**"
+msgstr ""
+
+#: ../../24.04/schedule.md 4f8faaec01d649e6ab17f1751e9d5e58
+msgid "93"
+msgstr ""
+
+#: ../../24.04/schedule.md 1fc96b363f0742728ebb09f5f698f50f
+msgid "August 07"
+msgstr ""
+
+#: ../../24.04/schedule.md 09d43cb2fb58446c877b521ccffdcc1d
+msgid "[24.04.3 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)"
+msgstr ""
+
+#: ../../24.04/schedule.md b468a0af116b4eba94cdb5322c6865e0
+msgid "94"
+msgstr ""
+
+#: ../../24.04/schedule.md c4ecf9abd5614b75b0ed141d994e00ce
+msgid "August 14"
+msgstr ""
+
+#: ../../24.04/schedule.md 4adc67bd23904ad99b3a6927a21f6ba8
+msgid "95"
+msgstr ""
+
+#: ../../24.04/schedule.md 6fa512d24f8f4d95a14995402171f918
+msgid "August 21"
+msgstr ""
+
+#: ../../24.04/schedule.md 884049554ecc4d7898f2ed491375271c
+msgid "96"
+msgstr ""
+
+#: ../../24.04/schedule.md cfd102fb7702433387198fdaa5959a8a
+msgid "August 28"
+msgstr ""
+
+#: ../../24.04/schedule.md 79aceb2c31ac4c11bac09db2d0936797
+msgid "**February 2026**"
+msgstr ""
+
+#: ../../24.04/schedule.md ce9c73a55bb3446c9bd833e4a19c12e9
+msgid "110"
+msgstr ""
+
+#: ../../24.04/schedule.md 36e767b8a7784b6a99a610cebde76f4a
+msgid "February 12"
+msgstr ""
+
+#: ../../24.04/schedule.md 70d80e7f73ab4a96b73bd0f24dc93fc8
+msgid "[24.04.4 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)"
+msgstr ""
+
+#: ../../24.04/schedule.md:67 b244f759c5054291a351d671c263790d
+msgid "Planned and potentially disruptive archive-wide activities"
+msgstr ""
+
+#: ../../24.04/schedule.md:69 914b32caa79447fd858e64a10a19cb0c
+msgid ""
+"If you're planning a change that might have a disruptive effect on the "
+"archive - e.g. transitions or switches of important defaults (such as "
+"compiler versions) - list it here."
+msgstr ""
+
+#: ../../24.04/schedule.md 60575b80f65846609fdad4f4e9257feb
+msgid "Planned activity"
+msgstr ""
+
+#: ../../24.04/schedule.md 97f4c4f19c9844c3929fe05d267c61d0
+msgid "Python 3.12 as supported Python3 version"
+msgstr ""
+
+#: ../../24.04/schedule.md ab9e6795267a430fb8b760e138273dfd
+msgid "binutils 2.42"
+msgstr ""
+
+#: ../../24.04/schedule.md f4de8ae7aaf048f686d3a3f44851a307
+msgid "ruby 3.2"
+msgstr ""
+
+#: ../../24.04/schedule.md 0c4c9e08e23f476cae797185d9a5819a
+msgid "PHP 8.3 transition"
+msgstr ""
+
+#: ../../24.04/schedule.md 80acbda10e5e4521941c75facf97dec6
+msgid "Python 3.12 as default version"
+msgstr ""
+
+#: ../../24.04/schedule.md bd147874063b4a319f6e3cb9a2c6f53e
+msgid "glibc 2.39 in -proposed, glib 2.79 in proposed"
+msgstr ""
+
+#: ../../24.04/schedule.md 9957a4d4975f472b9a28cec97c583b09
+msgid "[GNOME 46 Beta](https://wiki.gnome.org/FortySix)"
+msgstr ""
+
+#: ../../24.04/schedule.md acf7458ecaa74a34a0cd060a73c0fbfe
+msgid ""
+"64-bit time_t (est) / Go 1.22 as default / GCC 14 as non-default/Java 21 "
+"as default"
+msgstr ""
+
+#: ../../24.04/schedule.md 4c14a84116de44ebb1205b9d08cc42f7
+msgid "[GNOME 46.0](https://wiki.gnome.org/FortySix)"
+msgstr ""
+
+#: ../../24.04/schedule.md 714e333010c04a768de873701cb901b3
+msgid "LLVM 18 as default"
+msgstr ""
+
+#: ../../24.04/schedule.md:108 d2137b5d2ba641e48cd6d070bc7d271f
+msgid "Ubuntu Noble Numbat Release Task Signup Sheet"
+msgstr ""
+
+#: ../../24.04/schedule.md:110 65831f8a647c49f09e32d1f65c907cdd
+msgid "This signup sheet is to be used for planning release milestone tasks."
+msgstr ""
+
+#: ../../24.04/schedule.md:112 b1baf61788a0499e8b81fb8720f63f8a
+msgid ""
+"The Alpha and Beta 1 milestones have been replaced with [Testing "
+"Weeks](https://lists.ubuntu.com/archives/ubuntu-"
+"release/2018-April/004434.html), which are organized ad hoc at this "
+"point."
+msgstr ""
+
+#: ../../24.04/schedule.md c742ccba0a9a4e3dadbd1136101dcba6
+msgid "Milestone"
+msgstr ""
+
+#: ../../24.04/schedule.md 241d0dd7689449139b1388283098befa
+msgid "Date"
+msgstr ""
+
+#: ../../24.04/schedule.md c0b4bb2c6bb5483993e240fc12c9e959
+msgid "Image (Nusakan) Engineering"
+msgstr ""
+
+#: ../../24.04/schedule.md c0c9de7dbdb0469b83c16d7485b1b55e
+msgid "Checklist Tracking"
+msgstr ""
+
+#: ../../24.04/schedule.md fac4aad2ccbe4fd8b8ccbacb194933d9
+msgid "Announcement Email"
+msgstr ""
+
+#: ../../24.04/schedule.md d8c33eb4c91549f79ba6f8ce67cb2186
+msgid "Feature Freeze"
+msgstr ""
+
+#: ../../24.04/schedule.md 34eb3fa2d43d42caa023c1f1a4554846
+#: 3913b9d53b9c43e7918e8223ea0ae2f0 7d338cd6bf034db0897add260318427c
+#: a853759a2a82498e92f995adc00e814f bd4072fcd5194836896bb95015b57b79
+#: bee70b0123f543389960b7706328ec78
+msgid "n/a"
+msgstr ""
+
+#: ../../24.04/schedule.md 500d135ef1c04487b42576cb555e94b4
+#: a4c3656353e546318d517bcd76282446 b911c1beeee240e281914049578fcf40
+#: c33397a6036f49ed96f494c481819965 d68bdb874ee14849993d6ead16c88c0f
+#: e943910a4f734ee6ab978ecf8e8d765c f9d9b52940d04e4eb40bf72e93b2f728
+msgid "utkarsh"
+msgstr ""
+
+#: ../../24.04/schedule.md 48f749f2eedd49a3a4e5c7cc32894d84
+msgid "UI Freeze"
+msgstr ""
+
+#: ../../24.04/schedule.md ecd51403d0da4948af802fa4b5a37241
+msgid "Doc String Freeze"
+msgstr ""
+
+#: ../../24.04/schedule.md 0aab036c5d884c2f9357003675f4af77
+msgid "24.04 Beta"
+msgstr ""
+
+#: ../../24.04/schedule.md 027108d2aa534fc68832f13bedde287a
+msgid "Final Freeze"
+msgstr ""
+
+#: ../../24.04/schedule.md 98663eba23834125b411bf50bffe7a38
+msgid "24.04 Release"
+msgstr ""
+
+#: ../../24.04/schedule.md 0acb566e96ca4bd9b24f9ed6f1e017c4
+msgid "April 25 2024"
+msgstr ""
+
+#: ../../24.04/schedule.md:123 3292fdf504bc47279a0da289c58b2b06
+msgid ""
+"When the archive is frozen, all members of the release team are expected "
+"to participate in bug fix reviews."
+msgstr ""
+
+#: ../../24.04/schedule.md:125 62eaccd692f14abba717830b3062bc72
+msgid ""
+"After [Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), all "
+"members of the release team are expected to participate in Feature Freeze"
+" Exception reviews in their particular area of expertise."
+msgstr ""
+
+#: ../../24.04/schedule.md:127 8706242078114605966cc8cf9f2e6bfa
+msgid ""
+"After [Final Beta](https://wiki.ubuntu.com/FinalBetaRelease), all members"
+" of the release team are expected to participate in Bug fix reviews in "
+"their particular area of expertise."
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/24.10/index.po
+++ b/docs/locale/ja/LC_MESSAGES/24.10/index.po
@@ -1,0 +1,2323 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../24.10/index.md:10
+msgid "Release schedule"
+msgstr ""
+
+#: ../../24.10/index.md:6 197ffd794c8142028aa3fb35d0fbb028
+msgid "Ubuntu 24.10 release notes"
+msgstr ""
+
+#: ../../24.10/index.md:8 0e2c5d8bfadf4f388fab53d1335cfc9b
+msgid ""
+"These release notes for **Ubuntu 24.10** (Oracular Oriole) provide an "
+"overview of the release and document the known issues with Ubuntu and its"
+" flavors."
+msgstr ""
+
+#: ../../24.10/index.md:17 2d96f8a431a34e77b07580bff0f530e6
+msgid "Support lifespan"
+msgstr ""
+
+#: ../../24.10/index.md:19 05cd19372a8e4460b39c74cef16d4b9c
+msgid ""
+"Ubuntu 24.10 will be supported for 9 months until July 2025. If you need "
+"long term support, we recommend you use [Ubuntu 24.04.1 "
+"LTS](https://ubuntu.com/download) which is supported until at least 2029."
+msgstr ""
+
+#: ../../24.10/index.md:21 f72846a18b08498896f0cefffdf117c5
+msgid "Upgrades"
+msgstr ""
+
+#: ../../24.10/index.md:23 35f51ecff67c482caf86cba435723444
+msgid ""
+"Upgrades to to Ubuntu 24.10 will refresh seeded snaps to the appropriate "
+"snap channels, regardless of what was being tracked before. Snaps that "
+"are newly-seeded will be installed during the upgrade. In particular, the"
+" following snaps will be installed or refreshed on upgrade:"
+msgstr ""
+
+#: ../../24.10/index.md:25 2578fc9fe8c94c1a91c7670f961d499e
+msgid "`core24 latest/stable`"
+msgstr ""
+
+#: ../../24.10/index.md:26 49c2fac0888b4d0787ef9023e654c2ab
+msgid "`desktop-security-center 1/stable/ubuntu-24.10`"
+msgstr ""
+
+#: ../../24.10/index.md:27 6e19b58930f24f4db74fc90910ec6a3b
+msgid "`gnome-46-2404 stable/ubuntu-24.10`"
+msgstr ""
+
+#: ../../24.10/index.md:28 33eb4b4eafa14647b0e04d45e8a76302
+msgid "`mesa-2404 stable/ubuntu-24.10`"
+msgstr ""
+
+#: ../../24.10/index.md:29 6926c751f9a44a17a9ed5a902a5729a6
+msgid "`prompting-client 1/stable/ubuntu-24.10`"
+msgstr ""
+
+#: ../../24.10/index.md:30 93ae314f3c10430fafebb8f5bb2609ad
+msgid "`firefox stable/ubuntu-24.10`"
+msgstr ""
+
+#: ../../24.10/index.md:31 69e8a4f43c5f41d1974c244a8fed0e25
+msgid "`thunderbird stable/ubuntu-24.10`"
+msgstr ""
+
+#: ../../24.10/index.md:32 7c85c1af33ee4477bc45d5ee8d386079
+msgid "`snapd-desktop-integration stable/ubuntu-24.10`"
+msgstr ""
+
+#: ../../24.10/index.md:34 fe251c9a167740cebcb5cec89f4b3f45
+msgid "Early upgrades may wish to perform these updates manually."
+msgstr ""
+
+#: ../../24.10/index.md:37 0a039451d1194885ae6ddff12a52d56e
+msgid "New features in 24.10"
+msgstr ""
+
+#: ../../24.10/index.md:39 a3a1184ffe484e55886d0562b7d89483
+msgid "Updated Packages"
+msgstr ""
+
+#: ../../24.10/index.md:41 38dafffde1d44a8882bd9364428bf260
+msgid "OpenSSL 3.3"
+msgstr ""
+
+#: ../../24.10/index.md:43 70c005bcf61040cebdb2e1cd00855d6b
+msgid ""
+"OpenSSL has been updated to version 3.3 with large performance and "
+"scalability improvements compared to openssl 3.0. It is now also loading "
+"configuration dropins from `/etc/ssl/openssl.conf.d` for easier "
+"customisation."
+msgstr ""
+
+#: ../../24.10/index.md:46 8a579eb0cffa48f2a57ba891fa99f734
+msgid "Linux kernel 🐧"
+msgstr ""
+
+#: ../../24.10/index.md:47 06f95f3d2f8f4597853b01b8486d49e7
+msgid ""
+"Ubuntu 24.10 includes the new 6.11 Linux kernel that brings many new "
+"features."
+msgstr ""
+
+#: ../../24.10/index.md:49 d3273e82b501481b93d3c3bebc3ba2e4
+msgid ""
+"Crash dumps are now enabled by default for desktop and server "
+"installations. Please refer to the [Ubuntu Server Kernel crash "
+"dump](https://documentation.ubuntu.com/server/how-to/software/kernel-"
+"crash-dump/#kdump-enabled-by-default) documentation for complete details."
+msgstr ""
+
+#: ../../24.10/index.md:51 7f0e9a640a0c450f9b96fb8fc5169e4e
+msgid ""
+"Detailed changes are reported in the [Oracular Kernel Release "
+"Notes](https://discourse.ubuntu.com/t/introducing-kernel-6-11-for-"
+"the-24-10-oracular-oriole-release/47560) post."
+msgstr ""
+
+#: ../../24.10/index.md:53 13479aaeb8c1450cbed01c17e6a6d333
+msgid "systemd v256.5"
+msgstr ""
+
+#: ../../24.10/index.md:55 f24dc890842441819a646b4e7caa1dfc
+msgid ""
+"The init system was updated to systemd v256.5. See the [upstream "
+"changelog ](https://github.com/systemd/systemd/releases/tag/v256) for "
+"more information about individual features. To highlight a few things:"
+msgstr ""
+
+#: ../../24.10/index.md:57 2fd32a28552f4a66807b4e6b19e3a3f8
+msgid ""
+"Support for cgroup v1 ('legacy' and 'hybrid' hierarchies) is now "
+"considered obsolete and systemd by default will refuse to boot under it. "
+"To forcibly reenable cgroup v1 support, "
+"`SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1` must be set on kernel command "
+"line."
+msgstr ""
+
+#: ../../24.10/index.md:63 147f2950a2244372a1382a7472ac32de
+msgid ""
+"Support for System V service scripts is deprecated and will be removed in"
+" a future release. Please make sure to update your software *now* to "
+"include a native systemd unit file instead of a legacy System V script to"
+" retain compatibility with future systemd releases."
+msgstr ""
+
+#: ../../24.10/index.md:68 6d6e7b95158d4c12b58ec61e3d078302
+msgid ""
+"When `sshd` is installed on a system, a new systemd generator, `systemd-"
+"ssh-generator` binds a socket-activated SSH server to local `AF_VSOCK` "
+"and `AF_UNIX` sockets under certain conditions. See the [man "
+"page](https://www.freedesktop.org/software/systemd/man/devel/systemd-ssh-"
+"generator.html#) for more details. Note that this feature is different "
+"and indendent from `sshd-socket-generator` which is shipped in Ubuntu's "
+"`openssh-server` package."
+msgstr ""
+
+#: ../../24.10/index.md:70 f872322279b84785a8d7b22354b2e07e
+msgid ""
+"Ubuntu now ships upstream systemd's `tmp.mount` by default. In effect "
+"this means that `/tmp` is now a `tmpfs` by default."
+msgstr ""
+
+#: ../../24.10/index.md:72 71c970772c0f485d8afca61f63b5a21f
+msgid ""
+"cryptsetup tools such as `systemd-cryptsetup`, `systemd-cryptenroll`, "
+"`systemd-veritysetup`, and more, have been split into a new `systemd-"
+"cryptsetup` package to reduce dependencies pulled in by the main "
+"`systemd` package. This new package is only listed as a `Suggests`, so if"
+" this functionality is used ensure that either `Suggests` are installed "
+"or that it is manually installed."
+msgstr ""
+
+#: ../../24.10/index.md:79 129656ec75cb44afa489ddc8e6f3e4a8
+msgid ""
+"Ubuntu's `systemd-networkd` no longer sets `UseDomains=true` for managed "
+"network interfaces. In effect, this means that search domains configured "
+"in DHCP leases will not be reflected in `/etc/resolv.conf` by default. "
+"This change aligns Ubuntu's default behavior with that of upstream. "
+"System administrators may choose to override this default on a global, or"
+" per-interface basis. See "
+"[`systemd.network`](https://www.freedesktop.org/software/systemd/man/256/systemd.network.html#UseDomains=)"
+" for details."
+msgstr ""
+
+#: ../../24.10/index.md:81 0e6c98ac93a34c3faead9c20f68ec9dc
+msgid "Netplan v1.1 🌐"
+msgstr ""
+
+#: ../../24.10/index.md:82 5fbc82abb99f498bb1b4add87ae5f5d0
+msgid ""
+"The new [version 1.1 of "
+"Netplan](https://github.com/canonical/netplan/releases/tag/1.1) "
+"introduces a custom `systemd-networkd-wait-online` logic, waiting for "
+"link-local addresses and one routable interface, as described in the "
+"https://discourse.ubuntu.com/t/spec-definition-of-an-online-system/27838."
+" Besides improvements to the `embedded-switch-mode` setting for SR-IOV "
+"devices, the introduction of parser flag to skip broken configurations "
+"and fixes for ProtonVPN and Microsoft Azure Linux."
+msgstr ""
+
+#: ../../24.10/index.md:84 e3bef5adcb7940ba93a87f0a23f0a19e
+msgid "Toolchain Upgrades 🛠️"
+msgstr ""
+
+#: ../../24.10/index.md:86 f71ee8c6c77041838080c9b4f87ea38b
+msgid "GCC 🐄 is updated to 14.2, binutils to 2.43.1, and glibc to 2.40."
+msgstr ""
+
+#: ../../24.10/index.md:87 e56608cfbe9844149c62b96880b57136
+msgid "Python 🐍 is updated to 3.12.7"
+msgstr ""
+
+#: ../../24.10/index.md:88 5dc4201eb4f3437f989dbad9e1600200
+msgid "LLVM 🐉 now defaults to version 19"
+msgstr ""
+
+#: ../../24.10/index.md:89 30772056096b4aa890b6e985342d56e7
+msgid "Rust 🦀 toolchain defaults to version 1.80"
+msgstr ""
+
+#: ../../24.10/index.md:90 9cc382fa12054303b006d1e21778ce35
+msgid "Golang 🐀 is updated to 1.23"
+msgstr ""
+
+#: ../../24.10/index.md:91 8f15f5c3e4e94de28c7c6f78efdc46a2
+msgid ".NET 9 🤖 now available, .NET 8 support extended to IBM Power"
+msgstr ""
+
+#: ../../24.10/index.md:92 dc8126610d8a4f26b293e4dba087ce26
+msgid "OpenJDK ☕ versions 23 and 24 (early access snapshot) are now available"
+msgstr ""
+
+#: ../../24.10/index.md:94 6496e23123054cc68bf51bd76fee740c
+msgid "OpenJDK"
+msgstr ""
+
+#: ../../24.10/index.md:96 a331014c96914076b04fa0530afd5054
+msgid ""
+"OpenJDK 21 is still the default. OpenJDK 23 is included as an optional "
+"OpenJDK. An early access snapshot of OpenJDK 24  is also included. "
+"Support for OpenJDK LTS versions 17, 11 and 8 is being maintained."
+msgstr ""
+
+#: ../../24.10/index.md:98 79588f2377f042db8cdf11b127c040aa
+msgid ""
+"OpenJDK 21 and OpenJDK 17 packages are now TCK (Technology Compatibility "
+"Kit) certified on amd64, arm64, s390x, ppc64el and armhf. The Java TCK is"
+" the most comprehensive test suite that covers all aspects of Java SE "
+"specification including language features, libraries and APIs. This "
+"guarantees interoperability and conformance to standard."
+msgstr ""
+
+#: ../../24.10/index.md:100 32130598bdc04465907a660380713350
+msgid ".NET"
+msgstr ""
+
+#: ../../24.10/index.md:102 90395063acc24485a7c08957c8d7c452
+msgid ""
+"With the release of .NET 9, Ubuntu reinforces its commitment to "
+"supporting the .NET community. .NET 9 is fully supported on Ubuntu 24.10 "
+"and is also available for Ubuntu 24.04 LTS (Noble Numbat) and Ubuntu "
+"22.04 LTS (Jammy Jellyfish) through the [.NET Backports "
+"PPA](https://launchpad.net/~dotnet/+archive/ubuntu/backports)."
+msgstr ""
+
+#: ../../24.10/index.md:104 cc293c3f58f44a4ba9e2573d69eb71f6
+msgid ""
+"In addition, we have expanded .NET support to the IBM Power platform for "
+"both .NET 8 and .NET 9, further broadening the platform’s reach."
+msgstr ""
+
+#: ../../24.10/index.md:106 0bef7565c619466cabb8108ed0252801
+msgid ""
+"We are also excited to introduce the new and improved [.NET "
+"Snap](https://snapcraft.io/dotnet), allowing developers to seamlessly "
+"install any supported version of .NET on any Ubuntu system."
+msgstr ""
+
+#: ../../24.10/index.md:109 6efbeb87df7b43769fa5af65ff9d241e
+msgid "Default configuration changes ⚙️"
+msgstr ""
+
+#: ../../24.10/index.md:111 0b60c0a05cd1460a8cd5c6506b8f6a40
+msgid ""
+"As always there are many changes to defaults, mostly by newer versions of"
+" packages. But a few are worth spelling out if your former automation, "
+"configuration and tuning relied on those settings being one or the other "
+"way."
+msgstr ""
+
+#: ../../24.10/index.md:115 ../../24.10/index.md:560
+#: e55fe8d0e4ff4bc1b3970225446ad463 fffb47a3a14e43a6a781a2c87dbd9d7f
+msgid "Ubuntu Desktop"
+msgstr ""
+
+#: ../../24.10/index.md:117 cc8c35c61639497ba69b9ce52ceba517
+msgid "Installer and Upgrades"
+msgstr ""
+
+#: ../../24.10/index.md:119 918310ff2f684168b47ecbf5acef3f70
+msgid "The desktop installer now support local file paths for autoinstall import."
+msgstr ""
+
+#: ../../24.10/index.md:122 44eb7e8bd19d465b989950badacae928
+msgid ""
+"**Power Profiles Manager** [has been improved and "
+"optimized](https://gitlab.freedesktop.org/upower/power-profiles-"
+"daemon/-/releases/#0.23) to support better newer hardware features "
+"(especially AMD), can now support multiple optimization drivers and is "
+"now battery-aware to automatically increase the optimization levels when "
+"running on battery only."
+msgstr ""
+
+#: ../../24.10/index.md:124 578c720bd0634765b34bad771784df99
+msgid ""
+"**fprintd** has been updated and [**libfprint** supports now many other "
+"fingerprint drivers and "
+"devices](https://gitlab.freedesktop.org/libfprint/libfprint/-/releases#v1.94.8)."
+msgstr ""
+
+#: ../../24.10/index.md:126 5cbaf5880b8f43e2842500e4db6b9a31
+msgid "Store"
+msgstr ""
+
+#: ../../24.10/index.md:128 fb3257e10e164863b2aaef6fbcf2d721
+msgid "The App Center now includes improvements to the Manage page including:"
+msgstr ""
+
+#: ../../24.10/index.md:129 d0e98e4fdc634bd98107ee67ed939cf2
+msgid "Installs in progress"
+msgstr ""
+
+#: ../../24.10/index.md:130 c69daf086b154243b26b6e576ad97616
+msgid "Improved self-update handling"
+msgstr ""
+
+#: ../../24.10/index.md:131 50e9d05ea00647cb84087540a9fbf49c
+msgid "Messaging for running snaps"
+msgstr ""
+
+#: ../../24.10/index.md:132 a64ee4688d084db58beff17a42c9c2c4
+msgid "Direct uninstall of snaps from the manage page"
+msgstr ""
+
+#: ../../24.10/index.md:133 71e1fecce5cc49ebbd472fac620d837e
+msgid "Scrolling support for touch screens"
+msgstr ""
+
+#: ../../24.10/index.md:135 f51ca35c49fc4bb1b9051541361c602c
+msgid "Third party deb installation is now also supported."
+msgstr ""
+
+#: ../../24.10/index.md:138 dbdb86c86c5a47ce89dfc73467daa340
+msgid "Security Center"
+msgstr ""
+
+#: ../../24.10/index.md:140 c38c2632dc084cffb0aec1f580e0a815
+msgid ""
+"A new Security Center is included. It features the ability to easily "
+"enable or disable a new experimental [permissions "
+"prompting](https://discourse.ubuntu.com/t/ubuntu-desktop-s-24-10-dev-"
+"cycle-part-5-introducing-permissions-prompting/47963/1) feature for Home "
+"directory permissions."
+msgstr ""
+
+#: ../../24.10/index.md:141 1344a32de0ac4d7ab92cdd0f2c41cf2d
+msgid "More features will be added in future Ubuntu releases."
+msgstr ""
+
+#: ../../24.10/index.md:142 67292bf9cb3d422c9c4ec682c9818883
+msgid ""
+"Prompting is also supported by an additional seeded snap, `prompting-"
+"client`, for permissions prompt handling."
+msgstr ""
+
+#: ../../24.10/index.md:144 7f2e30a7482f4f239d76bd57f2af38f7
+msgid "20th Anniversary Celebration"
+msgstr ""
+
+#: ../../24.10/index.md:145 346f58ad556d4b84987f9819dbccf205
+msgid ""
+"20 years ago, the first version of Ubuntu was released, Ubuntu 4.10 "
+"\"Warty Warthog\". We are celebrating this monumental anniversary with "
+"several temporary flourishes"
+msgstr ""
+
+#: ../../24.10/index.md:146 d6157b96747646ce90521c5272764f65
+msgid ""
+"The return of the original startup sound, which can be disabled via "
+"Settings > Sound"
+msgstr ""
+
+#: ../../24.10/index.md:147 172c567ce24947c2aa6204a2f52ff7ce
+msgid ""
+"A 'Warty' brown accent colour that can be enabled in Settings > "
+"Appearance > Style"
+msgstr ""
+
+#: ../../24.10/index.md:148 aa7c033195cf4ce6b22d84c95035ab6d
+msgid "An anniversary logo"
+msgstr ""
+
+#: ../../24.10/index.md:150 a955113e21c1440e9a23095dc2383699
+msgid "GNOME 👣"
+msgstr ""
+
+#: ../../24.10/index.md:152 6e4e67445e96445181a1a37639b21b02
+msgid ""
+"GNOME has been updated to include new features and fixes from the latest "
+"GNOME release, [GNOME 47](https://release.gnome.org/47/)."
+msgstr ""
+
+#: ../../24.10/index.md:153 3b5e1a21f19b4d7abcd8fb84b4659d02
+msgid ""
+"In GNOME Shell and Mutter, Ubuntu includes additional patches to enhance "
+"stability and performance, which have not yet been merged upstream."
+msgstr ""
+
+#: ../../24.10/index.md:154 b5762851170b447caeb14b20deaf99f1
+msgid ""
+"The Ubuntu dock now visualises snap refreshes and includes better "
+"handling for PWAs installed via the Chromium snap."
+msgstr ""
+
+#: ../../24.10/index.md:156 c0787b59d85545298764ccdd43be3db9
+msgid "Default app changes"
+msgstr ""
+
+#: ../../24.10/index.md:157 580eff6002624b58af17ad1c8935de15
+msgid ""
+"The [Sysprof](https://apps.gnome.org/Sysprof/) app is installed by "
+"default as a new system utility. This makes it easier to discover "
+"performance issues in your apps."
+msgstr ""
+
+#: ../../24.10/index.md:159 e80fff14383d4a2c9eb8f4dbd1b387f4
+msgid "Updated Applications"
+msgstr ""
+
+#: ../../24.10/index.md:161 bbe34ef24c234e60ad758235bd3a5e81
+msgid "[Firefox](https://mozilla.org/firefox/releases/) 130 🔥🦊"
+msgstr ""
+
+#: ../../24.10/index.md:162 435f83f893ea4623847f73034ddf8c0f
+msgid ""
+"[LibreOffice 24.8](https://wiki.documentfoundation.org/ReleaseNotes/24.8)"
+" 📚"
+msgstr ""
+
+#: ../../24.10/index.md:163 081f7b90645c47779c4d7db7c1878254
+msgid ""
+"[Thunderbird 128 \"Supernova\"](https://blog.thunderbird.net/2023/07/our-"
+"fastest-most-beautiful-release-ever-thunderbird-XY-supernova-is-here/) "
+"🌩️🐦"
+msgstr ""
+
+#: ../../24.10/index.md:165 872dc9d7bda24efa89288a9af18dfa77
+msgid "Updated Subsystems"
+msgstr ""
+
+#: ../../24.10/index.md:166 035fa67da0d84129b577416e1da85fcf
+msgid ""
+"[BlueZ "
+"5.77](https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/ChangeLog?id=5.77)"
+" 💙"
+msgstr ""
+
+#: ../../24.10/index.md:167 8256ce35b76348019935706c45870e65
+msgid "[Cairo 1.18.2](https://cairographics.org/news/cairo-1.18.2/) 👁️⃤"
+msgstr ""
+
+#: ../../24.10/index.md:168 86b7246011a443698ffa41ff298a0c66
+msgid ""
+"[Noto Color Emoji Font 2.047 with Unicode 16 "
+"support](https://blog.emojipedia.org/google-debuts-emoji-16-0-support/) 🥳"
+msgstr ""
+
+#: ../../24.10/index.md:169 d141cedfdd064f26a419d42ff3b1050e
+msgid ""
+"[NetworkManager "
+"1.48](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/nm-1-48/NEWS)"
+" 🖧"
+msgstr ""
+
+#: ../../24.10/index.md:170 14e6925ef82c47708255b8f3e4cf0793
+msgid ""
+"[Pipewire "
+"1.2.4](https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/1.2.4/NEWS)"
+" 🔊"
+msgstr ""
+
+#: ../../24.10/index.md:171 451afa7d902a4acda22fa63083631734
+msgid ""
+"[Poppler "
+"24.08](https://gitlab.freedesktop.org/poppler/poppler/-/blob/poppler-24.08.0/NEWS)"
+" 📝"
+msgstr ""
+
+#: ../../24.10/index.md:172 6c05138515d34310a0b69412c0bb2edd
+msgid ""
+"[xdg-desktop-portal 1.18](https://github.com/flatpak/xdg-desktop-"
+"portal/blob/1.18.4/NEWS) ⛩️"
+msgstr ""
+
+#: ../../24.10/index.md:174 d0eacfb810e948e4be2d61a89eb51f95
+msgid "Nvidia"
+msgstr ""
+
+#: ../../24.10/index.md:176 ce87554dd9514075bdcb78cad9eb04bd
+msgid ""
+"Ubuntu 24.10 now defaults to Wayland instead of Xorg on machines using "
+"Nvidia graphics. If you require Xorg instead then select 'Ubuntu on Xorg'"
+" from the session menu on the login screen."
+msgstr ""
+
+#: ../../24.10/index.md:178 a46ce0c51f5b40879e1d0046649a8880
+msgid "Ubuntu WSL"
+msgstr ""
+
+#: ../../24.10/index.md:180 62e917be2ff64044b867db2836d70654
+msgid "--"
+msgstr ""
+
+#: ../../24.10/index.md:182 ../../24.10/index.md:582
+#: 762cfea67790477382c94a885f439fd4 dd0a08251a5242489a6b5ef6f2c8da58
+msgid "Ubuntu Server"
+msgstr ""
+
+#: ../../24.10/index.md:184 35e0629be4974500b152b5db676ba18c
+msgid "Apache2"
+msgstr ""
+
+#: ../../24.10/index.md:185 ca62821d139c40438350046fb746a4a7
+msgid ""
+"Apache2 has been updated from Noble's 2.4.58 to the current 2.4.62, and "
+"some of the more noteworthy changes include:"
+msgstr ""
+
+#: ../../24.10/index.md:187 3e4a60a18e324aa88b86c29f99192d1c
+msgid "htpasswd: Add support for passwords using SHA-2."
+msgstr ""
+
+#: ../../24.10/index.md:188 5cf8890893594c5696a34163975ec16f
+msgid "core: Allow mod_env to override system environment vars."
+msgstr ""
+
+#: ../../24.10/index.md:189 6df88cc1cf7c4f41a78bf618816d1f6d
+msgid ""
+"mod_xml2enc: Update check to accept any text/ media type or any XML media"
+" type per RFC 7303, avoiding corruption of Microsoft OOXML formats."
+msgstr ""
+
+#: ../../24.10/index.md:190 68235f5032e5439683184a44e3ea3f0e
+msgid ""
+"mod_ssl: SSLProxyMachineCertificateFile/Path may reference files which "
+"include CA certificates; those CA certs are treated as if configured with"
+" SSLProxyMachineCertificateChainFile."
+msgstr ""
+
+#: ../../24.10/index.md:191 91dc9f8cd74a4ff6b1689bd33d5e047c
+msgid ""
+"mod_ssl: Improve compatibility with OpenSSL 3, including handling when "
+"OPENSSL_NO_ENGINE is set and support for loading certs/keys from pkcs11."
+msgstr ""
+
+#: ../../24.10/index.md:192 23d6eaf202b84633a72c58d9937820c4
+msgid ""
+"mod_proxy: Ignore (and warn about) enablereuse=on for ProxyPassMatch when"
+" some dollar substitution (backreference) happens in the hostname or port"
+" part of the URL."
+msgstr ""
+
+#: ../../24.10/index.md:193 5bcfb668346d4bc1a1153cecf161c533
+msgid ""
+"mod_proxy: Add optional third argument for ProxyRemote, which configures "
+"Basic authentication credentials to pass to the remote proxy."
+msgstr ""
+
+#: ../../24.10/index.md:194 d7a32056e7b3475cb5f88449e8d13e97
+msgid ""
+"mod_md: Certificate renewals are triggerable using OCSP stapling "
+"information."
+msgstr ""
+
+#: ../../24.10/index.md:196 e75e49db6ad74706b898fc0f9e7ad1cc
+msgid ""
+"For more details, please see the [full set of "
+"changes](https://downloads.apache.org/httpd/CHANGES_2.4.59)."
+msgstr ""
+
+#: ../../24.10/index.md:199 f6ae2aeb0f974981bd960e6d434a7e21
+msgid "Clamav"
+msgstr ""
+
+#: ../../24.10/index.md:200 01c0d263288b4e59a44c235339197822
+msgid ""
+"Clamav is updated from version 1.0.5 to 1.3.1 in Oracular, bringing "
+"significant improvements and changes, including:"
+msgstr ""
+
+#: ../../24.10/index.md:202 cd42e0eaecf84aab92521f8b127f223d
+msgid ""
+"Added support for extracting and scanning attachments found in Microsoft "
+"OneNote section files."
+msgstr ""
+
+#: ../../24.10/index.md:203 62c128701c97411abb000a22caa4f586
+msgid "Added support for extracting Universal Disk Format (UDF) partitions."
+msgstr ""
+
+#: ../../24.10/index.md:204 683c50e8788b408c9e38908d45bcb026
+msgid ""
+"Added a --cache-size option to customize the size of ClamAV's clean file "
+"cache, which may improve scan performance at the expense of more RAM."
+msgstr ""
+
+#: ../../24.10/index.md:205 6545963a79754f92a4e7691d6e57bdf5
+msgid ""
+"Introduced a customizable SystemD timer for running Freshclam updates, "
+"without sending Freshclam into the background."
+msgstr ""
+
+#: ../../24.10/index.md:206 779fd79fe12941ab9a7bd48dbd8206f5
+msgid "Refined limit handling for large files"
+msgstr ""
+
+#: ../../24.10/index.md:207 b906940893394a398f7ee1e2c23dfc55
+msgid ""
+"Added ability for Freshclam to use a client certificate PEM file and a "
+"private key PEM file for authentication to a private mirror"
+msgstr ""
+
+#: ../../24.10/index.md:208 274908b196144946931aa8b21880f1ea
+msgid "Added the ability to extract images embedded in HTML CSS `<style>` blocks."
+msgstr ""
+
+#: ../../24.10/index.md:209 884d4672ff75415698096412d0bd59ea
+msgid "Enhancements relating to VBA extraction from office documents"
+msgstr ""
+
+#: ../../24.10/index.md:210 bb5c42f6777a4775bce3fca8715068b0
+msgid ""
+"Added support for aborting on standup if virus database is older than a "
+"configured number of days."
+msgstr ""
+
+#: ../../24.10/index.md:212 f420d3a9d2d044b289543f1d557aa5fd
+msgid ""
+"For a comprehensive listing of changes included since Ubuntu Noble, "
+"please see the changelogs for "
+"[1.1.0](https://blog.clamav.net/2023/05/clamav-110-released.html), "
+"[1.2.0](https://blog.clamav.net/2023/08/clamav-120-feature-version-"
+"and-111-102.html), "
+"[1.3.0](https://blog.clamav.net/2023/11/clamav-130-122-105-released.html),"
+" and [1.3.1](https://blog.clamav.net/2024/04/clamav-131-123-106-patch-"
+"versions.html)."
+msgstr ""
+
+#: ../../24.10/index.md:214 42adf04315894543bf9dc02fa46c3d82
+msgid "Chrony"
+msgstr ""
+
+#: ../../24.10/index.md:215 875a4f3455aa40049b1e3373eb6741e4
+msgid ""
+"The chrony package in Oracular was changed to no longer ship the default "
+"Ubuntu NTP pools in `/etc/chrony/chrony.conf`. A new snippet "
+"configuration file is created in `/etc/chrony/sources.d/ubuntu-ntp-"
+"pools.sources` defining those servers. The motivation for this change is "
+"explained in [LP: "
+"#2048876](https://bugs.launchpad.net/ubuntu/+source/chrony/+bug/2048876)."
+msgstr ""
+
+#: ../../24.10/index.md:217 e8f1fdfb11c3498eb81290b944e8511c
+msgid ""
+"If you changed your `chrony.conf`, an upgrade to this version will stop "
+"at a dpkg config prompt, showing the differences between the installed "
+"file and the new one. If you chose to keep the existing `chrony.conf`, "
+"keep in mind that the Ubuntu NTP pools from `/etc/chrony/sources.d"
+"/ubuntu-ntp-pools.sources` will also be used."
+msgstr ""
+
+#: ../../24.10/index.md:219 a60baacbe05e4ce89b04460b90d753d7
+msgid "@ankushpathak wrote a great post about this change:"
+msgstr ""
+
+#: ../../24.10/index.md:221 79315c7cccb9443a83545d6358ede722
+msgid ""
+"https://discourse.ubuntu.com/t/improving-chrony-time-source-"
+"configuration-in-ubuntu/47850"
+msgstr ""
+
+#: ../../24.10/index.md:223 9bdb7255a27049e5b98b3e33e66faac4
+msgid "cloud-init v. 24.3.1"
+msgstr ""
+
+#: ../../24.10/index.md:224 35c17833b43d43dab3ed561a05d262e5
+msgid "Notable features beyond v. 24.1 present in Noble:"
+msgstr ""
+
+#: ../../24.10/index.md:226 24aff31c87894305be7ef4fa891f7ae0
+msgid ""
+"Bootspeed improvement: support for socket-based shared python process "
+"across cloud-init boot stages ([#5595](https://github.com/canonical"
+"/cloud-init/pull/5595))"
+msgstr ""
+
+#: ../../24.10/index.md:228 2315b6019f774ad5a17c6a02543a139a
+msgid ""
+"NoCloud support for FTP and FTP over TLS "
+"([#4834](https://github.com/canonical/cloud-init/pull/4834))"
+msgstr ""
+
+#: ../../24.10/index.md:229 22a7009479c3484f8197bdd94ac60d8e
+msgid ""
+"Add network-config seed support for nocloud datasource "
+"([#5566](https://github.com/canonical/cloud-init/pull/5566))"
+msgstr ""
+
+#: ../../24.10/index.md:230 d476bad9977b4737962b9ded46363fab
+msgid ""
+"Network v2 schema validation ([#4892](https://github.com/canonical/cloud-"
+"init/pull/4892))"
+msgstr ""
+
+#: ../../24.10/index.md:231 c37fc53dedeb4429880e40d98ab673d3
+msgid ""
+"Add support for disk setup of nvme devices "
+"([#5263](https://github.com/canonical/cloud-init/pull/5263))"
+msgstr ""
+
+#: ../../24.10/index.md:232 a706b85549e148a5963db88bdefa4f07
+msgid ""
+"Support remote URI sources write_files module "
+"([#5505](https://github.com/canonical/cloud-init/pull/5055))"
+msgstr ""
+
+#: ../../24.10/index.md:233 df67560ad8364ed7bc093154b7169892
+msgid ""
+"provide option to set empty passwords and fix password unlock when "
+"lock_passwd: False on Alpine/FreeBSD/OpenBSD/DragonflyBSD "
+"([#5355](https://github.com/canonical/cloud-init/pull/5355))"
+msgstr ""
+
+#: ../../24.10/index.md:235 ac74702f3ebc409c8aa057ae3cf2c695
+msgid ""
+"WSL support multi-part MIME config parts as well as landscape tags for "
+"provisioning ([#5460](https://github.com/canonical/cloud-init/pull/5460),"
+" [#5538](https://github.com/canonical/cloud-init/pull/5538))"
+msgstr ""
+
+#: ../../24.10/index.md:237 581ad8c2ec374ac9a83c60afed1b1540
+msgid ""
+"Added support in cloudinit.features.DEPRECATION_INFO_BOUNDARY allowing "
+"stable downstream images to pin the original MAJOR.MINOR version of "
+"cloud-init released on that image. This avoids introduction of new "
+"deprecation messages (and potential exit 2 from cloud-init status) across"
+" cloud-init version upgrades."
+msgstr ""
+
+#: ../../24.10/index.md:239 28a5085660a54859aac4f6558ec9ab1e
+msgid "Breaking Changes:"
+msgstr ""
+
+#: ../../24.10/index.md:241 fde6b32443bc4520ab16937d98843ce5
+msgid ""
+"Warning issued for systemd environments if cloud-init boot stages are "
+"called by PIDs other than the root process. It is expected that boot "
+"stages are only called by systemd units and not post-production scripts "
+"or tools."
+msgstr ""
+
+#: ../../24.10/index.md:245 183332bcfdd0420fb6e6e5eb8b9e3639
+msgid ""
+"Introduce a [performance optimization by sharing the python environment "
+"and setup costs across all four boot stages with a new cloud-init-"
+"main.service](https://discourse.ubuntu.com/t/announcement-cloud-init-"
+"perfomance-optimization-single-process/47505)"
+msgstr ""
+
+#: ../../24.10/index.md:247 d2267c63f8484d8d914e7aef275ef06f
+msgid "Containerd"
+msgstr ""
+
+#: ../../24.10/index.md:248 8c9bea0f11d54444876093ce8b616013
+msgid ""
+"The Containerd application was updated to version `1.7.19`. Some "
+"highlights of this update:"
+msgstr ""
+
+#: ../../24.10/index.md:250 1826ce98986b4d589efa9bf3dcd3ffa8
+msgid "Remove overlayfs volatile option on temp mounts (#10332)"
+msgstr ""
+
+#: ../../24.10/index.md:251 876838217e5043098438c0b37878a4c7
+msgid ""
+"Update AppArmor template to allow confined runc to kill containers "
+"(#10129)"
+msgstr ""
+
+#: ../../24.10/index.md:252 0a780897ccc842cdad6b4c3b7d8ee697
+msgid "Update AppArmor template to better support rootlesskit (#10116)"
+msgstr ""
+
+#: ../../24.10/index.md:254 69660746df324db5837bd405a4c9ff8b
+msgid ""
+"For more information, check the [upstream release "
+"notes](https://github.com/containerd/containerd/releases)."
+msgstr ""
+
+#: ../../24.10/index.md:256 32b0959f7bd94390917b98ddf81ee4bb
+msgid "Django"
+msgstr ""
+
+#: ../../24.10/index.md:257 15bc491c148b466aa314b65b3ff590e3
+msgid ""
+"Django was updated from Noble's 4.2.11 to 4.2.15, which brings several "
+"bug fixes. For more information, see the upstream changelogs: "
+"[4.2.12](https://docs.djangoproject.com/en/4.2/releases/4.2.12/), "
+"[4.2.13](https://docs.djangoproject.com/en/4.2/releases/4.2.13/), "
+"[4.2.14](https://docs.djangoproject.com/en/4.2/releases/4.2.14/), "
+"[4.2.15](https://docs.djangoproject.com/en/4.2/releases/4.2.15/)"
+msgstr ""
+
+#: ../../24.10/index.md:259 ../../24.10/index.md:608
+#: 92ed731798de4ab3882a17148177d2dc fb591f532c7f435b97feed2ae1dbf40f
+msgid "Docker"
+msgstr ""
+
+#: ../../24.10/index.md:260 fe796d2c2dfe4976a23eb44213c75077
+msgid ""
+"The Docker application was updated to version `26.1.3`. Some highlights "
+"of this update:"
+msgstr ""
+
+#: ../../24.10/index.md:262 d30e5379d7934d24aff601eb1662bbdb
+msgid "AppArmor: Allow confined runc to kill containers"
+msgstr ""
+
+#: ../../24.10/index.md:263 786c92abe82a43be82b37f0efcc0667f
+msgid "Removal of AuFS, Legacy \"overlay\", and Device mapper storage drivers"
+msgstr ""
+
+#: ../../24.10/index.md:264 d403fec550364f3887b1af5376cc4c21
+msgid "Removal of support for interacting with V1 registries"
+msgstr ""
+
+#: ../../24.10/index.md:266 8927295e5f7f4f948a05889678f2c58e
+msgid ""
+"Watch out for deprecation or removal of features in this [upstream "
+"page](https://github.com/docker/cli/blob/v26.1.3/docs/deprecated.md)."
+msgstr ""
+
+#: ../../24.10/index.md:268 505f0aa523534f10b5b519b494ae60ef
+msgid "`unminimize`"
+msgstr ""
+
+#: ../../24.10/index.md:270 84ec793fdd374f9a90b7aa3ae0aba276
+msgid ""
+"`unminimize` has been moved to a dedicated package which can be installed"
+" with `apt-get install -y unminimize` rather than being available by "
+"default in all minimal images."
+msgstr ""
+
+#: ../../24.10/index.md:272 aaa352a71adf456c8cf2c1909586fab9
+msgid "Exim4"
+msgstr ""
+
+#: ../../24.10/index.md:273 b6bf1917287145b1bcfee9685fe456f4
+msgid ""
+"The Exim4 update in Oracular to 4.98 includes selected fixes from the "
+"upstream GIT repository.  This improves handling of new and old format "
+"message IDs, fixes certain crashes, refines memory usage for regexes, and"
+" avoids recording lookup credentials in the log files.  DKIM DNS record "
+"parsing is tightened up related to unexpected whitespace."
+msgstr ""
+
+#: ../../24.10/index.md:275 c4af4be4536943c4b452433836433c4b
+msgid "HAProxy"
+msgstr ""
+
+#: ../../24.10/index.md:276 0e15e2bc71f9480cbef3e12838b848a8
+msgid ""
+"The HAProxy package was upgraded to version 2.9.9. This new version "
+"introduces performance improvements, better integration, more "
+"reliability, and a new reverse-http feature. You can learn more about it "
+"at https://www.haproxy.com/blog/announcing-haproxy-2-9.  A complete list "
+"of changes is available at "
+"https://www.haproxy.org/download/2.9/src/CHANGELOG."
+msgstr ""
+
+#: ../../24.10/index.md:278 8debb93b3bb34717860e5dab49b8c98f
+msgid "libvirt"
+msgstr ""
+
+#: ../../24.10/index.md:279 d525bec9c0cc46f58395f86a7cac3589
+msgid ""
+"The [libvirt](https://libvirt.org) package was upgraded to version "
+"10.6.0.  Here are the changes since Ubuntu Noble:"
+msgstr ""
+
+#: ../../24.10/index.md:281 6fef31e08f3543b39c82b3c177c53097
+msgid "network: Make virtual domains resolvable from the host."
+msgstr ""
+
+#: ../../24.10/index.md:282 3acf7ce655e945caa557e5a40ca675d9
+msgid "qemu: Support clusters in CPU topology."
+msgstr ""
+
+#: ../../24.10/index.md:283 d93b63dcce35478598fb75cc628d7cfd
+msgid "qemu: Introduce `dynamicMemslots` attribute for `virtio-mem`."
+msgstr ""
+
+#: ../../24.10/index.md:284 980ea1c609f9440a8d8897f5ed322412
+msgid "qemu: Support for driver type `mtp` in `<filesystem/>` devices."
+msgstr ""
+
+#: ../../24.10/index.md:285 44af1264ae8e47f788d549e93a777a84
+msgid "qemu: Introduce `virDomainGraphicsReload` API."
+msgstr ""
+
+#: ../../24.10/index.md:286 256f0658ab96460c89400a1a637d9266
+msgid "qemu: Proper support for USB network device."
+msgstr ""
+
+#: ../../24.10/index.md:287 2546fb9d0ac74602a59dd31ccedea967
+msgid "SSH proxy for VM."
+msgstr ""
+
+#: ../../24.10/index.md:288 eec27c5f97ff44978d156ab3e24174c5
+msgid "Introduce `pstore` device."
+msgstr ""
+
+#: ../../24.10/index.md:290 2f907b1353bb499cbc68c3e0d695c51a
+msgid ""
+"For more details, please see [the upstream "
+"changelog](https://www.libvirt.org/news.html)."
+msgstr ""
+
+#: ../../24.10/index.md:292 1e68fb2b4fed4c56a4e6234ad078ea95
+msgid "Nginx"
+msgstr ""
+
+#: ../../24.10/index.md:293 6cd013c0c77c4e91bc757e9ae7ce6fd4
+msgid ""
+"Version 1.26.0 of NGINX was introduced in Oracular, bringing experimental"
+" HTTP/3 support, HTTP/2 on a per-server basis, virtual servers in the "
+"stream module, passing stream connections to listen sockets, and more."
+msgstr ""
+
+#: ../../24.10/index.md:295 a2dcf7d48c99429f80d866010ecf96fc
+msgid "OpenLDAP"
+msgstr ""
+
+#: ../../24.10/index.md:296 151a962388bc45539901ce99512217a5
+msgid ""
+"The [OpenLDAP](https://openldap.org/) package was updated to version "
+"2.6.8, which brings several bug fixes. For more details, please see [the "
+"upstream "
+"changelog](https://www.openldap.org/software/release/changes.html)."
+msgstr ""
+
+#: ../../24.10/index.md:298 e2928d0e01a34289811c25c03261d6ce
+msgid "OpenSSH"
+msgstr ""
+
+#: ../../24.10/index.md:299 d60b576735a74620ab91012ed008a1d6
+msgid ""
+"Starting with 1:9.6p1-3ubuntu17, openssh server no longer reads "
+"`~/.pam_environment` of the target system upon login."
+msgstr ""
+
+#: ../../24.10/index.md:301 00860ca6d04641709c3e5239a75f29dd
+msgid ""
+"In [Linux-PAM version 1.5.0](https://github.com/linux-pam/linux-"
+"pam/releases/tag/v1.5.0), the `pam_env.so` module [has "
+"deprecated](https://github.com/linux-pam/linux-"
+"pam/commit/ecd526743a27157c5210b0ce9867c43a2fa27784) the `user_readenv=1`"
+" parameter due to security concerns, and it will be removed by upstream "
+"in the future."
+msgstr ""
+
+#: ../../24.10/index.md:304 3672697ba99942659ee204c88703e2cf
+msgid ""
+"Following that change, `/etc/pam.d/sshd`'s invocation of `pam_env.so` "
+"[was "
+"changed](https://bugs.launchpad.net/ubuntu/+source/openssh/+bug/2059859/)"
+" to remove the `user_readenv=1` parameter."
+msgstr ""
+
+#: ../../24.10/index.md:306 e3f04c1152e54eb19221319325eaa1c3
+msgid ""
+"Systems that were relying on that behavior need to adapt, possibly via "
+"the openssh `AcceptEnv` (on the server) and `SendEnv` (on the client) "
+"parameters."
+msgstr ""
+
+#: ../../24.10/index.md:308 46eebb606c6d410fa5ffc56cbaec4bf1
+msgid ""
+"Note that the default configuration in `/etc/ssh/sshd_config` and "
+"`/etc/ssh/ssh_config` is already set to send and receive locale "
+"variables, which is one of the scenarios in which `~/.pam_environment` "
+"was used in the past."
+msgstr ""
+
+#: ../../24.10/index.md:310 2ddbf0fad7f442aab490b91557f47ff2
+msgid "OpenVmTools"
+msgstr ""
+
+#: ../../24.10/index.md:311 5e51206d8fac4886afcfaccaa35f9d59
+msgid ""
+"The new version 12.4.5 of open-vm-tools in oracular brings a handful of "
+"bug fixes; for details of these and existing known issues, please see the"
+" upstream release notes for [12.4.0](https://docs.vmware.com/en/VMware-"
+"Tools/12.4/rn/vmware-tools-1240-release-notes/index.html) and "
+"[12.4.5](https://docs.vmware.com/en/VMware-Tools/12.4/rn/vmware-"
+"tools-1245-release-notes/index.html)."
+msgstr ""
+
+#: ../../24.10/index.md:313 cfd0dd6cb29f4f6ba6913e223961f783
+msgid "Valkey"
+msgstr ""
+
+#: ../../24.10/index.md:314 3147ec90ff7a4e998fea10703080b5b9
+msgid ""
+"Valkey version 7.2.5 is available in Oracular. Since this version is a "
+"drop-in replacement for Redis (fully compatible), and with the [recent "
+"changes of Redis' license](https://redis.io/blog/redis-adopts-dual-"
+"source-available-licensing/), a way to migrate configuration and data "
+"from Redis to Valkey is implemented in a form of a new binary package. "
+"The `valkey-redis-compat` binary package will attempt a automatic "
+"configuration and data migration from Redis to Valkey. If you did not "
+"perform any drastic change to the configuration of your Redis service, it"
+" should work straight away.  However, if you performed some substantial "
+"changes or your setup is more complex, the automation may not work. Due "
+"to that, whenever the `valkey-redis-compat` binary package is installed "
+"and the migration is attempted, the file `/etc/valkey/REDIS_MIGRATION` "
+"will be created, and the services will not start automatically. This will"
+" avoid breaking the upgrade due to an incomplete migration. After the "
+"user has checked if the migration is OK, they need to remove the "
+"`/etc/valkey/REDIS_MIGRATION` file, then the Valkey services will be able"
+" to be started again."
+msgstr ""
+
+#: ../../24.10/index.md:316 1fdb2f15d7cc486b8e88e70f6fdfbdae
+msgid "Percona Xtrabackup"
+msgstr ""
+
+#: ../../24.10/index.md:317 a8c64218ea0b42f485028bd548d5e482
+msgid ""
+"Xtrabackup was updated to the next minor version 8.0.35-31. It provides "
+"additional arm64 architecture support along with various bug fixes. For "
+"more details, see the [upstream release notes](https://docs.percona.com"
+"/percona-xtrabackup/8.0/release-notes/8.0/8.0.35-31.0.html)."
+msgstr ""
+
+#: ../../24.10/index.md:319 b4c12235e2194f7e9af2642f56e07e5a
+msgid "PHP"
+msgstr ""
+
+#: ../../24.10/index.md:320 99ccf5c5a43b49aa957f49840bbe1133
+msgid ""
+"PHP was upgraded to version 8.3.9, which is introduces several bug fixes."
+"  You can read more about those in the upstream changelog at "
+"https://www.php.net/ChangeLog-8.php#8.3.9."
+msgstr ""
+
+#: ../../24.10/index.md:322 f4f97d4ff5ba493792b6b61bc2dac33c
+msgid "PostgreSQL"
+msgstr ""
+
+#: ../../24.10/index.md:323 7c68506486c7431683d3469023fd1306
+msgid ""
+"PostgreSQL was updated to version 16.4. Users running Ubuntu Noble will "
+"realize this version was also included there as part of our PostgreSQL "
+"upgrade policies. The new version introduces many bug and security fixes."
+" More details on the changes introduced since Noble are available at "
+"https://www.postgresql.org/docs/release/16.4/ and "
+"https://www.postgresql.org/docs/release/16.3/"
+msgstr ""
+
+#: ../../24.10/index.md:325 b9c302f1402e459a87b0285a99d2f860
+msgid "QEMU"
+msgstr ""
+
+#: ../../24.10/index.md:326 e513c2ed0d6341319ef406e2954c53da
+msgid ""
+"The [QEMU](https://qemu.org/) package was updated to version 9.0.2. Here "
+"are the changes since Ubuntu Noble."
+msgstr ""
+
+#: ../../24.10/index.md:328 eadbf0e7d3644c95bbe2e57f2b88bf90
+msgid ""
+"The behaviour of the `-serial none` option when used together with     "
+"other `-serial` options has been corrected. Previously when `-serial "
+"none` was followed by `-serial something` the `-serial none` was "
+"effectively ignored. Now it controls the existence of the first serial "
+"port, and the following `-serial` option controls the behaviour of the "
+"second serial port; this brings it in to line with how all other cases of"
+" multiple `-serial` options work. If you have a command line that was "
+"accidentally relying on the old behaviour, you can simply delete the "
+"unnecessary `-serial none`."
+msgstr ""
+
+#: ../../24.10/index.md:329 9e1925045a6741ac9d50299d0613a5ae
+msgid "ARM"
+msgstr ""
+
+#: ../../24.10/index.md:330 f533534d326f47189d0b3455f73adf3a
+msgid ""
+"New `raspi4b` board type, the Raspberry Pi 4 Model B. Note that QEMU does"
+" not yet model PCI or ethernet; this will be implemented on a future QEMU"
+" release."
+msgstr ""
+
+#: ../../24.10/index.md:331 ../../24.10/index.md:514
+#: 672d8a383ad745c4b45fe29b53fff4b7 e87a82ffe37f47e1aa2106d883ce90ce
+msgid "RISC-V"
+msgstr ""
+
+#: ../../24.10/index.md:332 d81f5ef60ddb4d7cb4ab299ce9b73f08
+msgid "Add support for `Zacas`, `B`, `Zaamo`, `Zalrsc`, `Ztso` extensions."
+msgstr ""
+
+#: ../../24.10/index.md:333 a7a0b7e0c7284c61b7768459d6859cad
+msgid "Add `amocas.[w,d,q]` instructions."
+msgstr ""
+
+#: ../../24.10/index.md:334 20193e1d77d446ffa24e4737779c0286
+msgid "`RVA22` profiles support."
+msgstr ""
+
+#: ../../24.10/index.md:335 0a56631938294345a0ac33d6ff343900
+msgid "Add RVV CSRs to KVM."
+msgstr ""
+
+#: ../../24.10/index.md:336 86116a8c6aa44716b5395c1f10a50850
+msgid "Implement optional CSR `mcontext` of debug `Sdtrig` extension."
+msgstr ""
+
+#: ../../24.10/index.md:337 066b9a19c73f499f91e2f32c2c6b6c6d
+msgid "Enable `xtheadsync` under user mode."
+msgstr ""
+
+#: ../../24.10/index.md:338 2a9b653cc46d47538062ee2554063fa2
+msgid "Use `zfa` instead of `Zfa`."
+msgstr ""
+
+#: ../../24.10/index.md:339 a5d54bb90d5043b4a252bc1d8fb97317
+msgid "Move ratified/frozen extensions to non-experimental."
+msgstr ""
+
+#: ../../24.10/index.md:340 57efba21da3f4a9d8baf4ee0cc1978a4
+msgid "s390x"
+msgstr ""
+
+#: ../../24.10/index.md:341 e653452fe3d34962987beb9e01895539
+msgid ""
+"Fix access register handling in the emulation of the `LOAD ADDRESS "
+"EXTENDED` (`LAE`) instruction."
+msgstr ""
+
+#: ../../24.10/index.md:342 9809864b9f82494cb3c67484a9837ac2
+msgid "Add emulation of `CVDG`, `CVB`, `CVBY` and `CVBG` instructions."
+msgstr ""
+
+#: ../../24.10/index.md:343 ba53a6ba7d784edca16f08bd34685fb3
+msgid ""
+"The `virtio-blk` device has gained true multiqueue support where "
+"different queues of a single disk can be processed by different I/O "
+"threads. This can improve scalability in cases where the guest submitted "
+"enough I/O to saturate the host CPU running a single I/O thread "
+"processing the `virtio-blk` requests. Multiple I/O threads can be "
+"configured using the new `iothread-vq-mapping` property."
+msgstr ""
+
+#: ../../24.10/index.md:344 fec91af196f1481e93118aba359e2cc1
+msgid ""
+"`usb-storage` doesn't ignore the properties `backend_defaults`, "
+"`logical_block_size`, `physical_block_size`, `min_io_size`, `opt_io_size`"
+" and `discard_granularity` any more."
+msgstr ""
+
+#: ../../24.10/index.md:345 b27663e15a684082a80302db222db0be
+msgid ""
+"Fixed `vhost-vdpa-device` to be compatible with `VDUSE` block exports "
+"again (this was broken in QEMU 8.2.0, in Ubuntu Noble)."
+msgstr ""
+
+#: ../../24.10/index.md:346 d3ceb83bae844e049650692c02ad1b54
+msgid "Introduced an IOMMU interface backend for VFIO devices."
+msgstr ""
+
+#: ../../24.10/index.md:347 e0e8a6f2e017465a9fa99a8a095259c9
+msgid "Introduced a new IOMMUFD backend for ARM, amd64 and s390x platforms."
+msgstr ""
+
+#: ../../24.10/index.md:348 0b67fdfef13f405aa96bbe3ff6de5f3e
+msgid ""
+"The `sm4` cipher algorithm is now supported and can be used with the "
+"`luks` block driver."
+msgstr ""
+
+#: ../../24.10/index.md:349 c06f59f26c72446ea8e0b5bfa6258b78
+msgid ""
+"QEMU 8.2 accidentally allowed for creation of memory backends with sizes "
+"that are not aligned to the (huge) page size. This has been fixed."
+msgstr ""
+
+#: ../../24.10/index.md:350 ab8a8435eb56442585f1ae0fd57a01ee
+msgid ""
+"Fixed migration for SUSPENDED VM, where we used to ignore the `SUSPENDED`"
+" state and kick off the VM even if it was suspended before the migration."
+msgstr ""
+
+#: ../../24.10/index.md:351 ad491435d55542109b81bf73d1255a46
+msgid ""
+"New capability called `mapped-ram`. It allows efficient VM snapshots "
+"save/load by providing both (1) constant size of ultimate VM image rather"
+" than unlimited, and (2) multi-threading support so that save/load of "
+"snapshots can be faster."
+msgstr ""
+
+#: ../../24.10/index.md:353 fe3b146c2f7d486ca42ab0a36e0eaf38
+msgid "For more details, please see related upstream changelogs:"
+msgstr ""
+
+#: ../../24.10/index.md:355 1dee4cd5d593480a8212cb20b69ad053
+msgid "[9.0](https://wiki.qemu.org/ChangeLog/9.0)"
+msgstr ""
+
+#: ../../24.10/index.md:357 f35d2a947f8a422c84f0829f6e6dbbe2
+msgid "Ruby 3.3"
+msgstr ""
+
+#: ../../24.10/index.md:358 970c85e5285d478192b79962c6297574
+msgid ""
+"The default Ruby version is now version 3.3. Some compatibility changes "
+"may arise from the upgrade from version 3.2, they are:"
+msgstr ""
+
+#: ../../24.10/index.md:360 fac93628593b42ba8a6675668a4cca95
+msgid ""
+"`it` calls without arguments in a block with no ordinary parameters are "
+"deprecated. `it` will be a reference to the first block parameter in Ruby"
+" 3.4. [Feature #18980]"
+msgstr ""
+
+#: ../../24.10/index.md:361 d3f1be77a4f244a0ad8ba756f4876fcd
+msgid ""
+"`Regexp::new` now only accepts up to 2 arguments instead of 3. This was "
+"deprecated in Ruby 3.2. [Bug #18797]"
+msgstr ""
+
+#: ../../24.10/index.md:362 032d77f7da7248a48019a4dfabcbcd47
+#, python-brace-format
+msgid ""
+"Environment variable `RUBY_GC_HEAP_INIT_SLOTS` has been deprecated and is"
+" a no-op. Please use environment variables "
+"`RUBY_GC_HEAP_{0,1,2,3,4}_INIT_SLOTS` instead. [Feature #19785]"
+msgstr ""
+
+#: ../../24.10/index.md:364 bcae1eb3886f430194bb8991e759c2bf
+msgid ""
+"For the complete list of changes in this new version, please check the "
+"[upstream release notes](https://www.ruby-"
+"lang.org/en/news/2023/12/25/ruby-3-3-0-released/) out."
+msgstr ""
+
+#: ../../24.10/index.md:366 5f8fa939f7ec49a3bdeea6c60ca24e27
+msgid "Samba"
+msgstr ""
+
+#: ../../24.10/index.md:367 0d88d007502d479bb0a00a8df390b13c
+msgid ""
+"Samba was updated to 4.20.4, and major changes in the 4.20.x series are "
+"documented in the [upstream release "
+"notes](https://www.samba.org/samba/history/samba-4.20.0.html)."
+msgstr ""
+
+#: ../../24.10/index.md:369 1289c677ef2b4221957163d034dd1959
+msgid ""
+"Normally the point releases of samba in a stable series only contain bug "
+"fixes, but this time 4.20.3 added a nice new feature which is LDAP "
+"TLS/SASL channel binding support. Details are shown in the [4.20.3 "
+"release notes](https://www.samba.org/samba/history/samba-4.20.3.html)."
+msgstr ""
+
+#: ../../24.10/index.md:371 b45d40abf9e146988b1afb5c37b66a9a
+msgid "In terms of packaging, the following changes have been done:"
+msgstr ""
+
+#: ../../24.10/index.md:373 3166e8b8f7de49fda55cf053f9ecb74a
+msgid ""
+"`samba-vfs-modules`: the VFS modules from this package were moved to the "
+"`samba` package, with the exception of the Ceph module, which got its own"
+" package: `samba-vfs-ceph`. The `samba-vfs-modules` package is now just a"
+" transitional package, and it can be safely removed after the release "
+"upgrade."
+msgstr ""
+
+#: ../../24.10/index.md:374 7afca91f53684441a1e6ba042035fe26
+msgid ""
+"`samba-vfs-modules-extra`: this package used to contain the GlusterFS VFS"
+" module. This module was moved to a new package called `samba-vfs-"
+"glusterfs`, and `samba-vfs-modules-extra` became a transitional package. "
+"It can also be safely removed after the release upgrade."
+msgstr ""
+
+#: ../../24.10/index.md:376 25b151cef30b4453a92364901cd324dc
+msgid "Squid"
+msgstr ""
+
+#: ../../24.10/index.md:377 5e3df10f50764639997b48d8ca848706
+msgid ""
+"Squid was upgraded to version 6.10. This new version includes several bug"
+" fixes. A complete set of changes together with a comprehensive changelog"
+" is available at https://github.com/squid-"
+"cache/squid/compare/SQUID_6_6..SQUID_6_10."
+msgstr ""
+
+#: ../../24.10/index.md:382 cd8b74e0deb0452580a0b67154624c8a
+msgid "SSSD"
+msgstr ""
+
+#: ../../24.10/index.md:383 6d974c1346c049059d4025d960a7c0c8
+msgid ""
+"The [SSSD](https://sssd.io/) package was updated to version 2.9.5. Here "
+"are the changes since Ubuntu Noble."
+msgstr ""
+
+#: ../../24.10/index.md:385 7ac0c5ac212d4cab868fd018491c4603
+msgid ""
+"Added `failover_primary_timeout` configuration option. This can be used "
+"to configure how often SSSD tries to reconnect to a primary server after "
+"a successful connection to a backup server. This was previously hardcoded"
+" to 31 seconds which is kept as the default value."
+msgstr ""
+
+#: ../../24.10/index.md:387 0f9d942b225146e58086b21c4529bfe4
+msgid ""
+"For more details, please see [the upstream changelog](https://sssd.io"
+"/release-notes/sssd-2.9.5.html)."
+msgstr ""
+
+#: ../../24.10/index.md:389 8c3f0d72fd4c45f2bebf2368c08e0f38
+msgid "Subiquity"
+msgstr ""
+
+#: ../../24.10/index.md:390 dad4231e923b4d069eb5fcb1619bbe22
+msgid ""
+"A new version of the Subiquity server installer has been released. Please"
+" read the full [release notes for "
+"24.04.1](https://github.com/canonical/subiquity/releases/tag/24.04.1) on "
+"GitHub."
+msgstr ""
+
+#: ../../24.10/index.md:392 5122a7509d2f4f7ca754ed505a10d018
+msgid "Ubuntu HA/Clustering"
+msgstr ""
+
+#: ../../24.10/index.md:394 feb6bf538c0f41199cb12fd3019e020e
+msgid "multipath-tools"
+msgstr ""
+
+#: ../../24.10/index.md:395 8cc46d44ebb047cda8b806af45f737fc
+msgid ""
+"multipath-tools was updated to 0.9.9. Please visit "
+"https://github.com/opensvc/multipath-tools/blob/master/NEWS.md for notes "
+"on the changes."
+msgstr ""
+
+#: ../../24.10/index.md:397 30e3ebceaa624de6b03162c3216dfa85
+msgid "kpartx-boot"
+msgstr ""
+
+#: ../../24.10/index.md:398 d4519a843a3b4bca9a3a80683d7177d6
+msgid ""
+"Starting with the Oracular release, the kpartx-boot package has been "
+"discontinued to align with Debian. Originally introduced to support "
+"dmraid booting, its functionality is preserved, as the kpartx package now"
+" includes everything previously provided by kpartx-boot."
+msgstr ""
+
+#: ../../24.10/index.md:400 4ce2f005e71646d78fd14684fc66bc90
+msgid "dmraid"
+msgstr ""
+
+#: ../../24.10/index.md:401 e97d3a49dc054eb9a356d494dcc66fcf
+msgid ""
+"The dmraid package has been removed from Oracular. The rationale for its "
+"removal is outlined in https://bugs.launchpad.net/bugs/2073677, primarily"
+" due to its removal from Debian unstable and minimal upstream support. If"
+" you require this functionality, consider using alternatives like "
+"`mdadm`."
+msgstr ""
+
+#: ../../24.10/index.md:403 4ad1a7bbb8534dacaf60fde1cdf10972
+msgid "Corosync"
+msgstr ""
+
+#: ../../24.10/index.md:404 a255764f074a47a98f022a2cffc9e240
+msgid ""
+"Corosync was upgraded to version 3.1.8. This release contains mostly "
+"smaller bugfixes and improvements of Rust bindings. You can learn more "
+"about it at https://github.com/corosync/corosync/releases."
+msgstr ""
+
+#: ../../24.10/index.md:406 2c98e644c9964197bf9728640b1b175c
+msgid "pacemaker"
+msgstr ""
+
+#: ../../24.10/index.md:407 2c74c718e1a840e3be31b76006d3b15f
+msgid ""
+"Pacemaker was upgraded to version 2.1.8. This release includes a "
+"significant number of bug fixes and a few new features.  It also "
+"deprecates some obscure features and many C APIs in preparation for the "
+"next Pacemaker major release which will drop support for them."
+msgstr ""
+
+#: ../../24.10/index.md:409 da9249caa1f54aa7b2453c7443c0996b
+msgid "fence-agents"
+msgstr ""
+
+#: ../../24.10/index.md:410 248bdebab88d42f59b32421351a817df
+msgid ""
+"fence-agents was upgraded to version 4.15.0. In this release, we are no "
+"longer shipping the transitional fence-agents package. You should now use"
+" either the fence-agents-base package with the agents available in main "
+"or the fence-agents-extra package with the agents in universe (or both, "
+"they are split based on the repository components they are available in)."
+" A complete list of upstream changes for this version is available at "
+"https://lists.clusterlabs.org/pipermail/developers/2024-July/003567.html."
+msgstr ""
+
+#: ../../24.10/index.md:412 2c600d00cad34b8e991b97ae1e69f57d
+msgid "resource-agents"
+msgstr ""
+
+#: ../../24.10/index.md:413 d2c3a7c7d66740b68e2b60876bd6300c
+msgid ""
+"resource-agents was upgraded to version 4.15.1. This new release "
+"introduces several bug fixes and enhancements including two new resource "
+"agents: outscale and powervs-subnet. Details on all changes introduced in"
+" this new version are available at "
+"https://lists.clusterlabs.org/pipermail/developers/2024-July/003570.html "
+"and "
+"https://lists.clusterlabs.org/pipermail/developers/2024-July/003572.html."
+msgstr ""
+
+#: ../../24.10/index.md:415 571fbd32a58d4e4a84aefbaa802354e0
+msgid "OpenStack"
+msgstr ""
+
+#: ../../24.10/index.md:416 cf8f222ef62546c1981aeed612c36497
+msgid ""
+"OpenStack has been updated to the [2024.2 (Dalmatian) "
+"release](https://releases.openstack.org/dalmatian/).  This includes "
+"packages for Aodh, Barbican, Ceilometer, Cinder, Designate, Glance, Heat,"
+" Horizon, Ironic, Keystone, Magnum, Manila, Masakari, Mistral, Neutron, "
+"Nova, Octavia, Swift, Vitrage, Watcher and Zaqar."
+msgstr ""
+
+#: ../../24.10/index.md:418 e0de151b604d4a9da3bd82a0eb713bf4
+msgid ""
+"This release is also provided for Ubuntu 24.04 LTS via the Ubuntu Cloud "
+"Archive."
+msgstr ""
+
+#: ../../24.10/index.md:420 d2af32e24f924387aa88f9562a42573e
+msgid "Ceph"
+msgstr ""
+
+#: ../../24.10/index.md:421 434bfbe08f874b95a5826bf6772295ba
+msgid "[Ceph](http://ceph.com) has been updated to the 19.2.0 (Squid) release."
+msgstr ""
+
+#: ../../24.10/index.md:423 7a67edb1bb1e4518b945b7d0d5bb5ff0
+msgid "Open vSwitch (OVS) and Open Virtual Network (OVN)"
+msgstr ""
+
+#: ../../24.10/index.md:424 415f342ac7f3439f9bb680ef17066ca4
+msgid ""
+"[Open vSwitch](https://www.openvswitch.org/) has been updated to the "
+"3.4.0 release."
+msgstr ""
+
+#: ../../24.10/index.md:426 330f01dbcdbe4ea68faff98a8e2b820a
+msgid ""
+"[Open Virtual Network](https://www.ovn.org/) has been updated to the "
+"24.09 release."
+msgstr ""
+
+#: ../../24.10/index.md:428 d2a5d4fa3c7449b098d954d3e0193e3f
+msgid ""
+"These releases are also provided for Ubuntu 24.04 LTS via the Ubuntu "
+"Cloud Archive."
+msgstr ""
+
+#: ../../24.10/index.md:430 b1406cf1eec7452885d9c09dbaac9268
+msgid "GRUB2"
+msgstr ""
+
+#: ../../24.10/index.md:432 f88ac77fac304fc0b75c395ef7385c77
+msgid ""
+"Chainloading of non-NX compatible versions of Windows 10 from UEFI GRUB2 "
+"might be broken on a limited subset of machines. This is  being actively "
+"investigated but the root cause haven't been found yet. If you are "
+"experiencing this, please see the linked bug for updates "
+"https://bugs.launchpad.net/ubuntu/+source/grub2/+bug/2084104."
+msgstr ""
+
+#: ../../24.10/index.md:435 b31f36a9631049b5a51d0a5888927eef
+msgid "Platforms"
+msgstr ""
+
+#: ../../24.10/index.md:437 2eb67f3060d145dd807a96d5dba0e3ec
+msgid "Public Cloud / Cloud images"
+msgstr ""
+
+#: ../../24.10/index.md:439 d6d40e9133f849d1bacc6e055d3f0eed
+msgid "Public Images (cloud-images.ubuntu.com) images"
+msgstr ""
+
+#: ../../24.10/index.md:441 fff789013995459785dfee39139f7dba
+msgid "Release notes/image diff"
+msgstr ""
+
+#: ../../24.10/index.md:442 dbf3ed726a8a434b8ad190c26995d943
+msgid ""
+"Since 19th April 2024 we have introduced `.image_changelog.json` files to"
+" accompany published images @ https://cloud-images.ubuntu.com/. This is a"
+" JSON document listing all the package additions, removals and changes as"
+" well as noting the changelog entries for the package changes. It also "
+"highlights any CVEs addressed in those package updates. The tool used to "
+"generate these diffs is `ubuntu-cloud-image-changelog` available @ "
+"[github.com/canonical/ubuntu-cloud-image-"
+"changelog](http://github.com/canonical/ubuntu-cloud-image-changelog)"
+msgstr ""
+
+#: ../../24.10/index.md:443 88fc7b704fc04f8fba65e512e3f67780
+msgid ""
+"Diffs are generated between the image being published and the previous "
+"daily image, and also between the image being published and the previous "
+"release image."
+msgstr ""
+
+#: ../../24.10/index.md:444 c50eaa19bf034b66a8d7a35aa9010416
+msgid ""
+"These image diffs have been backported to previous published Ubuntu "
+"release too."
+msgstr ""
+
+#: ../../24.10/index.md:446 ba0afae8807e4facba55f68e8594f009
+msgid "LXD Containers"
+msgstr ""
+
+#: ../../24.10/index.md:448 73486cc2086f4aa5b534aa669aa13178
+msgid ""
+"LXD 24.10 Oracular Oriole containers have a more specific set of "
+"requirements for running due to changes in systemd 256.5. Starting in "
+"Oracular, systemd services (systemd-resolved, systemd-journald) have "
+"migrated to using systemd credentials. This change necessitated changes "
+"in LXD to properly run 24.10 Oracular Oriole containers. This change is "
+"landed in LXD snap channels latest/stable, 5.21/stable, and 5.0/edge. "
+"Release to 5.0/stable is planned in the near future.."
+msgstr ""
+
+#: ../../24.10/index.md:450 298fd3af04a547579844b13b14a3af05
+msgid ""
+"Furthermore, there is a strict requirement in systemd 256.5 on cgroups "
+"v2. This means that the host operating system must be cgroups v2 enabled."
+" For Ubuntu based hosts, this means that Oracular containers launched by "
+"LXD will operate on the following versions:"
+msgstr ""
+
+#: ../../24.10/index.md:452 7c09a752dcbb429abe94f896a4659ef3
+msgid "24.04 Noble , all kernels"
+msgstr ""
+
+#: ../../24.10/index.md:453 2189d126eb0648dd8ae55c0009d0d481
+msgid "22.04 Jammy Jellyfish, all kernels"
+msgstr ""
+
+#: ../../24.10/index.md:454 cce9895e804846afaa2bfbd59146b2bb
+msgid "20.04 Focal Fossa, HWE kernel"
+msgstr ""
+
+#: ../../24.10/index.md:456 231de28283964e1b86177e239201019d
+msgid ""
+"If you are running a Focal based host system, and require running "
+"Oracular containers, you must install the HWE kernel and ensure that "
+"cgroups v2 is enabled. If you are on a system with cgroupsv2 enabled and "
+"running on LXD 5.0/stable, it is possible to boot the containers by "
+"providing the following in your flag in your launch command"
+msgstr ""
+
+#: ../../24.10/index.md:458 63770b559c8149e787c8c5d9764b9dda
+msgid "`-c security.nesting=true`"
+msgstr ""
+
+#: ../../24.10/index.md:460 fb13b38841dd48e4b43103d0dd54c191
+msgid ""
+"The inverse is also true – when running an older container that lacks "
+"cgroup v2 support, you will be unable to launch it on an Oracular host "
+"system. This affects anyone attempting to run older Ubuntu suites, from "
+"18.04 Bionic Beaver and back. Note that these suites are in Extended "
+"Support, and for security reasons should only be used if they are "
+"attached to Ubuntu Pro. If you require running older Ubuntu versions, "
+"running inside a virtual machine of an older Ubuntu will guarantee "
+"compatibility."
+msgstr ""
+
+#: ../../24.10/index.md:462 177c7489c1784061bbefe1e6f77596b2
+msgid ""
+"This only affects containers launched with LXD. It does not affect "
+"virtual machines."
+msgstr ""
+
+#: ../../24.10/index.md:465 e7e0b55ae84240ae87e5d2030b12fe67
+msgid "AWS EC2"
+msgstr ""
+
+#: ../../24.10/index.md:467 abc41072c468468ebe6d26aea951a875
+msgid "`/etc/ec2-version` will only show up on EC2 images"
+msgstr ""
+
+#: ../../24.10/index.md:469 ../../24.10/index.md:652
+#: d267deac55764ab687bbb4c85ea53298 fc7702588bab419692b3d543b3152d7e
+msgid "Microsoft Azure"
+msgstr ""
+
+#: ../../24.10/index.md:471 64c1d001826d427a80520e1852df1797
+msgid ""
+"Canonical introduced a new way of publishing on Azure with Ubuntu 24.04 "
+"LTS, which will continue for 24.10. All Ubuntu Images for 24.10 will be "
+"available under the same offer: `ubuntu-24_10`. Derivative images, such "
+"as the minimized version of Ubuntu server are available as plans under "
+"this main offer."
+msgstr ""
+
+#: ../../24.10/index.md:473 a06abdd293b94748bc874307ac8370ce
+msgid ""
+"Starting in 24.10 (but also backported to 20.04, 22.04 and 24.04) the "
+"values for `net.core.rmem_max` and `net.core.rmem_default` have been "
+"increased to 1048576 (the Ubuntu default is 212992). This change will "
+"apply to all newly published Ubuntu images published on Azure for the "
+"given versions. This increase in the socket receive buffer size was made "
+"to reduce UDP packet loss for some workloads."
+msgstr ""
+
+#: ../../24.10/index.md:475 5f394f44ebc14147a18eb4d09c209763
+msgid "Google"
+msgstr ""
+
+#: ../../24.10/index.md:477 c72b359dd7534ede868eac0fe6365a11
+msgid ""
+"Resume/suspend issue from noble [LP: "
+"#2063315](https://bugs.launchpad.net/ubuntu/+source/linux-"
+"gcp/+bug/2063315) is resolved"
+msgstr ""
+
+#: ../../24.10/index.md:478 4e91389c8fce4af994d9f1054bec467a
+msgid ""
+"TDX support: Ubuntu images now support Confidential VMs with Intel TDX. "
+"This capability is advertised by the presence of “TDX_CAPABLE” guest OS "
+"feature flag in the image metadata. Intel TDX is now also supported on "
+"Ubuntu Jammy and Noble GCE images."
+msgstr ""
+
+#: ../../24.10/index.md:480 62dd5f94d36442c592ab74c09ac63711
+msgid "How to report any issues resulting from these changes"
+msgstr ""
+
+#: ../../24.10/index.md:482 98d70b43dce34181affb606ad0bec011
+msgid ""
+"If you notice any unexpected changes or bugs in the minimal images, "
+"create a new bug in [cloud-images](https://bugs.launchpad.net/cloud-"
+"images)."
+msgstr ""
+
+#: ../../24.10/index.md:484 06427b755d0f4577ae620b5cd842f41e
+msgid "arm64"
+msgstr ""
+
+#: ../../24.10/index.md:486 930bd07ed7a54cecb1e48dea7b454fae
+msgid ""
+"The new arm64+largemem ISO includes a kernel with 64k page size. A larger"
+" page size can increase throughput, but comes at the cost of increased "
+"memory use, making this option more suitable for servers with plenty of "
+"memory. Typical use cases for this ISO include: machine learning, "
+"databases with many large entries, high performance computing."
+msgstr ""
+
+#: ../../24.10/index.md:488 0e4541fd559147a7a81c46371d94debd
+msgid ""
+"IBM Z and LinuxONE "
+"![image|32x32](upload://dZM0RRlelqCcZc6RhqJGMW8DMZr.png)"
+msgstr ""
+
+#: ../../24.10/index.md:488 a8dd677e8664435bb2fca78aaafafd89
+msgid "image|32x32"
+msgstr ""
+
+#: ../../24.10/index.md:490 4a5d83e0ccd64a9fa8d6777774c54510
+msgid ""
+"The key package 's390-tools' was step-by-step upgraded to latest version "
+"v2.34.1 ([LP: #2073786](https://launchpad.net/bugs/2073786)), which incl."
+" lots of updates, new tools and features, especially in the area of "
+"ap_tools/ap-check and libap - the skipped v.2.33 brought on top several "
+"modification in the Rust code and libutil ([LP: "
+"#2067355](https://launchpad.net/bugs/2067355))."
+msgstr ""
+
+#: ../../24.10/index.md:491 a985841bbc5a4682aa43be8d966d5081
+msgid ""
+"On top of the usual upgrade of the tool-chain, valgrind was also upgraded"
+" to it's latest v2.23, which includes support for IBM z16 hardware ([LP: "
+"#1982335](https://launchpad.net/bugs/1982335))."
+msgstr ""
+
+#: ../../24.10/index.md:492 fac2e59a9a6c42df88819ea7a1dc3cdf
+msgid ""
+"With the upgrade of openCryptoki to latest v3.23 ([LP: "
+"#2076450](https://launchpad.net/bugs/2076450)), support of protected keys"
+" for extractable keys (with EP11 tokens) was introduced ([LP: "
+"#2050018](https://launchpad.net/bugs/2050018))."
+msgstr ""
+
+#: ../../24.10/index.md:493 37103b0f0490473daebbdabdac669451
+msgid ""
+"And as usual a lot of s390x-specific packages (or package that are of "
+"special interest for s390x) got upgraded to it's latest version, like:"
+msgstr ""
+
+#: ../../24.10/index.md:494 d8d7117f337d4780b71dd872a49263cf
+msgid "libzpc to v1.2.0 ([LP: #2076444](https://launchpad.net/bugs/2076444))"
+msgstr ""
+
+#: ../../24.10/index.md:495 231b69894ad449dd8ad7591365dca8b5
+msgid "libzdnn to v1.0.1 ([LP: #2076445](https://launchpad.net/bugs/2076445))"
+msgstr ""
+
+#: ../../24.10/index.md:496 de4d33359eed481794f5d8b518c25c39
+msgid "qclib to v2.5.0 ([LP: #2076446](https://launchpad.net/bugs/2076446))"
+msgstr ""
+
+#: ../../24.10/index.md:497 4ce3c01b751b4728864cd35a0a0634a2
+msgid "smc-tools to v1.8.3 ([LP: #2076447](https://launchpad.net/bugs/2076447))"
+msgstr ""
+
+#: ../../24.10/index.md:498 dc005f81d1c44f96933a2edc6f5395b3
+msgid ""
+"openssl-ibmca to v2.4.1 ([LP: "
+"#2076448](https://launchpad.net/bugs/2076448))"
+msgstr ""
+
+#: ../../24.10/index.md:499 afb0e176a7994865acf879c6fc7b8383
+msgid "libica to v4.3.0 ([LP: #2076449](https://launchpad.net/bugs/2076449))"
+msgstr ""
+
+#: ../../24.10/index.md:500 dd33c4ae73434a2ea260f7ecd39d4219
+msgid ""
+"Kernel 6.11 move (via 6.10 code) the kernel image into vmalloc space, "
+"where random physical pages are used to map virtual pages ([LP: "
+"#2072661](https://launchpad.net/bugs/2072661)). Even if kernel 6.11 is "
+"brand new, a patch set from the next kernel for 'Vertical CPU "
+"Polarization Support Stage 2\" that esp. provides improved 'cpu capacity'"
+" support for the Linux scheduler ([LP: "
+"#2072760](https://launchpad.net/bugs/2072760)) was included."
+msgstr ""
+
+#: ../../24.10/index.md:503 c5b7726d0fc84233bac6daef2a9916b4
+msgid "IBM POWER (ppc64el)"
+msgstr ""
+
+#: ../../24.10/index.md:505 03897bfb1156473b8b36384a601eeac6
+msgid ""
+"KVM running in IBM PowerVM LPARs: Ubuntu Server 24.04 has the required "
+"technology enablement and support for running KVM in a PowerVM LPAR. This"
+" technology enables expanded open-source based innovations and solutions "
+"for Ubuntu Server on the IBM Power platform. Below are the firmware and "
+"hardware requirements:"
+msgstr ""
+
+#: ../../24.10/index.md:509 f40d0b5874554ef78717daf8c970f9ca
+msgid "Firmware: FW1060.10"
+msgstr ""
+
+#: ../../24.10/index.md:510 d8fd4104a125492aaea78e63a6efce59
+msgid "Hardware: IBM Power10"
+msgstr ""
+
+#: ../../24.10/index.md:511 1700a082813842af941e526ca2ca7df5
+msgid ""
+"KVM virtualization continues to be supported on POWER9 bare-metal / OPAL "
+"based systems."
+msgstr ""
+
+#: ../../24.10/index.md:512 14a42fcd0f3d496ea42878fd801b32c4
+msgid "Ubuntu 24.10 includes so called 'Book3S HV nestedv2' support and fixes."
+msgstr ""
+
+#: ../../24.10/index.md:516 32cf2448faf544418d62c4daf0b4bfc8
+msgid ""
+"For an overview of supported boards see "
+"https://ubuntu.com/download/risc-v."
+msgstr ""
+
+#: ../../24.10/index.md:518 6ded6053c6084540b99c4c12a7403df0
+msgid "The RISC-V Ubuntu userland is compatible with all RVA20 hardware."
+msgstr ""
+
+#: ../../24.10/index.md:522 39ea05c921184733a605771e7ad26c14
+msgid "Known Issues"
+msgstr ""
+
+#: ../../24.10/index.md:524 abc68064cb004f20abea2e2c401735d2
+msgid ""
+"As is to be expected with any release, there are some significant known "
+"bugs that users may encounter with this release of Ubuntu. The ones we "
+"know about at this point (and some of the workarounds) are documented "
+"here, so you don't need to spend time reporting these bugs again:"
+msgstr ""
+
+#: ../../24.10/index.md:526 34b70a56d8ff474a83c1f144e521d6fc
+msgid "General"
+msgstr ""
+
+#: ../../24.10/index.md:528 7b0dfbed45a844c58292d108c435f252
+msgid ""
+"The Live Session of the new Ubuntu Desktop installer is not localized. It"
+" is still possible to perform a non-English installation using the new "
+"installer, but internet access at install time is required to download "
+"the language packs. ([LP: #2013329](https://bugs.launchpad.net/ubuntu-"
+"release-notes/+bug/2013329))"
+msgstr ""
+
+#: ../../24.10/index.md:529 a969e79385cb4064a5d94fd6ed18a45f
+msgid ""
+"ZFS with Encryption on Ubuntu 24.10 will [fail to activate the cryptoswap"
+" "
+"partition](https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/2084089)."
+"  This affects both new installs and upgrades.  We expect to address this"
+" post-release with an archive update."
+msgstr ""
+
+#: ../../24.10/index.md:530 a4033738385c47e8a4b68ce2c00ce617
+msgid ""
+"Some particular hardware (e.g. Thinkpad x201) might have issues ([general"
+" freeze](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2084055), "
+"[`desktop-security-center` not launching](https://github.com/canonical"
+"/desktop-security-center/issues/81)), when booted without `nomodeset` "
+"(Safe graphics). Follow these steps if you encounter such an issue:"
+msgstr ""
+
+#: ../../24.10/index.md:532 162178880b214a0eaac03c9eae860cda
+msgid ""
+"At the GRUB boot menu, press `e` (keep `Shift` pressed during early boot "
+"if the menu doesn't show up)."
+msgstr ""
+
+#: ../../24.10/index.md:533 3485d34be4aa446a9feaadce215afce4
+msgid "Add `nomodeset` to `linux` line, like the example below:"
+msgstr ""
+
+#: ../../24.10/index.md:539 5c538bae805c41b1b6f8e76c3d38fa06
+msgid "Press `Ctrl-x` to continue the boot process"
+msgstr ""
+
+#: ../../24.10/index.md:540 ce43d4aad74846f6822a560f86be6c3d
+msgid ""
+"After installation is complete, reboot, use `nomodeset` again, like the "
+"example below:"
+msgstr ""
+
+#: ../../24.10/index.md:546 721ab2c969a045528f8eeced4e05fff2
+msgid ""
+"Add `nomodeset` to the GRUB config file, `/etc/default/grub`, like the "
+"example below:"
+msgstr ""
+
+#: ../../24.10/index.md:552 4f63cd0d41844ccf9dad79dedbcc1de8
+msgid "Finally, run `sudo update-grub` to make the change take effect."
+msgstr ""
+
+#: ../../24.10/index.md:555 8bb65ec55f344457822b0026703213d8
+msgid "Linux kernel"
+msgstr ""
+
+#: ../../24.10/index.md:557 7ef6ef1922a642a4bb099235a1bb5701
+msgid ""
+"A bug prevents the IO scheduler from being reset to \"none\" ([LP: "
+"#2083845](https://bugs.launchpad.net/bugs/2083845)): the fix is already "
+"in v6.11.2, and will be part of the first SRU kernel."
+msgstr ""
+
+#: ../../24.10/index.md:558 b5b6d9b31288428eaa13089a81ff433b
+msgid ""
+"Support for FAN networking has been dropped in the 6.11 release kernel. "
+"It will be re-introduced in the next 6.11 kernel update shortly."
+msgstr ""
+
+#: ../../24.10/index.md:562 49cc8b2726c14f2092e7757cca06314b
+msgid ""
+"Screen reader support is present with the new desktop installer, but is "
+"incomplete ([LP: #2061015](https://launchpad.net/bugs/2061015), [LP: "
+"#2061018](https://launchpad.net/bugs/2061018), [LP: "
+"#2036962](https://launchpad.net/bugs/2036962), [LP: "
+"#2061021](https://launchpad.net/bugs/2061021))"
+msgstr ""
+
+#: ../../24.10/index.md:564 1cefd4deb80c4613adc39e18d951edae
+msgid ""
+"OEM installs are not supported yet ([LP: "
+"#2048473](https://launchpad.net/bugs/2048473))"
+msgstr ""
+
+#: ../../24.10/index.md:566 5773f3b51dcd4eacac4a0f8e4ac585be
+msgid ""
+"Application icons don't use the correct High Contrast theme when High "
+"Contrast is enabled [(LP: #2013107](https://launchpad.net/bugs/2013107))"
+msgstr ""
+
+#: ../../24.10/index.md:568 b171f79754e944e5a401fb1533e24dff
+msgid ""
+"GTK4 apps (including the desktop wallpaper) do not display correctly with"
+" VirtualBox or VMWare with 3D Acceleration ([LP: "
+"#2061118](https://launchpad.net/bugs/2061118))."
+msgstr ""
+
+#: ../../24.10/index.md:570 537ebadb2a90440fa3a05d791125070a
+msgid ""
+"**Incompatibility between TPM-backed Full Disk Encryption and Absolute:**"
+" TPM-backed Full Disk Encryption (FDE) has been introduced to enhance "
+"data security. However, it's important to note that this feature is "
+"incompatible with Absolute (formerly Computrace) security software. If "
+"Absolute is enabled on your system, the machine will not boot post-"
+"installation when TPM-backed FDE is also enabled. Therefore, disabling "
+"Absolute from the BIOS is recommended to avoid booting issues."
+msgstr ""
+
+#: ../../24.10/index.md:571 29473378e58d4e46bcc11dcdb170e5a3
+msgid ""
+"**Hardware-Specific Kernel Module Requirements for TPM-backed Full Disk "
+"Encryption:** TPM-backed Full Disk Encryption (FDE) requires a specific "
+"kernel snap which may not include certain kernel modules necessary for "
+"some hardware functionalities. A notable example is the `vmd` module "
+"required for NVMe RAID configurations. In scenarios where such specific "
+"kernel modules are indispensable, the hardware feature may need to be "
+"disabled in the BIOS (such as RAID) to ensure the continued availability "
+"of the affected hardware post-installation. If disabling in the BIOS is "
+"not an option, the related hardware will not be available post-"
+"installation with TPM-backed FDE enabled."
+msgstr ""
+
+#: ../../24.10/index.md:572 163a10d891294b819812c2a335b10cbc
+msgid ""
+"[FDE specific bug "
+"reports](https://bugs.launchpad.net/bugs/+bugs?field.searchtext=&orderby=-importance&field.status%3Alist=NEW&field.status%3Alist=CONFIRMED&field.status%3Alist=TRIAGED&field.status%3Alist=INPROGRESS&field.status%3Alist=FIXCOMMITTED&field.status%3Alist=INCOMPLETE_WITH_RESPONSE&field.status%3Alist=INCOMPLETE_WITHOUT_RESPONSE&assignee_option=any&field.assignee=&field.bug_reporter=&field.bug_commenter=&field.subscriber=&field.tag=fde&field.tags_combinator=ANY&field"
+".status_upstream-empty-"
+"marker=1&field.has_cve.used=&field.omit_dupes.used=&field.omit_dupes=on&field.affects_me.used=&field.has_patch.used=&field.has_branches.used=&field.has_branches=on&field.has_no_branches.used=&field.has_no_branches=on&field.has_blueprints.used=&field.has_blueprints=on&field.has_no_blueprints.used=&field.has_no_blueprints=on&search=Search)."
+msgstr ""
+
+#: ../../24.10/index.md:574 b18cc21bf53f4655bc2a449a463b7caa
+msgid ""
+"Some Nvidia desktops perform worse in Wayland sessions than Xorg "
+"([LP#2081140](https://bugs.launchpad.net/bugs/2081140)). To work around "
+"this you can select ‘Ubuntu on Xorg’ from the login screen."
+msgstr ""
+
+#: ../../24.10/index.md:576 2260fbe26de34b139c7d51d3d5dc4079
+msgid ""
+"Nvidia hybrid machines that have an external monitor connected to the "
+"discrete GPU (usually via the laptop’s HDMI port) may experience lower "
+"performance on that monitor in Wayland sessions "
+"([LP#2064205](https://bugs.launchpad.net/bugs/2064205)). To work around "
+"this you may:"
+msgstr ""
+
+#: ../../24.10/index.md:577 63ba6458ea1848e09c2719e8ba84f72f
+msgid ""
+"Plug all external monitors into the integrated GPU (such as by USB-C). "
+"The discrete GPU can still be used to launch apps."
+msgstr ""
+
+#: ../../24.10/index.md:578 b74b8516e88041138948942ca5951e5c
+msgid "Or select ‘Ubuntu on Xorg’ from the login screen."
+msgstr ""
+
+#: ../../24.10/index.md:580 b95ef5c393ef4b65a5b2467d0051b2e8
+msgid ""
+"Installing `ubuntu-fonts-classic` results in a non-Ubuntu font being "
+"displayed ([LP#2083683](https://bugs.launchpad.net/bugs/2083683)). To "
+"resolve this, install `gnome-tweaks` and set ‘Interface Text’ to "
+"‘Ubuntu’."
+msgstr ""
+
+#: ../../24.10/index.md:584 5c481dca6c074f91aff0464fad884f6b
+msgid "rabbitmq-server"
+msgstr ""
+
+#: ../../24.10/index.md:585 394d4f215eb0468db4f287d3da166c81
+msgid ""
+"Certain version hops may be unsupported due to feature flags, raising "
+"questions about how Ubuntu will maintain this package moving forward. We "
+"are currently exploring the use of snaps as a potential solution to "
+"enable smoother upgrades. For more information please read "
+"https://bugs.launchpad.net/bugs/2074309."
+msgstr ""
+
+#: ../../24.10/index.md:587 b23ce93fb758484dbf5e2b83d91bd459
+msgid "Installer"
+msgstr ""
+
+#: ../../24.10/index.md:589 7c663b2cb3674655b4dbf2fdb71b0d3e
+msgid ""
+"In some situations, it is acceptable to proceed with an offline "
+"installation when the mirror is inaccessible. In this scenario, it is "
+"advised to use:"
+msgstr ""
+
+#: ../../24.10/index.md:596 ab758def494d447ba69a40ec933623c1
+msgid ""
+"Network interfaces left unconfigured at install time are assumed to be "
+"configured via dhcp4. If this doesn't happen (for example, because the "
+"interface is physically not connected) the boot process will block and "
+"wait for a few minutes ([LP: "
+"#2063331](https://bugs.launchpad.net/subiquity/+bug/2063331)). This can "
+"be fixed by removing the extra interfaces from `/etc/netplan/50-cloud-"
+"init.conf` or by marking them as `optional: true`. Cloud-init is disabled"
+" on systems installed from ISO images, so settings will persist."
+msgstr ""
+
+#: ../../24.10/index.md:598 63c93b3d81fc4cdebfd424717a8dcc20
+msgid "samba apparmor profile"
+msgstr ""
+
+#: ../../24.10/index.md:599 b559b66c1c0347669457695b92db4d5a
+msgid ""
+"Due to [bug LP: "
+"#2063079](https://bugs.launchpad.net/ubuntu/+source/samba/+bug/2063079), "
+"the samba `smbd.service` unit file is no longer calling out to the helper"
+" script to dynamically create apparmor profile snippets according to the "
+"existing shares."
+msgstr ""
+
+#: ../../24.10/index.md:601 e26c8fdc514145318c41d5c1e482b91c
+msgid ""
+"By default, the `smbd` service from samba is not confined. To be affected"
+" by this bug, users have to:"
+msgstr ""
+
+#: ../../24.10/index.md:602 a5f81b26e9714d859d23db9dcf6a1d9e
+msgid "install the optional `apparmor-profiles` package"
+msgstr ""
+
+#: ../../24.10/index.md:603 cd8d771f73b24e9798b976b2d118296c
+msgid "switch the `smbd` profile confinement from `complain` to `enforce`"
+msgstr ""
+
+#: ../../24.10/index.md:605 9251668f6ff74dd0aaf9fef64363905a
+msgid ""
+"Therefore, only users who have taken those steps and upgrade to Noble, "
+"will be affected by this bug. An SRU to fix it will be done shortly after"
+" release."
+msgstr ""
+
+#: ../../24.10/index.md:610 d560421e9627464ba4c79e064528b5ec
+msgid ""
+"There is a AppArmor related bug where containers cannot be promptly "
+"stopped due to the recently added AppArmor profile for `runc`. The "
+"containers are always killed with `SIGKILL` due to the denials when "
+"trying to receive a signal. More details about this bug can be found "
+"[here](https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/2063099),"
+" and a workaround is described "
+"[here](https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/2063099/comments/4)."
+msgstr ""
+
+#: ../../24.10/index.md:612 1badfb47e8b540408be25ec3c826e149
+msgid "PPC64EL"
+msgstr ""
+
+#: ../../24.10/index.md:614 df16cb92eb7d4fa5ab400b4ed8c4da39
+msgid ""
+"PMDK sees some hardware-specific failures in its test suite, which may "
+"make the software partially or fully inoperable on the ppc64el "
+"architecture. ([LP: "
+"#2061913](https://bugs.launchpad.net/ubuntu/+source/pmdk/+bug/2061913/))"
+msgstr ""
+
+#: ../../24.10/index.md:616 7029240003f34ac2846f4da798e5f372
+msgid "Raspberry Pi"
+msgstr ""
+
+#: ../../24.10/index.md:618 c4290c16f56b4fda9e444144c6487ea6
+msgid ""
+"Raspberry Pi 500 is missing an entry in the flash-kernel database ([LP: "
+"#2092216](https://launchpad.net/bugs/2092216))"
+msgstr ""
+
+#: ../../24.10/index.md:620 f5493912822c437face8097cffa09776
+msgid ""
+"Raspberry Pi models with the 2712 D0 stepping (at time of release, only "
+"the Pi 5 2GB, but anticipated to become common on other models in "
+"future), are incompatible with the version of mesa used by snaps "
+"(Firefox, Thunderbird, and the Snap Store). This will be corrected post-"
+"release, but users on these models must run `sudo snap refresh` once, "
+"prior to launching these applications ([LP: "
+"#2082072](https://launchpad.net/bugs/2082072))"
+msgstr ""
+
+#: ../../24.10/index.md:622 647a178a17dd43d39d85c2768fc9adc4
+msgid ""
+"During boot on the server image, if your `cloud-init` configuration (in "
+"`user-data` on the boot partition) relies upon networking (importing SSH "
+"keys, installing packages, etc.) you *must* ensure that at least one "
+"network interface is required (`optional: false`) in `network-config` on "
+"the boot partition. This is due to netplan changes to the wait-online "
+"service ([LP: #2060311](https://launchpad.net/bugs/2060311))"
+msgstr ""
+
+#: ../../24.10/index.md:624 ea2bc20cca0a42ffa34e178dace80fc0
+msgid ""
+"The startup sound does not play before the initial setup process, hence "
+"users cannot currently rely on hearing this sound to determine if the "
+"system has booted ([LP: #2060693](https://launchpad.net/bugs/2060693))"
+msgstr ""
+
+#: ../../24.10/index.md:626 b63d9bd5d7184cfeb1c1861b9f8516ae
+msgid ""
+"The seeded totem video player will not prompt users to install missing "
+"codecs when attempting to play a video requiring them ([LP: "
+"#2060730](https://launchpad.net/bugs/2060730))"
+msgstr ""
+
+#: ../../24.10/index.md:628 62b61addc0794344bef389ca25f0ac1e
+msgid ""
+"With some monitors connected to a Raspberry Pi, it is possible that a "
+"monitor powers off after a period of inactivity but then powers back on "
+"and shows a black screen. Investigation into the types of monitors "
+"affected is ongoing in [LP: "
+"#1998716](https://bugs.launchpad.net/ubuntu/+source/mutter/+bug/1998716)."
+msgstr ""
+
+#: ../../24.10/index.md:630 8495a0a2e35d4281803ab3562c741868
+msgid ""
+"With the removal of the `crda` package in 22.04, the method of setting "
+"the wifi regulatory domain (editing `/etc/default/crda`) no longer "
+"operates. On server images, use the `regulatory-domain` option in the "
+"Netplan configuration. On desktop images, append "
+"`cfg80211.ieee80211_regdom=GB` (substituting `GB` for the relevant "
+"country code) to the kernel command line in the `cmdline.txt` file on the"
+" boot partition  ([LP: #1951586](https://launchpad.net/bugs/1951586))."
+msgstr ""
+
+#: ../../24.10/index.md:632 cce2ee673a0742559508ab86d9fcdd10
+msgid ""
+"The power LED on the Raspberry Pi 2B, 3B, 3A+, 3B+, and Zero 2W currently"
+" goes off and stays off once the Ubuntu kernel starts booting ([LP: "
+"#2060942](https://launchpad.net/bugs/2060942))"
+msgstr ""
+
+#: ../../24.10/index.md:634 3a92650e03574fd38114adc7fd253733
+msgid ""
+"libcamera support is currently broken; this will be a priority for next "
+"cycle and fixes will be SRU'd to noble as and when they become available "
+"([LP: "
+"#2038669](https://bugs.launchpad.net/ubuntu/+source/libcamera/+bug/2038669))"
+msgstr ""
+
+#: ../../24.10/index.md:636 b6b9e4511d384f26aaba9b016c495ac2
+msgid ""
+"Colours appear incorrectly in the Ubuntu App Centre ([LP: "
+"#2076919](https://launchpad.net/bugs/2076919))"
+msgstr ""
+
+#: ../../24.10/index.md:638 d2d9a4b694c8455c8f938486067432a4
+msgid ""
+"On desktop images, changes in the home directory result in log spam from "
+"tracker-miner complaining about lack of landlock ([LP: "
+"#2066885](https://launchpad.net/bugs/2066885))"
+msgstr ""
+
+#: ../../24.10/index.md:640 59f6cc29975845c28bcbb9acdcb09dc7
+msgid ""
+"On desktop images, on some systems the Wayland desktop option does not "
+"appear on first boot. Logging in, then logging out results in the default"
+" Wayland option being restored"
+msgstr ""
+
+#: ../../24.10/index.md:642 8c4b4d3563b140a4b4c29697ef67f753
+msgid ""
+"On server images, re-authentication to WiFi APs when regulatory domain is"
+" set result in `dmesg` spam to the console ([LP: "
+"#2063365](https://launchpad.net/bugs/2063365))"
+msgstr ""
+
+#: ../../24.10/index.md:644 8c8ab768646444edb3e7e3a34c739965
+msgid "ARM64 Systems with NVIDIA GPUs"
+msgstr ""
+
+#: ../../24.10/index.md:646 6623d598143043569b2f544d2ed21968
+msgid ""
+"The current versions of the NVIDIA GPU drivers may cause freezes or "
+"crashes ([LP: #2062380](https://launchpad.net/bugs/2062380)). This will "
+"be fixed in a future driver update."
+msgstr ""
+
+#: ../../24.10/index.md:648 4564f873ce7d4dc6ab31a1e1d5f6deec
+msgid "Google Compute Platform"
+msgstr ""
+
+#: ../../24.10/index.md:650 ../../24.10/index.md:654 ../../24.10/index.md:658
+#: 43b2685b22544c28a2c1e2fa78070946 f26ae259a25042b9bfc52a7689c6ca39
+#: ffc21f55bfbf48fb920b73b46cb72b0d
+msgid "Nothing yet."
+msgstr ""
+
+#: ../../24.10/index.md:656 2faaa266dfde42019502d8127e69c251
+msgid "s390X"
+msgstr ""
+
+#: ../../24.10/index.md:661 4e619bc80aed4f10bcf9bef6749246ac
+msgid "Official flavors"
+msgstr ""
+
+#: ../../24.10/index.md:663 a3df507cfe0f4f1c9ff876a982ae9f93
+msgid "Find the release notes for the official flavors at the following links:"
+msgstr ""
+
+#: ../../24.10/index.md:665 bf1a7c113e5948278789ae46ea50db4b
+msgid ""
+"[Edubuntu Release "
+"Notes](https://discourse.ubuntu.com/t/edubuntu-24-10-released/48647)"
+msgstr ""
+
+#: ../../24.10/index.md:666 dbd7497a9f8f4558b2cf04997864333c
+msgid ""
+"[Kubuntu Release Notes](https://kubuntu.org/news/kubuntu-24-10-oracular-"
+"oriole-released/)"
+msgstr ""
+
+#: ../../24.10/index.md:667 d2c8b78f91724a8788f7a4162d70d480
+msgid ""
+"[Lubuntu Release Notes](https://lubuntu.me/lubuntu-24-10-oracular-oriole-"
+"released/)"
+msgstr ""
+
+#: ../../24.10/index.md:668 3aae2dd6113e49aa8d4013dc07507ff1
+msgid ""
+"[Ubuntu Budgie Release Notes](https://ubuntubudgie.org/2024/10/ubuntu-"
+"budgie-24-10-release-notes/)"
+msgstr ""
+
+#: ../../24.10/index.md:669 d67648c2a0dc4534aced679965a01d3e
+msgid ""
+"[Ubuntu MATE Release Notes](https://ubuntu-mate.org/blog/ubuntu-mate-"
+"oracular-oriole-release-notes/)"
+msgstr ""
+
+#: ../../24.10/index.md:670 0d07e4a79c9f48898ce7c9cf124cac79
+msgid ""
+"[Ubuntu Studio Release Notes](https://ubuntustudio.org/ubuntu-"
+"studio-24-10-release-notes/)"
+msgstr ""
+
+#: ../../24.10/index.md:671 80bb861a42114ede8967bf9021f01656
+msgid ""
+"[Ubuntu Unity Release Notes](https://ubuntuunity.org/posts/ubuntu-"
+"unity-2410-released/)"
+msgstr ""
+
+#: ../../24.10/index.md:672 72fd14016b4a46c48a634105945b281c
+msgid ""
+"[Xubuntu Release Notes](https://wiki.xubuntu.org/releases/24.10/release-"
+"notes)"
+msgstr ""
+
+#: ../../24.10/index.md:673 523b54afa1f14f9890fe1a6e8e82f45c
+msgid ""
+"[Ubuntu Kylin Release "
+"Notes](https://ubuntukylin.com/news/ubuntukylin2410-en.html)"
+msgstr ""
+
+#: ../../24.10/index.md:674 c5626677cf8b432a9aa6d44666ebc0ce
+msgid "[Ubuntu Cinnamon Release Notes](https://ubuntucinnamon.org/?p=1348)"
+msgstr ""
+
+#: ../../24.10/index.md:678 4efedf76159b4e20be1541122e41711b
+msgid "More information"
+msgstr ""
+
+#: ../../24.10/index.md:680 bf88b762abe1461cb20afd82284f1ac6
+#, python-brace-format
+msgid ""
+"Refer to {ref}`release-policy-and-schedule` and {ref}`project-and-"
+"community`."
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/24.10/schedule.po
+++ b/docs/locale/ja/LC_MESSAGES/24.10/schedule.po
@@ -1,0 +1,546 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../24.10/schedule.md:2 3ab992a483684b29ba67158dd5b6067f
+msgid "Ubuntu Oracular Oriole Release Schedule"
+msgstr ""
+
+#: ../../24.10/schedule.md 321e623749874bffa36b40989a64bb9f
+#: f80a5df9a19e4778a20674d328fce95f
+msgid "Week"
+msgstr ""
+
+#: ../../24.10/schedule.md 06c71721bc6a4df6a32f82a38b23d9a2
+#: bda44df2ebcd430b9f52baab943d3c6e
+msgid "Date (Thursday)"
+msgstr ""
+
+#: ../../24.10/schedule.md 497be6d708b048e8b75a2a2b7d00a681
+msgid "24.10 events"
+msgstr ""
+
+#: ../../24.10/schedule.md b0a2ef6123714eb0a16cb34c4aff2663
+#: f50f56f0d28340b480998596da1d4307
+msgid "**April 2024**"
+msgstr ""
+
+#: ../../24.10/schedule.md 4c2a1532869d425cbf9d81db69d1be72
+#: c674c893147c46c3b47657b1071dae0f
+msgid "1"
+msgstr ""
+
+#: ../../24.10/schedule.md 0504efbc4bf746dbb60fb6912fcac52f
+#: 5a38f7fdfacd490eb1cdd11f54935c6d
+msgid "April 25"
+msgstr ""
+
+#: ../../24.10/schedule.md 5aa037ec20a74fab88047dacf51fd8d3
+msgid "Toolchain Uploaded"
+msgstr ""
+
+#: ../../24.10/schedule.md f89c41b12c364aa39a1dc9ee1bfe0248
+#: fa0402d3e2a242f29cced028267c97fa
+msgid "**May 2024**"
+msgstr ""
+
+#: ../../24.10/schedule.md 7fa6c81c23934309b94f5a0a31218035
+#: b77611b854414efb8a9756644dd9b6cc
+msgid "2"
+msgstr ""
+
+#: ../../24.10/schedule.md 3581c7e1596c453ab8d9d08d8ade039d
+#: e72cab12b1ff440cabf2127837f793cb
+msgid "May 02"
+msgstr ""
+
+#: ../../24.10/schedule.md 4ccf5c13e90a42468302b543e762799f
+#: d998ab2e76574b7fb7a0bf30655bfe8e
+msgid "3"
+msgstr ""
+
+#: ../../24.10/schedule.md 1078db1537314bbf9a102de85698eb3c
+#: 33aadda6f6cb427f8eafa7c4c2ca0b11
+msgid "May 09"
+msgstr ""
+
+#: ../../24.10/schedule.md 75f6ed426316473fadd59e63f2696620
+#: fb9cd169a5ea4d478cb82a8b968df004
+msgid "4"
+msgstr ""
+
+#: ../../24.10/schedule.md 547b6c6ee98648c280506a5594d696ad
+#: d16630f94339447d9901c74b5f1817b1
+msgid "May 16"
+msgstr ""
+
+#: ../../24.10/schedule.md 81362c6e1628499fb1cea5d6bc8c67ff
+#: 9366c5c95846416cb3b379bc6043e9d5
+msgid "5"
+msgstr ""
+
+#: ../../24.10/schedule.md e5065c58d5f4473fb04a0beb102d682b
+#: fc4d2a3fe54846b9b5b1da030f411cac
+msgid "May 23"
+msgstr ""
+
+#: ../../24.10/schedule.md 5c06670ea69e4d8e81447962c30916be
+#: b9c2e62678b944cfb32259ab3cc08305
+msgid "6"
+msgstr ""
+
+#: ../../24.10/schedule.md 4499b00bd8844c1f9661bae369d1a4f5
+#: 5d3e2d1a9fc24b7681b61940a28cbb26
+msgid "May 30"
+msgstr ""
+
+#: ../../24.10/schedule.md 42bb90b0af3a45648406da6e5e685aef
+#: 779a7b83a5ea4db6baa4db779e35571b
+msgid "**June 2024**"
+msgstr ""
+
+#: ../../24.10/schedule.md 46ec2290bf424d2696e44617b6870270
+#: 654f876d7066412cb56fe33d29727094
+msgid "7"
+msgstr ""
+
+#: ../../24.10/schedule.md 0c3a7047faae44ea893b75eebf01fd10
+#: 37adadc4131b49e1aeae059dceddee7a
+msgid "June 06"
+msgstr ""
+
+#: ../../24.10/schedule.md 303f56880f884bed95443caca4f31c0f
+#: 309fb85326394414bbe15ccb01695bcf
+msgid "8"
+msgstr ""
+
+#: ../../24.10/schedule.md 3780327850c64cb6b633f3ec43429fca
+#: 79e5f3afdb4b4da3b5b36a6b3bffd6fc
+msgid "June 13"
+msgstr ""
+
+#: ../../24.10/schedule.md 2ad42216d1cb469b8501c691db09b627
+#: de7a6aef60db476387d4d2357d206050
+msgid "9"
+msgstr ""
+
+#: ../../24.10/schedule.md ca278f98075a4f2d9b231ad4eb1275cf
+#: e9cbe60b1d49417385ae19bd9e9111f1
+msgid "June 20"
+msgstr ""
+
+#: ../../24.10/schedule.md 618e106b30a04692a0494bc00dad2a84
+#: c3b5803488244109aacf1ccfe6970c42
+msgid "10"
+msgstr ""
+
+#: ../../24.10/schedule.md 183e6afa74b64602abdb82627520d98e
+#: 5bec5d6c6aba4f4bb9061b602bdf2344
+msgid "June 27"
+msgstr ""
+
+#: ../../24.10/schedule.md 7d1a95988357461eab8023ec56262cf7
+#: 8b5e1d5cc93441c592e117934e61357c
+msgid "Ubuntu Testing Week (optional)"
+msgstr ""
+
+#: ../../24.10/schedule.md 931b88444d6743c49edc191235046000
+#: d697b6d01dc744a7b18b26cf247deb5e
+msgid "**July 2024**"
+msgstr ""
+
+#: ../../24.10/schedule.md 4a7d40467a724f6dabe1e0a1529e3f42
+#: 93735891d4d34dc99d4bcf08f5a7573e
+msgid "11"
+msgstr ""
+
+#: ../../24.10/schedule.md f08775f35a8c4d1fafbd95c1bc2333ec
+#: f3f3955144c842afb29ab17f431c52e3
+msgid "July 04"
+msgstr ""
+
+#: ../../24.10/schedule.md 1e614ce3c65b4002866d16d39d7ae72a
+#: 98bf1cfc88ad456d92fa3acb561f347d
+msgid "12"
+msgstr ""
+
+#: ../../24.10/schedule.md 6e4a734a3d7f418fbba1bd6d2f90504b
+#: a812ec2d578046e5b6b4d0909eb5553a
+msgid "July 11"
+msgstr ""
+
+#: ../../24.10/schedule.md 37302b96cf784e53b315a7471f4cb2c0
+#: ef1aa906a6de452eb145d0f438150470
+msgid "13"
+msgstr ""
+
+#: ../../24.10/schedule.md 72a1f08b9a394b598c31ab68479ee792
+#: ab510edff4a54d32b08207224d8b4e6a
+msgid "July 18"
+msgstr ""
+
+#: ../../24.10/schedule.md 3d324450e6e441ccb47a495f43835694
+#: affe522df9ee4a2890ba29baef2c25d2
+msgid "14"
+msgstr ""
+
+#: ../../24.10/schedule.md 20d63c17895d48fe87b0a57680ed03c4
+#: 2241abd5a91c45b297fa425bc77f6cee
+msgid "July 25"
+msgstr ""
+
+#: ../../24.10/schedule.md 339c41efb9614d9b93ebc3e4ef66d371
+#: debd0e84cb5b4e1dae33b1b33d1bac2f
+msgid "**August 2024**"
+msgstr ""
+
+#: ../../24.10/schedule.md 5b2c88b28ac94e50a46e0564864e7f96
+#: 9e6547f87cb2401e92f5c0f7e2a283c9
+msgid "15"
+msgstr ""
+
+#: ../../24.10/schedule.md 06310c51cf5c4ab389185a91a613d5ab
+#: 0c6ac04e149e4485b1c5584810ed44b3
+msgid "August 01"
+msgstr ""
+
+#: ../../24.10/schedule.md c303e76992784c24acd486e0b3872e91
+#: c87c1d624e504443b9520ae972e179f6
+msgid "16"
+msgstr ""
+
+#: ../../24.10/schedule.md 95c6797dc93a4c5e94c4ee1741f1f069
+#: 982de59ed80644cd907cde4c72104f1c
+msgid "August 08"
+msgstr ""
+
+#: ../../24.10/schedule.md a5064c84886d496d930454159137979c
+#: d1c46693d9aa466dbac94be1912b2978
+msgid "17"
+msgstr ""
+
+#: ../../24.10/schedule.md c653d2b0a219412e9f23497935394be9
+#: fa23680052ad4c6285a65682d4ef91a2
+msgid "August 15"
+msgstr ""
+
+#: ../../24.10/schedule.md 2e463df246064fa69d0117f062d476d5
+msgid ""
+"[Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), Debian Import "
+"Freeze"
+msgstr ""
+
+#: ../../24.10/schedule.md 7a973e9f65154e5ba0fc3e9da39fdb36
+#: f7f830f694b44ad383735c8187256fbc
+msgid "18"
+msgstr ""
+
+#: ../../24.10/schedule.md 2c53a9efcfd94d12be03d2cf2f733997
+#: d70812fcf48644069a7a2cf76a7f6253
+msgid "August 22"
+msgstr ""
+
+#: ../../24.10/schedule.md 5d092312fc5440efb548baffabaf4e0c
+#: 674645bfe7904e4cbe4353ffb54700dd
+msgid "19"
+msgstr ""
+
+#: ../../24.10/schedule.md 428af77a8dd745f58939414ad7ee678f
+#: 6f1d0e06ab254effb347654f25ffbcf8
+msgid "August 29"
+msgstr ""
+
+#: ../../24.10/schedule.md 873a3850e71b4120beb8b3cec5a9ccbe
+#: d3611ec737ae480bbd71973386c504d3
+msgid "**September 2024**"
+msgstr ""
+
+#: ../../24.10/schedule.md cde41fd1764743eb8c02d53c5e02f81c
+#: fdd94e57585e488d88404a6490d0098a
+msgid "20"
+msgstr ""
+
+#: ../../24.10/schedule.md 25b83397254c4175a0342be041963a12
+#: 43f54429680c4e4fa8741a82d5a7b996
+msgid "September 05"
+msgstr ""
+
+#: ../../24.10/schedule.md def9fe57ef384d43b4b75505580464ec
+msgid "[User Interface Freeze](https://wiki.ubuntu.com/UserInterfaceFreeze)"
+msgstr ""
+
+#: ../../24.10/schedule.md 001621e3869d424284e8cf1f96868f4b
+#: c2a9bfd0b417442e97a939f21244c52f
+msgid "21"
+msgstr ""
+
+#: ../../24.10/schedule.md da85333dfadd4b36bd9f2d14f0651224
+#: f2d762b06f074a6cb9a60f56c4bde9ff
+msgid "September 12"
+msgstr ""
+
+#: ../../24.10/schedule.md 4ef2db481a1640919a48fda753aab5c2
+msgid ""
+"[Documentation String "
+"Freeze](https://wiki.ubuntu.com/DocumentationStringFreeze), [Kernel "
+"Feature Freeze](https://wiki.ubuntu.com/KernelFeatureFreeze)"
+msgstr ""
+
+#: ../../24.10/schedule.md 2dbfcf0249b24450ba20b8f13454559c
+#: 92c6cdf671da44daaf991a7507d462fe
+msgid "22"
+msgstr ""
+
+#: ../../24.10/schedule.md 6b80d16adb2745cd93d5d67c49066b46
+msgid "September 16 (Monday)"
+msgstr ""
+
+#: ../../24.10/schedule.md 912ca6af0c094eb2a25912698f6ab899
+msgid ""
+"[Beta Freeze](https://wiki.ubuntu.com/BetaFreeze), [Hardware Enablement "
+"Freeze](https://wiki.ubuntu.com/HardwareEnablementFreeze)"
+msgstr ""
+
+#: ../../24.10/schedule.md 77bf4790976e4954ae9b20cacf9cd2a6
+msgid "⠀"
+msgstr ""
+
+#: ../../24.10/schedule.md 21521e138a324cffa06fec32c38084ab
+#: f9b503569e124bcd82d28a0cd68c105f
+msgid "September 19"
+msgstr ""
+
+#: ../../24.10/schedule.md ae3b96f6dbbb44d9be776863c1dc49b5
+msgid "Beta (mandatory)"
+msgstr ""
+
+#: ../../24.10/schedule.md b537356f664d40f7827647825c6beb3e
+#: c08da04ce3244810bf0d7db2f405ced9
+msgid "23"
+msgstr ""
+
+#: ../../24.10/schedule.md 2c04cdf38c014dc881ea588239281943
+#: 50f10f7874644db4aff37a097ab9ce84
+msgid "September 26"
+msgstr ""
+
+#: ../../24.10/schedule.md 9f80f75a57904d82b9768974bf85fc28
+msgid ""
+"[Kernel Freeze](https://wiki.ubuntu.com/KernelFreeze), [Non Language Pack"
+" Translation "
+"Deadline](https://wiki.ubuntu.com/NonLanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../24.10/schedule.md 09c66f826a4b4cfdaa45bc439b5863d1
+#: 15253dd665eb4bd4997154b8dbd84aef
+msgid "**October 2024**"
+msgstr ""
+
+#: ../../24.10/schedule.md 43c8faacbebb4049a993dd2b31d01eb2
+#: 61acdf1b67154018bf5d0a76b6b28449
+msgid "24"
+msgstr ""
+
+#: ../../24.10/schedule.md ae022abf19a7409a9d084d8e2a1aee4a
+#: fa628b23819147569bf3a2ed359b0c81
+msgid "October 03"
+msgstr ""
+
+#: ../../24.10/schedule.md 1f7c138430e94a44b7eca8e02d1f6663
+msgid ""
+"[Final Freeze](https://wiki.ubuntu.com/FinalFreeze), [Release "
+"Candidate](https://wiki.ubuntu.com/ReleaseCandidate), [Language Pack "
+"Translation "
+"Deadline](https://wiki.ubuntu.com/LanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../24.10/schedule.md 21d8470c8dbd454eb8a5f8d7dc9d77ea
+#: 5ec5eb9c03b846ef8ad6ef555995031c
+msgid "25"
+msgstr ""
+
+#: ../../24.10/schedule.md 7a1ea992b2b140bda4a4ba804f70568d
+#: f0941be26bdb47f99899ac858c3b79a6
+msgid "October 10"
+msgstr ""
+
+#: ../../24.10/schedule.md 1f2d2830c612428a89a57418c05e41ee
+msgid "[Final Release](https://wiki.ubuntu.com/FinalRelease)"
+msgstr ""
+
+#: ../../24.10/schedule.md:41 5415918800884a85b6dd3ccaad183592
+msgid "Planned and potentially disruptive archive-wide activities"
+msgstr ""
+
+#: ../../24.10/schedule.md:43 2558c5781bca4b4e95597870aaff0019
+msgid ""
+"If you're planning a change that might have a disruptive effect on the "
+"archive - e.g. transitions or switches of important defaults (such as "
+"compiler versions) - list it here."
+msgstr ""
+
+#: ../../24.10/schedule.md c881fadf65014b429d53549f66612818
+msgid "Planned activity"
+msgstr ""
+
+#: ../../24.10/schedule.md 503def7ee37649b5886cf81d41ca7b55
+msgid "Qt 6.6.2"
+msgstr ""
+
+#: ../../24.10/schedule.md 8775cfd71e5c4823a745b7fc1eba5ddb
+msgid "KDE Frameworks 6 (60/71 source NEW packages accepted)"
+msgstr ""
+
+#: ../../24.10/schedule.md 0bf6cdec70d34e9c943b5acf9c8140e6
+msgid "binutils 2.43"
+msgstr ""
+
+#: ../../24.10/schedule.md 86f787ffedcb462bb2d2ce3fb6d4bda8
+msgid "GCC 14 as default"
+msgstr ""
+
+#: ../../24.10/schedule.md 036d2a0bed774005ac7c4c54ccc21d74
+msgid "Ruby 3.3"
+msgstr ""
+
+#: ../../24.10/schedule.md 2e260b706ffa43948abc6251a06aa342
+msgid "glibc 2.40"
+msgstr ""
+
+#: ../../24.10/schedule.md 6f2db8fb1df94339ba4fbe49958b73a2
+msgid "[GNOME 47.beta](https://release.gnome.org/calendar/), Go 1.23 as default"
+msgstr ""
+
+#: ../../24.10/schedule.md 58714771c0e845a992a8fc3763d59c96
+msgid "LLVM 19 as default"
+msgstr ""
+
+#: ../../24.10/schedule.md c57dcb864e6b4075979f9754af699d08
+msgid "[GNOME 47.rc](https://release.gnome.org/calendar/)"
+msgstr ""
+
+#: ../../24.10/schedule.md 1058b998f19244e79cb058b2ba028f69
+msgid "[GNOME 47](https://release.gnome.org/calendar/)"
+msgstr ""
+
+#: ../../24.10/schedule.md:80 fd938fa343484d93a7b5d6c9c7485e1f
+msgid "Ubuntu O O Release Task Signup Sheet"
+msgstr ""
+
+#: ../../24.10/schedule.md:82 c8c6d9ab4fe1479ca909e07a07b2eaf1
+msgid "This signup sheet is to be used for planning release milestone tasks."
+msgstr ""
+
+#: ../../24.10/schedule.md:84 902e864e0cce4eeca55923d796a3deda
+msgid ""
+"The Alpha and Beta 1 milestones have been replaced with [Testing "
+"Weeks](https://lists.ubuntu.com/archives/ubuntu-"
+"release/2018-April/004434.html), which are organized ad hoc at this "
+"point."
+msgstr ""
+
+#: ../../24.10/schedule.md 7cdb9134657f44469d2baac653cbf56c
+msgid "Milestone"
+msgstr ""
+
+#: ../../24.10/schedule.md 83010a0b208c40ed9a0ab0af80a3e4da
+msgid "Date"
+msgstr ""
+
+#: ../../24.10/schedule.md ff41493571a641d8842952974cb5be81
+msgid "Image (Nusakan) Engineering"
+msgstr ""
+
+#: ../../24.10/schedule.md 849de76ce2814213b8a81c484ca8df72
+msgid "Checklist Tracking"
+msgstr ""
+
+#: ../../24.10/schedule.md 6b2ad65c1e5d4a45a63ff793b350fede
+msgid "Announcement Email"
+msgstr ""
+
+#: ../../24.10/schedule.md f70fb2aff79d4405bceb0cd312284adf
+msgid "Feature Freeze"
+msgstr ""
+
+#: ../../24.10/schedule.md 37901ba01d73493a96a93c12a56d5b14
+#: a03e4846ce37416fb8cc98f02a2a69b4 b57c476eee4a4bfeba5deefe179d29ed
+#: c114e43d79534e0e8bfec0cba26f1559 efddc5a60ebf49baa1d8f8d1ccdab03b
+#: fd052b99c35c4b7ba467165f1dbf2fb3
+msgid "n/a"
+msgstr ""
+
+#: ../../24.10/schedule.md 292d8a261d504040b812fb26e6f99708
+#: 40f641f8c0eb4484a177c4801d9286f2 554d70545e4a49d785c2082a02d965fd
+#: 72ef3dc4d53b4431a4dbed49de9db971 99eddb48dfae4afb92ca3d90a2f7e226
+#: a38765f5944e4fbda68efb7b8ea8e9cc a632d102d0874768abbe4ec8fbfa1ba1
+#: ab6a6d94130f4e5889e7e71a7d6ce989 f6dda2b3df6c4617bfca2bb086152710
+msgid "utkarsh"
+msgstr ""
+
+#: ../../24.10/schedule.md 954e8105d8444739a72b1eeef4579285
+msgid "UI Freeze"
+msgstr ""
+
+#: ../../24.10/schedule.md 6a942cb6ef7c4981b17fcee30fb10843
+msgid "Doc String Freeze"
+msgstr ""
+
+#: ../../24.10/schedule.md 6463b3df39154e3593c76e9a16106ee8
+msgid "24.10 Beta"
+msgstr ""
+
+#: ../../24.10/schedule.md ad521e3171c44e77b55d61ac2dd23d83
+msgid "Final Freeze"
+msgstr ""
+
+#: ../../24.10/schedule.md e35e510b43c745d2869043bf73ec07b1
+msgid "24.10 Release"
+msgstr ""
+
+#: ../../24.10/schedule.md 9c02fc23c13e4a4ba28569a1c109afce
+msgid "October 10 2024"
+msgstr ""
+
+#: ../../24.10/schedule.md 436f684e78ab4c8bb6f04aa29af115a7
+msgid "vorlon"
+msgstr ""
+
+#: ../../24.10/schedule.md:95 1ad7eef24ec645c693a44e36dcb33a3c
+msgid ""
+"When the archive is frozen, all members of the release team are expected "
+"to participate in bug fix reviews."
+msgstr ""
+
+#: ../../24.10/schedule.md:97 a02cd473bc08459692ed7b822bfb70da
+msgid ""
+"After [Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), all "
+"members of the release team are expected to participate in Feature Freeze"
+" Exception reviews in their particular area of expertise."
+msgstr ""
+
+#: ../../24.10/schedule.md:99 839fa88709264cd58361beee1590d83b
+msgid ""
+"After [Final Beta](https://wiki.ubuntu.com/FinalBetaRelease), all members"
+" of the release team are expected to participate in Bug fix reviews in "
+"their particular area of expertise."
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/25.04/index.po
+++ b/docs/locale/ja/LC_MESSAGES/25.04/index.po
@@ -1,0 +1,3210 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../25.04/index.md:10
+msgid "Release schedule"
+msgstr ""
+
+#: ../../25.04/index.md:6 2ba0d8a4e82248559f98fe6dc6afe569
+msgid "Ubuntu 25.04 release notes"
+msgstr ""
+
+#: ../../25.04/index.md:8 300690df4f874836ad4114a2e351e280
+msgid ""
+"These release notes for **Ubuntu 25.04** (Plucky Puffin) provide an "
+"overview of the release and document the known issues with Ubuntu and its"
+" flavors."
+msgstr ""
+
+#: ../../25.04/index.md:17 0abef773feb8469f8b92f4d47487ef09
+msgid "Dedication"
+msgstr ""
+
+#: ../../25.04/index.md:19 61746697360f457f89e0335eb2405767
+#, python-brace-format
+msgid ""
+"Subscribers to the `ubuntu-{devel-}announce` mailing list and long term "
+"participants in the Ubuntu community will have come across Steve "
+"Langasek's work. Steve, known in the community as vorlon, was a long-term"
+" member of the Release team (along with being a member of Archive Admin, "
+"Techboard, SRU team, and so on) and a colleague to many of us at "
+"Canonical. As a member of the Release team, Steve was responsible for "
+"devising many of the processes, policies, and tools which we use today, "
+"and teaching his fellow members the ropes. [Steve passed away on 1st "
+"January 2025](https://discourse.ubuntu.com/t/remembering-and-thanking-"
+"steve-langasek/52665) after being unwell for quite some time. The Ubuntu "
+"Release Team dedicates 25.04 “Plucky Puffin” to our colleague and friend,"
+" Steve Langasek. He is missed and will live in our hearts forever. Thank "
+"you for everything, Steve."
+msgstr ""
+
+#: ../../25.04/index.md:21 ../../25.04/index.md:37
+#: 0912cb8f102742d7b706de61308e566c 587399e23be24052bc703b4aca26c5bb
+msgid "Upgrades"
+msgstr ""
+
+#: ../../25.04/index.md:23 649e59b6f58a4522af4d384b33f33caa
+msgid ""
+"We've identified two issues in the `ubuntu-release-upgrader` affecting "
+"upgrades to Ubuntu 25.04 \"Plucky Puffin\":"
+msgstr ""
+
+#: ../../25.04/index.md:25 ecc5620437c74e9398406cfc80b4c122
+msgid ""
+"[Handling of Qt dependencies](https://bugs.launchpad.net/ubuntu/+source"
+"/ubuntu-release-upgrader/+bug/2095535)"
+msgstr ""
+
+#: ../../25.04/index.md:26 66ff8ab2329b4741bb360402e6e97aff
+msgid ""
+"[Removal of foreign packages from disabled "
+"sources](https://bugs.launchpad.net/ubuntu/+source/ubuntu-release-"
+"upgrader/+bug/2107657)"
+msgstr ""
+
+#: ../../25.04/index.md:28 9c6480393bde45a1a66052b9c07deda4
+msgid ""
+"As a result, upgrades to Ubuntu 25.04 have been temporarily suspended "
+"while these issues are being addressed."
+msgstr ""
+
+#: ../../25.04/index.md:30 f493275e36b642f49d2f7a8440256fb9
+msgid ""
+"The necessary updates are already in the pipeline, and we expect to re-"
+"enable upgrades very soon. Thank you for your patience."
+msgstr ""
+
+#: ../../25.04/index.md:33 3c38187c3beb4fa782137227a8dc0b91
+msgid "Support lifespan"
+msgstr ""
+
+#: ../../25.04/index.md:35 5676dea6bbeb410787360ff568963884
+msgid ""
+"Ubuntu 25.04 will be supported for 9 months until January 2026. If you "
+"need long term support, we recommend you use [Ubuntu 24.04.2 "
+"LTS](https://ubuntu.com/download) which is supported until at least 2029."
+msgstr ""
+
+#: ../../25.04/index.md:39 207ef0974d4741e0893d9b3794311e6f
+msgid ""
+"Upgrades to to Ubuntu 25.04 will refresh seeded snaps to the appropriate "
+"snap channels, regardless of what was being tracked before. Snaps that "
+"are newly-seeded will be installed during the upgrade. In particular, the"
+" following snaps will be installed or refreshed on upgrade:"
+msgstr ""
+
+#: ../../25.04/index.md:41 e3918a4474244f1bb08178d93a1f1db7
+msgid "Early upgrades may wish to perform these updates manually."
+msgstr ""
+
+#: ../../25.04/index.md:44 472e66c2c7af431c931c39c59c6bca23
+msgid "New features in 25.04"
+msgstr ""
+
+#: ../../25.04/index.md:46 dcf961fbc95a466eb4c045f264c000df
+msgid "Updated Packages"
+msgstr ""
+
+#: ../../25.04/index.md:48 7f06b22e0da94fd891f8356886eeb73e
+msgid "Linux kernel 6.14🐧"
+msgstr ""
+
+#: ../../25.04/index.md:50 96ea9ae6cd6f439091fb189ffd1a7eb2
+msgid ""
+"This release delivers the latest Linux kernel, following Canonical’s new "
+"policy. Kernel developers can now make use of a [new scheduling "
+"system](https://canonical.com/blog/crafting-new-linux-schedulers-with-"
+"sched-ext-rust-and-ubuntu), \"sched_ext\", which provides a mechanism to "
+"implement scheduling policies as eBPF programs. This enables developers "
+"to defer scheduling decisions to standard user-space programs and "
+"implement fully functional hot-swappable Linux schedulers, using any "
+"language, tool, library, or resource accessible in user-space."
+msgstr ""
+
+#: ../../25.04/index.md:52 230dc0d652134d138084633f9218a236
+msgid ""
+"A new NTSYNC driver that emulates WinNT sync primitives is also "
+"available, delivering better performance potential for Windows games "
+"running on Wine and Proton (Steam Play)."
+msgstr ""
+
+#: ../../25.04/index.md:54 5dfcff3755054bbe81f78e4c55ae401b
+msgid ""
+"The \"bpftools\" and linux-perf tools have been decoupled from the kernel"
+" version, making dependency management easier for developers working with"
+" containers. These tools are now shipped in their own packages."
+msgstr ""
+
+#: ../../25.04/index.md:56 7363a4a88e20451f9fc3338638a2cdd8
+msgid ""
+"Other features can be found in the [Linux 6.14 "
+"upstream](https://kernelnewbies.org/Linux_6.14) changelog."
+msgstr ""
+
+#: ../../25.04/index.md:58 bd5385266e774646922f4ca36e129d41
+msgid ""
+"After the generic kernel grew the ability to [tune responsiveness at boot"
+" time](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2051342), the"
+" linux-lowlatency binary package has been retired in favour of a "
+"combination of linux-generic and a new userspace `lowlatency-kernel` "
+"package, responsible of tuning the grub cmdline."
+msgstr ""
+
+#: ../../25.04/index.md:60 e6585983260d433d9a16f3e6c3a9ede0
+msgid "systemd v257.4"
+msgstr ""
+
+#: ../../25.04/index.md:62 4165f8fbf071409ead6e3fbaeaccd469
+msgid ""
+"The init system was updated to systemd v257.4. See the [upstream "
+"changelog ](https://github.com/systemd/systemd/releases/tag/v257) for "
+"more information about individual features. To highlight a few things:"
+msgstr ""
+
+#: ../../25.04/index.md:64 6801f11f75434d2bbede72d8441e4e5c
+msgid ""
+"In Ubuntu, systemd is no longer built with utmp support. Among other "
+"things, this means that systemd's default "
+"`/usr/lib/tmpfiles.d/systemd.conf` no longer creates `/run/utmp`. There "
+"is currently this known bug ([LP: "
+"#2103489](https://launchpad.net/bugs/2103489)) in Ubuntu 25.04, that "
+"prevents 'who' from properly working and requires a coreutils rebuild."
+msgstr ""
+
+#: ../../25.04/index.md:67 08148e8ed1c54093a2c77f6c4b762a96
+msgid ""
+"The complete removal of support for cgroup v1 ('legacy' and 'hybrid' "
+"hierarchies) is scheduled for v258."
+msgstr ""
+
+#: ../../25.04/index.md:70 b65cce2abeda46e8a90d44bfc9434c73
+msgid ""
+"Support for System V service scripts is deprecated and will be removed in"
+" v258. Please make sure to update your software *now* to include a native"
+" systemd unit file instead of a legacy System V script to retain "
+"compatibility with future systemd releases."
+msgstr ""
+
+#: ../../25.04/index.md:75 a5096d1a826c4311af4ea3a37f41090b
+msgid "Netplan v1.1.2 🌐"
+msgstr ""
+
+#: ../../25.04/index.md:76 a987754921314e5ba86f004d025bc23b
+msgid ""
+"Adding support for **wpa-psk-sha256** WiFis and allowing to configure "
+"**routing-policy** on the NetworkManager backend (LP: "
+"[#2086544](https://launchpad.net/bugs/2086544)). Additionally, the "
+"version shipped in Ubuntu enables [new "
+"functionality](https://github.com/systemd/systemd/pull/34640) in "
+"**systemd-networkd-wait-online** to wait for DNS servers to be configured"
+" and reachable, before [considering an interface to be "
+"online](https://discourse.ubuntu.com/t/spec-definition-of-an-online-"
+"system/27838)."
+msgstr ""
+
+#: ../../25.04/index.md:78 cf6a165dbe8743afb260270029e3b408
+msgid "Toolchain Upgrades 🛠️"
+msgstr ""
+
+#: ../../25.04/index.md:80 48567963a09a41fb9a2ea69d60397bf3
+msgid ""
+"GCC 🐄 a snapshot of the upcoming GCC 15, binutils updated to 2.44, and "
+"glibc to 2.41."
+msgstr ""
+
+#: ../../25.04/index.md:81 80f04b1d31f74e74a542f85070fc5c22
+msgid "Python 🐍 is updated to 3.13.3"
+msgstr ""
+
+#: ../../25.04/index.md:82 8ea89ad6137946869afe69bd1cd863b4
+msgid "LLVM 🐉 now defaults to version 20"
+msgstr ""
+
+#: ../../25.04/index.md:83 e5246ccea6be4b63b39a0c2fb43c9c3d
+msgid "Rust 🦀 toolchain defaults to version 1.84"
+msgstr ""
+
+#: ../../25.04/index.md:84 6c2faf661c86416498439eadbd9c1f0c
+msgid "Golang 🐀 is updated to 1.24"
+msgstr ""
+
+#: ../../25.04/index.md:85 f40a9fead34c4ff19601617b903eca33
+msgid "OpenJDK ☕ versions 24 GA and 25 early access snapshot are now available"
+msgstr ""
+
+#: ../../25.04/index.md:87 43a73d19072e44e1858a884588954ece
+msgid "OpenJDK"
+msgstr ""
+
+#: ../../25.04/index.md:89 d50daf5b87f64dfdb9f3660a9bda49b9
+msgid ""
+"OpenJDK 21 is still the default. OpenJDK 24 is included as an optional "
+"OpenJDK. An early access snapshot of OpenJDK 25 is also included. Support"
+" for OpenJDK LTS versions 17, 11 and 8 is being maintained. OpenJDK with "
+"CRaC versions 17 and 21 also continue to be supported."
+msgstr ""
+
+#: ../../25.04/index.md:91 f6cd084c9afe4edab2d3b178bf4222fc
+msgid ""
+"We are excited to announce the [devpack-for-spring](https://snapcraft.io"
+"/devpack-for-spring) snap and a set of Spring® [content "
+"snaps](https://snapcraft.io/devpack-for-spring-manifest) that will serve "
+"as development tools for Spring® projects. Developers can now quickly "
+"build Ubuntu ROCK images for their Java applications using the [Gradle "
+"and Maven plugins for Rockcraft](https://github.com/rockcrafters/java-"
+"rockcraft-plugins)."
+msgstr ""
+
+#: ../../25.04/index.md:93 dc1fc8a6a0af4dbfb16c7e956df67dac
+msgid ""
+"Additionally, GraalVM Community Edition for JDK versions 21, 24 and 25ea "
+"is now available as a [snap](https://snapcraft.io/graalvm-jdk). Java "
+"developers now have a choice to build and deploy their applications with "
+"standard OpenJDK, with OpenJDK-CRaC or as a GraalVM native image."
+msgstr ""
+
+#: ../../25.04/index.md:95 8ddd67afb53948949cabe8f1573e3fc8
+msgid ".NET"
+msgstr ""
+
+#: ../../25.04/index.md:97 f662c092f6b644eea838fcead4b4f937
+msgid ".NET versions 8 and 9 continue to be supported."
+msgstr ""
+
+#: ../../25.04/index.md:99 d00bfeb47348451eb2f12946edb9d7a2
+msgid ""
+"The [dotnet](https://snapcraft.io/dotnet) snap is updated to include .NET"
+" version 9. The [powershell-preview](https://snapcraft.io/powershell-"
+"preview) snap has been updated to build from source."
+msgstr ""
+
+#: ../../25.04/index.md:101 2acdc271ea73468cbee5e8241aed27ec
+msgid "Default configuration changes ⚙️"
+msgstr ""
+
+#: ../../25.04/index.md:103 49181997f0e349f69a7cbaafb03161ed
+msgid "AppArmor profiles"
+msgstr ""
+
+#: ../../25.04/index.md:105 466b0027fd80402f854bed851adb41f7
+msgid "AppArmor profile writing effort"
+msgstr ""
+
+#: ../../25.04/index.md:107 c6d1331ce5de492a9355564275c72070
+msgid ""
+"As part of a profile writing effort to improve overall system security, "
+"the AppArmor package now includes many new profiles for applications. "
+"This improved sandboxing can help mitigate the impact of any exploit in "
+"the confined applications. However, these profiles may cause breakage for"
+" unanticipated uses of those applications, and we encourage users to file"
+" a bug on "
+"[Launchpad](https://bugs.launchpad.net/ubuntu/+source/apparmor/+filebug) "
+"for AppArmor-induced breakage in common use cases. When AppArmor denies "
+"an action, it usually generates a log entry describing the denial, which "
+"will help us investigate the bug, but which can also be used to add "
+"additional rules for customization or to work around the denials. "
+"AppArmor log entries can be read in the auditd logs, if auditd is "
+"installed, or in the `syslog` otherwise. [This "
+"page](https://gitlab.com/apparmor/apparmor/-/wikis/denial_quick_guide) "
+"describes how the information contained in the denial log can be used to "
+"update a local override."
+msgstr ""
+
+#: ../../25.04/index.md:109 440f951a380d4b5bbf4ab8a242d8d607
+msgid "AppArmor profile for `bwrap`"
+msgstr ""
+
+#: ../../25.04/index.md:111 fdd3c014df9f4b7fb0095107ca24b6f9
+msgid ""
+"AppArmor now comes with a `bwrap` profile (`bwrap-userns-restrict`) that "
+"allows it to create user namespaces and set up sandboxing, before "
+"transitioning to a tighter profile that denies capabilities for the "
+"processes running inside the `bwrap` sandbox. The addition of this "
+"profile should unblock more use cases for `bwrap` while allowing a "
+"reduction in the kernel attack surface opened up by unprivileged user "
+"namespaces. However, this profile still restricts unprivileged userns "
+"creation and capability usage even when `bwrap` (and its sandboxed "
+"application) are run as a privileged user, so such use cases may not be "
+"fully supported yet."
+msgstr ""
+
+#: ../../25.04/index.md:113 20991d54a24f41b7bf8566ef7f62dc86
+msgid "AppArmor profile removals"
+msgstr ""
+
+#: ../../25.04/index.md:115 0f982561eb184fa7ba48c93cf6ec591a
+msgid ""
+"As part of [hardening improvements around AppArmor user namespace "
+"mediation](https://discourse.ubuntu.com/t/understanding-apparmor-user-"
+"namespace-restriction/58007), profiles for busybox and nautilus that "
+"directly allowed them access to user namespaces have been removed. As a "
+"result, the busybox unshare function can no longer be used to create "
+"unprivileged user namespaces. Nautilus' use of user namespaces should "
+"still work due to the new `bwrap-users-restrict` profile, but regressions"
+" are possible if there are bugs in the `bwrap` profile."
+msgstr ""
+
+#: ../../25.04/index.md:117 9f7567ee435746b4a2be6f999b0767ac
+msgid "tzdata"
+msgstr ""
+
+#: ../../25.04/index.md:119 bb23f193d73d41f39ef22f616afa5e51
+msgid ""
+"Previously, the tzdata package in Ubuntu used the `/etc/timezone` file to"
+" configure the system's timezone. This method is not supported by systemd"
+" and certain desktop environments, which instead only change the "
+"`/etc/localtime` symlink to point to a file in `/usr/share/zoneinfo`."
+msgstr ""
+
+#: ../../25.04/index.md:121 61049d1c5ed44034851f8b6345da24f5
+msgid ""
+"For this reason, starting with version 2024b-5, the tzdata package no "
+"longer automatically creates the `/etc/timezone` file, but still updates "
+"it if it exists. In the next Ubuntu 25.10 release, the `/etc/timezone` "
+"file will be automatically removed and support for it in the maintainer "
+"scripts will be completely dropped."
+msgstr ""
+
+#: ../../25.04/index.md:123 ../../25.04/index.md:824
+#: 0679106dc5654bb4af51002c9e03d935 820d53fcf36c4917b1711bb0ba2afe21
+msgid "Ubuntu Desktop"
+msgstr ""
+
+#: ../../25.04/index.md:125 fc14952fdee345639b552dc07d7c1315
+msgid "New ARM64 Desktop Image"
+msgstr ""
+
+#: ../../25.04/index.md:126 3a0546e2c6d94e29925a7a3bcfb73e5e
+msgid ""
+"There is now also an official generic arm64 desktop ISO targeting VMs, "
+"ACPI + EFI platforms and Snapdragon based WoA devices."
+msgstr ""
+
+#: ../../25.04/index.md:127 ../../25.04/index.md:720
+#: 23e2fc4bc7d74f7aae347307f81a8e05 d1609cd6dbf949bb8dddabc979f40941
+msgid ""
+"Initial hardware enablement work for the Snapdragon X Elite platform is "
+"included in the desktop ISO"
+msgstr ""
+
+#: ../../25.04/index.md:129 3b2f1595ef114ba0806f3085b23a84a8
+msgid "Installer and Upgrades"
+msgstr ""
+
+#: ../../25.04/index.md:131 b068889fdb7a42b2bfc28dfa37b27d71
+msgid "Added the option to replace an existing Ubuntu installation"
+msgstr ""
+
+#: ../../25.04/index.md:132 e86046f482584891a774352690e7fcb0
+msgid ""
+"Improved dual boot UX (with a focus on BitLocker protected Windows "
+"systems):"
+msgstr ""
+
+#: ../../25.04/index.md:133 2b3c052439334fd3bfb6669953dde951
+msgid ""
+"Added the option to install Ubuntu alongside existing BitLocker "
+"partitions if enough unallocated  space (or a sufficiently large and "
+"resizable partition) is available"
+msgstr ""
+
+#: ../../25.04/index.md:134 ff33a3eb68d14a0486a7e8cf19e31042
+msgid ""
+"Made encrypted installations and other 'advanced options' available for "
+"dual boot scenarios"
+msgstr ""
+
+#: ../../25.04/index.md:136 056074b5564746cdbcc10de09a415a17
+msgid "Enterprise"
+msgstr ""
+
+#: ../../25.04/index.md:138 c3279efea5134fdfbd7799d215f7ca99
+msgid ""
+"[authd](https://github.com/ubuntu/authd): Ubuntu's cloud authentication "
+"solution:"
+msgstr ""
+
+#: ../../25.04/index.md:139 b4e781e9156844f1a8124e20b64a433b
+msgid "Many fixes and improvements to the EntraID provider"
+msgstr ""
+
+#: ../../25.04/index.md:140 179c7b145b374d1bb1d29511243153f1
+msgid "New Google provider"
+msgstr ""
+
+#: ../../25.04/index.md:141 e5f7d343086b4f5c9397512878a46ab0
+msgid ""
+"New [authd "
+"documentation](https://documentation.ubuntu.com/authd/en/stable/)"
+msgstr ""
+
+#: ../../25.04/index.md:143 2f62f075e84b49489e5383e8835fbfe7
+msgid ""
+"New [ADSys Release](https://github.com/ubuntu/adsys): the Active "
+"Directory Group Policy client for Ubuntu, supports the latest Polkit and "
+"comes with improvements and bug fixes to certificates enrolment."
+msgstr ""
+
+#: ../../25.04/index.md:145 6527d99975754f578d222059dbebf00a
+msgid "GNOME 👣"
+msgstr ""
+
+#: ../../25.04/index.md:147 f0d29aadd6774ca58cc0e2a8ba505350
+msgid ""
+"GNOME has been updated to include new features and fixes from the latest "
+"GNOME release, [GNOME 48](https://release.gnome.org/48/)"
+msgstr ""
+
+#: ../../25.04/index.md:148 986c5b655492486187174c9f89960463
+msgid ""
+"GNOME 48 now includes the [triple "
+"buffering](https://discourse.ubuntu.com/t/triple-"
+"buffering-a-debrief/56314) feature from Ubuntu"
+msgstr ""
+
+#: ../../25.04/index.md:150 c1cdb8c6350b4a0bb2a49013799cb3fe
+msgid "Default app changes"
+msgstr ""
+
+#: ../../25.04/index.md:152 6da2fbc191934554b87d5c12d9b32494
+msgid ""
+"The **Document Viewer** app for viewing PDFs is now provided by Papers "
+"instead of Evince. Papers started with the Evince codebase but it has "
+"been updated to use GTK4 and partially rewritten in Rust."
+msgstr ""
+
+#: ../../25.04/index.md:153 7dd578038d5c4aac8724abfcd81eca3b
+msgid ""
+"**`xdg-terminal-exec`** is installed by default making it easier to "
+"switch a user's default terminal for the Ctrl+Alt+T keyboard shortcut and"
+" for opening terminal apps ([LP: "
+"#2107326](https://launchpad.net/bugs/2107326))"
+msgstr ""
+
+#: ../../25.04/index.md:154 a40a8e5b42e945d4be76e9baaf907cee
+msgid ""
+"**Geolocation** services are now backed by "
+"[BeaconDB](https://beacondb.net/) after Mozilla Location Services was "
+"retired last year"
+msgstr ""
+
+#: ../../25.04/index.md:155 5a7b137c5f114dcb86dc225ad8804e04
+msgid ""
+"The **JPEG XL** format is now supported without needing to install any "
+"additional packages"
+msgstr ""
+
+#: ../../25.04/index.md:157 21f9a33731304ba89f9320884ede0ccd
+msgid "Updated Applications"
+msgstr ""
+
+#: ../../25.04/index.md:159 b0ae4e141841492894c245d8f2e78d8d
+msgid "[Firefox](https://mozilla.org/firefox/releases/) 137 🔥🦊"
+msgstr ""
+
+#: ../../25.04/index.md:160 546b09ed6a3a4c50a739fb3adc512a50
+msgid ""
+"[LibreOffice 25.2](https://wiki.documentfoundation.org/ReleaseNotes/25.2)"
+" 📚"
+msgstr ""
+
+#: ../../25.04/index.md:161 f2f344d404fa43309c5c350b8ebce965
+msgid ""
+"[Thunderbird 128 \"Supernova\"](https://blog.thunderbird.net/2023/07/our-"
+"fastest-most-beautiful-release-ever-thunderbird-XY-supernova-is-here/) "
+"🌩️🐦"
+msgstr ""
+
+#: ../../25.04/index.md:162 0c3a158f2fbf43e7bb9d9604934f6106
+msgid ""
+"[GNU Image Manipulation Program "
+"3.0](https://www.gimp.org/news/2025/03/16/gimp-3-0-released/) 🖼️ is "
+"available for install"
+msgstr ""
+
+#: ../../25.04/index.md:163 edd217ad06b44f6d9eb1e8ca13f06921
+msgid ""
+"The `fish` shell has always been known for its smart and user-friendly "
+"interface, making command-line interactions more intuitive and efficient."
+" With the release of version 4, `fish` has undergone a significant "
+"transformation, rewritten entirely in Rust."
+msgstr ""
+
+#: ../../25.04/index.md:165 7437ec13f810404d94465beec0d0ba08
+msgid ""
+"This change brings a on one side the values of the ecosystem like "
+"enhanced performance and improved stability, while on the other side is "
+"not compromising on the feature set. The upstream community had a great "
+"[blog about the rust port](https://fishshell.com/blog/rustport/), which "
+"we recommend reading if you are curious."
+msgstr ""
+
+#: ../../25.04/index.md:167 4e79f5371945409ca8be27dd98458cbb
+msgid ""
+"As shells go, this is about your taste and preferences: if you have not "
+"been trying [fish](https://fishshell.com/) before, consider to try it out"
+" now and experience its features for yourself."
+msgstr ""
+
+#: ../../25.04/index.md:169 0fdb0da1720d4cfabd87494e0a6722de
+msgid "Updated Subsystems"
+msgstr ""
+
+#: ../../25.04/index.md:171 18f69301e76b4ea9ba233ef5b5e931f6
+msgid ""
+"[BlueZ "
+"5.79](https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/ChangeLog?id=5.79)"
+" 💙"
+msgstr ""
+
+#: ../../25.04/index.md:172 61a91fdab9cd4b2588eeb5141c33e6ac
+msgid "[Cairo 1.18.4](https://cairographics.org/news/cairo-1.18.4/) 🐫"
+msgstr ""
+
+#: ../../25.04/index.md:173 fa8f88588bde495baf722a217211bc90
+msgid ""
+"[NetworkManager "
+"1.52](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/nm-1-52/NEWS)"
+" 🖧"
+msgstr ""
+
+#: ../../25.04/index.md:174 8582926e1a1c4d7195266e1fea5a701c
+msgid ""
+"[Pipewire "
+"1.2.7](https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/1.2.7/NEWS)"
+" 🔊"
+msgstr ""
+
+#: ../../25.04/index.md:175 219b03d842874690bdf7cb364e9e451b
+msgid ""
+"[Poppler "
+"25.03](https://gitlab.freedesktop.org/poppler/poppler/-/blob/poppler-25.03.0/NEWS)"
+" 📝"
+msgstr ""
+
+#: ../../25.04/index.md:176 096dc8b0a780462dad5c9081c5dd6955
+msgid ""
+"[xdg-desktop-portal 1.20](https://github.com/flatpak/xdg-desktop-"
+"portal/blob/1.20.0/NEWS.md) ⛩️"
+msgstr ""
+
+#: ../../25.04/index.md:177 fbead2c197264c559e91764a9119570c
+msgid "[Nvidia 570](https://www.nvidia.com/en-us/drivers/details/242273/) 👁️"
+msgstr ""
+
+#: ../../25.04/index.md:178 b593d9bba4624852b754b5464ae30b83
+msgid ""
+"The `libva` library is now available in the *Main* repository component. "
+"The library implements VA-API (Video Acceleration API) for hardware video"
+" decoding and encoding. Applications can now use VA-API out of box. "
+"Notably, you can record your screen at the original screen rate. Without "
+"VA-API, your screen recording has a reduced frame rate because it's "
+"limited by the CPU. To use VA-API, enable third-party drivers during "
+"Ubuntu installation. You can also install the library after installation:"
+msgstr ""
+
+#: ../../25.04/index.md:184 ce37f4b7a3604de4b998d24a556a4bad
+msgid "Gaming"
+msgstr ""
+
+#: ../../25.04/index.md:185 6ebf624c38f345c3bb6ac5c1f5a1fd27
+msgid "NVIDIA Dynamic Boost"
+msgstr ""
+
+#: ../../25.04/index.md:186 f399d4141fb9414c85f66283fb0449a7
+msgid ""
+"This release enabled NVIDIA Dynamic Boost by default on supported laptops"
+" with NVIDIA GPUs."
+msgstr ""
+
+#: ../../25.04/index.md:188 15444471ca744382a613682d1881e3df
+msgid ""
+"NVIDIA Dynamic Boost is a feature of the NVIDIA drivers that dynamically "
+"shifts power between CPU and GPU depending on the workload on the system."
+" While gaming, this allows extracting more performance by granting more "
+"power to the GPU."
+msgstr ""
+
+#: ../../25.04/index.md:190 aff876b3b5554f68a41b61d57aa9975e
+msgid ""
+"Dynamic Boost will be active only when the laptop is powered by AC and "
+"there is enough load on the GPU. It will not be engaged when the system "
+"is running on battery."
+msgstr ""
+
+#: ../../25.04/index.md:192 d3ea3bc16124410a81bf44479775cfd8
+msgid ""
+"For more details refer to [NVIDIA's "
+"documentation](https://download.nvidia.com/XFree86/Linux-x86_64/570.133.07/README/dynamicboost.html)."
+msgstr ""
+
+#: ../../25.04/index.md:194 77e7ac2d5b7f47a6b5d0f7cfa442e1b1
+msgid "Support for new Intel® integrated and discrete GPUS"
+msgstr ""
+
+#: ../../25.04/index.md:195 0448aa99d67943fd94bd45454d4fbe3c
+msgid ""
+"This release brings full support for Intel® Core™ Ultra Xe2 integrated "
+"Intel® Arc™ graphics, and Intel® Arc™ B580 and B570 “Battlemage” discrete"
+" GPUs.  Moreover, the following features are also included:"
+msgstr ""
+
+#: ../../25.04/index.md:197 662c82faf7674972ae5f3e2a628d06ea
+msgid ""
+"Improved GPU and CPU ray tracing rendering performance in applications "
+"with Intel Embree support, such as Blender (v4.2+). Ray tracing hardware "
+"acceleration on the GPU improves frame rendering by 20-30%, due to a 2-4x"
+" speed-up for the ray tracing component."
+msgstr ""
+
+#: ../../25.04/index.md:198 8ed6dfa911da4392993e371ba44b990a
+msgid ""
+"Full hardware accelerated video encoding of AVC, JPEG, HEVC, and AV1 on "
+"“Battlemage” devices."
+msgstr ""
+
+#: ../../25.04/index.md:199 8d156cb1e71a403792075059b279bfaa
+msgid "Introduction of the new CCS optimization in Intel® Compute Runtime."
+msgstr ""
+
+#: ../../25.04/index.md:200 007a7d6e7a59456fbbe2fdbad8392464
+msgid "Enable debugging support for Intel Xe GPUs."
+msgstr ""
+
+#: ../../25.04/index.md:201 863c80bec9f847a3a9a4a462e1e897a9
+msgid ""
+"oneAPI Level Zero Ray Tracing improves AI/ML workload speeds via Embree "
+"on SYCL"
+msgstr ""
+
+#: ../../25.04/index.md:203 f31e9ea41d7d4e2696cead5715d52dd1
+msgid "Ubuntu Foundations"
+msgstr ""
+
+#: ../../25.04/index.md:205 fb9ead0beaf949ab9a992a400fdaacaf
+msgid "Cryptography"
+msgstr ""
+
+#: ../../25.04/index.md:207 129c8cfdfd6f414ab63e4d577eb2ad2a
+msgid "Libraries"
+msgstr ""
+
+#: ../../25.04/index.md:208 1a9ce2278b524e609d425997ee5936e8
+msgid ""
+"OpenSSL has been updated to "
+"[3.4.1](https://github.com/openssl/openssl/blob/openssl-3.4.0/NEWS.md) "
+"and GnuTLS has been updated to "
+"[3.8.9](https://gitlab.com/gnutls/gnutls/-/blob/master/NEWS). In "
+"addition, patches from their git stable branches have been added in order"
+" to include as many fixes as possible starting with release day."
+msgstr ""
+
+#: ../../25.04/index.md:211 e3f8bdf83dbb4aae9180cc78e7411efa
+msgid "Package Management: APT 3.0"
+msgstr ""
+
+#: ../../25.04/index.md:213 01587cff54e047049279bfbdaf18d66d
+msgid "APT has been updated to 3.0."
+msgstr ""
+
+#: ../../25.04/index.md:215 6aaf996e25dd4e958b5f379ce3c53588
+msgid ""
+"The new dependency solver is now automatically used if the classic solver"
+" cannot find a solution to either find a solution or add more context to "
+"the failure, and in other cases to [evaluate its "
+"performance](https://discourse.ubuntu.com/t/evaluating-the-new-apt-"
+"solver-in-25-04/55618)."
+msgstr ""
+
+#: ../../25.04/index.md:217 f6e0dc08fd8a475f986ab7ef456a477e
+msgid ""
+"APT has switched from GnuTLS and gcrypt to the OpenSSL library for TLS "
+"connections and file hashing, which should improve compatibility and "
+"reduces the footprint of minimal installations."
+msgstr ""
+
+#: ../../25.04/index.md:219 35aee7e315b3464f8a2c09bf9e367bd4
+msgid ""
+"An automatic pager has been added to `apt(8)` for commands such as show "
+"and list, similar to `git log` and `journalctl`."
+msgstr ""
+
+#: ../../25.04/index.md:221 9089a4ae0f8c473a9168232b6be509f5
+msgid ""
+"The `apt-key` command has been removed. Signature verification now makes "
+"direct use of `gpgv`. Some packages and system administration scripts may"
+" need adjustment for managing keys directly, advice can be found in the "
+"`apt-secure(8)` manual page."
+msgstr ""
+
+#: ../../25.04/index.md:223 ../../25.04/index.md:840
+#: b60fdab15cf748ae8d52134f73b9a500 e7ec6fb17bde4e8289566fc4d7d29e6b
+msgid "Ubuntu Server"
+msgstr ""
+
+#: ../../25.04/index.md:225 75be05c5f0b14320bf0827d2644c01aa
+msgid "Apache2"
+msgstr ""
+
+#: ../../25.04/index.md:227 0cb771108957492d82a5d370fb0bade7
+msgid "mod_md: update to version 2.4.31"
+msgstr ""
+
+#: ../../25.04/index.md:228 e169089a8ece42b591eb94091fa80c8e
+msgid "Improved behavior waiting for ACME server to verify domains."
+msgstr ""
+
+#: ../../25.04/index.md:229 4d9e3e3dc5b84ee6aba7ebb20460f89b
+msgid ""
+"Fix certificate retrieval on ACME renewal to not require a 'Location:' "
+"header returned by the ACME CA. This was the way it was done in ACME "
+"before it became an IETF standard. Let's Encrypt still supports this, but"
+" other CAs do not."
+msgstr ""
+
+#: ../../25.04/index.md:230 4444472dd2da4f2c991669a21977cc0e
+msgid ""
+"When the server starts, it looks for new, staged certificates to "
+"activate. If the staged set of files in `md/staging/<domain>` is messed "
+"up, this could prevent further renewals to happen. Now, when the staging "
+"set is present, but could not be activated due to an error, purge the "
+"whole directory."
+msgstr ""
+
+#: ../../25.04/index.md:231 ca0a9dc5250c4151afb7208b489e87a8
+msgid "Restore compatibility with OpenSSL < 1.1."
+msgstr ""
+
+#: ../../25.04/index.md:232 b1badaa5654d42b9a002d0ac7acf153f
+msgid ""
+"Add the ldap-search option to mod_authnz_ldap, allowing authorization to "
+"be based on arbitrary expressions that do not include the username."
+msgstr ""
+
+#: ../../25.04/index.md:233 4d848bbc40434a62b3709a6e71db6d1c
+msgid ""
+"mod_ssl: Restore support for loading PKCS#11 keys via ENGINE without "
+"\"SSLCryptoDevice\" configured."
+msgstr ""
+
+#: ../../25.04/index.md:234 cb567750265b45fab3a814efcf4b84f7
+msgid ""
+"http: Remove support for Request-Range header sent by Navigator 2-3 and "
+"MSIE 3."
+msgstr ""
+
+#: ../../25.04/index.md:235 0de0612ed0e24c9bb8b64be5f927a02a
+msgid ""
+"mod_rewrite: Don't require [UNC] flag to preserve a leading // added by "
+"applying the perdir prefix to the substitution."
+msgstr ""
+
+#: ../../25.04/index.md:236 b98d91a0c98a46e2ab6835045ad0221b
+msgid ""
+"mod_proxy: Avoid AH01059 parsing error for SetHandler \"unix:\" URLs in "
+"`<Location>` (incomplete fix in 2.4.62)."
+msgstr ""
+
+#: ../../25.04/index.md:237 81dada6880b14599a3bc1bf13d43d5a8
+msgid ""
+"mod_tls: removed the experimental module. It now is available standalone "
+"from https://github.com/icing/mod_tls. The rustls provided API is not "
+"stable and does not align with the httpd release cycle."
+msgstr ""
+
+#: ../../25.04/index.md:238 a33a6317069343a89010a693eff02ede
+msgid "mod_rewrite: Better question mark tracking to avoid UnsafeAllow3F."
+msgstr ""
+
+#: ../../25.04/index.md:239 a3175a449f9a4d09ac6464210a902fc5
+msgid ""
+"mod_http2: Return connection monitoring to the event MPM when blocking on"
+" client updates."
+msgstr ""
+
+#: ../../25.04/index.md:241 5dc42ab176444805bb3e536b3d2ee30c
+msgid "Clamav"
+msgstr ""
+
+#: ../../25.04/index.md:243 54c638bec9454d7b93a855d0f4fa254a
+msgid ""
+"ClamAV was updated from 1.3 in Ubuntu 24.10, to version 1.4.2 in 25.04. "
+"This brings a number of fixes, along with the following noteworthy "
+"changes from the Clamav 1.4.0 feature release:"
+msgstr ""
+
+#: ../../25.04/index.md:247 7071cfc247e6432d980827dfc181ec36
+msgid ""
+"Added support for extracting ALZ archives. The new ClamAV file type for "
+"ALZ archives is CL_TYPE_ALZ. Added a DCONF (Dynamic CONFiguration) option"
+" to enable or disable ALZ archive support, via ClamAV .cfg "
+"\"signatures\"."
+msgstr ""
+
+#: ../../25.04/index.md:248 684e9c8079db4f4db34954bd64d39619
+msgid ""
+"Added support for extracting LHA/LZH archives. The new ClamAV file type "
+"for LHA/LZH archives is CL_TYPE_LHA_LZH. Added a DCONF option to enable "
+"or disable LHA/LZH archive support."
+msgstr ""
+
+#: ../../25.04/index.md:249 c6163730436f496f8f14932a6992dc22
+msgid ""
+"Added the ability to disable image fuzzy hashing, if needed. For context,"
+" image fuzzy hashing is a detection mechanism useful for identifying "
+"malware by matching images included with the malware or phishing "
+"email/document."
+msgstr ""
+
+#: ../../25.04/index.md:250 0996cae6821d42e0ab7eb88a7e65759b
+msgid "Added a DCONF option to enable or disable image fuzzy hashing support."
+msgstr ""
+
+#: ../../25.04/index.md:251 fa92367ea82247a3bee2198baa20c049
+msgid "Fixed an unaligned pointer dereference issue on select architectures."
+msgstr ""
+
+#: ../../25.04/index.md:253 28a71a842eb3499394219eebb5004f77
+msgid ""
+"For complete details of all changes leading up to 1.4.2, please see the "
+"upstream release notes at:  https://blog.clamav.net/"
+msgstr ""
+
+#: ../../25.04/index.md:256 c31f09dd7532498ca695aa939d181682
+msgid "Chrony"
+msgstr ""
+
+#: ../../25.04/index.md:258 f85dbfb0c4a84ee4b0514b2ce2dba784
+msgid ""
+"Starting with version [4.5-3ubuntu4]( "
+"https://launchpad.net/ubuntu/+source/chrony/4.5-3ubuntu4), chrony will "
+"ship with a default configuration set to use Ubuntu NTS servers by "
+"default."
+msgstr ""
+
+#: ../../25.04/index.md:260 b5e04915f6b64409810add093368a074
+msgid "The two main changes are:"
+msgstr ""
+
+#: ../../25.04/index.md:262 91ac65fd025d42fabeeb041c8c4805ba
+msgid ""
+"NTS/KE uses a separate port (4460/tcp) to negotiate security parameters, "
+"which are then used via the normal NTP port (123/udp). This is a new "
+"deployment, running on different IP addresses than the service without "
+"NTS."
+msgstr ""
+
+#: ../../25.04/index.md:264 0495425240954eaeade4cc0402db8797
+msgid ""
+"A new CA is installed in `/etc/chrony/nts-bootstrap-ubuntu.crt` that is "
+"used specifically for the Ubuntu NTS bootstrap server, needed for when "
+"the clock is too far off. This is added to certificate set ID \"1\", and "
+"defined via `/etc/chrony/conf.d/ubuntu-nts.conf`. There is also a staging"
+" CA shipped with the package, but it's not referred to anywhere and is "
+"just there as a convenience for testing the staging servers."
+msgstr ""
+
+#: ../../25.04/index.md:266 1d23560021d4493b8bf970a7fe8e1d7d
+msgid ""
+"If your network does not allow access to the Ubuntu NTS servers and the "
+"required ports, and the new configuration is in place, chrony will not be"
+" able to adjust this system's clock. To revert to NTP, just edit the "
+"configuration file in `/etc/chrony/sources.d/ubuntu-ntp-pools.sources` "
+"and revert to using the listed NTP servers in favor of the NTS ones. Or "
+"revert to your previous copy of that configuration file."
+msgstr ""
+
+#: ../../25.04/index.md:268 13460dd92e9643729eef8ea186679d38
+msgid ""
+"For other changes introduced in version 4.6.1, please refer to the "
+"[upstream release notes](https://chrony-"
+"project.org/news.html#_8_oct_2024_chrony_4_6_1_released)."
+msgstr ""
+
+#: ../../25.04/index.md:270 7abfcf74b8c34897bad655aafcc7b82a
+msgid "cloud-init v. 25.1.1"
+msgstr ""
+
+#: ../../25.04/index.md:272 16403b01ca0a415a97c676627637d251
+msgid "Notable features beyond v. 24.3 present in Oracular:"
+msgstr ""
+
+#: ../../25.04/index.md:273 9c59fd7578b74018914d29bd3e7968e8
+msgid ""
+"oracle: [add true single stack ipv6 support](https://github.com/canonical"
+"/cloud-init/pull/5785)"
+msgstr ""
+
+#: ../../25.04/index.md:274 f74f8763126c4ecca48e41dba75294ab
+msgid ""
+"networkd: [Support RequiredForOnline option](https://github.com/canonical"
+"/cloud-init/pull/5852)"
+msgstr ""
+
+#: ../../25.04/index.md:275 31aefd097da24704b20fc43adf9f1ed5
+msgid ""
+"smartos: [Add addrconf IPv6 support](https://github.com/canonical/cloud-"
+"init/pull/5831)"
+msgstr ""
+
+#: ../../25.04/index.md:276 5a862b7ee43f4f578d28eebe0707d984
+msgid ""
+"networkd: Conditionally remove networkd online dependency on Ubuntu "
+"(#5772)-"
+msgstr ""
+
+#: ../../25.04/index.md:277 4dea4ddf60394817ba11e43b90402a72
+msgid ""
+"security: [Ensure random passwords contain multiple character "
+"types](https://github.com/canonical/cloud-init/pull/5815)"
+msgstr ""
+
+#: ../../25.04/index.md:278 3954792f9025447abdd8d3c4eff0b4b6
+msgid "Enable new datasource for CloudCIX platform"
+msgstr ""
+
+#: ../../25.04/index.md:279 4476e2164ecb4108a07f465708bb4ba7
+msgid "vmware:"
+msgstr ""
+
+#: ../../25.04/index.md:280 9bdf4fc18caa4dc39a71831f1517f60a
+msgid ""
+"Move DS VMware to be in front of DS OVF "
+"([#5912](https://github.com/canonical/cloud-init/pull/5912))"
+msgstr ""
+
+#: ../../25.04/index.md:281 15d7616915fd4e669026bf8fb31c343c
+msgid ""
+"Convert imc network config to v2 ([#5937](https://github.com/canonical"
+"/cloud-init/pull/5937))"
+msgstr ""
+
+#: ../../25.04/index.md:282 6a11dd4bc57447659b5c34398a6848e3
+msgid ""
+"Identify Samsung Cloud Platform as OpenStack "
+"([#5924](https://github.com/canonical/cloud-init/pull/5924))"
+msgstr ""
+
+#: ../../25.04/index.md:283 d225473c1ac546d982fd4cb0ff9dbe8b
+msgid ""
+"aliyun: support crawl metadata at once "
+"([#5942](https://github.com/canonical/cloud-init/pull/5942)) "
+"[jinkangkang]"
+msgstr ""
+
+#: ../../25.04/index.md:285 42bdbcc8c7294668b6fc836c2afa2845
+msgid ""
+"For the full list of changes, please see the upstream [release "
+"notes](https://github.com/canonical/cloud-init/releases)"
+msgstr ""
+
+#: ../../25.04/index.md:287 ca9306078f3942b3b5dacb7f139423e7
+msgid "Breaking changes:"
+msgstr ""
+
+#: ../../25.04/index.md:288 2bd67297b1ce4808927bba793fa67a30
+msgid ""
+"To avoid installing unnecessary debian package dependencies on all "
+"images, cloud-init debian package now creates separate binaries:"
+msgstr ""
+
+#: ../../25.04/index.md:289 6fcd8e77a014479d9f19f08dca638a7a
+msgid ""
+"`cloud-init-base`: installs all debian package `Depends:` common to all "
+"cloud platforms"
+msgstr ""
+
+#: ../../25.04/index.md:290 a23e51a14c464d91adca088a91ad8175
+msgid ""
+"separate `cloud-init-<cloudname>` metapackage defining cloud-specific "
+"package dependencies for platforms such as CloudSigma, SmartOs."
+msgstr ""
+
+#: ../../25.04/index.md:292 e01fa47265a8437c98b7a93a27db5e84
+msgid ""
+"Seeding the `cloud-init` metapackage in Plucky and later will continue to"
+" install all package dependencies previously provided by the `cloud-init`"
+" package on Noble and Oracular."
+msgstr ""
+
+#: ../../25.04/index.md:296 9baaaec4f01b4210bc13511ceb40d2a8
+msgid "Containerd"
+msgstr ""
+
+#: ../../25.04/index.md:298 8b781fc0196548599501c26481cbdeba
+msgid ""
+"The containerd (src:containerd-app) package was updated to version 2.0.2."
+" Version 2 includes the stabilization of new features added in the last "
+"1.x release as well as the removal of features which were deprecated in "
+"1.x, meaning you should expect breaking changes here."
+msgstr ""
+
+#: ../../25.04/index.md:300 d41748807b194f00859d1d9509a78609
+msgid ""
+"For further details on such changes, please refer to [the upstream "
+"release "
+"notes](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md)."
+msgstr ""
+
+#: ../../25.04/index.md:307 6b1a25ac770c415b876a3dd0c7021187
+msgid "runc"
+msgstr ""
+
+#: ../../25.04/index.md:309 86a2f412f2cf432fa202fb3d50d6351a
+msgid ""
+"runc (src:runc-app) was updated to upstream version 1.2.5. This new "
+"version includes several fixes and changes including"
+msgstr ""
+
+#: ../../25.04/index.md:311 856d09a0a8284f859e6a69a70f041573
+msgid ""
+"When using cgroups v2, allow to set or update memory limit to "
+"\"unlimited\" and swap limit to a specific value."
+msgstr ""
+
+#: ../../25.04/index.md:312 7a729d3b43ed4f64bc35ce6a5f14c005
+msgid ""
+"Mount options on bind-mounts that clear a mount flag are now always "
+"applied. Previously, if a user requested a bind-mount with only clearing "
+"options (such as `rw,exec,dev`) the options would be ignored and the "
+"original bind-mount options would be set."
+msgstr ""
+
+#: ../../25.04/index.md:313 e52e2d6cf17741ef9b3c3f60ba2af6a0
+msgid ""
+"Container configurations using bind-mounts with superblock mount flags "
+"(i.e. filesystem-specific mount flags, referred to as \"data\" in "
+"`mount(2)`, as opposed to VFS generic mount flags like `MS_NODEV`) will "
+"now return an error."
+msgstr ""
+
+#: ../../25.04/index.md:314 4ca45e5412bc4416ba6f4423af17b7fe
+msgid ""
+"Fix CVE-2024-45310, a low-severity attack that allowed maliciously "
+"configured containers to create empty files and directories on the host."
+msgstr ""
+
+#: ../../25.04/index.md:315 07083f9288344358916cbc17ee28962b
+msgid "`runc features` is no longer experimental."
+msgstr ""
+
+#: ../../25.04/index.md:316 a87f9fdc1f994dc9a79e9bbe767e9fe3
+msgid ""
+"`runc` option `--criu` is now ignored (with a warning), and the option "
+"will be removed entirely in a future release."
+msgstr ""
+
+#: ../../25.04/index.md:317 eb8c88cdad8f47229accf410946deb15
+msgid ""
+"`runc kill` option `-a` is now deprecated. Previously, it had to be "
+"specified to kill a container (with SIGKILL) which does not have its own "
+"private PID namespace (so that runc would send SIGKILL to all processes)."
+" Now, this is done automatically."
+msgstr ""
+
+#: ../../25.04/index.md:318 39ef85f6745d408888dc081daea6c96d
+msgid ""
+"runc now supports id-mapped mounts for bind-mounts (with no restrictions "
+"on the mapping used for each mount)."
+msgstr ""
+
+#: ../../25.04/index.md:319 22fb41a19cf3482c93745fe8d1efdd44
+msgid ""
+"runc will now use `cgroup.kill` if available to kill all processes in a "
+"container (such as when doing `runc kill`)."
+msgstr ""
+
+#: ../../25.04/index.md:321 9872b512e58e4d68965e697035f43b13
+msgid ""
+"For a complete list of changes and more details on the ones above, refer "
+"to the [upstream "
+"changelog](https://github.com/opencontainers/runc/blob/main/CHANGELOG.md)."
+msgstr ""
+
+#: ../../25.04/index.md:323 ../../25.04/index.md:881
+#: b6afbb02e30f4fb0b39b5d59b334a947 cc3bb0751b004272b0c7d2a933d3184e
+msgid "Docker"
+msgstr ""
+
+#: ../../25.04/index.md:325 4f83e8efbd4e480b911e2b4ca2e7e198
+msgid ""
+"The docker.io (src:docker.io-app) package was updated to version 27.5.1. "
+"Some highlights of this version include:"
+msgstr ""
+
+#: ../../25.04/index.md:327 89015ce5ce6645a39009a6a12d7d9114
+msgid ""
+"`docker image ls` now supports `--tree` flag that shows a multiplatform-"
+"aware image list."
+msgstr ""
+
+#: ../../25.04/index.md:328 e1eba9406dd44aaebba69c9ff2f782b6
+msgid ""
+"The `Aliases` field returned by `docker inspect` contains the container "
+"short ID once the container is started. This behavior was removed. Now, "
+"the `Aliases` field only contains the aliases set through the `docker "
+"container create` and `docker run` flag `--network-alias`. A new field "
+"`DNSNames` containing the container name (if one was specified), the "
+"hostname, the network aliases, as well as the container short ID, has "
+"been introduced in v25.0 and should be used instead of the `Aliases` "
+"field."
+msgstr ""
+
+#: ../../25.04/index.md:329 f814138a867746adba05479f310e00b9
+msgid ""
+"Add `--platform` flag to `docker image push` and improve the default "
+"behavior when not all platforms of the multi-platform image are available"
+" locally."
+msgstr ""
+
+#: ../../25.04/index.md:330 92f43c1002be43f6867ea56e6a026329
+msgid "Several improvements to IPv6 network configuration."
+msgstr ""
+
+#: ../../25.04/index.md:331 583ecfc80abe45bc81fe0b0efc4dcded
+msgid ""
+"`ip6tables` is no longer experimental. You may remove the `experimental` "
+"configuration option and continue to use IPv6, if it is not required by "
+"any other features."
+msgstr ""
+
+#: ../../25.04/index.md:332 69a0bd22c29942e5bfde288697ecc247
+msgid "`ip6tables` is now enabled for Linux bridge networks by default."
+msgstr ""
+
+#: ../../25.04/index.md:334 377ca083f32147ff8bdd0093aa558ae6
+msgid ""
+"Watch out for deprecation or removal of features in this [upstream "
+"page](https://github.com/docker/cli/blob/v27.5.1/docs/deprecated.md)"
+msgstr ""
+
+#: ../../25.04/index.md:336 894e85ecd9034ec4835adedc363b6830
+msgid ""
+"**docker-buildx:** docker-buildx was updated to version 0.20.1. This "
+"version introduces new features such as"
+msgstr ""
+
+#: ../../25.04/index.md:338 398aa54d82a7437c9b686cd4e0be2e87
+msgid ""
+"New `--call` option allows setting evaluation method for a build, "
+"replacing the previous experimental `--print` flag."
+msgstr ""
+
+#: ../../25.04/index.md:339 aebabdced3f54d79b00c0a09ceacea1e
+msgid ""
+"Build command now ensures that multi-node builds use the same build "
+"reference for each node."
+msgstr ""
+
+#: ../../25.04/index.md:340 2cfac7b01893437e898362471f090f84
+msgid "Several improvements for the `bake` command."
+msgstr ""
+
+#: ../../25.04/index.md:341 0b0741bbeb06404d8fa6a5febc73f1a6
+msgid ""
+"New `buildx history` command has been added that allows working with "
+"build records of completed and running builds."
+msgstr ""
+
+#: ../../25.04/index.md:343 1c39cdd6015a4693ad958d20c92cda9a
+msgid ""
+"**docker-compose-v2:** docker-compose-v2 was updated to version 2.33.0. "
+"This version introduces several fixes and new features such as"
+msgstr ""
+
+#: ../../25.04/index.md:345 2f1aeea3a7ef46ab9a1c1b15b58f51fa
+msgid ""
+"A new `--environment` flag to `config` command to output the resolved "
+"environment variables used for interpolation."
+msgstr ""
+
+#: ../../25.04/index.md:346 8f5812ef6c624c60b6235248ff37d833
+msgid ""
+"A new `--prune` option to the docker-compose `watch` command to ensure "
+"that dangling images are pruned automatically when rebuilding."
+msgstr ""
+
+#: ../../25.04/index.md:347 5fc9e091dee74d3fa43a86c9d23f9184
+msgid "Support to bake was added."
+msgstr ""
+
+#: ../../25.04/index.md:354 f94a1213b2f44ed588416456615c7a22
+msgid "HAProxy"
+msgstr ""
+
+#: ../../25.04/index.md:355 5eaac3a7b61745d28e0cfe1ba7e7c077
+msgid ""
+"The HAProxy package was upgraded to version 3.0.7. This new version "
+"introduces performance improvements for Lua scripts and stick tables, "
+"support for virtual ACL and map files, limiting glitchy HTTP/2 "
+"connections, and persistent stats after a reload. **Breaking changes** "
+"include detection of accidental multiple commands sent to the Runtime "
+"API, rejecting the `enabled` keyword for dynamic servers, stricter "
+"parsing of non-standard URIs and renaming of `tune.ssl.ocsp-update` to "
+"`tune.ocsp-update`. You can learn more about it at "
+"[https://www.haproxy.com/blog/announcing-"
+"haproxy-3-0](https://www.haproxy.com/blog/announcing-haproxy-3-0). A "
+"complete list of changes is available at "
+"[https://www.haproxy.org/download/3.0/src/CHANGELOG](https://www.haproxy.org/download/3.0/src/CHANGELOG)."
+msgstr ""
+
+#: ../../25.04/index.md:358 97e5ae578202403f9aa42b2cea52d22f
+msgid "`freeradius`"
+msgstr ""
+
+#: ../../25.04/index.md:360 aee7801dd27f42b8b092c6ae6b8412e5
+msgid ""
+"`freeradius` 3.2.7+dfsg-1ubuntu1 drops `radlast`. This is due to "
+"`radlast` calling `last`, which is no longer available in Ubuntu. These "
+"use `wtmp` 32 bit files, which are not 2038 compliant. Upstream source "
+"has dropped `radlast` and other tools in [an upstream "
+"commit](https://github.com/FreeRADIUS/freeradius-"
+"server/commit/b0f4123c84a0aeaa6fc393fd5e6fdaa0e0a86eaf). These were "
+"originally made optional, and later removed entirely. Information in [lp:"
+" "
+"2096611](https://bugs.launchpad.net/ubuntu/+source/freeradius/+bug/2096611)"
+msgstr ""
+
+#: ../../25.04/index.md:362 ../../25.04/index.md:846
+#: ae49ff85f61e4d079ed7f06c8c95c269 ddf67f3a8bf544bface4122c925ce031
+msgid "libvirt"
+msgstr ""
+
+#: ../../25.04/index.md:364 85b9e31cb9e24093864073fe5d658dcd
+msgid ""
+"The [libvirt ](https://libvirt.org) package was upgraded to version "
+"10.10.0. Here are the changes since Ubuntu Oracular:"
+msgstr ""
+
+#: ../../25.04/index.md:366 5e1183ea9aa64392968b2e3336a29db2
+msgid ""
+"network: make networks with `<forward mode='open'/>` more useful.  It is "
+"now permissible to have a `<forward mode='open'>` network that has no IP "
+"address assigned to the host's port of the bridge. This is the only way "
+"to create a libvirt network where guests are unreachable from the host "
+"(and vice versa) and also 0 firewall rules are added on the host."
+msgstr ""
+
+#: ../../25.04/index.md:369 fe67f34326dc40ed9f6e0fbf78905ec5
+msgid ""
+"It is now also possible for a `<forward mode='open'/>` network to use the"
+" `zone` attribute of `<bridge>` to set the firewalld zone of the bridge "
+"interface (normally it would not be set, as is done with other forward "
+"modes)."
+msgstr ""
+
+#: ../../25.04/index.md:371 6e73dac10f3242cf86acea4199984a6d
+msgid "qemu: zero block detection for non-shared-storage migration"
+msgstr ""
+
+#: ../../25.04/index.md:373 b9dd416244914a1ab49edadfe979a332
+msgid ""
+"Users can now request that all-zero blocks are not transferred when "
+"migrating non-shared disk data without actually enabling zero detection "
+"on the disk itself. This allows sparsifying images during migration where"
+" the source has no access to the allocation state of blocks at the cost "
+"of CPU overhead."
+msgstr ""
+
+#: ../../25.04/index.md:375 bfaa4d6ffa4a49fcb87022bbe6285387
+msgid ""
+"This feature is available via the `--migrate-disks-detect-zeroes` option "
+"for `virsh migrate` or `VIR_MIGRATE_PARAM_MIGRATE_DISKS_DETECT_ZEROES` "
+"migration parameter. See the documentation for caveats."
+msgstr ""
+
+#: ../../25.04/index.md:377 9dcc43bc00074d0eb8e31de4dd28758f
+msgid "qemu: internal snapshot improvements"
+msgstr ""
+
+#: ../../25.04/index.md:379 69ec95aee7054cdab7e04460a9f8ad06
+msgid ""
+"The qemu internal snapshot handling code was updated to use modern "
+"commands which avoid the problems the old ones had, preventing use of "
+"internal snapshots on VMs with UEFI NVRAM. Internal snapshots of VMs "
+"using UEFI are now possible provided that the NVRAM is in `qcow2` format."
+msgstr ""
+
+#: ../../25.04/index.md:381 dc9100ae4f8e4ca5ab47a2577ab23d36
+msgid "qemu: add multi boot device support on s390x"
+msgstr ""
+
+#: ../../25.04/index.md:383 fa8fad41e60c4555b3b75c6ab6610d29
+msgid ""
+"For classical mainframe guests (i.e. LPAR or z/VM installations), you "
+"always have to explicitly specify the disk where you want to boot from "
+"(or \"IPL\" from, in s390x-speak -- IPL means \"Initial Program Load\")."
+msgstr ""
+
+#: ../../25.04/index.md:385 f4d8824972614fed984636dede198422
+msgid ""
+"In the past QEMU only used the first device in the boot order to IPL "
+"from. With the new multi boot device support on s390x that is available "
+"with QEMU version 9.2 and newer, this limitation is lifted. If the IPL "
+"fails for the first device with the lowest boot index, the device with "
+"the second lowest boot index will be tried and so on until IPL is "
+"successful or there are no remaining boot devices to try."
+msgstr ""
+
+#: ../../25.04/index.md:387 c2bc0ce8faf24d1c9430072b67c430fc
+msgid ""
+"Limitation: The s390x BIOS will try to IPL up to 8 total devices, any "
+"number of which may be disks or network devices."
+msgstr ""
+
+#: ../../25.04/index.md:389 ffb73416ee5f4dd687c6a66d8a966316
+msgid "qemu: Add support for versioned CPU models"
+msgstr ""
+
+#: ../../25.04/index.md:391 bb97453635a4465ba57327c10231fa5e
+msgid ""
+"Updates to QEMU CPU models with `-vN` suffix can now be used in libvirt "
+"just like any other CPU model."
+msgstr ""
+
+#: ../../25.04/index.md:393 735c3382c66d4699b5244e7652e89123
+msgid "qemu: Automatically add IOMMU when needed"
+msgstr ""
+
+#: ../../25.04/index.md:395 b8c4cf1e165b4911a22d04def0428bb4
+msgid ""
+"When domain of `qemu` or `kvm` type have more than 255 vCPUs, IOMMU with "
+"EIM mode is required. Starting with this release libvirt automatically "
+"adds one (or turns on the EIM mode if there's IOMMU without it)."
+msgstr ""
+
+#: ../../25.04/index.md:397 84d7fda8723e4a7ca6baf81288820991
+msgid ""
+"In 10.5 (thereby oracular) already support for `SEV-SNP` was introduced "
+"as another type of `<launchSecurity/>`. Its support is reported in both "
+"domain capabilities and virt-host-validate. Now also the qemu version in "
+"the release is ready to provide that."
+msgstr ""
+
+#: ../../25.04/index.md:399 44ec08ad8b3d4e49a4a865e1b55f8570
+msgid ""
+"The Debian (and consequently the Ubuntu) libvirt package has been "
+"significantly redesigned. To quote its NEWS file:"
+msgstr ""
+
+#: ../../25.04/index.md:401 caa00ddfc15140d99ff1054b9ebb1b85
+msgid ""
+"All the various drivers and storage backends come in their own separate "
+"binary packages now, which makes it possible to install exactly as many "
+"or as few as desired."
+msgstr ""
+
+#: ../../25.04/index.md:403 6550947d4fa14845bbb4cb44aa80e3a5
+msgid ""
+"The system-wide configuration for the libvirtd daemon is no longer "
+"shipped separately from the daemon itself, as was the case until now. The"
+" `libvirt-daemon-system` package still exists, but it's now simply a "
+"convenient way to install the \"typical\" libvirt deployment consisting "
+"of all the components needed to run a QEMU-based hypervisor."
+msgstr ""
+
+#: ../../25.04/index.md:405 37815333e8ae4797857715032a3b94d8
+msgid ""
+"For more details, please see [the upstream changelog "
+"](https://www.libvirt.org/news.html#v10-10-0-2024-12-02)."
+msgstr ""
+
+#: ../../25.04/index.md:407 e07a6f8bbb894fc78cce727b03d27588
+msgid "Monitoring Plugins"
+msgstr ""
+
+#: ../../25.04/index.md:409 34b5c2111d754d91a9e34f068ed1da7f
+msgid ""
+"Monitoring-plugins is upgraded to the 2.4.0 release in Plucky Penguin. "
+"While primarily a bugfix release, this includes a few minor enhancements:"
+msgstr ""
+
+#: ../../25.04/index.md:411 5068150200c74810863c68c8b01a2ec0
+msgid "Add new test function for percentage expressions"
+msgstr ""
+
+#: ../../25.04/index.md:412 bc307a4ab81c44d78099e580429e7c4a
+msgid "check_ups: output ups.realpower if supported"
+msgstr ""
+
+#: ../../25.04/index.md:413 30738d21430c42ccb1d8c81ce46a72f4
+msgid "check_curl: add haproxy protocol option"
+msgstr ""
+
+#: ../../25.04/index.md:414 d917488de1b94ad38dcacd6cb3e30ea4
+msgid "check_disk: increase alert precision"
+msgstr ""
+
+#: ../../25.04/index.md:415 678ed35c07f848129a176cc82aa31f2b
+msgid "check_ircd: IPv6 support"
+msgstr ""
+
+#: ../../25.04/index.md:416 01c130b5b9284674b067405611bf3133
+msgid "check_nwstat: adds percentage used space"
+msgstr ""
+
+#: ../../25.04/index.md:417 4c2caac09dd34bcdad5bd69605fb4caf
+msgid "check_swap: Possibility to run check_swap without thresholds"
+msgstr ""
+
+#: ../../25.04/index.md:418 1e02bed1e7634b3d8f316ff6a49eb97e
+msgid "check_ups: additional alarm conditions"
+msgstr ""
+
+#: ../../25.04/index.md:420 565c47d74344464faded54b535abad9d
+msgid ""
+"For the full list of changes, please see the upstream [release "
+"notes](https://github.com/monitoring-plugins/monitoring-plugins/releases)"
+msgstr ""
+
+#: ../../25.04/index.md:423 083ee0e65a6a468db35ede0ca9014134
+msgid "Nginx"
+msgstr ""
+
+#: ../../25.04/index.md:425 70f4707d15304a5bb83f00221a2c2244
+msgid ""
+"The upgrade from Oracular's 1.26.0 to Plucky's 1.26.3 brings a handful of"
+" bug fixes, along with security fixes (already backported to the Oracular"
+" version).  There are no feature changes this release."
+msgstr ""
+
+#: ../../25.04/index.md:427 d42effd08e3f4590895b0c0de400e751
+msgid "OpenLDAP"
+msgstr ""
+
+#: ../../25.04/index.md:429 111462a1e65746259e861fadeab80cc1
+msgid ""
+"The 2.6.9 release is a bugfix-only release with improvements to libldap, "
+"slapd, and slapo subcomponents.  For the full list of changes please see "
+"the [release "
+"notes](https://www.openldap.org/software/release/changes.html)."
+msgstr ""
+
+#: ../../25.04/index.md:431 2296bb8670454dcfa0e487ba0082700a
+msgid "OpenSSH"
+msgstr ""
+
+#: ../../25.04/index.md:433 e5efa26a2b2b4ea3a92b130a05ad8448
+msgid ""
+"OpenSSH was updated to version 9.9. Here are some highlights since 9.7, "
+"last shipped in Ubuntu 24.10:"
+msgstr ""
+
+#: ../../25.04/index.md:435 1d50691378f6402cbb542e2948aecb93
+msgid ""
+"new `PerSourcePenalties` option that will penalise client addresses that "
+"for some reason do not complete authentication. New in version 9.8."
+msgstr ""
+
+#: ../../25.04/index.md:436 b4dc74d916b243dcaf82cef9f80dd2be
+msgid ""
+"support for a new hybrid post-quantum key exchange algorithm, called "
+"\"mlkem768x25519-sha256\". Described in "
+"https://datatracker.ietf.org/doc/html/draft-kampanakis-curdle-ssh-pq-"
+"ke-03, it's available by default. New in version 9.8."
+msgstr ""
+
+#: ../../25.04/index.md:437 0d14aa6bfada4863a8f9e97941ca2df9
+msgid ""
+"new match option `invalid-user`, which can be used when the target "
+"username is not valid"
+msgstr ""
+
+#: ../../25.04/index.md:438 239ecc31c44748f59853878c2e240ee3
+msgid ""
+"prevent private keys from being included in core dump files for most of "
+"their lifespans. New in version 9.8."
+msgstr ""
+
+#: ../../25.04/index.md:439 34e45cdccbbf41a8bc58629402a4488b
+msgid ""
+"and more For a detailed list of the changes since 9.7, please consult the"
+" upstream release notes at https://www.openssh.com/releasenotes.html."
+msgstr ""
+
+#: ../../25.04/index.md:442 daef3703ec1c41ce8beb7bf287988698
+msgid ""
+"In terms of Ubuntu and Debian packaging, here are the most important "
+"changes:"
+msgstr ""
+
+#: ../../25.04/index.md:443 e8f5bfccf3f94e01a5f804788f9433eb
+msgid ""
+"New `sshd.service` alias to `ssh.service`. Both names can now be used in "
+"`systemctl` commands."
+msgstr ""
+
+#: ../../25.04/index.md:444 503a1bfbd48d4dc5bf49cb5174976cf3
+msgid ""
+"New binary packages called `openssh-client-gssapi` and `openssh-server-"
+"gssapi` . This is in preparation for a future split of the GSSAPI "
+"authentication mechanism into separate packages in the near future. For "
+"now, they just pull in their non-gssapi counterparts, if installed. See "
+"https://lists.debian.org/debian-devel/2024/04/msg00044.html for the "
+"detailed plan."
+msgstr ""
+
+#: ../../25.04/index.md:445 6ccfedae8dcd4fd087f575371ec7fa07
+msgid "Host DSA keys are no longer generated."
+msgstr ""
+
+#: ../../25.04/index.md:447 19bb59be84c74a26a4a106aea4cd52d3
+msgid "Valkey"
+msgstr ""
+
+#: ../../25.04/index.md:449 40f09e1f8f65464e971b9eeff01625af
+msgid ""
+"Valkey was updated to version 8, starting with 8.0.2. This includes "
+"significant performance and reliability improvements, without any "
+"backwards-incompatible changes to commands and responses. For more "
+"information on the new version, see the [Valkey 8 blog "
+"post](https://valkey.io/blog/valkey-8-0-0-rc1/). Release notes are "
+"available on the [Valkey project GitHub](https://github.com/valkey-"
+"io/valkey/releases/tag/8.0.2)."
+msgstr ""
+
+#: ../../25.04/index.md:452 0495d820f9864d6eabdb4043a980f3a9
+msgid "MySQL"
+msgstr ""
+
+#: ../../25.04/index.md:454 dbc00e87ead3492895fb014ff8afdde4
+msgid ""
+"MySQL was updated from 8.0 to 8.4 LTS, starting with 8.4.4. This is "
+"MySQL's first official long term support release, including various "
+"internal improvements, new features, and some important configuration "
+"changes."
+msgstr ""
+
+#: ../../25.04/index.md:456 fc679ca7b1dd403ab9ea8e8c87356772
+msgid ""
+"Upstream release notes are now available in the [Mysql 8.4 documentation "
+"library](https://dev.mysql.com/doc/relnotes/mysql/8.4/en/). For more "
+"information about the transition from MySQL 8.0 to 8.4, see the [MySQL "
+"8.4 overview](https://dev.mysql.com/doc/refman/8.4/en/mysql-"
+"nutshell.html)."
+msgstr ""
+
+#: ../../25.04/index.md:458 36465d5df5514e4ba2c1b31608c92666
+msgid ""
+"Due to upstream policy, support for 32-bit MySQL Server has been removed."
+" However, Ubuntu will continue to provide a MySQL client and client "
+"library for 8.4."
+msgstr ""
+
+#: ../../25.04/index.md:461 e31fdbb6edd44c4a97c4d5e41cc48ee5
+msgid "MySQL Shell"
+msgstr ""
+
+#: ../../25.04/index.md:463 7c9afc139f934a94bbe6700e1c70cd94
+msgid ""
+"MySQL Shell was updated from 8.0.38 to 8.4.4 to coincide with MySQL 8.4. "
+"It adds support for MySQL 8.4 servers, and provides additional "
+"improvements for interacting with MySQL 8.0 servers. For a list of "
+"features, see the [MySQL Shell 8.4 "
+"documentation](https://dev.mysql.com/doc/mysql-shell/8.4/en/). Release "
+"notes for MySQL Shell 8.4 can be found "
+"[here](https://dev.mysql.com/doc/relnotes/mysql-shell/8.4/en/)."
+msgstr ""
+
+#: ../../25.04/index.md:466 fadc69fd3d794a45a1265d830932366a
+msgid "Percona Xtrabackup"
+msgstr ""
+
+#: ../../25.04/index.md:468 4f258099e5794cb682d77e83cc9c3b09
+msgid ""
+"Percona-Xtrabackup was updated from the 8.0 track to 8.4 with 8.4.0-1, "
+"also to coincide with the release of MySQL 8.4. This version provides "
+"changes to match MySQL 8.4, along with support for the `keyring_vault` "
+"component. For more information see the [upstream release "
+"notes](https://docs.percona.com/percona-xtrabackup/8.4/release-"
+"notes/8.4.0-1.html)."
+msgstr ""
+
+#: ../../25.04/index.md:471 e19b194343b4469e97729c58da88aced
+msgid "PHP"
+msgstr ""
+
+#: ../../25.04/index.md:473 70363816a8ff40378eeea2fd95e54d68
+msgid ""
+"PHP was updated to version 8.4. This is a major update of the languages "
+"including new features such as property hooks, asymmetric visibility, an "
+"updated DOM API, and more."
+msgstr ""
+
+#: ../../25.04/index.md:475 95b5615a0f0e4a5f84fd3ffcc5fc3c46
+msgid ""
+"For more details see the [upstream release "
+"notes](https://www.php.net/releases/8.4/en.php)."
+msgstr ""
+
+#: ../../25.04/index.md:477 4248639a0bbc4cd1a3c7cad4a8b96843
+msgid "PostgreSQL"
+msgstr ""
+
+#: ../../25.04/index.md:479 baae5e07196b4452b8dbd1dd25ed278b
+msgid ""
+"PostgreSQL was updated to version 17, which contains several new features"
+" and enhancements, including"
+msgstr ""
+
+#: ../../25.04/index.md:481 1a2eadca908040a590fddcbef72e0f26
+msgid ""
+"A new memory management system for `VACUUM`, which reduces memory "
+"consumption and can improve overall vacuuming performance;"
+msgstr ""
+
+#: ../../25.04/index.md:482 3ef9ac15c1c048a893528e9cbeddb1dd
+msgid ""
+"New SQL/JSON capabilities, including constructors, identity functions, "
+"and the `JSON_TABLE()` function, which converts JSON data into a table "
+"representation;"
+msgstr ""
+
+#: ../../25.04/index.md:483 6bca57073ae0497db4f90d220cb84c27
+msgid ""
+"Various query performance improvements and Logical replication "
+"enhancements; and"
+msgstr ""
+
+#: ../../25.04/index.md:484 b518101c946441179a3b59f104ba4323
+msgid ""
+"A new client-side connection option, `sslnegotiation=direct`], that "
+"performs a direct TLS handshake to avoid a round-trip negotiation."
+msgstr ""
+
+#: ../../25.04/index.md:486 f46fc866945e4733902bf8d4bb094ffd
+msgid ""
+"For more details, see the [upstream release "
+"notes](https://www.postgresql.org/docs/17/release-17.html)."
+msgstr ""
+
+#: ../../25.04/index.md:488 4a6c7f012905429ab66ccf952eeeb5f5
+msgid "QEMU"
+msgstr ""
+
+#: ../../25.04/index.md:490 7d4572f35ba54358b3e3e690b4c2dd88
+msgid ""
+"The [QEMU ](https://qemu.org/) package was updated to version 9.2.0. Here"
+" are the changes since Ubuntu Oracular."
+msgstr ""
+
+#: ../../25.04/index.md:492 c226e11472714238ba1fb31504ccaf83
+msgid ""
+"The `scsi` property of `virtio-blk` devices has been removed. SCSI "
+"command passthrough had never been present on `virtio-blk` 1.0 devices, "
+"and is now removed from legacy devices as well. Use `virtio-scsi` "
+"instead."
+msgstr ""
+
+#: ../../25.04/index.md:493 c051932028bd4dfba90a377f42ab3626
+msgid ""
+"The `block migration` options to the migrate commands (`blk` and `inc` "
+"for QMP, `-b`/`-i` for the human monitor) have been removed; guest "
+"management software such as libvirt is able to perform block migration "
+"more efficiently using block jobs and NBD devices."
+msgstr ""
+
+#: ../../25.04/index.md:494 d199f54aa7fe48d9b66f79d30c6ef9b2
+msgid ""
+"The `compress` migration capability has been removed; `multifd` migration"
+" is able to do compression and can be used instead."
+msgstr ""
+
+#: ../../25.04/index.md:495 8e60f2e89a944fbfb3fd5812ecfe5557
+msgid ""
+"The `proxy` backend for 9pfs, and the `virtfs-proxy-helper` program, have"
+" been removed. Use the `local` backend driver or `virtio-fs` instead."
+msgstr ""
+
+#: ../../25.04/index.md:497 12a8792947564e098e5209b86637b8ed
+msgid "x86"
+msgstr ""
+
+#: ../../25.04/index.md:498 3b99e7041a0845e58f84fca010e6212a
+msgid ""
+"Support for AMD SEV-SNP using the \"-object sev-snp-guest\" command line "
+"option in QEMU 9.1 followed by fixups for related virtio handling in QEMU"
+" 9.2."
+msgstr ""
+
+#: ../../25.04/index.md:499 8c7f10054c13410999fcaa73d05ab2c1
+msgid ""
+"As usual new named CPU models and detection of their related CPU "
+"features, this time new variants of Icelake-Server, Cascadelake-Server, "
+"GraniteRapids, and SapphireRapids"
+msgstr ""
+
+#: ../../25.04/index.md:501 523ede77e2fe4d709062d982ef364d6a
+msgid "ARM"
+msgstr ""
+
+#: ../../25.04/index.md:502 c4a9c67dbcbf41b2b72e2db25d566a85
+msgid ""
+"New CPU architectural features emulated:   `FEAT_NMI`   `FEAT_CSV2_3`   "
+"`FEAT_ETS2`   `FEAT_Spec_FPACC`   `FEAT_WFxT`   `FEAT_Debugv8p8`   "
+"`FEAT_EBF16`   `FEAT_CMOW`"
+msgstr ""
+
+#: ../../25.04/index.md:511 7bdb8c9478e7435689abf3d651b7574b
+msgid ""
+"The `max` CPU and any new CPU types will default to a 1GHz generic timer "
+"frequency rather than the old 62.5MHz (this is architecturally required "
+"from ARMv8.6 onwards)."
+msgstr ""
+
+#: ../../25.04/index.md:512 d46cd8f878d14dcda618d65686c6f6e8
+msgid "KVM-based VMs can now support MTE (if the host CPU has MTE support)."
+msgstr ""
+
+#: ../../25.04/index.md:515 ../../25.04/index.md:775
+#: ca7a2d226bee41009eefa709124e23d2 e02d5b6f724c4276b7ce5dc6caf26e56
+msgid "RISC-V"
+msgstr ""
+
+#: ../../25.04/index.md:516 995d86a705234482bf70b56e3242cb60
+msgid "Support RISC-V privilege 1.13 spec."
+msgstr ""
+
+#: ../../25.04/index.md:517 3c4ce878ac5b4a7f88a3f3d2f6fc7f80
+msgid "Implement SBI debug console (`DBCN`) calls for KVM."
+msgstr ""
+
+#: ../../25.04/index.md:518 cbe2b794c36848439c1ee9340a810ac1
+msgid "Add support for `Zve32x` extension."
+msgstr ""
+
+#: ../../25.04/index.md:519 14038e0828b34d7683b2ef357caa15ae
+msgid "Add support for `Zve64x` extension."
+msgstr ""
+
+#: ../../25.04/index.md:520 57188ec36e5544cbbf6311db51f2f722
+msgid "Add `th.sxstatus` CSR emulation."
+msgstr ""
+
+#: ../../25.04/index.md:521 4c99d6d370b44c3cb27129207fd28ce2
+msgid "Remove experimental prefix from `B` extension."
+msgstr ""
+
+#: ../../25.04/index.md:522 9be6e94e9f6447cba9cda7dbdd3b8712
+msgid "Support the `zimop`, `zcmop`, `zama16b` and `zabha` extensions."
+msgstr ""
+
+#: ../../25.04/index.md:523 1ec060f4867f476ebf45c77818e99fec
+msgid "Add decode support for `Zawrs` extension."
+msgstr ""
+
+#: ../../25.04/index.md:524 1eb28dc7d7d74eddbbb1f2af741d1e85
+msgid "Add `smcntrpmf` extension support."
+msgstr ""
+
+#: ../../25.04/index.md:525 5bc5911cbaca49de9692420405147b5b
+msgid "Support 64-bit addresses for `initrd`."
+msgstr ""
+
+#: ../../25.04/index.md:526 2ad40234953345cdaaa74ed44371b950
+msgid "QEMU support for KVM Guest Debug on RISC-V."
+msgstr ""
+
+#: ../../25.04/index.md:527 0c0cc0bd005b42a8b956f790f7dd7591
+msgid "Add `fcsr` register to QEMU log as a part of F extension."
+msgstr ""
+
+#: ../../25.04/index.md:528 5a84adaa67c842979f35744282e92a82
+msgid "Add `Svvptc` extension support."
+msgstr ""
+
+#: ../../25.04/index.md:529 476bad35cbcf46a0b7e12fb6821d08ff
+msgid "Support for control flow integrity extensions."
+msgstr ""
+
+#: ../../25.04/index.md:530 59fb93b7c5b94d159df577ebab03e18a
+msgid "Support for the IOMMU with the virt machine."
+msgstr ""
+
+#: ../../25.04/index.md:532 ../../25.04/index.md:885
+#: 6d78c9b11225428292aae3619d1eb383 996bab37b18f4bdaa26fcf7656b38778
+msgid "s390x"
+msgstr ""
+
+#: ../../25.04/index.md:533 34ba9874cbbd4fdaa14c862974b78303
+msgid "New architectural features emulated: `FMAF` `IMA` `VIS3` `VIS4`"
+msgstr ""
+
+#: ../../25.04/index.md:538 1ad47338028c43ab9cad79abac611044
+msgid ""
+"No new cpu types with these features are added, yet, but one may enable "
+"them manually with `-cpu <type>,+<feature>`."
+msgstr ""
+
+#: ../../25.04/index.md:539 01d41b5f647c46e1944a868204e3b590
+msgid ""
+"The `s390-ccw` guest firmware now supports booting from other devices in "
+"case the previous ones fail."
+msgstr ""
+
+#: ../../25.04/index.md:541 e0c8db87ac9f428aa73ed180f38cb3b0
+msgid "For more details, please see related upstream changelogs:"
+msgstr ""
+
+#: ../../25.04/index.md:543 30e1cd66efb04e4390ddf64e9ad92643
+msgid "[9.1](https://wiki.qemu.org/ChangeLog/9.1)"
+msgstr ""
+
+#: ../../25.04/index.md:544 2acf6bed740948ab8e2dd1956e243b3e
+msgid "[9.2](https://wiki.qemu.org/ChangeLog/9.2)"
+msgstr ""
+
+#: ../../25.04/index.md:547 a4b4deca7c1f47d192848a9e1c439e8c
+msgid "Samba"
+msgstr ""
+
+#: ../../25.04/index.md:549 2c1b1a75a3e54e388844a4b6f6ae3d0d
+msgid "Samba was updated to series 4.21.x. Here are some of the highlights:"
+msgstr ""
+
+#: ../../25.04/index.md:551 66cfa442be3f4064bc598731f65e34f0
+msgid "LDAP TLS/SASL channel binding support"
+msgstr ""
+
+#: ../../25.04/index.md:552 4534f351d931470989f30fa4e682b43e
+msgid "Group Managed Service Accounts"
+msgstr ""
+
+#: ../../25.04/index.md:553 31f93a3da7bd474292a2f91dd76bd5c2
+msgid "Samba can now claim Functional Level 2012R2 support"
+msgstr ""
+
+#: ../../25.04/index.md:554 ab96ffb1eafa4aea84d281efae31f7b8
+msgid "Some Samba public libraries made private by default"
+msgstr ""
+
+#: ../../25.04/index.md:555 4672d3c5e3e042fa9cb97694a48c9b77
+msgid "Samba AD will rotate expired passwords on smartcard-required accounts"
+msgstr ""
+
+#: ../../25.04/index.md:556 843bd4b90e6e42eaa87e7a077030d8b3
+msgid "Automatic keytab update after machine password change"
+msgstr ""
+
+#: ../../25.04/index.md:557 c1192e636513464d96e1e222bb53ffc1
+msgid "and more"
+msgstr ""
+
+#: ../../25.04/index.md:559 50ba09929b4e46c794ddc0d7ab087899
+msgid ""
+"For a more detailed explanation, please refer to the upstream release "
+"notes at https://www.samba.org/samba/history/samba-4.21.0.html"
+msgstr ""
+
+#: ../../25.04/index.md:561 ac7511b1253e425ca4ca8b4257974882
+msgid "samba on i386"
+msgstr ""
+
+#: ../../25.04/index.md:563 59222eb042774256acbe8700f1dda8fb
+msgid ""
+"Samba version 4.21.x added a dependency to the `python3-samba` package: "
+"`python3-cryptography`. Unfortunately, `python3-cryptography` was last "
+"built for i386 for Ubuntu Bionic 18.04, and is no longer available for "
+"that architecture, making this new dependency unsatisfiable."
+msgstr ""
+
+#: ../../25.04/index.md:565 d137a05a55a44c0689fc0be5040279db
+msgid ""
+"For Ubuntu Plucky, it was decided to not build `python3-samba` for i386. "
+"Please see [LP: "
+"#2099895](https://bugs.launchpad.net/ubuntu/+source/samba/+bug/2099895) "
+"for details. The main consequence is that the `samba-tool` script (part "
+"of that package) is no longer available for i386."
+msgstr ""
+
+#: ../../25.04/index.md:567 abc209bcb87a4f8db271df8a6f7ff902
+msgid "Upgrading an AD/DC from previous Ubuntu releases"
+msgstr ""
+
+#: ../../25.04/index.md:569 82e17039b7074aca9abd6a723fae895c
+msgid ""
+"If you have deployed a Samba Active Directory Domain Controller WITHOUT "
+"having installed the `samba-ad-dc` package, you should install it before "
+"doing a release upgrade to Ubuntu Plucky Puffin 25.04. If `samba-ad-dc` "
+"is not installed prior to the release upgrade, the Active Directory "
+"Domain Controller functionality will not work on the upgraded system due "
+"to many missing components."
+msgstr ""
+
+#: ../../25.04/index.md:571 b40d9204eff14bdd879a5800b98642a9
+msgid ""
+"See [LP: "
+"#2101838](https://bugs.launchpad.net/ubuntu/+source/samba/+bug/2101838) "
+"for more information."
+msgstr ""
+
+#: ../../25.04/index.md:574 7613abe45e024fb7b2b1f5dd308d5edc
+msgid "Squid"
+msgstr ""
+
+#: ../../25.04/index.md:576 bd52b7b2533e4b2fae65f28f5404defe
+msgid ""
+"Squid 6.13 is a stable release consisting mainly of bugfixes and "
+"cleanups.  One functional change of note is that `ext_time_quota_acl` no "
+"longer supports the -l option.  For the complete list of changes, see the"
+" [v6.13 change list](https://github.com/squid-cache/squid/releases)."
+msgstr ""
+
+#: ../../25.04/index.md:578 5b03d4357d66437789d1c09320520c1b
+msgid "SSSD"
+msgstr ""
+
+#: ../../25.04/index.md:580 02b66d39bbcf45159bf4415be8bd24ad
+msgid "SSSD has been updated to 2.10.1 and these are the highlights:"
+msgstr ""
+
+#: ../../25.04/index.md:582 8a9520ab03f9427a8f20a494d5dbb9e3
+msgid ""
+"unprivileged service user: there is initial support for running `sssd` "
+"with less privileges, but in Debian/Ubuntu the main daemons still run "
+"under root. Filesystem capabilities had to be added to many binary "
+"helpers, though:"
+msgstr ""
+
+#: ../../25.04/index.md:583 a0e2c3949552465b88bd7a760710e7a7
+msgid "`sssd_pam`: *cap_dac_read_search*"
+msgstr ""
+
+#: ../../25.04/index.md:584 3db1fcdec64043edb2ab635441fa1f49
+msgid "`selinux_child`: *cap_setuid*, *cap_setgid*"
+msgstr ""
+
+#: ../../25.04/index.md:585 23be0a13afef471785a42c4c6198813c
+msgid "`ldap_child`: *cap_dac_read_search*"
+msgstr ""
+
+#: ../../25.04/index.md:586 f458849033594108b90940a3fb75f21f
+msgid ""
+"`krb5_child`: *cap_dac_read_search*, *cap_setuid*, *cap_setgid* This "
+"should all be transparent."
+msgstr ""
+
+#: ../../25.04/index.md:588 2090ca19fd1240eda90b01ec1a6c9ea5
+msgid ""
+"The `sssctl cache-upgrade` command was removed. SSSD will do automatic "
+"cache upgrades at startup if needed."
+msgstr ""
+
+#: ../../25.04/index.md:589 682a842b62ba42b19472ba48e501f9a1
+msgid "Default `ldap_id_use_start_tls` value changed from `false` to `true`."
+msgstr ""
+
+#: ../../25.04/index.md:590 94886fca4e8b49368878f4d83857bc0a
+msgid "Obsolete `config_file_version` option was removed."
+msgstr ""
+
+#: ../../25.04/index.md:591 593ab3d8383a48379cc1d102e3f814f5
+msgid "Option `reconnection_retries` was removed."
+msgstr ""
+
+#: ../../25.04/index.md:593 d5189a9d0e7841899925e41a23a0d62d
+msgid ""
+"For more details and other changes, please refer to the upstream release "
+"notes at https://sssd.io/release-notes/sssd-2.10.0.html."
+msgstr ""
+
+#: ../../25.04/index.md:595 a57d6002a8f24bcd9918a3f9f848f4a3
+msgid "Intel® QuickAssist Technology (Intel® QAT)"
+msgstr ""
+
+#: ../../25.04/index.md:597 c346982fa0ef4e28b5bf6a614d49f032
+msgid ""
+"Intel® QAT components have been updated to their most recent versions. "
+"Those are:"
+msgstr ""
+
+#: ../../25.04/index.md:598 9cea9e92fe7049369b6367467c691512
+msgid ""
+"qatlib : 24.09.0 For more information, visit the project’s "
+"[repo](https://github.com/intel/qatlib?tab=readme-ov-file#features)."
+msgstr ""
+
+#: ../../25.04/index.md:600 3af0903b1be04464af9dec64110df165
+msgid ""
+"qatengine : 1.8.1 For more information, visit the project’s "
+"[repo](https://github.com/intel/QAT_Engine/blob/master/docs/features.md)."
+msgstr ""
+
+#: ../../25.04/index.md:602 8a9a6f04a6eb4803911337bd97ef5001
+msgid ""
+"qatzip : 1.2.1 For more information, visit the project’s "
+"[repo](https://github.com/intel/QATzip?tab=readme-ov-file#features)."
+msgstr ""
+
+#: ../../25.04/index.md:604 bfa52ddfeae54684a1c318094719aac3
+msgid ""
+"ipp-crypto : 1:1.0.0 For more information, visit the project’s "
+"[repo](https://github.com/intel/ipp-crypto)."
+msgstr ""
+
+#: ../../25.04/index.md:607 37563d5df96b474198f94d09543ce42f
+msgid "Subiquity"
+msgstr ""
+
+#: ../../25.04/index.md:609 af62dc653dd7443fa237285e20cd51ba
+msgid ""
+"Please see the [25.04 Release "
+"Notes](https://github.com/canonical/subiquity/releases/tag/25.04) post on"
+" GitHub."
+msgstr ""
+
+#: ../../25.04/index.md:611 da312cadbf2245d5baec2df8493f9986
+msgid "thin-provisioning-tools"
+msgstr ""
+
+#: ../../25.04/index.md:613 65fa9c9095bc42728fdb14d9b66610ac
+msgid ""
+"The thin-provisioning tools package was updated to version 1.1.0, which "
+"was fully re-written in rust from scratch."
+msgstr ""
+
+#: ../../25.04/index.md:615 9675c1c7752942d0937cc6e65c1df68a
+msgid ""
+"See the [upstream changelog](https://github.com/jthornber/thin-"
+"provisioning-tools/blob/v1.1.0/CHANGES) for more details."
+msgstr ""
+
+#: ../../25.04/index.md:617 b324eee169fc43ac921f5d0e8d50d055
+msgid "Ubuntu HA/Clustering"
+msgstr ""
+
+#: ../../25.04/index.md:620 f33e2f579b2d4ebf9e0c3763725e29f9
+msgid "fence-agents"
+msgstr ""
+
+#: ../../25.04/index.md:622 ecad970e82a04e828b1f8b983298f9f4
+msgid ""
+"fence-agents was updated to version 4.16.0, which introduces bug fixes "
+"and a new fence-agents-nutanix-ahv which adds support for Nutanix AHV "
+"Cluster."
+msgstr ""
+
+#: ../../25.04/index.md:624 1a4723299d7f41f1ad7a84683c4d9f74
+msgid "resource-agents"
+msgstr ""
+
+#: ../../25.04/index.md:626 5f0c9ef3029945329dee361d5b33f0c9
+msgid ""
+"fence-agents was updated to version 4.16.0, which introduces bug fixes "
+"and improvements, including support for the asure aznfs filesystem."
+msgstr ""
+
+#: ../../25.04/index.md:628 4718218af9644ac29bed83f0b2bcfc26
+msgid "sos (sosreport)"
+msgstr ""
+
+#: ../../25.04/index.md:630 86c794449c5f476c8a0bc1236e66120c
+msgid ""
+"The `sosreport` package was renamed to `sos` with the upgrade to 4.9.0 "
+"from 4.8.0."
+msgstr ""
+
+#: ../../25.04/index.md:632 ddde57b00e484683b2c811947512bcd7
+msgid ""
+"The rename follows upstream name change in 2020 and the removal of "
+"`sosreport` and `sos-collector` commands."
+msgstr ""
+
+#: ../../25.04/index.md:633 bce0069ac79b42e29d05dda23f862425
+msgid ""
+"The `sosreport` package will remain as a transitional package that will "
+"carry the `sosreport` and `sos-collector` command for a few revisions of "
+"Ubuntu."
+msgstr ""
+
+#: ../../25.04/index.md:634 21ae573cc7a44c18b34a2b0fc13bce78
+msgid ""
+"`sos upload` is a new sub command, that allows you to upload a collected "
+"`sos` or a file to a vendor primarily Canonical or RedHat See [man "
+"pages](https://manpages.ubuntu.com/manpages/plucky/en/man1/sos-"
+"upload.1.html) for more details."
+msgstr ""
+
+#: ../../25.04/index.md:635 3be13ce791cb4a7287285d2bb6f4d7a5
+msgid ""
+"Further details on the changes between 4.8.0 and 4.9.0 can be viewed "
+"[upstream release notes](https://github.com/sosreport/sos/releases)"
+msgstr ""
+
+#: ../../25.04/index.md:637 65f9d12849aa43f2965d1bed569b2ae8
+msgid "Ubuntu WSL"
+msgstr ""
+
+#: ../../25.04/index.md:639 670e9aa6dcfe4491a47acb00d329c1e6
+msgid ""
+"WSL images publication has moved to "
+"[cdimage.ubuntu.com](https://cdimage.ubuntu.com/ubuntu-wsl/) (previously "
+"on cloud-images.ubuntu.com)"
+msgstr ""
+
+#: ../../25.04/index.md:641 c5910ec329eb4affbd0c84f96306b6a1
+msgid "OpenStack"
+msgstr ""
+
+#: ../../25.04/index.md:643 309128259e3342e282cc88d75eb2a8dd
+msgid ""
+"OpenStack has been updated to the [2025.1 "
+"(Epoxy)](https://releases.openstack.org/epoxy/) release. This includes "
+"packages for Aodh, Barbican, Ceilometer, Cinder, Designate, Glance, Heat,"
+" Horizon, Ironic, Keystone, Magnum, Manila, Masakari, Mistral, Neutron, "
+"Nova, Octavia, Swift, Vitrage, Watcher and Zaqar."
+msgstr ""
+
+#: ../../25.04/index.md:645 888bf70150d34811a51f4668240e9db2
+msgid ""
+"This release is also provided for Ubuntu 24.04 LTS via the Ubuntu Cloud "
+"Archive."
+msgstr ""
+
+#: ../../25.04/index.md:647 26164785b24247e2992c5f42c974f248
+msgid "Ceph"
+msgstr ""
+
+#: ../../25.04/index.md:649 55312ec8e9414b279ee5becca7631c5c
+msgid "Open vSwitch (OVS) and Open Virtual Network (OVN)"
+msgstr ""
+
+#: ../../25.04/index.md:651 1d32e1b986394c4da2b564fe2d66f62b
+msgid "OVS was updated to version 3.5.0, and OVN to 25.03.0."
+msgstr ""
+
+#: ../../25.04/index.md:653 eeb4fab089dc47aeb802b9d4ee5c1efd
+msgid "Common to both projects are changes in SSL/TLS support:"
+msgstr ""
+
+#: ../../25.04/index.md:654 abc13d4e354d4955b6610122110df5cb
+msgid "Protocols can be specified as ranges, e.g `TLSv1.2+` or `TLSv1.2-TLSv1.3`."
+msgstr ""
+
+#: ../../25.04/index.md:656 233649b00cb446698d0df0203d4c1a86
+msgid ""
+"Explicit support for configuring `TLSv1.3` protocol and accompanying "
+"ciphersuites. TLSv1.3 was supported in earlier versions only when "
+"protocols option was not set."
+msgstr ""
+
+#: ../../25.04/index.md:658 c8272e074fbf4b62b9081e2fc5882686
+msgid ""
+"Support for TLSv1 and TLSv1.1 is deprecated and will be removed in the "
+"next release."
+msgstr ""
+
+#: ../../25.04/index.md:660 26cb552616ec40b8b00b1b02553fada5
+msgid "OVS:"
+msgstr ""
+
+#: ../../25.04/index.md:661 8d0056e1abb943028dc34c63129fe65f
+msgid "DPDK 24.11.1 support."
+msgstr ""
+
+#: ../../25.04/index.md:663 850786863f9244b1914f4d9db9fbe80e
+msgid ""
+"New tool called `ovs-flowviz` capable of visualizing OpenFlow and "
+"datapath flow dumps."
+msgstr ""
+
+#: ../../25.04/index.md:665 31149008647c4a088df0eeb3a681080f
+msgid ""
+"Prefix tracking is enabled by default for both IPv4 and IPv6, allowing to"
+" significantly reduce amount of datapath flows generated from mixed "
+"IPv4+IPv6 flow tables."
+msgstr ""
+
+#: ../../25.04/index.md:667 a227d7f9914c4dceb143105451c66607
+msgid ""
+"Userspace datapath TSO now includes support for VXLAN, Geneve and GRE "
+"tunneled packets."
+msgstr ""
+
+#: ../../25.04/index.md:669 0528860c3b9c465b864d2b40536057bf
+msgid ""
+"TC offload now supports matching on tunnel flags as well as setting the "
+"Don't Fragment (DF) flag in `encap` action."
+msgstr ""
+
+#: ../../25.04/index.md:671 5ecba3b594494f8982375e30d91e2315
+msgid "Various improvements in `ovs-ctl` for handling IPSec configuration."
+msgstr ""
+
+#: ../../25.04/index.md:673 f0a27bffeda44fa6b054b79d579e8077
+msgid "OVN:"
+msgstr ""
+
+#: ../../25.04/index.md:674 6de155622efc47cdb7da9601933a5964
+msgid ""
+"Dynamic routing support allows the `ovn-controller` to exchange routing "
+"information with a routing protocol daemon.  The `dynamic-routing-"
+"redistribute` option controls what routes are redistributed including "
+"`lb` and `nat` options which can be used for resource location.  When "
+"used together with the routing protocol redirect feature, a routing "
+"protocol daemon can speak using a Logical Router Port (LRP) IP "
+"implemented in the OVS datapath, facilitating accelerated networking."
+msgstr ""
+
+#: ../../25.04/index.md:676 c11047a169a04f20b08b5abfb99d25d0
+msgid ""
+"Support was added for routing IPv4 packets over IPv6 networks as well as "
+"the ability to create LRPs without specifying an IPv4 address.  When used"
+" together with the new dynamic routing features and a suitable routing "
+"protocol daemon, this can be used to configure BGP unnumbered peering."
+msgstr ""
+
+#: ../../25.04/index.md:678 a975aec98e0c4e0bb3e5a69e8a4d9dee
+msgid ""
+"New Logical Switch Port (LSP) type `switch` to directly connect two "
+"logical switches, which can be used to construct multi-stage clos "
+"topology for logical switches."
+msgstr ""
+
+#: ../../25.04/index.md:680 18bdb0c4eb27409abfd3e6d04db3b4b9
+msgid ""
+"New Transit Router concept for use with OVN Interconnect which may "
+"improve traffic flow between AZs for some configurations."
+msgstr ""
+
+#: ../../25.04/index.md:682 b95fdebba278485285deff70cc330338
+msgid ""
+"New ACL option `persist-established` that allows for established "
+"connections to bypass ACL matching."
+msgstr ""
+
+#: ../../25.04/index.md:684 41b3adf4ce564b3aac7693e9eeaeaafa
+msgid ""
+"Logical router policies can now be arranged in chains, using the new "
+"`jump`, `chain` and `jump_chain` actions."
+msgstr ""
+
+#: ../../25.04/index.md:686 32886b55514a458590bf36450df5ece0
+msgid ""
+"Support for STT tunnels is deprecated and will be removed in the next "
+"release."
+msgstr ""
+
+#: ../../25.04/index.md:689 769b32e19a084579b4af6f931b894108
+msgid "GRUB2"
+msgstr ""
+
+#: ../../25.04/index.md:691 131884bfa7094070a9dbdbd7aa061e36
+msgid ""
+"The cd-boot-images-* packages are no longer used in the build process of "
+"plucky ISOs and were removed from the archive. Instead the ISO build "
+"processes uses the shim, grub2 and u-boot packages directly, streamlining"
+" the build process and reducing maintenance burden."
+msgstr ""
+
+#: ../../25.04/index.md:693 451863caa387488bb4edd8dc365b5b76
+msgid ""
+"Also there was about [27 CVE fixes](https://git.launchpad.net/~ubuntu-"
+"core-"
+"dev/grub/+git/ubuntu/commit/?id=0ac81e083f719a990a0f905e0b80238eda00b2fc)"
+" in grub2 release for Plucky!"
+msgstr ""
+
+#: ../../25.04/index.md:695 49c85f0b1d5b4b258b3ffccfa1266500
+msgid "Platforms"
+msgstr ""
+
+#: ../../25.04/index.md:697 3707e89050294d188f1c74ee72d6d7ea
+msgid "Public Cloud / Cloud images"
+msgstr ""
+
+#: ../../25.04/index.md:699 c643847a88214a65b35ca9b5d014cc49
+msgid ""
+"`UseDomains=true` is set in `/etc/systemd/networkd.conf.d/50-cloudimg-"
+"settings.conf` to restore the pre-Oracular behavior of adding search "
+"domains from DHCP responses to `/etc/resolv.conf`. The new default "
+"behavior introduced in Oracular broke some common use cases and it is too"
+" strict for cloud environments where there's usually no risk of a "
+"malicious DHCP server on the network ([LP: "
+"#2106729](https://bugs.launchpad.net/cloud-images/+bug/2106729))."
+msgstr ""
+
+#: ../../25.04/index.md:701 5680d78546b743d191f1ac4f91deb5b7
+msgid "How to report any issues resulting from these changes"
+msgstr ""
+
+#: ../../25.04/index.md:703 77317939293b407e8281ed52113ca240
+msgid ""
+"If you notice any unexpected changes or bugs in the minimal images, "
+"create a new bug in [cloud-images](https://bugs.launchpad.net/cloud-"
+"images)."
+msgstr ""
+
+#: ../../25.04/index.md:705 66b99e2fdcea4171ac7f77cf3b7357cc
+msgid "Raspberry Pi 🍓"
+msgstr ""
+
+#: ../../25.04/index.md:707 1ea89cbc4c1147d2af884ac473f8084d
+msgid ""
+"Camera support is now included with libcamera 0.4 and libpisp ([LP: "
+"#2038669](https://launchpad.net/bugs/2038669))"
+msgstr ""
+
+#: ../../25.04/index.md:709 08193e0dafd04c88b328a928dd5d5480
+msgid ""
+"The desktop now uses [gnome-initial-"
+"setup](https://launchpad.net/ubuntu/+source/gnome-initial-setup) as the "
+"first time setup guide. This runs directly under Wayland, and is much "
+"quicker than the legacy ubiquity installer. Please see the known issues "
+"section below before reporting bugs against gnome-initial-setup as it is "
+"possible you are running into something being worked on"
+msgstr ""
+
+#: ../../25.04/index.md:711 17b590baeb5043a39a000d8829b1427b
+msgid ""
+"The above change also means cloud-init is now useable on the Raspberry Pi"
+" desktop images; this can be used to automate initial user creation, "
+"package installation, customization, etc."
+msgstr ""
+
+#: ../../25.04/index.md:713 ec95940f193a4507929dfedc4271ca34
+msgid ""
+"The legacy libraspberry-bin utilities have been replaced with [raspi-"
+"utils](https://launchpad.net/ubuntu/+source/raspi-utils)"
+msgstr ""
+
+#: ../../25.04/index.md:715 db0ac8cf98cf4250961442f86c9de3ae
+msgid ""
+"nbd-client is now seeded in the Raspberry Pi images, making it simple to "
+"network boot your Pi with these images"
+msgstr ""
+
+#: ../../25.04/index.md:717 46536781785d46a5a699521d0697b08f
+msgid "arm64"
+msgstr ""
+
+#: ../../25.04/index.md:719 c8e21694e9d44a069bb446158f87f243
+msgid ""
+"In addition to arm64 server ISO there is now also an official generic "
+"arm64 desktop ISO targeting VMs, ACPI + EFI platforms and Snapdragon "
+"based WoA devices."
+msgstr ""
+
+#: ../../25.04/index.md:722 a173592b04e4456280f8fac16dd18ffd
+msgid ""
+"IBM Z and LinuxONE (s390x) "
+"![image|32x32](upload://dZM0RRlelqCcZc6RhqJGMW8DMZr.png)"
+msgstr ""
+
+#: ../../25.04/index.md:722 05201d6d761242fc9a95bd1dfb2da508
+msgid "image|32x32"
+msgstr ""
+
+#: ../../25.04/index.md:724 3347cc12fb704f77b84a2ef6aafe14fb
+msgid ""
+"The key package, 's390-tools', was step-by-step upgraded to latest "
+"version v2.37.0 ([LP: #2096789](https://launchpad.net/bugs/2096789), via "
+"[LP: #2091549](https://launchpad.net/bugs/2091549)), that covers the "
+"removal of scsi_logging_level, since it's now in sg3_utils ([LP: "
+"#2098500](https://launchpad.net/bugs/2098500)), the new pvimg and with "
+"that the rewritten genprotimg tool in Rust ([LP: "
+"#2098046](https://launchpad.net/bugs/2098046)), with it's new info "
+"command ([LP: #2098047](https://launchpad.net/bugs/2098047)), to display "
+"of encrypted & unencrypted Secure Execution (SE) image information, "
+"validations in genprotimg, if an SE image can run on particular host "
+"([LP: #2097576](https://launchpad.net/bugs/2097576)), supporting "
+"unencrypted SE images by exposing the resp. SE header flag ([LP: "
+"#2098045](https://launchpad.net/bugs/2098045)), supporting extended "
+"attestation for SE ([LP: #2097535](https://launchpad.net/bugs/2097535)) "
+"and support for retrievable secrets in SE guests ([LP: "
+"#2097533](https://launchpad.net/bugs/2097533) and kernel [LP: "
+"#2097534](https://launchpad.net/bugs/2097534))."
+msgstr ""
+
+#: ../../25.04/index.md:726 8a00b634cb7f4b42a68a3bf08c15b5d7
+msgid ""
+"Further enhancements based on the new 6.14 kernel are support for kprobes"
+" without stop machine ([LP: "
+"#2100329](https://launchpad.net/bugs/2100329)), providing topology-map "
+"information to userspace ([LP: "
+"#2098392](https://launchpad.net/bugs/2098392)), PCHID per port toleration"
+" ([LP: #2095480](https://launchpad.net/bugs/2095480)) and the new option "
+"to display available host key hashes for SE, aka Query Host-key hash UVC "
+"([LP: #2101108](https://launchpad.net/bugs/2101108))."
+msgstr ""
+
+#: ../../25.04/index.md:728 21aa63cf78c04654bab768b6da0cbe6c
+msgid ""
+"Improvements in the area of zPCI came on top, with enhanced RAS and Call "
+"Home support ([LP: #2095413](https://launchpad.net/bugs/2095413)), the "
+"new option of optics monitoring for PF in access mode (s390-tools: [LP: "
+"#2095429](https://launchpad.net/bugs/2095429), kernel: [LP: "
+"#2095427](https://launchpad.net/bugs/2095427)), the promiscuous mode "
+"exploitation for new VFs ([LP: "
+"#2096791](https://launchpad.net/bugs/2096791)) and base work in the "
+"kernel for CPU-MF counters in support for new IBM Z hardware ([LP: "
+"#2101111](https://launchpad.net/bugs/2101111))."
+msgstr ""
+
+#: ../../25.04/index.md:730 6fcb258c491842f18b03f7c932d058aa
+msgid ""
+"So support of new hardware is another significant area of work - starting"
+" with new IBM Z hardware base support in the kernel ([LP: "
+"#2100303](https://launchpad.net/bugs/2100303)) PAI/NNPA was updated for "
+"new IBM Z hardware ([LP: #2100302](https://launchpad.net/bugs/2100302)) "
+"and a new CPU model for new IBM Z hardware (kernel: [LP: "
+"#2097523](https://launchpad.net/bugs/2097523) and qemu: [LP: "
+"#2097521](https://launchpad.net/bugs/2097521)). Also user space "
+"components were enabled for new IBM Z hardware, like for gdb v16.2 ([LP: "
+"#2095361](https://launchpad.net/bugs/2095361)), valgrind v3.24 ([LP: "
+"#2095363](https://launchpad.net/bugs/2095363)), binutils v2.44 ([LP: "
+"#2095372](https://launchpad.net/bugs/2095372)), libzdnn v1.1.1 for "
+"exploiting new AI hardware ([LP: "
+"#2095373](https://launchpad.net/bugs/2095373)) - and the smc-tool update "
+"to latest v1.8.4 ([LP: #2095005](https://launchpad.net/bugs/2095005))."
+msgstr ""
+
+#: ../../25.04/index.md:733 d23f202977ba4d969a34f607ec4a705c
+msgid "Several dedicated new features were added, like:"
+msgstr ""
+
+#: ../../25.04/index.md:734 f9c4a308388a4f28b7c0c3224eb63af4
+msgid ""
+"the cpacfinfo tool to provide CPACF (on-chip crypto co-processor) "
+"information (kernel: [LP: #2096894](https://launchpad.net/bugs/2096894), "
+"s390-tools: [LP: #2096896](https://launchpad.net/bugs/2096896))"
+msgstr ""
+
+#: ../../25.04/index.md:735 d17809b840b743ba9a921171334f53fb
+msgid ""
+"the zpwr tool, for LPAR level power consumption reporting (kernel: [LP: "
+"#2098391](https://launchpad.net/bugs/2098391), s390-tools: [LP: "
+"#2098358](https://launchpad.net/bugs/2098358))"
+msgstr ""
+
+#: ../../25.04/index.md:736 15111092cd964872954eea470c415732
+msgid ""
+"the chpstat tool, for additional channel measurements (kernel: [LP: "
+"#2095483](https://launchpad.net/bugs/2095483), s390-tools [LP: "
+"#2095485](https://launchpad.net/bugs/2095485))"
+msgstr ""
+
+#: ../../25.04/index.md:737 411eb4df56144177b5bb9b1075af28c6
+msgid ""
+"full boot order support in KVM (qemu: [LP: "
+"#2049698](https://launchpad.net/bugs/2049698), libvirt: [LP: "
+"#2051239](https://launchpad.net/bugs/2051239))"
+msgstr ""
+
+#: ../../25.04/index.md:738 cc20439637e745d08b7da1fa5e9e0699
+msgid ""
+"enablement of virtio-mem support (kernel: [LP: "
+"#2097883](https://launchpad.net/bugs/2097883), qemu: [LP: "
+"#2097884](https://launchpad.net/bugs/2097884) and libvirt: [LP: "
+"#2097886](https://launchpad.net/bugs/2097886)) and"
+msgstr ""
+
+#: ../../25.04/index.md:739 7a8751bffee341f3bf6c7d26a8dc8992
+msgid ""
+"enablement of dynamic updates of vfio-ap mediated (crypto) devices for "
+"management applications (kernel: [LP: "
+"#2097489](https://launchpad.net/bugs/2097489), s390-tools: [LP: "
+"#2097488](https://launchpad.net/bugs/2097488), libvirt: [LP: "
+"#2097487](https://launchpad.net/bugs/2097487) and mdevctl: [LP: "
+"#2097486](https://launchpad.net/bugs/2097486))"
+msgstr ""
+
+#: ../../25.04/index.md:741 9c25f688dbad40e292cc63ac59b53802
+msgid ""
+"While mentioning cryptography, there are many more enhancements in this "
+"area, like in kernel crypto support:"
+msgstr ""
+
+#: ../../25.04/index.md:742 6ca80c0a98bc4d8c912cff37dd0fc5bf
+msgid "for MSA 10 XTS ([LP: #2096809](https://launchpad.net/bugs/2096809))"
+msgstr ""
+
+#: ../../25.04/index.md:743 ecb005e65d8848f697c79990576c08f6
+msgid "for MSA 11 HMAC ([LP: #2096812](https://launchpad.net/bugs/2096812))"
+msgstr ""
+
+#: ../../25.04/index.md:744 f1ba556590714a8391fc49d7db9b455e
+msgid "for for MSA 12 (SHA3) ([LP: #2100946](https://launchpad.net/bugs/2100946))"
+msgstr ""
+
+#: ../../25.04/index.md:745 44897def59be45f3985dec3fb64080a1
+msgid ""
+"for PAES support for MSA 10 XTS ([LP: "
+"#2100935](https://launchpad.net/bugs/2100935)) but also:"
+msgstr ""
+
+#: ../../25.04/index.md:747 b5e856ba0d5e435cbc5039fb16289ed3
+msgid ""
+"of MSA 10 and MSA 11 in cpacfstats ([LP: "
+"#2096890](https://launchpad.net/bugs/2096890))"
+msgstr ""
+
+#: ../../25.04/index.md:748 91248e2a5a2c441db625416596bf8cc8
+msgid ""
+"for zkey key for dm-crypt with XTS keys ([LP: "
+"#2096892](https://launchpad.net/bugs/2096892))"
+msgstr ""
+
+#: ../../25.04/index.md:749 dcbe2256100d418d879300ca383a8648
+msgid ""
+"for pkey, protected XTS and HMAC keys ([LP: "
+"#2100936](https://launchpad.net/bugs/2100936)) and support"
+msgstr ""
+
+#: ../../25.04/index.md:750 33e9414c40f941b89a3f8c30e7cf000e
+msgid ""
+"for SE retrieved protected keys ([LP: "
+"#2097543](https://launchpad.net/bugs/2097543))"
+msgstr ""
+
+#: ../../25.04/index.md:752 a422fb6536184fdaad4ff3561bac0a2e
+msgid "This partially also requires updates in openSSL:"
+msgstr ""
+
+#: ../../25.04/index.md:753 b92caa3e91304217b5850725abea0ed4
+msgid ""
+"for MSA 10 XTS support ([LP: "
+"#2096810](https://launchpad.net/bugs/2096810))"
+msgstr ""
+
+#: ../../25.04/index.md:754 984f3c3934094997898c0b35785f7104
+msgid ""
+"for MSA 11 HMAC support ([LP: "
+"#2096811](https://launchpad.net/bugs/2096811)) and support"
+msgstr ""
+
+#: ../../25.04/index.md:755 bb3627e030be47f7a38449c85cdde2da
+msgid "for MSA 12 (SHA3) ([LP: #2096949](https://launchpad.net/bugs/2096949))"
+msgstr ""
+
+#: ../../25.04/index.md:757 4004988a583742e0abdec5725ce66bf8
+msgid ""
+"In addition openCryptoki was upgraded to the latest v3.24 ([LP: "
+"#2095337](https://launchpad.net/bugs/2095337)), that includes support "
+"for:"
+msgstr ""
+
+#: ../../25.04/index.md:758 befa4ac66ca94a0d9df5871ad3f05172
+msgid "CCA token SHA3 ([LP: #2096950](https://launchpad.net/bugs/2096950))"
+msgstr ""
+
+#: ../../25.04/index.md:759 bfbda8d2becb4c719a68c2421e8e8ccf
+msgid ""
+"CCA token RSA OAEP v2.1 ([LP: "
+"#2096951](https://launchpad.net/bugs/2096951))"
+msgstr ""
+
+#: ../../25.04/index.md:760 cdc8403f20f24c71b4ab27b2e770e118
+msgid "CCA token cipher keys ([LP: #2097111](https://launchpad.net/bugs/2097111))"
+msgstr ""
+
+#: ../../25.04/index.md:761 afb9b83f92c241b2bf80896a9b46c314
+msgid ""
+"CCA token of Dilithium ([LP: "
+"#2096897](https://launchpad.net/bugs/2096897)) and support of"
+msgstr ""
+
+#: ../../25.04/index.md:762 a5c6560adf1948d69dc4d997f7004c61
+msgid ""
+"CKM_RSA_AES_KEY_WRAP for cca, ica and soft tokens ([LP: "
+"#2097110](https://launchpad.net/bugs/2097110))"
+msgstr ""
+
+#: ../../25.04/index.md:764 21075fbf8410422588baac2753638f5d
+msgid "Finally further cryptography-related packages were updated, like:"
+msgstr ""
+
+#: ../../25.04/index.md:765 69bfb4f30adc463084b362a624cd81b2
+msgid ""
+"p11-kit v0.25.5, to update IBM specific mechanisms (up to IBM z16) ([LP: "
+"#2098092](https://launchpad.net/bugs/2098092))"
+msgstr ""
+
+#: ../../25.04/index.md:766 3443c0f2f28a468ea7e9bf17d741ede1
+msgid ""
+"libica, to latest v4.4.0 ([LP: "
+"#2095409](https://launchpad.net/bugs/2095409))"
+msgstr ""
+
+#: ../../25.04/index.md:767 724458e86bb64b189b7d56df693f240e
+msgid ""
+"libzpc v1.3.0, to support protected key derived from SE retrievable "
+"secrets ([LP: #2097545](https://launchpad.net/bugs/2097545))"
+msgstr ""
+
+#: ../../25.04/index.md:769 a9989d89ed104c8a901eac4a87a89283
+msgid "IBM POWER (ppc64el)"
+msgstr ""
+
+#: ../../25.04/index.md:771 cfddc570b9f94247a3e8a6bbbd7602dd
+msgid ""
+"The powerpc-utils package was upgraded to the latest available version  "
+"1.3.13 ([LP: #2096946](https://launchpad.net/bugs/2096946))."
+msgstr ""
+
+#: ../../25.04/index.md:773 6f036d36afd74a04b76fd171f441eb1a
+msgid ""
+"The new package 'secvarctl' was added ([LP: "
+"#2064345](https://launchpad.net/bugs/2064345)), that allows to handle "
+"secureboot artifacts and key management on ppc64el."
+msgstr ""
+
+#: ../../25.04/index.md:777 2447610171924eac81a22b869c677713
+msgid "Provide a single pre-installed image for all JH7110 boards."
+msgstr ""
+
+#: ../../25.04/index.md:778 0f89ebaa0da1425090fb64285d2ccb79
+msgid "Support Pine64 Star64"
+msgstr ""
+
+#: ../../25.04/index.md:782 f5f5930fba8c4622900d8e9460f5fa8e
+msgid "Known Issues"
+msgstr ""
+
+#: ../../25.04/index.md:784 f1724da9c06a41ed926f8a134c8a4a64
+msgid ""
+"As is to be expected with any release, there are some significant known "
+"bugs that users may encounter with this release of Ubuntu. The ones we "
+"know about at this point (and some of the workarounds) are documented "
+"here, so you don't need to spend time reporting these bugs again:"
+msgstr ""
+
+#: ../../25.04/index.md:786 1c84fd8c018a455fb32390b34385cba0
+msgid "General"
+msgstr ""
+
+#: ../../25.04/index.md:788 b2c3607cf10c4eeaa1d418b12e7a385e
+msgid ""
+"There is a bug ([LP: #2104316](https://bugs.launchpad.net/ubuntu-power-"
+"systems/+bug/2104297)) in the *beta* images that prevents netboot "
+"installs in some scenarios."
+msgstr ""
+
+#: ../../25.04/index.md:789 d9c7f4abb0954df0a78c92529f0f3596
+msgid ""
+"It has been reported that cloud-init may fails to upgrade properly in the"
+" Oracular to Plucky upgrade path, see [LP: "
+"#2104316](https://bugs.launchpad.net/ubuntu-power-systems/+bug/2104297)."
+msgstr ""
+
+#: ../../25.04/index.md:790 6a7bead3b7504c9b9ae35137dac005fe
+msgid ""
+"The Live Session of the new Ubuntu Desktop installer is not localized. It"
+" is still possible to perform a non-English installation using the new "
+"installer, but internet access at install time is required to download "
+"the language packs. ([LP: #2013329](https://bugs.launchpad.net/ubuntu-"
+"release-notes/+bug/2013329))"
+msgstr ""
+
+#: ../../25.04/index.md:791 a82f1d2fbdbc4321b3759cbae379c577
+msgid ""
+"ZFS with Encryption on Ubuntu 24.10 will [fail to activate the cryptoswap"
+" "
+"partition](https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/2084089)."
+"  This affects both new installs and upgrades.  We expect to address this"
+" post-release with an archive update."
+msgstr ""
+
+#: ../../25.04/index.md:792 9ddf36b073cb4756b969ff00076e2e71
+msgid ""
+"Some particular hardware (e.g. Thinkpad x201) might have issues ([general"
+" freeze](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2084055), "
+"[`desktop-security-center` not launching](https://github.com/canonical"
+"/desktop-security-center/issues/81)), when booted without `nomodeset` "
+"(Safe graphics). Follow these steps if you encounter such an issue:"
+msgstr ""
+
+#: ../../25.04/index.md:794 9d03cab19d4e4c728f93d2fbfa305e9e
+msgid ""
+"At the GRUB boot menu, press `e` (keep `Shift` pressed during early boot "
+"if the menu doesn't show up)."
+msgstr ""
+
+#: ../../25.04/index.md:795 a321a45348a44ee4b7d64f7c9d773f8a
+msgid "Add `nomodeset` to `linux` line, like the example below:"
+msgstr ""
+
+#: ../../25.04/index.md:801 4e6aa57858e84a64acc928bd323b9f70
+msgid "Press `Ctrl-x` to continue the boot process"
+msgstr ""
+
+#: ../../25.04/index.md:802 b8cce59320074afbaa55f955ddbd1799
+msgid ""
+"After installation is complete, reboot, use `nomodeset` again, like the "
+"example below:"
+msgstr ""
+
+#: ../../25.04/index.md:808 4a84381ca7994dac94f4a51daf48e68c
+msgid ""
+"Add `nomodeset` to the GRUB config file, `/etc/default/grub`, like the "
+"example below:"
+msgstr ""
+
+#: ../../25.04/index.md:814 0061d13c7dc842d389e672c5a42e862d
+msgid "Finally, run `sudo update-grub` to make the change take effect."
+msgstr ""
+
+#: ../../25.04/index.md:817 67a73bc40a784c75973972552f256c58
+msgid "Linux kernel"
+msgstr ""
+
+#: ../../25.04/index.md:819 31afdce4d0514b9db4b3b61c1f09300a
+msgid ""
+"A bug prevents the IO scheduler from being reset to \"none\" ([LP: "
+"#2083845](https://bugs.launchpad.net/bugs/2083845)): the fix is already "
+"in v6.11.2, and will be part of the first SRU kernel."
+msgstr ""
+
+#: ../../25.04/index.md:820 5cea5577bd4a46a886d7fd825f43e5ca
+msgid ""
+"Support for FAN networking has been dropped in the 6.11 release kernel. "
+"It will be re-introduced in the next 6.11 kernel update shortly."
+msgstr ""
+
+#: ../../25.04/index.md:821 1add8b76eff34c50b7b7c10f51b69be9
+msgid ""
+"ZFS may cause kernel freezes during the 25.10 upgrades, rendering the "
+"upgrade unable to complete, due to a bug in the interaction between newer"
+" ZFS userspace utilities with older kernel modules. ([LP: "
+"#2110891](https://bugs.launchpad.net/ubuntu/+source/ubuntu-release-"
+"upgrader/+bug/2110891))"
+msgstr ""
+
+#: ../../25.04/index.md:826 56dbfe6173a0417c8104801115bc85b7
+msgid ""
+"Screen reader support is present with the new desktop installer, but is "
+"incomplete ([LP: #2061015](https://launchpad.net/bugs/2061015), [LP: "
+"#2061018](https://launchpad.net/bugs/2061018), [LP: "
+"#2036962](https://launchpad.net/bugs/2036962), [LP: "
+"#2061021](https://launchpad.net/bugs/2061021))"
+msgstr ""
+
+#: ../../25.04/index.md:828 420ee8b8074e43ac9f64398a2e6d8a43
+msgid ""
+"OEM installs are not supported yet ([LP: "
+"#2048473](https://launchpad.net/bugs/2048473))"
+msgstr ""
+
+#: ../../25.04/index.md:830 43518577a0af482496cdf4c80cc378f7
+msgid ""
+"GTK4 apps (including the desktop wallpaper) do not display correctly with"
+" VirtualBox or VMWare with 3D Acceleration ([LP: "
+"#2061118](https://launchpad.net/bugs/2061118))."
+msgstr ""
+
+#: ../../25.04/index.md:832 eb35950ae2dc4c629d414097eda74399
+msgid ""
+"**Incompatibility between TPM-backed Full Disk Encryption and Absolute:**"
+" TPM-backed Full Disk Encryption (FDE) has been introduced to enhance "
+"data security. However, it's important to note that this feature is "
+"incompatible with Absolute (formerly Computrace) security software. If "
+"Absolute is enabled on your system, the machine will not boot post-"
+"installation when TPM-backed FDE is also enabled. Therefore, disabling "
+"Absolute from the BIOS is recommended to avoid booting issues."
+msgstr ""
+
+#: ../../25.04/index.md:833 505b36e9bbcc47a784897b698fe82f39
+msgid ""
+"**Hardware-Specific Kernel Module Requirements for TPM-backed Full Disk "
+"Encryption:** TPM-backed Full Disk Encryption (FDE) requires a specific "
+"kernel snap which may not include certain kernel modules necessary for "
+"some hardware functionalities. A notable example is the `vmd` module "
+"required for NVMe RAID configurations. In scenarios where such specific "
+"kernel modules are indispensable, the hardware feature may need to be "
+"disabled in the BIOS (such as RAID) to ensure the continued availability "
+"of the affected hardware post-installation. If disabling in the BIOS is "
+"not an option, the related hardware will not be available post-"
+"installation with TPM-backed FDE enabled."
+msgstr ""
+
+#: ../../25.04/index.md:834 14ecdd0d98da413cb3c649ea647e03c3
+msgid ""
+"[FDE specific bug "
+"reports](https://bugs.launchpad.net/bugs/+bugs?field.searchtext=&orderby=-importance&field.status%3Alist=NEW&field.status%3Alist=CONFIRMED&field.status%3Alist=TRIAGED&field.status%3Alist=INPROGRESS&field.status%3Alist=FIXCOMMITTED&field.status%3Alist=INCOMPLETE_WITH_RESPONSE&field.status%3Alist=INCOMPLETE_WITHOUT_RESPONSE&assignee_option=any&field.assignee=&field.bug_reporter=&field.bug_commenter=&field.subscriber=&field.tag=fde&field.tags_combinator=ANY&field"
+".status_upstream-empty-"
+"marker=1&field.has_cve.used=&field.omit_dupes.used=&field.omit_dupes=on&field.affects_me.used=&field.has_patch.used=&field.has_branches.used=&field.has_branches=on&field.has_no_branches.used=&field.has_no_branches=on&field.has_blueprints.used=&field.has_blueprints=on&field.has_no_blueprints.used=&field.has_no_blueprints=on&search=Search)."
+msgstr ""
+
+#: ../../25.04/index.md:836 95ef657d9b9649ba8c8cbfba5b588482
+msgid ""
+"Resuming from suspend on Nvidia desktops (where Nvidia is the primary GPU"
+" so generally not laptops)  will exhibit visual corruption and freezes "
+"using the default Wayland session  "
+"([LP#1876632](https://bugs.launchpad.net/bugs/1876632)). If you need "
+"suspend/resume support then the simplest solution is to select 'Ubuntu on"
+" Xorg' at the login screen."
+msgstr ""
+
+#: ../../25.04/index.md:838 9376a59014a04d48a24a5854ecdb61fc
+msgid ""
+"Installing `ubuntu-fonts-classic` results in a non-Ubuntu font being "
+"displayed ([LP#2083683](https://bugs.launchpad.net/bugs/2083683)). To "
+"resolve this, install `gnome-tweaks` and set ‘Interface Text’ to "
+"‘Ubuntu’."
+msgstr ""
+
+#: ../../25.04/index.md:842 f5f2dabe8aca451a80ede48106b5b5b3
+msgid "rabbitmq-server"
+msgstr ""
+
+#: ../../25.04/index.md:844 e030951f03f3444498c6213feeff98f1
+msgid ""
+"Certain version hops may be unsupported due to feature flags, raising "
+"questions about how Ubuntu will maintain this package moving forward. We "
+"are currently exploring the use of snaps as a potential solution to "
+"enable smoother upgrades. For more information please read "
+"https://bugs.launchpad.net/bugs/2074309."
+msgstr ""
+
+#: ../../25.04/index.md:848 8870a0cc71df41118476968bbe76ba0a
+msgid ""
+"Libvirt provides the default network on install, in a nested installation"
+" it modified the configuration to not conflict with the one already "
+"provided by the first level host. There is an "
+"[issue](https://bugs.launchpad.net/ubuntu-release-notes/+bug/2107448) "
+"where the file it needs to modify is not yet present when it needs to "
+"modify it. That will be fixed via an SRU, but until then it can be worked"
+" around by installing `libvirt-daemon-config-network` before installing "
+"the other libvirt components that are needed in that nested environment."
+msgstr ""
+
+#: ../../25.04/index.md:850 f1e32016e8824ecdb863d613773b460a
+msgid "Openstack"
+msgstr ""
+
+#: ../../25.04/index.md:852 450f92b971f643afb6c976b33371d353
+msgid ""
+"Currently, Nova Compute is non-functional because of a python3.13 "
+"incompatibility "
+"([LP:#2103413](https://bugs.launchpad.net/ubuntu/+source/nova/+bug/2103413))."
+" The Openstack team and Upstream work on it and it will be resolved via "
+"an SRU later."
+msgstr ""
+
+#: ../../25.04/index.md:855 a4a980e101d04f698c77dca327e75b65
+msgid "The Ubuntu Cloud Archive is not affected by this bug."
+msgstr ""
+
+#: ../../25.04/index.md:857 c23ca969fc3942bba18c647d70b62fb0
+msgid "Installer"
+msgstr ""
+
+#: ../../25.04/index.md:859 db10960296f34e7497f3936752a7c0a1
+msgid ""
+"On systems booting via U-Boot, U-Boot should be updated to the current "
+"Plucky version before installation as subiquity does not run flash-kernel"
+" and grub-update during the installation. So for first boot the device-"
+"tree from U-Boot will be used."
+msgstr ""
+
+#: ../../25.04/index.md:861 2fdc08c9030f4842bca5637ddaaca3eb
+msgid ""
+"In some situations, it is acceptable to proceed with an offline "
+"installation when the mirror is inaccessible. In this scenario, it is "
+"advised to use:"
+msgstr ""
+
+#: ../../25.04/index.md:868 a1d1b82a87c74e35af62fc4f15ebf157
+msgid ""
+"Network interfaces left unconfigured at install time are assumed to be "
+"configured via dhcp4. If this doesn't happen (for example, because the "
+"interface is physically not connected) the boot process will block and "
+"wait for a few minutes ([LP: "
+"#2063331](https://bugs.launchpad.net/subiquity/+bug/2063331)). This can "
+"be fixed by removing the extra interfaces from `/etc/netplan/50-cloud-"
+"init.conf` or by marking them as `optional: true`. Cloud-init is disabled"
+" on systems installed from ISO images, so settings will persist."
+msgstr ""
+
+#: ../../25.04/index.md:870 d71969cea3894beab71cec0f81dcbfdd
+msgid "samba apparmor profile"
+msgstr ""
+
+#: ../../25.04/index.md:872 c5ec2b28934742e7ab2572f8dab3fffc
+msgid ""
+"Due to [bug LP: "
+"#2063079](https://bugs.launchpad.net/ubuntu/+source/samba/+bug/2063079), "
+"the samba `smbd.service` unit file is no longer calling out to the helper"
+" script to dynamically create apparmor profile snippets according to the "
+"existing shares."
+msgstr ""
+
+#: ../../25.04/index.md:874 eb1b56553ca844d7b40bcfa09eb53bfe
+msgid ""
+"By default, the `smbd` service from samba is not confined. To be affected"
+" by this bug, users have to:"
+msgstr ""
+
+#: ../../25.04/index.md:875 c869122db01943acb66be1578e9e70bb
+msgid "install the optional `apparmor-profiles` package"
+msgstr ""
+
+#: ../../25.04/index.md:876 afa76b5913564f9ba1155d861365eb33
+msgid "switch the `smbd` profile confinement from `complain` to `enforce`"
+msgstr ""
+
+#: ../../25.04/index.md:878 72ea031ab1754af59fb3c6d01ce3b128
+msgid ""
+"Therefore, only users who have taken those steps and upgrade to Noble, "
+"will be affected by this bug. An SRU to fix it will be done shortly after"
+" release."
+msgstr ""
+
+#: ../../25.04/index.md:883 3b4aeee9c3af4663842387cf1cf1e860
+msgid ""
+"There is a AppArmor related bug where containers cannot be promptly "
+"stopped due to the recently added AppArmor profile for `runc`. The "
+"containers are always killed with `SIGKILL` due to the denials when "
+"trying to receive a signal. More details about this bug can be found "
+"[here](https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/2063099),"
+" and a workaround is described "
+"[here](https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/2063099/comments/4)."
+msgstr ""
+
+#: ../../25.04/index.md:887 c8e1f64406ce4f949c9b902de084d241
+msgid ""
+"Plucky provides better AppArmor isolation for the tools in util-linux "
+"which is great, but it was found that on s390x this might break usage of "
+"lsblk. Fixes will soon be provided via bug "
+"[2107402](https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/2107402)"
+" and bug "
+"[2107455](https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/2107455)."
+" Until then the effect will be that lsblk on s390x will show no devices "
+"or in s390x based containers segfault. Until the SRU is available that "
+"can be mitigated by disabling the related AppArmor profile via `aa-"
+"disable lsblk`."
+msgstr ""
+
+#: ../../25.04/index.md:889 a9aa888144804bd2b68e8835ea4f3f53
+msgid "ppc64el"
+msgstr ""
+
+#: ../../25.04/index.md:891 d106bdb5dd1f43afa0a71f6da0ec5931
+msgid ""
+"Ubuntu Server for IBM Power installation using SAN disks ([LP: "
+"#2107523](https://bugs.launchpad.net/bugs/2107523/), [LP: "
+"#2080474](https://bugs.launchpad.net/bugs/2080474/)) will fail in case "
+"disks have existing configurations. A potential workaround is to wipe "
+"(wipefs) the disks first (using the installer shell) and then restart the"
+" installation with a clean disk."
+msgstr ""
+
+#: ../../25.04/index.md:892 4b6d5c6d7aeb46b080bdc7f65b57bac4
+msgid ""
+"PMDK sees some hardware-specific failures in its test suite, which may "
+"make the software partially or fully inoperable on the ppc64el "
+"architecture. ([LP: "
+"#2061913](https://bugs.launchpad.net/ubuntu/+source/pmdk/+bug/2061913/))"
+msgstr ""
+
+#: ../../25.04/index.md:893 88f093e2fa814fe993bddc3e99fabc6b
+msgid ""
+"For interfaces attached via 'virsh attach-interface' to be reflected and "
+"visible in a ppc64el KVM guest running inside a PowerVM LPAR a reboot is "
+"required (regardless if option '--live' got used or not) ([LP: "
+"#2111231](https://bugs.launchpad.net/bugs/2111231))."
+msgstr ""
+
+#: ../../25.04/index.md:895 4edc98114ca742d4b1ffd96f51e5888b
+msgid "Raspberry Pi"
+msgstr ""
+
+#: ../../25.04/index.md:897 668e001384b24a228a015421d208802a
+msgid "The new gnome-initial-setup has some teething issues:"
+msgstr ""
+
+#: ../../25.04/index.md:898 b68c4a5f13b843128928fccfec4e4efa
+msgid ""
+"Time zone input dropdown can \"wobble\" ([LP: "
+"#2084611](https://launchpad.net/bugs/2084611))"
+msgstr ""
+
+#: ../../25.04/index.md:899 bb58c285bec34175917614766509913a
+msgid ""
+"The localization of the application fails ([LP: "
+"#2104148](https://launchpad.net/bugs/2104148))"
+msgstr ""
+
+#: ../../25.04/index.md:900 04decaddbc1b4337baf2bbf218e63d4d
+msgid ""
+"The hostname change is mandatory ([LP: "
+"#2093132](https://launchpad.net/bugs/2093132))"
+msgstr ""
+
+#: ../../25.04/index.md:902 e045e0d53d50449ab4071191c5ef6c4d
+msgid ""
+"During boot on the server image, if your `cloud-init` configuration (in "
+"`user-data` on the boot partition) relies upon networking (importing SSH "
+"keys, installing packages, etc.) you *must* ensure that at least one "
+"network interface is required (`optional: false`) in `network-config` on "
+"the boot partition. This is due to netplan changes to the wait-online "
+"service (~~[LP: #2060311](https://launchpad.net/bugs/2060311)~~)"
+msgstr ""
+
+#: ../../25.04/index.md:904 ab742facae1247e1a0764024e5aca938
+msgid ""
+"The seeded totem video player will not prompt users to install missing "
+"codecs when attempting to play a video requiring them ([LP: "
+"#2060730](https://launchpad.net/bugs/2060730))"
+msgstr ""
+
+#: ../../25.04/index.md:906 98d5c4299f7848b19d4a5f561b72bcc0
+msgid ""
+"With the removal of the `crda` package in 22.04, the method of setting "
+"the wifi regulatory domain (editing `/etc/default/crda`) no longer "
+"operates. On server images, use the `regulatory-domain` option in the "
+"Netplan configuration. On desktop images, append "
+"`cfg80211.ieee80211_regdom=GB` (substituting `GB` for the relevant "
+"country code) to the kernel command line in the `cmdline.txt` file on the"
+" boot partition  ([LP: #1951586](https://launchpad.net/bugs/1951586))."
+msgstr ""
+
+#: ../../25.04/index.md:908 8f22a963e9eb484186c1b87bb2c12ac1
+msgid ""
+"The power LED on the Raspberry Pi 2B, 3B, 3A+, 3B+, and Zero 2W currently"
+" goes off and stays off once the Ubuntu kernel starts booting ([LP: "
+"#2060942](https://launchpad.net/bugs/2060942))"
+msgstr ""
+
+#: ../../25.04/index.md:910 ab70a0e8dedf4ee88749d8291fae20fd
+msgid ""
+"Colours appear incorrectly in the Ubuntu App Centre ([LP: "
+"#2076919](https://launchpad.net/bugs/2076919))"
+msgstr ""
+
+#: ../../25.04/index.md:912 c84e52bec381460c8d752180b6cfead4
+msgid ""
+"On server images, re-authentication to WiFi APs when regulatory domain is"
+" set result in dmesg spam to the console ([LP: "
+"#2063365](https://launchpad.net/bugs/2063365))"
+msgstr ""
+
+#: ../../25.04/index.md:914 a409fdd28d5c4edbad9b0fdc16e63f1b
+msgid ""
+"The default audio output on the Raspberry Pi 4 is \"Analogue Output - "
+"Built-in Audio\" instead of \"HDMI/Displayport\", so you might be "
+"confused after the first boot when you hear no sound even after moving "
+"the volume slider. You can change the audio output to HDMI in the "
+"settings, which persists in subsequent boots. ([LP: "
+"#1993347](https://bugs.launchpad.net/ubuntu/+source/pipewire/+bug/1993347))"
+msgstr ""
+
+#: ../../25.04/index.md:916 d03fcfbdd5bf4af4b66fa4039899c1fc
+msgid "Google Compute Platform"
+msgstr ""
+
+#: ../../25.04/index.md:918 ../../25.04/index.md:926
+#: 7dea97f3d0b54211bf8579dfe87713ed a6309a9acc964712849eda7347614b91
+msgid "Nothing yet."
+msgstr ""
+
+#: ../../25.04/index.md:920 b6300978d18e454c86204639e2c94104
+msgid "Microsoft Azure"
+msgstr ""
+
+#: ../../25.04/index.md:922 5b74064ff61c4827aaf6351b46c0da5c
+msgid ""
+"The current version of walinuxagent relies on python3-legacycrypt for "
+"password changing functionality but it cannot be made a dependency due to"
+" a component mismatch ([LP: "
+"#2106484](https://launchpad.net/bugs/2106484))."
+msgstr ""
+
+#: ../../25.04/index.md:924 d1a99a5f2b874e83bef319d47ce3a623
+msgid "s390X"
+msgstr ""
+
+#: ../../25.04/index.md:929 a3eb46ec909c4585aff3bd3600a72097
+msgid "Official flavors"
+msgstr ""
+
+#: ../../25.04/index.md:931 ddc115d5352a48edad8f7ba8a937adb1
+msgid "Find the release notes for the official flavors at the following links:"
+msgstr ""
+
+#: ../../25.04/index.md:933 c91493b6b3864aa4b1df73358233c385
+msgid ""
+"[Edubuntu Release "
+"Notes](https://discourse.ubuntu.com/t/edubuntu-25-04-released)"
+msgstr ""
+
+#: ../../25.04/index.md:934 30807f8635924dd183204239a102b2d7
+msgid ""
+"[Kubuntu Release "
+"Notes](https://wiki.ubuntu.com/PluckyPuffin/ReleaseNotes/Kubuntu)"
+msgstr ""
+
+#: ../../25.04/index.md:935 eb63e7701adb4754af0f9503ff505ef8
+msgid "[Lubuntu Release Notes](https://lubuntu.me/plucky-released/)"
+msgstr ""
+
+#: ../../25.04/index.md:936 4e96008f2751481682a6bdbb69b06104
+msgid ""
+"[Ubuntu Budgie Release Notes](https://ubuntubudgie.org/2025/04/ubuntu-"
+"budgie-25-04-release-notes/)"
+msgstr ""
+
+#: ../../25.04/index.md:937 6338e904eecd4abb9b903bf9f42eda73
+msgid ""
+"[Ubuntu MATE Release Notes](https://ubuntu-mate.org/blog/ubuntu-mate-p-p"
+"-release-notes/)"
+msgstr ""
+
+#: ../../25.04/index.md:938 b0f4327cb13f455eb20f07f53cd8fe00
+msgid ""
+"[Ubuntu Studio Release Notes](https://discourse.ubuntu.com/t/ubuntu-"
+"studio-25-04-release-notes/)"
+msgstr ""
+
+#: ../../25.04/index.md:939 b994eb98f6df46369e52d4d4230644d7
+msgid ""
+"[Ubuntu Unity Release Notes](https://ubuntuunity.org/posts/ubuntu-"
+"unity-2504-released/)"
+msgstr ""
+
+#: ../../25.04/index.md:940 d754958f2e75457c93aabac79a1d27d9
+msgid ""
+"[Xubuntu Release Notes](https://wiki.xubuntu.org/releases/25.04/release-"
+"notes)"
+msgstr ""
+
+#: ../../25.04/index.md:941 86ae9e1b4c2e4a0b857de1055c63cef9
+msgid ""
+"[Ubuntu Kylin Release "
+"Notes](https://ubuntukylin.com/news/ubuntukylin2504-en.html)"
+msgstr ""
+
+#: ../../25.04/index.md:942 2842fbb5a99444a690281f7213d60046
+msgid "[Ubuntu Cinnamon Release Notes](https://ubuntucinnamon.org/?p=1348)"
+msgstr ""
+
+#: ../../25.04/index.md:946 8501569c40a542069441009466f4f004
+msgid "More information"
+msgstr ""
+
+#: ../../25.04/index.md:948 10a4a53b6f0c4b3cb9a80a54b765f4c5
+#, python-brace-format
+msgid ""
+"Refer to {ref}`release-policy-and-schedule` and {ref}`project-and-"
+"community`."
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/25.04/schedule.po
+++ b/docs/locale/ja/LC_MESSAGES/25.04/schedule.po
@@ -1,0 +1,557 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../25.04/schedule.md:2 d19db63440634f3eb3223ec65747be38
+msgid "Ubuntu Plucky Puffin Release Schedule"
+msgstr ""
+
+#: ../../25.04/schedule.md 578a0b570b6a43ac94d5f3fcd1bb322a
+#: 63e4e0199e4b43f1845d71731d1c3caa
+msgid "Week"
+msgstr ""
+
+#: ../../25.04/schedule.md 1923cc8d515a4a7eb37354396e488a55
+#: 4fa9f6b5e6294b1e8d9424fce3a14b40
+msgid "Date (Thursday)"
+msgstr ""
+
+#: ../../25.04/schedule.md 00d6edea9a894e6988840aebd20e55df
+msgid "25.04 events"
+msgstr ""
+
+#: ../../25.04/schedule.md b56f5c9c53d64cebb954ae389ce01381
+#: e366bf8a722b4a7e91cfc073a0c9c5e6
+msgid "**October 2024**"
+msgstr ""
+
+#: ../../25.04/schedule.md bf9fb9d2d7894b56b73386e4e0331efd
+#: c3ef3b90adcf4ab5975d9166235c88b9
+msgid "1"
+msgstr ""
+
+#: ../../25.04/schedule.md 1dedcee25cde47e08a436a852d4b849e
+#: 3ac847c22b3e4f36b855a6ba1d6fae86
+msgid "October 17"
+msgstr ""
+
+#: ../../25.04/schedule.md 6fbdecaa3d814103b433ac86283ebaff
+msgid "Toolchain Uploaded"
+msgstr ""
+
+#: ../../25.04/schedule.md 6082098a6cc5402b99e0a0ccbaf0cfc7
+#: e455a340bb87474297cd62667150fe75
+msgid "2"
+msgstr ""
+
+#: ../../25.04/schedule.md 2d0f6d80b9444447b89d7cfd64338199
+#: fd1748d93274401e8042585de2f0a0df
+msgid "October 24"
+msgstr ""
+
+#: ../../25.04/schedule.md 4ffdca02a4b64c1394a94744654baf7b
+msgid "Build with -O3 on amd64"
+msgstr ""
+
+#: ../../25.04/schedule.md 76028726a10c466b94ce6889b784b88d
+#: b3e2e48cceec432bbce4b3227e62c10f
+msgid "3"
+msgstr ""
+
+#: ../../25.04/schedule.md 48cbd789dba04c7fa5b9d3fd992fa505
+#: e88c0eaa60b449469cdf6cbf19742964
+msgid "October 31"
+msgstr ""
+
+#: ../../25.04/schedule.md 31dcb37064f8437986832511312506ee
+#: 8ee54d4ace224fce810161737c18046c
+msgid "**November 2024**"
+msgstr ""
+
+#: ../../25.04/schedule.md 49ce04d1684b48009e674fb6b29f799d
+#: 534e3f951f8c4f93b5035b2ade3e7cf3
+msgid "4"
+msgstr ""
+
+#: ../../25.04/schedule.md 1503046403eb476f81adee70a53aca9c
+#: bffb7ea338064aaa8190286847764de1
+msgid "November 07"
+msgstr ""
+
+#: ../../25.04/schedule.md 7358286f80ae433f8f0693d45ba3e838
+#: 92025e7900844f3cba7acdc5f5af7d64
+msgid "5"
+msgstr ""
+
+#: ../../25.04/schedule.md 640a0c1b764843828d51e3b46d37ecc1
+#: ad947e53d14d40f8a3be88455561849e
+msgid "November 14"
+msgstr ""
+
+#: ../../25.04/schedule.md 4f1951a9a6e84ab98ceef8ee2b36094c
+#: db6a44b17f2e4564b0f3b3e77304baec
+msgid "6"
+msgstr ""
+
+#: ../../25.04/schedule.md 8571150ce6e34e7aacad0549ceccdf2c
+#: 9589dce3196d47df8da6aa2dda09e921
+msgid "November 21"
+msgstr ""
+
+#: ../../25.04/schedule.md 1dad71dff47340aa8ee5f186f91c9911
+#: 4fd6ed4a6964493e8013fe836cb3f669
+msgid "7"
+msgstr ""
+
+#: ../../25.04/schedule.md b53f07d75a224abf81c5bea8b2bc937b
+#: f8129857ffec4a36b1f7a9d9485cd94e
+msgid "November 28"
+msgstr ""
+
+#: ../../25.04/schedule.md 0bdeef3e39764f428cf46db50a470960
+#: aafee8d33922481d90f409d38b3f339b
+msgid "**December 2024**"
+msgstr ""
+
+#: ../../25.04/schedule.md b2016ec71ce9433bac5bdfa1be443ecd
+#: d6dbef525c274f2b971fe5e52b31efff
+msgid "8"
+msgstr ""
+
+#: ../../25.04/schedule.md d1add02dc84b4b319440aff2275bfdec
+#: d61c262824374bbc95ee064ced4cb92e
+msgid "December 05"
+msgstr ""
+
+#: ../../25.04/schedule.md 012a3051216144a9b12b37887a35ccc3
+#: 3d36dfea979a46fca5114e07e6ae23ed
+msgid "9"
+msgstr ""
+
+#: ../../25.04/schedule.md 186f7778c340402da99fb204c5f76e35
+#: 894d5648d9ab4ed394250e4a27652719
+msgid "December 12"
+msgstr ""
+
+#: ../../25.04/schedule.md af93227363204c1cb15a6818c062a243
+#: ffd7c1d39d9045048b9bb5880b7e47a2
+msgid "10"
+msgstr ""
+
+#: ../../25.04/schedule.md 1f013efaa28343b6ba98e4521144dc2f
+#: 5e21934447824d46a79945334ac14514
+msgid "December 19"
+msgstr ""
+
+#: ../../25.04/schedule.md 13ba73716dfe4323a87f0d39a10520b6
+#: 4f6b1adebc744ec4a2976b81b0b7383e
+msgid "Ubuntu Testing Week (optional)"
+msgstr ""
+
+#: ../../25.04/schedule.md 7c574f69327644dc8c0cb28181e7d9b3
+#: 83b4fbf044584413b0f49ce5cb33310c
+msgid "11"
+msgstr ""
+
+#: ../../25.04/schedule.md 4a7ed1635ce24311840fbf8d25044710
+#: 727f50112d3d4fdbacdfc43d5a61aa14
+msgid "December 26"
+msgstr ""
+
+#: ../../25.04/schedule.md 84d6eda7f63b4ff1ba03843a1ff6feaf
+#: f627c0a042e94fe7b5fde930e20fb583
+msgid "**January 2025**"
+msgstr ""
+
+#: ../../25.04/schedule.md 1490d5a6574144d199c2a8f229fc14e0
+#: 7c203ddf4e5c4db7a064052c4930cd9a
+msgid "12"
+msgstr ""
+
+#: ../../25.04/schedule.md 31f69acfd0d34b9bb5fd845a84a8de5b
+#: 612c0dc292c84373913c5849b9accf66
+msgid "January 02"
+msgstr ""
+
+#: ../../25.04/schedule.md 1d42dc727961434290160a55a62b0645
+#: b1e04d029c3a4f07ae56b8264baf0cbc
+msgid "13"
+msgstr ""
+
+#: ../../25.04/schedule.md 462d81b037ea435a9d3c7be7507ff7a9
+#: e74c08972bcd4514ae17fc3830364d79
+msgid "January 09"
+msgstr ""
+
+#: ../../25.04/schedule.md 215d1f706ab14476bc65b1fe90f24c8e
+#: 2bf2657bc9bc4ca084589e202c1bdd92
+msgid "14"
+msgstr ""
+
+#: ../../25.04/schedule.md 127ad32bf946426fbc8baf16c672ea58
+#: 5e21684283504961bd2e82f5186a9714
+msgid "January 16"
+msgstr ""
+
+#: ../../25.04/schedule.md 3e4da2040f764a2eaa911cce90452361
+#: 7afad6c59aa64f72be9c446c76944c48
+msgid "15"
+msgstr ""
+
+#: ../../25.04/schedule.md 9b53f73b5c024d55a958cbed05df4d43
+#: b772e38ca56d4ac890255ac7d6864d46
+msgid "January 23"
+msgstr ""
+
+#: ../../25.04/schedule.md 1bbc9baac9444ded96a2c8e544628e76
+#: c08320d22cc04d00a0321070878e1554
+msgid "16"
+msgstr ""
+
+#: ../../25.04/schedule.md aad73f68ba72451096098168ef81004f
+#: f958ff16fd8744b99063588ef5ca4b2f
+msgid "January 30"
+msgstr ""
+
+#: ../../25.04/schedule.md 63398f5b681040aaa8131fe685426dfb
+#: d6810d6df42d48e78ffa1a268beb4db3
+msgid "**February 2025**"
+msgstr ""
+
+#: ../../25.04/schedule.md 6c2de1cdb0a346749f3a242f1a3b5fb1
+#: feea84a28a844f04b6bd377cbd335f25
+msgid "17"
+msgstr ""
+
+#: ../../25.04/schedule.md 5b3567199ecd41ca8f5432df81b21321
+#: 5ea0822e81734189bb65e1d936c83144
+msgid "February 06"
+msgstr ""
+
+#: ../../25.04/schedule.md 3479d2a5401c4231b81c5fddfcead681
+#: b02ec2314c044f78a9493a1371be619e
+msgid "18"
+msgstr ""
+
+#: ../../25.04/schedule.md 74ed7baf79a84303a056f2e17363d97d
+#: eff7b9b878c54c8fb0dc1e521e0f0ed3
+msgid "February 13"
+msgstr ""
+
+#: ../../25.04/schedule.md 130a60c9acaa49e6ae66690711c622eb
+#: 4553098a9f274b6ba596bd1863014711
+msgid "19"
+msgstr ""
+
+#: ../../25.04/schedule.md e6f4b51e45254f5395a8425ba47ae826
+#: ec76b32f1866459d96a70de09ffe4a5d
+msgid "February 20"
+msgstr ""
+
+#: ../../25.04/schedule.md 21b52d9d225845d58695ca7a5cc276c2
+msgid ""
+"[Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), Debian Import "
+"Freeze"
+msgstr ""
+
+#: ../../25.04/schedule.md 3b1208566993451d8c92414a91dd41fa
+#: 96717ab5414741489b61a3a5f659fbf9
+msgid "20"
+msgstr ""
+
+#: ../../25.04/schedule.md 03a1f4c796054aa58ba6fa070d8b3cfc
+#: f9ddff8aabdb4c29a8c1c81d58d2f79b
+msgid "February 27"
+msgstr ""
+
+#: ../../25.04/schedule.md dd4c211360d34e5f9d916e9f74144af3
+#: f00e35659c3a4c969155b5f55c7d4391
+msgid "**March 2025**"
+msgstr ""
+
+#: ../../25.04/schedule.md 288a59fd7ebf41ffa0f9d90d7b36b8a3
+#: 5a9401b772e4436e8e48630e64f8138c
+msgid "21"
+msgstr ""
+
+#: ../../25.04/schedule.md 895a43d87791473e878c4a453766d991
+#: b0424638664245edb3f13810e12d9679
+msgid "March 06"
+msgstr ""
+
+#: ../../25.04/schedule.md 493997b98b2d4978966353cc4a23d87d
+#: 7e40b9c93ec94b54b74ea9582c3b26e4
+msgid "22"
+msgstr ""
+
+#: ../../25.04/schedule.md 625dba4ef75b43a5839f4c141fd5eee1
+#: f04e6104a2ee4bdb97684b938eb1dd1a
+msgid "March 13"
+msgstr ""
+
+#: ../../25.04/schedule.md 9ffe4794bd524756b56340527597e42d
+msgid "[User Interface Freeze](https://wiki.ubuntu.com/UserInterfaceFreeze)"
+msgstr ""
+
+#: ../../25.04/schedule.md 3e8471bf2d7943819c8e4ca1b466a58e
+#: a601854e227b4d0abd581d9f9936eaf8
+msgid "23"
+msgstr ""
+
+#: ../../25.04/schedule.md e59cac5f181442bd98de9243bbdc804d
+#: e79b01dc03244bd9b396aac5be327cef
+msgid "March 20"
+msgstr ""
+
+#: ../../25.04/schedule.md 6fab6f4539064b4c85709227381cd387
+msgid ""
+"[Documentation String "
+"Freeze](https://wiki.ubuntu.com/DocumentationStringFreeze), [Kernel "
+"Feature Freeze](https://wiki.ubuntu.com/KernelFeatureFreeze)"
+msgstr ""
+
+#: ../../25.04/schedule.md 2f05516bd2af428bbf7a731f149cceeb
+#: f5ea577e12f44995b73b93af048f0cb0
+msgid "24"
+msgstr ""
+
+#: ../../25.04/schedule.md cc5c4538dc4f4a92b91ff535bb043cc9
+msgid "March 24 (Monday)"
+msgstr ""
+
+#: ../../25.04/schedule.md edb1ac5d888640b69c3ab137f5e13666
+msgid ""
+"[Beta Freeze](https://wiki.ubuntu.com/BetaFreeze), [Hardware Enablement "
+"Freeze](https://wiki.ubuntu.com/HardwareEnablementFreeze)"
+msgstr ""
+
+#: ../../25.04/schedule.md 100da93112e5474496a356566a5ac0e2
+msgid "⠀"
+msgstr ""
+
+#: ../../25.04/schedule.md 4b81a3801d9f408295d2351e009da42e
+#: 8dde029e95ae4b8a9a90ac40aef28bbf
+msgid "March 27"
+msgstr ""
+
+#: ../../25.04/schedule.md 6667f3894e1b451aa22b0b97fe2dd079
+msgid "Beta (mandatory)"
+msgstr ""
+
+#: ../../25.04/schedule.md 1b46d81479424c24b98abd11256a6254
+#: fa60d617f4944f849e829dc011e017bd
+msgid "**April 2025**"
+msgstr ""
+
+#: ../../25.04/schedule.md 41c22b2f743346e5ad17ca4f5a1a985b
+#: 470e280f94094153a6ae25f0a7f2c9b5
+msgid "25"
+msgstr ""
+
+#: ../../25.04/schedule.md 0942f1f22b084bfc8fed2e9785b1fec9
+#: 6f4b7e7b7a95448294f3e7aa8c81a2fe
+msgid "April 03"
+msgstr ""
+
+#: ../../25.04/schedule.md c4755d1edfac4ac5933efd1ec00bc7d8
+msgid ""
+"[Kernel Freeze](https://wiki.ubuntu.com/KernelFreeze), [Non Language Pack"
+" Translation "
+"Deadline](https://wiki.ubuntu.com/NonLanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../25.04/schedule.md 0e70277acd1c458aa3468b9d612153d8
+#: 835eafe06d2d4b21b77e1fcdeb4d75b0
+msgid "26"
+msgstr ""
+
+#: ../../25.04/schedule.md 7ab18084c50643709968174bca4fcb32
+#: a961b77981f144428b593bbdc72b2561
+msgid "April 10"
+msgstr ""
+
+#: ../../25.04/schedule.md 3e8840cc2b574d5da40c450a6f5f6bda
+msgid ""
+"[Final Freeze](https://wiki.ubuntu.com/FinalFreeze), [Release "
+"Candidate](https://wiki.ubuntu.com/ReleaseCandidate), [Language Pack "
+"Translation "
+"Deadline](https://wiki.ubuntu.com/LanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../25.04/schedule.md f304eaff863246cc882dc08135d0abf4
+#: f45e36514c50426398dcf44ea77b03d1
+msgid "27"
+msgstr ""
+
+#: ../../25.04/schedule.md 0933b49c47624a83857643d0927082a6
+#: c09c46b81255401ca99273ccb538a2bc
+msgid "April 17"
+msgstr ""
+
+#: ../../25.04/schedule.md 6541475d472e4df3b50db6d76cc12090
+msgid "[Final Release](https://wiki.ubuntu.com/FinalRelease)"
+msgstr ""
+
+#: ../../25.04/schedule.md:43 4dc3b22f49ec4f579cfb93de2d96e438
+msgid "Planned and potentially disruptive archive-wide activities"
+msgstr ""
+
+#: ../../25.04/schedule.md:45 c0477d175bf642dd9e418ecc9491ce34
+msgid ""
+"If you're planning a change that might have a disruptive effect on the "
+"archive - e.g. transitions or switches of important defaults (such as "
+"compiler versions) - list it here."
+msgstr ""
+
+#: ../../25.04/schedule.md fa10ece88ed04f868efa483303094203
+msgid "Planned activity"
+msgstr ""
+
+#: ../../25.04/schedule.md 29a61be12f0f43b791c6e9076641a640
+msgid "Python 3.13 as supported"
+msgstr ""
+
+#: ../../25.04/schedule.md 76c72f10947c4f80b460f3ecc7f57a0e
+msgid "binutils 2.44"
+msgstr ""
+
+#: ../../25.04/schedule.md 1990880f7ffb4462a6830a8d170a0ed3
+msgid "Python 3.13 as default"
+msgstr ""
+
+#: ../../25.04/schedule.md c6864a595dae4290a39bcf7c02ebafc4
+msgid "Qt 6.8.2 ([tentative](https://wiki.qt.io/Qt_6.8_Release))"
+msgstr ""
+
+#: ../../25.04/schedule.md ccd09f87bede44c986804e30976f6a79
+msgid "[GNOME 48 Beta](https://release.gnome.org/calendar/)"
+msgstr ""
+
+#: ../../25.04/schedule.md b4d476cb290d4929802961409a70bd58
+msgid "LLVM 20 as default, Go 1.24 as default"
+msgstr ""
+
+#: ../../25.04/schedule.md ff330511f6104a019a47d7a90a23bb6f
+msgid "Qt 6.8.3 (18th, [tentative](https://wiki.qt.io/Qt_6.8_Release))"
+msgstr ""
+
+#: ../../25.04/schedule.md 913a3db1b6dd4cbe921065bb69cb1ca0
+msgid "[GNOME 48.0](https://release.gnome.org/calendar/)"
+msgstr ""
+
+#: ../../25.04/schedule.md:84 511ae0166fb14806a6d7b0e2e8149786
+msgid "Ubuntu Plucky Puffin Release Task Signup Sheet"
+msgstr ""
+
+#: ../../25.04/schedule.md:86 17fef4abe0a64a0585b1469c9b3f6d46
+msgid "This signup sheet is to be used for planning release milestone tasks."
+msgstr ""
+
+#: ../../25.04/schedule.md:88 a88e9e7ce50844eea323faa6543e2166
+msgid ""
+"The Alpha and Beta 1 milestones have been replaced with [Testing "
+"Weeks](https://lists.ubuntu.com/archives/ubuntu-"
+"release/2018-April/004434.html), which are organized ad hoc at this "
+"point."
+msgstr ""
+
+#: ../../25.04/schedule.md 171699142d034ddb9b2036463fbc8c80
+msgid "Milestone"
+msgstr ""
+
+#: ../../25.04/schedule.md beda570accb54312b0862e5a7662a1b3
+msgid "Date"
+msgstr ""
+
+#: ../../25.04/schedule.md 11bede34274f48bbb5955d7361455f11
+msgid "Image (Nusakan) Engineering"
+msgstr ""
+
+#: ../../25.04/schedule.md 785c4a74b3714ae49280bf6fd8364720
+msgid "Checklist Tracking"
+msgstr ""
+
+#: ../../25.04/schedule.md 478a0e20f7cc4d8cb664ee03ac5c2660
+msgid "Announcement Email"
+msgstr ""
+
+#: ../../25.04/schedule.md 062614f3990d4beb811d5986f6be2db5
+msgid "Feature Freeze"
+msgstr ""
+
+#: ../../25.04/schedule.md 28ce4f9d8c4546578f12b17795cd4686
+#: 5d4a231b360d453ab5dc8cb2fe1f8637 e0244f3e24ae4e77a309e9109fce5fe2
+#: e8702e2a6aa040dea91651c2b258a7a7 ef06a3112fd6499ca0eddaea09e85adf
+#: f51bf90b3d1c4e359e38d6b2e35a5c5c
+msgid "n/a"
+msgstr ""
+
+#: ../../25.04/schedule.md 0a4966dca4f449028785fbfa546af0ec
+#: 23eb8379616245f0aa2e250ffa4686b4 784a1bc5417344308c823b05f8b1a0f3
+#: a11f02d71252474495ba0038cdf5bf23 af0cef9bc7e84018bed69e43c7745e6b
+#: d1e312307f654d7d8f25aa2359a5e994 fe2ebb4548d642b9a78ad169f857fc7a
+msgid "utkarsh"
+msgstr ""
+
+#: ../../25.04/schedule.md 51388f0f1bc1482799e05f612c4f929a
+msgid "UI Freeze"
+msgstr ""
+
+#: ../../25.04/schedule.md e3181446d80a4e41933b7fb1171b49b7
+msgid "Doc String Freeze"
+msgstr ""
+
+#: ../../25.04/schedule.md d4f260159bba46ee925da9595eae8989
+msgid "25.04 Beta"
+msgstr ""
+
+#: ../../25.04/schedule.md 3b19f15728d34487b94fd320e54736c0
+msgid "Final Freeze"
+msgstr ""
+
+#: ../../25.04/schedule.md 35109ea473e546a988002dea15064645
+msgid "25.04 Release"
+msgstr ""
+
+#: ../../25.04/schedule.md 134d7a3d58d643d5a962bfa0da8cce6d
+msgid "April 17 2025"
+msgstr ""
+
+#: ../../25.04/schedule.md:99 067184da6b7a4d6692f69f206e60d93b
+msgid ""
+"When the archive is frozen, all members of the release team are expected "
+"to participate in bug fix reviews."
+msgstr ""
+
+#: ../../25.04/schedule.md:101 3027b03cd98148ffa23e9bde4f9b9b02
+msgid ""
+"After [Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), all "
+"members of the release team are expected to participate in Feature Freeze"
+" Exception reviews in their particular area of expertise."
+msgstr ""
+
+#: ../../25.04/schedule.md:103 3cfbeaafbf5c445598720f4ba36020cd
+msgid ""
+"After [Final Beta](https://wiki.ubuntu.com/FinalBetaRelease), all members"
+" of the release team are expected to participate in Bug fix reviews in "
+"their particular area of expertise."
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/25.10/index.po
+++ b/docs/locale/ja/LC_MESSAGES/25.10/index.po
@@ -1,0 +1,2529 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../25.10/index.md:10
+msgid "Release schedule"
+msgstr ""
+
+#: ../../25.10/index.md:6 925cc2ec121743f4be76581fee458b0b
+msgid "Ubuntu 25.10 release notes"
+msgstr ""
+
+#: ../../25.10/index.md:8 f6de04f809034b83ade3541f96c19216
+msgid ""
+"These release notes for **Ubuntu 25.10** (Questing Quokka) provide an "
+"overview of the release and document the known issues with Ubuntu and its"
+" flavors."
+msgstr ""
+
+#: ../../25.10/index.md:17 b28f1e558f284e2da428d3b4b4a2230b
+msgid "Support lifespan"
+msgstr ""
+
+#: ../../25.10/index.md:19 4eb5d7eb7e134336bb65a74d4089b04d
+msgid ""
+"Ubuntu 25.10 will be supported for 9 months until July 2026. If you need "
+"long term support, we recommend you use [Ubuntu 24.04.3 "
+"LTS](https://ubuntu.com/download) which is supported until at least 2029."
+msgstr ""
+
+#: ../../25.10/index.md:21 6a728fb5192a4e098fdc86cab5ca41ca
+msgid "Upgrades"
+msgstr ""
+
+#: ../../25.10/index.md:23 549f95878dbf4058aad43d5a1cf88332
+msgid "Upgrades to 25.10 are expected to be enabled on or before Nov 3."
+msgstr ""
+
+#: ../../25.10/index.md:25 7ded0d0082854b8bad85f791a1624d43
+msgid "Current blockers:"
+msgstr ""
+
+#: ../../25.10/index.md:27 a0f54d283a694523b9f8ee0c889fe454
+msgid ""
+"[LP#2125535](https://bugs.launchpad.net/ubuntu/+source/rust-"
+"coreutils/+bug/2125535)"
+msgstr ""
+
+#: ../../25.10/index.md:28 1b4a2a20ac894a2c906a93f4e3af0e0d
+msgid ""
+"[LP#2127970](https://bugs.launchpad.net/ubuntu/+source/rust-"
+"coreutils/+bug/2127970)"
+msgstr ""
+
+#: ../../25.10/index.md:31 37ba3e1bac7244b99d471d2f241996ff
+msgid "New features in 25.10"
+msgstr ""
+
+#: ../../25.10/index.md:33 ba1d960141c14e54ba24e0f4081ad3dd
+msgid "Updated Packages"
+msgstr ""
+
+#: ../../25.10/index.md:35 9ed96dd8dd7c4ede8c7f199ad4a3063e
+msgid "Linux kernel 6.17🐧"
+msgstr ""
+
+#: ../../25.10/index.md:36 03e143cdbc654c02b718de2c65573cde
+msgid ""
+"This release delivers the newest 6.17 Linux kernel. Due to the final "
+"upstream release occurring after Kernel Freeze, the kernels shipped with "
+"the release images will be based on `6.17-rc7`. Updates for all Questing "
+"Quokka kernels are scheduled for release in the subsequent week to "
+"incorporate the final upstream 6.17 release."
+msgstr ""
+
+#: ../../25.10/index.md:38 d6a218e95d3c40348bbaf01668245eae
+msgid "Highlights for this release:"
+msgstr ""
+
+#: ../../25.10/index.md:39 627c90db83984bb1859cca3379661642
+msgid ""
+"The `linux-modules-extra-*` packages have been deprecated "
+"([LP#2042831](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2042831))."
+" All the kernel modules are now shipped by the `linux-"
+"modules-<version>-<flavor>` packages."
+msgstr ""
+
+#: ../../25.10/index.md:40 2274702c61e3438880cd066d49aab3a1
+msgid ""
+"`linux-generic` for arm64 will provide via `stubble` broader "
+"compatibility for arm64 desktop platforms that utilize UEFI for booting "
+"([LP#2121352](https://bugs.launchpad.net/ubuntu/+source/linux-"
+"signed/+bug/2121352))."
+msgstr ""
+
+#: ../../25.10/index.md:41 88e080a8fc704b8a9a7da3928fb880d3
+msgid ""
+"The foundation for Intel TDX Host Support was merged upstream on Linux "
+"6.16 with additional improvements included in 6.17. The Ubuntu 6.17 "
+"kernel will ship with early support for kexec/kdump for TDX-enabled hosts"
+" "
+"([LP#2121873](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2121873))."
+msgstr ""
+
+#: ../../25.10/index.md:42 4d059643b769411597546d2cbc7ade28
+msgid ""
+"From 25.10, the Ubuntu RISC-V kernel (`linux-riscv`) will only support "
+"hardware that implements the RVA23S64 ISA profile. Systems that don't "
+"satisfy this requirement will not be able to run 25.10. The RISC-V kernel"
+" in 24.04 will continue to support boards with RVA20 processor cores."
+msgstr ""
+
+#: ../../25.10/index.md:43 4e2cfab522eb441b839bd849d4725b2f
+msgid ""
+"Other features can be found in the [Linux 6.17 "
+"upstream](https://kernelnewbies.org/Linux_6.17) changelog."
+msgstr ""
+
+#: ../../25.10/index.md:45 19d05694dcce4da8b8e0a1d05f5d04b6
+msgid "systemd v257.9"
+msgstr ""
+
+#: ../../25.10/index.md:46 1fa4c8161ed44852ae134ece4ec4a4b3
+msgid ""
+"The init system was updated to systemd v257.9. See the [upstream "
+"changelog ](https://github.com/systemd/systemd/releases/tag/v257) for "
+"more information about individual features."
+msgstr ""
+
+#: ../../25.10/index.md:48 893585c4d8604067ac988c2984ebb16e
+msgid "sudo-rs and sudo"
+msgstr ""
+
+#: ../../25.10/index.md:50 55d699d1cb7d4b69a38ec2ad18cb323f
+msgid ""
+"sudo-rs is the **default sudo provider** on Ubuntu from 25.10 onwards. "
+"0.2.8 release includes support for older Linux kernels < 5.9, sudoedit, "
+"support for NOEXEC and AppArmor profile switching. The Ubuntu release "
+"also includes various bug fixes picked from the main upstream branch."
+msgstr ""
+
+#: ../../25.10/index.md:52 949aed95543943bb9d3ffa290f60578a
+msgid ""
+"sudo (original sudo maintained by Todd C. Miller) has been upgraded to "
+"the latest version 1.9.17p2. The binary files are now renamed with the "
+"`.ws` suffix. Additionally, sudo-ldap package has been removed, please "
+"switch to using LDAP authentication via PAM."
+msgstr ""
+
+#: ../../25.10/index.md:54 d685a43e844d4942b537780a494f9275
+msgid ""
+"Please see [Ubuntu Server Docs](https://documentation.ubuntu.com/server"
+"/how-to/security/user-management/#sudo-rs) for configuring default sudo "
+"provider and differences between sudo-rs and sudo.ws."
+msgstr ""
+
+#: ../../25.10/index.md:56 30546091889744379f59877c1ba8ec5c
+msgid "rust-coreutils and gnu-coreutils"
+msgstr ""
+
+#: ../../25.10/index.md:57 a5d958bbf8bf4bb1bfa07b10e725360b
+msgid ""
+"The core utilities of the operating system are now provided by the "
+"**[rust-coreutils ](https://launchpad.net/ubuntu/+source/rust-coreutils) "
+"package**. We just updated to the latest version of it: 0.2.2, which "
+"features incredible performance improvements to base64 amongst other "
+"things."
+msgstr ""
+
+#: ../../25.10/index.md:59 de6a76fe84c54c5c9c7bd3fa9b7048aa
+msgid ""
+"As rust-coreutils are not necessarily fully compatible yet, we are "
+"providing the old utilities by the side, so you can switch back and forth"
+" between them. We are also keeping a list of these diversions "
+"[here](https://git.launchpad.net/ubuntu/+source/coreutils-"
+"from/tree/debian/coreutils-from-uutils.links)."
+msgstr ""
+
+#: ../../25.10/index.md:61 251bc1176764472591ef42ce7a926671
+msgid "Netplan v1.1.2ubuntu3 🌐"
+msgstr ""
+
+#: ../../25.10/index.md:62 362f4fe3d62b46b78c2f0bb7eabc7454
+msgid "Adds support non-standard OVS setups, e.g. inside snap environments."
+msgstr ""
+
+#: ../../25.10/index.md:64 a639b0888be84e1c9285dadfdb6fb503
+msgid "Toolchain Upgrades 🛠️"
+msgstr ""
+
+#: ../../25.10/index.md:65 62417172779141b1bf77a9644f9162a0
+msgid "GCC 🐄 GCC is updated to 15.2, binutils to 2.45, and glibc to 2.42"
+msgstr ""
+
+#: ../../25.10/index.md:66 29a0b633d78e44ddb78da2d117cb3c10
+msgid "Python 🐍 is updated to 3.13.7 while 3.14 is now available"
+msgstr ""
+
+#: ../../25.10/index.md:67 17c159055cc244689eab49f99c639d32
+msgid "LLVM 🐉 defaults to version 20 while 21 is now available"
+msgstr ""
+
+#: ../../25.10/index.md:68 37fd5e39228a4a1f9a32dc53272ec942
+msgid "Rust 🦀 toolchain defaults to version 1.85 while 1.88 is now available"
+msgstr ""
+
+#: ../../25.10/index.md:69 db55a6a939114b8cb0868c1be61a8fd1
+msgid "Golang 🐀 is updated to 1.24"
+msgstr ""
+
+#: ../../25.10/index.md:70 0a94d20787594869a01d8513fb07fbd9
+msgid ""
+"OpenJDK ☕ defaults to 21 (LTS), while version 25 (LTS) and an early "
+"access snapshot of version 26 are now available"
+msgstr ""
+
+#: ../../25.10/index.md:71 4ae05a8a8ff84efb9bc70425e06189f2
+msgid ".NET 10 🦄 now available"
+msgstr ""
+
+#: ../../25.10/index.md:72 f30d89f085c4438a976ed1c0bc5ac0d1
+msgid ""
+"Zig ⚡ is available for the first time in Ubuntu, defaults to version "
+"0.14.1."
+msgstr ""
+
+#: ../../25.10/index.md:73 f9d713c503fc47ebb1b23704eb8bc59f
+msgid "And Ubuntu Toolchains has a new [homepage](https://ubuntu.com/toolchains)"
+msgstr ""
+
+#: ../../25.10/index.md:75 2c369377e0f84335a70d4465127b4d9c
+msgid "OpenJDK"
+msgstr ""
+
+#: ../../25.10/index.md:77 e1c2627c3cb147cd9fa83e752426a64f
+msgid ""
+"OpenJDK 21 is still the default. OpenJDK 25 (LTS) is now available. An "
+"early access snapshot of OpenJDK 26 is also included. Support for OpenJDK"
+" LTS versions 17, 11 and 8 is being maintained. OpenJDK with CRaC version"
+" 25 is also made available, while versions 17 and 21 continue to be "
+"supported."
+msgstr ""
+
+#: ../../25.10/index.md:79 fbe2a2956eb14a3fbdeeff605e9438b0
+msgid ""
+"The [devpack-for-spring snap](https://snapcraft.io/devpack-for-spring) "
+"now supports development environment setup, by automating the "
+"installation and configuration of development tools (OpenJDK, container "
+"runtime, IDEs etc.) selected by the user. The [Maven and Gradle plugins "
+"for Rockcraft](https://github.com/rockcrafters/java-rockcraft-plugins) "
+"have been extended to support native images compiled by GraalVM."
+msgstr ""
+
+#: ../../25.10/index.md:81 4911d421ce7742208dd888bd643c7629
+msgid ""
+"GraalVM Community Edition v25 is available through the graalvm-jdk "
+"[snap](https://snapcraft.io/graalvm-jdk), while GraalVM CE v21 continues "
+"to be supported. The snap is now available on arm64 too."
+msgstr ""
+
+#: ../../25.10/index.md:83 83d2f9f0c41841c69e0cc342f8c36836
+msgid ".NET"
+msgstr ""
+
+#: ../../25.10/index.md:84 ac101735162b45008301c6d12f10e0df
+msgid ".NET versions 8 and 9 continue to be supported."
+msgstr ""
+
+#: ../../25.10/index.md:86 dad0aa499c2e4b0291a7b5f3ce7fefdb
+msgid ""
+"The .NET 10 RC1 SDK and runtimes are now included. Following its general "
+"availability in November, the final release will be provided as a "
+"subsequent package update."
+msgstr ""
+
+#: ../../25.10/index.md:88 192dfea980504d438de3c9625867a2be
+msgid ""
+"Alternatively, .NET 10 is available on the `latest/beta` channel of the "
+"official .NET snap. It will be promoted to the `latest/stable` channel "
+"upon final release in November."
+msgstr ""
+
+#: ../../25.10/index.md:90 aade2caa07cf4752a21eb8a8f201df52
+msgid ""
+"Support for the PowerShell snap has been expanded to include the `arm64`,"
+" `s390x`, and `ppc64el` architectures, broadening its availability across"
+" platforms."
+msgstr ""
+
+#: ../../25.10/index.md:92 8659dd2a5b6f4dbfb7a21af1849893e1
+msgid "Default configuration changes ⚙️"
+msgstr ""
+
+#: ../../25.10/index.md:94 ../../25.10/index.md:622
+#: 0222d6676db84b3e87490ca54e2561e2 d885741cbac844d9b4193124ef4ac44b
+msgid "Ubuntu Desktop"
+msgstr ""
+
+#: ../../25.10/index.md:96 ../../25.10/index.md:662
+#: 61a2183f374c43fc8fb317bd472e8d7a 7df8c1c2c2bf48bd996def9b8d9187e1
+msgid "Installer"
+msgstr ""
+
+#: ../../25.10/index.md:98 f6610371c918427ba73dff1eff7a6a9e
+msgid ""
+"New [TPM-Backed disk encryption](https://canonical-ubuntu-desktop-"
+"documentation.readthedocs-hosted.com/en/latest/explanation/hardware-"
+"backed-disk-encryption/) features include:"
+msgstr ""
+
+#: ../../25.10/index.md:100 5dbb42740ad8443e9e94a01a7230db43
+msgid "Passphrase support and management"
+msgstr ""
+
+#: ../../25.10/index.md:101 5d69e8f9d56f4e6493e145ef34e7538f
+msgid "Regeneration of the recovery key"
+msgstr ""
+
+#: ../../25.10/index.md:102 d8da785f866e4eb59e72985273273de1
+msgid "Better integration with firmware updates"
+msgstr ""
+
+#: ../../25.10/index.md:104 8cbf597bd02b48979e1df0b5558c7bbd
+msgid ""
+"When you enable *Install third-party software for graphics and Wi-Fi "
+"hardware and additional media formats* during installation, screen "
+"recording will be hardware accelerated for supported hardware."
+msgstr ""
+
+#: ../../25.10/index.md:106 9bcd3bf9e435424a98197e1e79810486
+msgid "The installer has also seen plenty of accessibility fixes."
+msgstr ""
+
+#: ../../25.10/index.md:108 1026dafae06141119c6bb93f73623b3b
+msgid "Updates"
+msgstr ""
+
+#: ../../25.10/index.md:110 4c8f857a5d474131a01017b1f64b7e4a
+msgid ""
+"When system updates are available, the Software Updater window no longer "
+"pops up unprompted, stealing the keyboard focus. Instead, a notification "
+"shows up with options to open the Software Updater or to install all "
+"updates directly."
+msgstr ""
+
+#: ../../25.10/index.md:112 6ee4479185804f4bbbcbe22d1f93e142
+msgid ""
+"An icon in the system tray reminds you that updates are available even "
+"after dismissing the notification. It also provides a quick way to apply "
+"all the updates or inspect them in the Software Updater."
+msgstr ""
+
+#: ../../25.10/index.md:114 5d406db617634c628b944fc9897dca09
+msgid "Enterprise"
+msgstr ""
+
+#: ../../25.10/index.md:116 efe8d537ad89428ea089f98c260a814c
+msgid ""
+"[authd](https://github.com/ubuntu/authd): Ubuntu’s cloud authentication "
+"solution:"
+msgstr ""
+
+#: ../../25.10/index.md:117 c25b50e343d14766bf0db10b43ba1efe
+msgid "Supports device registration with EntraID"
+msgstr ""
+
+#: ../../25.10/index.md:118 92e9df54a5b7400782bad7982540b1db
+msgid "authctl is a new command line tool to manage authd"
+msgstr ""
+
+#: ../../25.10/index.md:119 f5c86a6e45764c77aea862bf4402fc86
+msgid "Many improvements and important bug fixes such as UID/GID handling"
+msgstr ""
+
+#: ../../25.10/index.md:121 7154e3bd5d094de3bb314bf1a5ca8721
+msgid "Wayland"
+msgstr ""
+
+#: ../../25.10/index.md:123 7adf43ac2baf42b3b23237065099fb3b
+msgid ""
+"The Ubuntu Desktop session now runs only on the Wayland back end. The "
+"[Ubuntu on X\\.org session is no longer "
+"available](https://discourse.ubuntu.com/t/ubuntu-25-10-drops-support-for-"
+"gnome-on-xorg/62538) because GNOME Shell can no longer run as an X\\.org "
+"session."
+msgstr ""
+
+#: ../../25.10/index.md:125 bbd71ab6509f47fabb461aaf342881d1
+msgid ""
+"Suspend-resume support is now enabled in the proprietary Nvidia driver so"
+" as to prevent corruption and freezes when waking an Nvidia desktop."
+msgstr ""
+
+#: ../../25.10/index.md:127 61c773da464641ce90f3a5d8857ee785
+msgid "GNOME 👣"
+msgstr ""
+
+#: ../../25.10/index.md:129 794336330fe543f5980bbee3724b96fa
+msgid ""
+"GNOME Shell and related components have been updated to [GNOME "
+"49](https://release.gnome.org/49/)."
+msgstr ""
+
+#: ../../25.10/index.md:130 b1d1a867d3a14cedae8f18b56738aa05
+msgid ""
+"You can now set an application to start automatically after login in "
+"Settings -> Apps."
+msgstr ""
+
+#: ../../25.10/index.md:131 512bc19cf9274cf7a6aba5a757cc17e9
+msgid "Fractional scaling factors are now optimized so as to minimize blur."
+msgstr ""
+
+#: ../../25.10/index.md:132 fde7fbfdd22e442d8af36b7924ef60d4
+msgid ""
+"The default monospace font size has been reduced to match the default "
+"user interface font size. The monospace font is used in terminals and "
+"similar applications."
+msgstr ""
+
+#: ../../25.10/index.md:134 51832bdd9b504798a8d664c16bbe822c
+msgid "New default applications"
+msgstr ""
+
+#: ../../25.10/index.md:136 b81eb75395b348e8baf1c1bfd23c5729
+msgid ""
+"The **Image Viewer** app is now provided by "
+"[Loupe](https://apps.gnome.org/Loupe/) instead of Eye of GNOME (EOG). "
+"Loupe is written in Rust and powered by the "
+"[Glycin](https://gitlab.gnome.org/GNOME/glycin) library."
+msgstr ""
+
+#: ../../25.10/index.md:137 d74c4fd8ac614d0ab778f9907513cea9
+msgid ""
+"The **Terminal** app is now provided by "
+"[Ptyxis](https://gitlab.gnome.org/chergert/ptyxis/-/blob/main/README.md?ref_type=heads)"
+" instead of GNOME Terminal."
+msgstr ""
+
+#: ../../25.10/index.md:139 0565a25493894eee908520c9830b6a09
+msgid "Security Center"
+msgstr ""
+
+#: ../../25.10/index.md:141 2110e3f2fdd64f98bf43e0daef1e8496
+msgid ""
+"You can now manage your recovery key for the TPM-backed Full Disk "
+"Encryption. For details, see [Encrypt your disk with TPM](https"
+"://canonical-ubuntu-desktop-documentation.readthedocs-"
+"hosted.com/en/latest/how-to/encrypt-your-disk-with-tpm/)."
+msgstr ""
+
+#: ../../25.10/index.md:143 b180c557c74f488288cce071b8ab4773
+msgid "Ubuntu Insights"
+msgstr ""
+
+#: ../../25.10/index.md:145 7e955fac8e02424aada9ef695c7fca6f
+msgid ""
+"[Ubuntu Insights](https://github.com/ubuntu/ubuntu-insights) is being "
+"developed as a replacement for [Ubuntu Report](https://github.com/ubuntu"
+"/ubuntu-report) and gives you more control over the non-personally "
+"identifying system metrics that you choose to share with Canonical. The "
+"metrics collection is opt-in."
+msgstr ""
+
+#: ../../25.10/index.md:147 ed84df4b65ec4b9c873f65e9da4977ba
+msgid ""
+"In this release, Ubuntu Insights introduces periodic metric collection "
+"and replaces Ubuntu Report integration in GNOME Initial Setup."
+msgstr ""
+
+#: ../../25.10/index.md:149 90e3abdebb144d379a0d86f14828d164
+msgid ""
+"Note: Any consent that you previously granted to Ubuntu Report will not "
+"be carried over to Ubuntu Insights."
+msgstr ""
+
+#: ../../25.10/index.md:151 55a989ecbe894842941849939741e69f
+msgid "Dracut"
+msgstr ""
+
+#: ../../25.10/index.md:153 8d04a0e058bc4c74b5153f111ba59e48
+msgid ""
+"Ubuntu Desktop 25.10 now uses Dracut as its default initial ramdisk "
+"infrastructure, replacing `initramfs-tools`. Dracut uses `systemd` in the"
+" initial ramdisk and supports new features like Bluetooth and NVM Express"
+" over Fabrics (NVMe-oF). Ubuntu Server installations and Ubuntu Desktop "
+"for Raspberry Pi continue to use `initramfs-tools` while we port the "
+"[remaining "
+"hooks](https://bugs.launchpad.net/ubuntu/+source/dracut/+bug/2125790). "
+"The original `initramfs-tools` remains supported and you can switch "
+"between the two implementations if required. For details about the "
+"switch, see https://discourse.ubuntu.com/t/spec-switch-to-dracut/54776."
+msgstr ""
+
+#: ../../25.10/index.md:155 785d06f611a94676a3364e1f6aa43b5c
+msgid "Updated Applications"
+msgstr ""
+
+#: ../../25.10/index.md:156 01ec3270b4464b05b3d931d279a066d4
+msgid "[Firefox](https://mozilla.org/firefox/releases/) 143 🔥🦊"
+msgstr ""
+
+#: ../../25.10/index.md:157 49a7f5f7b06b49c68aa8c93e83fe20e8
+msgid ""
+"[LibreOffice 25.8](https://wiki.documentfoundation.org/ReleaseNotes/25.8)"
+" 📚"
+msgstr ""
+
+#: ../../25.10/index.md:158 ad35dfce6ee04b57b29066fc53e7eedd
+msgid ""
+"[OpenVINO™ Toolkit "
+"2025.2.0](https://github.com/openvinotoolkit/openvino/releases/tag/2025.2.0)"
+" 🤖 includes "
+"[openvino.genai](https://github.com/openvinotoolkit/openvino.genai) for "
+"the first time.  Also related to that:"
+msgstr ""
+
+#: ../../25.10/index.md:160 18908f1d519240a4aea871226b045967
+msgid ""
+"[Audacity 3.7.1](https://support.audacityteam.org/additional-"
+"resources/changelog/audacity-3.7) 🎧 comes with OpenVINO™ AI plugins for "
+"music separation, noise suppression, music generation and continuation, "
+"transcription, and super resolution, and can be run on Intel CPU, GPU, "
+"and NPU."
+msgstr ""
+
+#: ../../25.10/index.md:161 87a85ca6e470467b833ec2a93d31f8cc
+msgid ""
+"[GIMP 3.0.4](https://www.gimp.org/news/2025/05/18/gimp-3-0-4-released/) "
+"🖼️ which supports the usage of the [snap](https://snapcraft.io/openvino-"
+"ai-plugins-gimp) to add AI functionality to GIMP for stable diffusion, "
+"super resolution, and semantic segmentation via [OpenVINO™ AI plugins for"
+" GIMP 3.1.2](https://github.com/intel/openvino-ai-plugins-"
+"gimp/releases/tag/3.1.2)."
+msgstr ""
+
+#: ../../25.10/index.md:163 a9cbbcaa08054ab2af428c6d870e9abc
+msgid "Updated Subsystems"
+msgstr ""
+
+#: ../../25.10/index.md:164 00f465761cbe44d5bec9ad8f778d3697
+msgid ""
+"[BlueZ "
+"5.83](https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/ChangeLog?id=5.83)"
+" 💙"
+msgstr ""
+
+#: ../../25.10/index.md:165 c567c6954aa44e868a4401a94619d6e0
+msgid ""
+"[Pipewire "
+"1.4.7](https://gitlab.freedesktop.org/pipewire/pipewire/-/raw/1.4.7/NEWS)"
+" 🔊"
+msgstr ""
+
+#: ../../25.10/index.md:167 6ad760ac80ce4c9a8dbbc6b58d038357
+msgid "Support for new Intel® integrated and discrete GPUS"
+msgstr ""
+
+#: ../../25.10/index.md:169 d2c1084e095b4ab0b3b2f9e0c00d8849
+msgid ""
+"This release brings full support for Intel® Core™ Ultra Xe3 integrated "
+"Intel® Arc™ graphics, and Intel® Arc™ Pro B50 and B60 “Battlemage” "
+"discrete GPUs. Further Intel® Graphics related features are now available"
+" by changes in various components:"
+msgstr ""
+
+#: ../../25.10/index.md:171 a978b75bdeba4534a2d56200c08797b0
+msgid "Via the [Linux Kernel](https://launchpad.net/ubuntu/+source/linux) v6.17:"
+msgstr ""
+
+#: ../../25.10/index.md:172 324430999c4d438184ed39820b41f93c
+msgid ""
+"Initial support for Intel's next-gen client platform codenamed Panther "
+"Lake"
+msgstr ""
+
+#: ../../25.10/index.md:173 1864a5d5a04c4c63b897e547e48364e8
+msgid ""
+"Enhanced IOMMU and PCIe subsystem for improved GPU virtualization and "
+"passthrough."
+msgstr ""
+
+#: ../../25.10/index.md:174 fdc48c2648814e96b458278a9a1fcfb8
+msgid "Improved multi-GPU configuration support for Intel hardware."
+msgstr ""
+
+#: ../../25.10/index.md:175 d9b7779c3aa34f6c8c06d44808c2bf36
+msgid "Via [Mesa](https://launchpad.net/ubuntu/+source/mesa) 25.2.3:"
+msgstr ""
+
+#: ../../25.10/index.md:176 f9344f9097344fbf88d5533bb2ed3b62
+msgid ""
+"VK_KHR_shader_bfloat16 enabled in Intel ANV Vulkan driver for Battlemage "
+"and Panther Lake** (GFX125+)."
+msgstr ""
+
+#: ../../25.10/index.md:177 8d15795b0ccd456886eb40571702466e
+msgid "Completed OpenCL 2.0 coarse grain buffer SVM support in Iris driver."
+msgstr ""
+
+#: ../../25.10/index.md:178 b45c3ffb0e9e48e88b9dcc7740f42c41
+msgid ""
+"Improved color fast-clear handling and multi-engine surface usage for "
+"Intel Vulkan (ANV) driver."
+msgstr ""
+
+#: ../../25.10/index.md:179 7e82530705ee4438bd4229c509b3615a
+msgid ""
+"Via [intel-media-driver](https://launchpad.net/ubuntu/+source/intel-"
+"media-driver) 25.3.0:"
+msgstr ""
+
+#: ../../25.10/index.md:180 34adbfc91fff422992da8045c7089ad8
+msgid "Panther Lake Upstream decoding and VP9 encoding support"
+msgstr ""
+
+#: ../../25.10/index.md:181 61b0f58025384ec0a4b01f893d3c7147
+msgid ""
+"Via [intel-compute-runtime](https://launchpad.net/ubuntu/+source/intel-"
+"compute-runtime) 25.31:"
+msgstr ""
+
+#: ../../25.10/index.md:182 31a632e5c4bb43459563cbcd37b1f28a
+msgid ""
+"Enabling a Level Zero device unified shared memory (USM) pool as a "
+"performance change."
+msgstr ""
+
+#: ../../25.10/index.md:183 1778fec135f04f4b99d56ec68d877dca
+msgid ""
+"A performance-minded change for Xe2 graphics to ensure Level Zero events "
+"are always allocated in the local device memory."
+msgstr ""
+
+#: ../../25.10/index.md:184 cde21cdc306945b888c4abc01620c8a5
+msgid "Via [level-zero](https://launchpad.net/ubuntu/+source/level-zero) 1.24"
+msgstr ""
+
+#: ../../25.10/index.md:185 648f9de20194403498e406441c8f986f
+msgid "Update Level Zero Loader and Headers to support v1.13.1 of L0 Spec"
+msgstr ""
+
+#: ../../25.10/index.md:186 d7957f25487941c1b53b23218803dab3
+msgid ""
+"Via [level-zero-raytracing](https://launchpad.net/ubuntu/+source/level-"
+"zero-gpu-raytracing) 1.1.0:"
+msgstr ""
+
+#: ../../25.10/index.md:187 698d46715f6b4ebd849541f4fb348355
+msgid "Ray Tracing Acceleration Structure (RTAS) Extensions"
+msgstr ""
+
+#: ../../25.10/index.md:189 6023d23c18874acd97daa5c8a93a17bc
+msgid "Ubuntu Foundations"
+msgstr ""
+
+#: ../../25.10/index.md:191 2744ded9eaa945969664814ba3d5ffdd
+msgid ""
+"https://discourse.ubuntu.com/t/ubuntu-25-10-foundations-edition-what-s"
+"-coming-and-what-s-next/68147#p-177120-foundations-toolchains"
+msgstr ""
+
+#: ../../25.10/index.md:193 da235e30b31c4c91a330df758299f8e6
+msgid "Cryptography"
+msgstr ""
+
+#: ../../25.10/index.md:195 d28f9ed6908043edafacfd0cb0999284
+msgid "Libraries"
+msgstr ""
+
+#: ../../25.10/index.md:197 441ee85df1704ba886ff12faed94f809
+msgid ""
+"OpenSSL has been updated to [3.5.3 "
+"](https://github.com/openssl/openssl/blob/master/NEWS.md#openssl-35) (It "
+"includes security patches from 3.5.4). The most notable updates are:"
+msgstr ""
+
+#: ../../25.10/index.md:198 005bec3259394473bed03a2e9cf2a40e
+msgid "Support for server side QUIC (RFC 9000)."
+msgstr ""
+
+#: ../../25.10/index.md:199 eff49d300cd847748060be7c07e8799a
+msgid "Support for PQC algorithms (ML-KEM, ML-DSA and SLH-DSA)."
+msgstr ""
+
+#: ../../25.10/index.md:200 4e8c9f4821d446ac8233e0b31ffed1f5
+msgid ""
+"The default TLS supported groups list has been changed to include and "
+"prefer Hybrid PQC KEM groups."
+msgstr ""
+
+#: ../../25.10/index.md:202 8d87c7e119c54018852ddb02f2e77d61
+msgid "Package Management: APT 3.1"
+msgstr ""
+
+#: ../../25.10/index.md:204 c94099916f3747fdb487cc15d835ad55
+msgid ""
+"APT has been updated to 3.1.6, the latest release, including many new "
+"features:"
+msgstr ""
+
+#: ../../25.10/index.md:206 3bb3acb69ab941be87e475f66d3403d6
+msgid ""
+"The new solver is now the default. For more insight, see the post \"[How "
+"we delivered the new APT solver in 25.10](https://discourse.ubuntu.com/t"
+"/how-we-delivered-the-new-apt-solver-in-25-10/68920)\""
+msgstr ""
+
+#: ../../25.10/index.md:207 571912f119f341cab5713f0ecbb145b5
+msgid ""
+"The `apt why` and `apt why-not` commands have been added that tell you "
+"why the solver installed or could not install a package."
+msgstr ""
+
+#: ../../25.10/index.md:208 c111c23671fa47be886f8c08925a841f
+msgid ""
+"Repositories can now be configured with `Include` and `Exclude` "
+"directives. In the `Include` case, only these packages are included; in "
+"the `Exclude` case, these packages are excluded from the repository. This"
+" allows you to restrict a repository to specific packages."
+msgstr ""
+
+#: ../../25.10/index.md:209 83bde24d4f314fa99219e91a9b18ffb9
+msgid ""
+"The `apt history-list` and `apt history-info` commands are included as an"
+" early preview easter egg. Enjoy!"
+msgstr ""
+
+#: ../../25.10/index.md:211 ../../25.10/index.md:649
+#: 9ec29d029ac54926b476a34836566f68 ea7d73dc45964f059638a32c0495936d
+msgid "Ubuntu Server"
+msgstr ""
+
+#: ../../25.10/index.md:213 9d0a0886c4594ea485bc0cce6c40e45e
+msgid "ubuntu-server Meta and Seed"
+msgstr ""
+
+#: ../../25.10/index.md:215 9c92dc2b00514bdc849a67b408830096
+msgid ""
+"Starting in 25.10, the default Ubuntu server image and `ubuntu-server` "
+"metapackage have been updated. Read more at the [public spec on "
+"Discourse.](https://discourse.ubuntu.com/t/ubuntu-server-seed-changes-"
+"for-25-10/61552)"
+msgstr ""
+
+#: ../../25.10/index.md:217 cab7e2650aa04f6ba066ddb27db59edb
+msgid ""
+"`screen` has been removed from the ubuntu-server seed, and moved to a "
+"supported seed. `screen` remains in `main`. Users will still see `screen`"
+" installed in most cases, as it is now listed as a [dependency of "
+"`ubuntu-release-upgrader`](https://bugs.launchpad.net/ubuntu/+source"
+"/ubuntu-release-upgrader/+bug/2116874)"
+msgstr ""
+
+#: ../../25.10/index.md:218 8b0019e6fd6c4e78be21d46deb6b166a
+msgid ""
+"`wget` has been removed from the ubuntu-server seed, and moved to a "
+"supported seed. `wget` remains in `main`. Users utilizing `wget` have a "
+"number of options."
+msgstr ""
+
+#: ../../25.10/index.md:219 dca5801a552f449bbda4e856d53493be
+msgid ""
+"for simple cases (downloading a file from the internet), `wcurl` is "
+"available as part of the still included `curl`.  This can be a drop-in "
+"replacement for simple calls such as `wget $URL` to `wcurl $URL`. `wcurl`"
+" exposes all of `curl`'s options, so adding retries is easy."
+msgstr ""
+
+#: ../../25.10/index.md:220 dc7038515f6e4557a941c3aee9b676aa
+msgid ""
+"For more specialized cases, ensuring `wget` is installed prior to running"
+" is required."
+msgstr ""
+
+#: ../../25.10/index.md:221 c02e7986ceff46eba34c7520d80356ad
+msgid ""
+"`byobu` has been removed from the ubuntu-server seed and meta-package and"
+" demoted to `universe`. `byobu` is still available in Ubuntu."
+msgstr ""
+
+#: ../../25.10/index.md:222 1e45795e7ee14df183bfa0ba7eea66ae
+msgid ""
+"`cloud-guest-utils` has been removed from the ubuntu-server seed and "
+"meta-package. It is expected to still be installed via `cloud-init-base` "
+"which is a dependency of `cloud-init`."
+msgstr ""
+
+#: ../../25.10/index.md:223 9ce8da05b978416d94915250097cb8c7
+msgid ""
+"`dirmngr` has been removed from the ubuntu-server seed and metapackage. "
+"it is expected to still be installed as it is a dependency of many "
+"packages (`gnupg`, `gpg`, `vanilla-gnome-desktop` and other desktop "
+"flavors)."
+msgstr ""
+
+#: ../../25.10/index.md:225 aa6a101c61664aa3a5dd8326e6790b3c
+msgid "Apache 2"
+msgstr ""
+
+#: ../../25.10/index.md:227 701bc18145964dc3bfa3f601892cfbfa
+msgid ""
+"Apache 2 has been upgraded to version 2.4.64. This new release includes "
+"several bug and security fixes. It also includes the following changes to"
+" specific modules:"
+msgstr ""
+
+#: ../../25.10/index.md:229 acd72296e959454daa4448f7aa93c5aa
+msgid ""
+"core: Report invalid Options= argument when parsing AllowOverride "
+"directives."
+msgstr ""
+
+#: ../../25.10/index.md:230 14776606de764bc092f487d97af9cf43
+msgid "mod_systemd added systemd socket activation support."
+msgstr ""
+
+#: ../../25.10/index.md:231 d501ebd38f5d489d90bfc1c21f35fdaf
+msgid ""
+"Mod_http2 was updated to version 2.0.32, which includes a new directive "
+"`H2MaxHeaderBlockLen` to set the limit on response header sizes."
+msgstr ""
+
+#: ../../25.10/index.md:232 9388466e97bf457fbf3274fae5fe6a6b
+msgid "Mod_proxy now reuses ProxyRemote connections when possible."
+msgstr ""
+
+#: ../../25.10/index.md:234 28003d69b9144b8a91f1e569c0ca0552
+msgid ""
+"For more details, see the [upstream release "
+"notes](https://www.apachelounge.com/Changelog-2.4.html)."
+msgstr ""
+
+#: ../../25.10/index.md:236 c4918fce55f347f4a53a9d45ac23ac16
+msgid "Bacula"
+msgstr ""
+
+#: ../../25.10/index.md:238 84702454a1d942f1b151b545f722968f
+msgid ""
+"This is a newly supported package in our “main” repo (was “universe” "
+"before)."
+msgstr ""
+
+#: ../../25.10/index.md:240 82ee778acde44341ba9a877585f69dd5
+msgid "It was updated from 13.0.4 to 15.0.3 (there was no v14)."
+msgstr ""
+
+#: ../../25.10/index.md:242 f4cb4b60f25d429ab4e2f056c9930440
+msgid "You must upgrade the director and storage daemons at the same time."
+msgstr ""
+
+#: ../../25.10/index.md:243 14d2138d19ff411a9e8a19a3e0106ff8
+msgid "Old file daemons are still compatible."
+msgstr ""
+
+#: ../../25.10/index.md:244 93fc28393504456684cd36b6e5052374
+msgid ""
+"Storage volume format was updated from `BB02` to `BB03`, old volumes are "
+"still supported."
+msgstr ""
+
+#: ../../25.10/index.md:245 8bfdcc347b1b42e7aa35739b67e95cd9
+msgid ""
+"The catalog database schema needs migration, which is automatically "
+"applied if you have installed `dbconfig-common`."
+msgstr ""
+
+#: ../../25.10/index.md:247 271fb74d86d94353bd02606c84a1daca
+msgid ""
+"For more details, see the upstream [v15](http://gitlab.bacula.org/bacula-"
+"community-edition/bacula-community/-/releases/Beta-15.0.1) and "
+"[v15.0.3](https://gitlab.bacula.org/bacula-community-edition/bacula-"
+"community/-/blob/Release-15.0.3/bacula/ChangeLog) changelog."
+msgstr ""
+
+#: ../../25.10/index.md:249 c3c476b9ea9a446b9770277be6a576eb
+msgid "Chrony"
+msgstr ""
+
+#: ../../25.10/index.md:250 e63db731d23b44fcb78747ae66fe1c22
+msgid ""
+"Chrony was upgraded to version v4.7 and comes pre-installed as the new "
+"default *time-daemon* in Ubuntu 25.10, replacing **systemd-timesyncd**. "
+"It ships with a configuration set to use Ubuntu **Network Time Security "
+"(NTS)** servers by default. In order to migrate upgraded systems to "
+"**chrony** you can execute `apt-mark auto systemd-timesyncd && apt "
+"install chrony`."
+msgstr ""
+
+#: ../../25.10/index.md:252 07af131b127c4ebe867061b33539a6da
+msgid ""
+"See upstream [release notes for v4.7](https://chrony-"
+"project.org/news.html#_jun_11_2025_chrony_4_7_released)."
+msgstr ""
+
+#: ../../25.10/index.md:254 3a9779e406574cafb1e282f2261afc43
+msgid "The two primary changes related to NTS are:"
+msgstr ""
+
+#: ../../25.10/index.md:256 8efb5d8f9667480985063df4aa4ab8e4
+msgid ""
+"NTS/KE (\"Key Exchange\") uses a separate port (4460/tcp) to negotiate "
+"security parameters,   which are then used via the normal NTP port "
+"(123/udp)."
+msgstr ""
+
+#: ../../25.10/index.md:258 767434f8178247c0a80d0aac3dbb8459
+msgid ""
+"A new CA is installed in `/etc/chrony/nts-bootstrap-ubuntu.crt` that is "
+"used specifically for the Ubuntu NTS bootstrap server, needed for when "
+"the clock is too far off. This is added to certificate set ID \"1\", and "
+"defined via `/etc/chrony/conf.d/ubuntu-nts.conf`."
+msgstr ""
+
+#: ../../25.10/index.md:260 39725b2139f447e4819362298868f59a
+msgid ""
+"If your network does not allow access to the Ubuntu NTS servers or the "
+"required ports, and the new configuration is in place, **chrony** will "
+"not be able to adjust this system's clock. To revert to NTP, edit the "
+"configuration file in `/etc/chrony/sources.d/ubuntu-ntp-pools.sources` "
+"and revert to using the listed NTP servers in favor of the NTS ones."
+msgstr ""
+
+#: ../../25.10/index.md:262 78eef603210a4b9caee9c9a6e7191707
+msgid "cloud-init v. 25.3"
+msgstr ""
+
+#: ../../25.10/index.md:264 5a0f5a16512b4e17a906e588cdcb4357
+msgid "Notable features beyond 25.1.2 in Plucky:"
+msgstr ""
+
+#: ../../25.10/index.md:266 be632aba08ff44e787b76f36d8503ba0
+msgid "Add RaspberryPi OS support"
+msgstr ""
+
+#: ../../25.10/index.md:267 8bddb1ba21014ecb8ab45a27d8aa09aa
+msgid "CentOS support for ca_certs writing"
+msgstr ""
+
+#: ../../25.10/index.md:268 b711e22d10a94ef89e5573b708f0f2c0
+msgid "Azure: better reporting of platform VM ID errors"
+msgstr ""
+
+#: ../../25.10/index.md:269 04956918cc6e402db33163a92bb92fbb
+msgid "CloudStack: add ephemeral network support for early boot config"
+msgstr ""
+
+#: ../../25.10/index.md:270 f6386c9805b5423f8cc0ea2f3f933662
+msgid ""
+"EC2: Support metadata retrieval over multiple NICs when crawling the "
+"datasource"
+msgstr ""
+
+#: ../../25.10/index.md:271 9cb3df3996e14209a38b1c2452b8294e
+msgid "GCE: add template rendering support for processing instance data"
+msgstr ""
+
+#: ../../25.10/index.md:272 6feab370d7ea4e75aab946671a5f499b
+msgid "Hetzner: report private networks in cloud-init metadata"
+msgstr ""
+
+#: ../../25.10/index.md:273 02f4ca582dff48f5ac21e9160960c411
+msgid "Oracle: detect ipv6 only for private ULA addresses"
+msgstr ""
+
+#: ../../25.10/index.md:274 9e741ea491c0428db4c99581f0d063c6
+msgid ""
+"VMware: support to apply network configuration updates per-boot and "
+"hotplug events"
+msgstr ""
+
+#: ../../25.10/index.md:275 a5bb0c2fb8ba4984812cf40bdd94db04
+msgid "WSL: support for Landscape installation request id provisioning"
+msgstr ""
+
+#: ../../25.10/index.md:276 4c649abbd81d4d459db19121e914bbac
+msgid "Add a generalized datasource clean operation for `sudo cloud-init clean`"
+msgstr ""
+
+#: ../../25.10/index.md:277 776aa2d494c74b689420df677f33893a
+msgid "Security fix: hotplug socket file is now only root-writable CVE-2024-11584"
+msgstr ""
+
+#: ../../25.10/index.md:278 27a2ccec3b47429a8dcd6ff75ab9f117
+msgid "NetworkManager bug fix for reloading multiple connections"
+msgstr ""
+
+#: ../../25.10/index.md:279 2cd367f8d68a4838a8d67d0c2d6cf820
+msgid "ENI rendering filter out dns entries from written config"
+msgstr ""
+
+#: ../../25.10/index.md:281 4563782775ca4be9a58838868d303407
+msgid "Breaking changes:"
+msgstr ""
+
+#: ../../25.10/index.md:283 912d0093993145efbb2a1b4660e968a9
+msgid ""
+"Security fix CVE-2024-6174: cloud-init will be disabled on non-x86 "
+"platforms which do not declare a known datasource in early boot through "
+"DMI data, kernel boot params, filesystem configuration or environment "
+"files. Such environments may experience inability to SSH into launched "
+"VMs. [This may require action for non-x86 image creators or OpenStack "
+"admins](https://cloudinit.readthedocs.io/en/latest/reference/breaking_changes.html#id2)."
+msgstr ""
+
+#: ../../25.10/index.md:285 82c4fb56fda54f9b90d5fb06ccaf1de8
+msgid "Container runtimes"
+msgstr ""
+
+#: ../../25.10/index.md:287 7aee338c3b1743f8bc84a23d7c4649d2
+msgid ""
+"Containerd was updated to the recent 2.1.3 and runC to 1.3.0, docker.io "
+"was updated to 28.2 But even more importantly along these updates it "
+"established a pattern to either keep the regular updates to the latest "
+"version or to opt for slower more stable updates throughout the time the "
+"release is active. For more please read [Ubuntu Server Gazette - Issue 8 "
+"- Containers: Steady paths for agile stacks "
+"](https://discourse.ubuntu.com/t/ubuntu-server-gazette-issue-8"
+"-containers-steady-paths-for-agile-stacks/68680)"
+msgstr ""
+
+#: ../../25.10/index.md:290 f4aa7dc938474d8fa5bdddbfa9bf2ded
+msgid "Django"
+msgstr ""
+
+#: ../../25.10/index.md:292 a3e4dd2e7e7b4c6da03a29c260c4033a
+msgid ""
+"Django has been updated to the latest LTS release 5.2 from 4.2, which "
+"includes many new features and bug fixes. All Django middleware provided "
+"in Ubuntu has also been updated to be compatible with the new version. "
+"See the [5.0 release notes "
+"](https://docs.djangoproject.com/en/5.2/releases/5.0/) for features and "
+"updates added with the major version change and the [5.2 release notes "
+"](https://docs.djangoproject.com/en/5.2/releases/5.2/) for the changes "
+"made leading up to the LTS release."
+msgstr ""
+
+#: ../../25.10/index.md:294 b2158d09c6d0470a81c0e49a24923801
+msgid "Dovecot"
+msgstr ""
+
+#: ../../25.10/index.md:295 10f3ef4c6c264262b368ba5f45ad7443
+msgid ""
+"Upgrading from Dovecot 2.3.x to 2.4 requires several important config "
+"file changes. These are explained in detail in the link below. This "
+"includes renamed configuration parameters as well as a major change to "
+"the syntax. While converting an existing config is possible, it will need"
+" careful review to ensure your site customizations are carried through "
+"properly."
+msgstr ""
+
+#: ../../25.10/index.md:297 68e1e7b6079d43328023af1600fd7eb1
+msgid ""
+"Additionally, Dovecot 2.4 brings new features including support for the "
+"ARGON2 password scheme, SCRAM-SHA-1 and SCRAM-SHA-256 SASL mechanisms, "
+"and the X25519 and X448 cryptographic curves for some plugins. A number "
+"of features are being removed, changed, or deprecated; for the full list "
+"please see:"
+msgstr ""
+
+#: ../../25.10/index.md:299 50fe044a26344284a1cdbaeddfd19790
+msgid "https://doc.dovecot.org/main/installation/upgrade/2.3-to-2.4.html"
+msgstr ""
+
+#: ../../25.10/index.md:301 b5faa23d116849dabc7b8fd969b477a1
+msgid ""
+"Notably, support for building for 32-bit architectures has ended, so "
+"dovecot will no longer be natively installable on i386 and armhf "
+"platforms."
+msgstr ""
+
+#: ../../25.10/index.md:303 f2d727b42096442e9485c66dacd309d5
+msgid "EDK2"
+msgstr ""
+
+#: ../../25.10/index.md:305 831379bb07dc43c6bffa03cf314e95ba
+msgid ""
+"Added firmware for Intel ® TDX guests with secure boot capability "
+"([LP#2125123](https://bugs.launchpad.net/ubuntu/+source/edk2/+bug/2125123))"
+msgstr ""
+
+#: ../../25.10/index.md:307 374c00b44f494b759443b4a8372e4e56
+msgid "frr"
+msgstr ""
+
+#: ../../25.10/index.md:308 c4c72f357cee4a30826c04e4ffc5c4c5
+msgid ""
+"FRRouting is a free and open source Internet routing protocol suite for "
+"Linux and Unix platforms. It implements BGP, OSPF, RIP, IS-IS, PIM, LDP, "
+"BFD, Babel, PBR, OpenFabric and VRRP, with alpha support for EIGRP and "
+"NHRP."
+msgstr ""
+
+#: ../../25.10/index.md:310 d3dca04746e644e2b2474e6733f6f9c1
+msgid ""
+"The FRRouting package was updated to version 10.4.1. Series 10.4.x "
+"introduced many new features and bugfixes: please see "
+"https://github.com/FRRouting/frr/releases/tag/frr-10.4.0 for details."
+msgstr ""
+
+#: ../../25.10/index.md:312 97114eedbfb347e380e474a61524e0c5
+msgid "HAProxy"
+msgstr ""
+
+#: ../../25.10/index.md:314 a8bd16dc96c7443cb05003f575f8d427
+msgid "Updated from 3.0.8 to the recent release 3.0.10 which includes"
+msgstr ""
+
+#: ../../25.10/index.md:316 f208673921e248e881804d2cb10edce7
+msgid "https://www.mail-archive.com/haproxy@formilux.org/msg45741.html"
+msgstr ""
+
+#: ../../25.10/index.md:318 7c114723e72349769dccc929175fa55b
+msgid "https://www.mail-archive.com/haproxy@formilux.org/msg45804.html"
+msgstr ""
+
+#: ../../25.10/index.md:320 56bb2549312e46d0a264b355d246f09e
+msgid ""
+"Furthermore, it now uses jemalloc for memory allocation which is [faster "
+"and less memory hungry than the default "
+"allocator](https://github.com/haproxy/haproxy/issues/1782#issuecomment-1183128613)."
+msgstr ""
+
+#: ../../25.10/index.md:322 bdf22540327f450ab4c58227c11cb41d
+msgid "iPXE"
+msgstr ""
+
+#: ../../25.10/index.md:324 a9c4ffe8087348ba9d62c2285975f165
+msgid ""
+"[iPXE](https://ipxe.org/) was updated to [upstream version from June "
+"2025](https://github.com/ipxe/ipxe/compare/fbbdc3926...b3ebf8b24ae40a6f9f9f78491702d508f843e56)."
+msgstr ""
+
+#: ../../25.10/index.md:325 eab38ebd9049495e8a9414fd2eb771c0
+msgid ""
+"For physically booting to iPXE (e.g. via grub), make sure to install the "
+"`grub-ipxe` package and to adjust you GRUB scripts/config to use "
+"`ipxe.efi` (UEFI) or `ipxe.lkrn` (x86 BIOS)."
+msgstr ""
+
+#: ../../25.10/index.md:326 7df10271b2f94e1983c05ae4cd4a42f7
+msgid ""
+"UEFI network boot roms for qemu (from `ipxe-qemu`) are network drivers "
+"only (for PXE or HTTP boot) without the iPXE stack. To boot x86-64 qemu "
+"VMs with UEFI and network boot using iPXE scripts, make sure to chainload"
+" `ipxe.efi` (from `ipxe` package) (see "
+"https://ipxe.org/howto/chainloading)."
+msgstr ""
+
+#: ../../25.10/index.md:329 df1e71d83cd540ff8aeacb40de81ff9c
+msgid "libvirt"
+msgstr ""
+
+#: ../../25.10/index.md:331 fe81288660724331bbd34e519d2e5247
+msgid ""
+"The [libvirt ](https://libvirt.org) package was upgraded to version "
+"11.6.0. Here are the important changes since Ubuntu Plucky:"
+msgstr ""
+
+#: ../../25.10/index.md:333 94bc215def54472d96c8e27f538f42ac
+msgid "qemu: ppc64 POWER11 processor support"
+msgstr ""
+
+#: ../../25.10/index.md:334 65e0f8dae88a48b9be0ab5622581f606
+msgid "Allow control over QEMU TLS priority strings"
+msgstr ""
+
+#: ../../25.10/index.md:335 221b76fdcb4c4be59dace483ad7b1894
+msgid "qemu: Add support for NVMe disks"
+msgstr ""
+
+#: ../../25.10/index.md:336 c5e0d1ee31bb4d7fbd9eae90b5272246
+msgid "qemu: add support for AMD IOMMU device"
+msgstr ""
+
+#: ../../25.10/index.md:337 9f2e471cd94d4e488bd8ef164c1d6d18
+msgid "qemu: Add support for Intel ® TDX guests"
+msgstr ""
+
+#: ../../25.10/index.md:338 3a559184e02047da90e58a6cd57ffe8f
+msgid "Adds TDX as a new type of `<launchSecurity/>`."
+msgstr ""
+
+#: ../../25.10/index.md:339 c84af9d3aa7d4e06b0caf47e8e62bd6e
+msgid ""
+"All helper programs are now detected from $PATH during runtime - allowing"
+" you to modify its behavior more easily"
+msgstr ""
+
+#: ../../25.10/index.md:340 829841c3c91348adbf5ed6091380dfff
+msgid "qemu: Added guest load averages to the output of virDomainGetGuestInfo"
+msgstr ""
+
+#: ../../25.10/index.md:341 66764d0dd4a24500bb1458b5db424ce6
+msgid "qemu: Add support for multiple iothreads for virtio-scsi controller"
+msgstr ""
+
+#: ../../25.10/index.md:342 7669536087b5453d906c1b41d3b400b0
+msgid ""
+"qemu: integrate support for VM shutdown on host shutdown - a new opt-in "
+"way to shut down guests on host shutdown"
+msgstr ""
+
+#: ../../25.10/index.md:343 91de5b97ee8b4f0db3660d83cfa7c666
+msgid "qemu: Add support for parallel save/restore"
+msgstr ""
+
+#: ../../25.10/index.md:344 d180e3cc1fbc47a9bc75e53435930985
+msgid "qemu: Support for Block Disk Along with Throttle Filters"
+msgstr ""
+
+#: ../../25.10/index.md:345 14eef95d33c249018b0a9020e25a120a
+msgid "nodedev: Support ccwgroup based qeth devices"
+msgstr ""
+
+#: ../../25.10/index.md:346 18cb7ebf82374b94b67250dbb51a9c70
+msgid "Introduce virtio-mem `<memory/>` model for s390 guests"
+msgstr ""
+
+#: ../../25.10/index.md:348 f36fdf82cde44efaa0986185bd23c0af
+msgid ""
+"For more details, please see [the upstream changelog "
+"](https://libvirt.org/news.html#v11-4-0-2025-06-02). Additionally in "
+"Ubuntu, the **default URI choice** behavior was modified slightly: In the"
+" past Ubuntu enforced the `qemu:///system` URI by overriding "
+"`LIBVIRT_DEFAULT_URI` in `/etc/profile.d/libvirt-uri.sh`. Starting with "
+"Ubuntu 25.10, we're dropping that `profile.d` script in favour of a "
+"fallback mechanism, which still **preserves the default behavior** as "
+"`qemu:///system` for privileged and non-privileged users, but allows to "
+"override that default choice by setting `LIBVIRT_DEFAULT_URI` manually or"
+" changing the `uri_default` parameter in `/etc/libvirt/libvirt.conf` or "
+"`~/.config/libvirt/libvirt.conf` (for non-privileged users) respectively."
+msgstr ""
+
+#: ../../25.10/index.md:351 5f6bc32920f44eeaae0694da3b101596
+msgid "MySQL"
+msgstr ""
+
+#: ../../25.10/index.md:353 b7d6821751414f63b049bc8879713ade
+msgid ""
+"MySQL 8.4 now builds directly against tcmalloc for additional memory "
+"efficiency. For more information, see the most recent edition of the "
+"[Ubuntu Server Gazette](https://discourse.ubuntu.com/t/ubuntu-server-"
+"gazette-issue-7-mysql-memory-allocation/66197)."
+msgstr ""
+
+#: ../../25.10/index.md:355 c22f6bd8c5104eb9ac428f9823f389af
+msgid "Nginx"
+msgstr ""
+
+#: ../../25.10/index.md:357 ece96120d075494094469a690cd8426e
+msgid ""
+"Nginx was updated from 1.26.3 that we had in plucky to the latest stable "
+"version 1.28 which, among many other fixes and improvements, brings:"
+msgstr ""
+
+#: ../../25.10/index.md:359 a7253a8269594fa59c6e470506aa8c0c
+msgid "Performance and stability improvements in HTTP/3 and QUIC"
+msgstr ""
+
+#: ../../25.10/index.md:361 3c598a8bc58a4eac8c3150daa734e047
+msgid ""
+"Feature: SSL certificates, secret keys, and CRLs are now cached on start "
+"or during reconfiguration."
+msgstr ""
+
+#: ../../25.10/index.md:363 c4b6d7f808934b50b0a8a891d0eace1f
+msgid ""
+"For more details see the [upstream release "
+"notes](https://nginx.org/en/CHANGES-1.28)"
+msgstr ""
+
+#: ../../25.10/index.md:365 b8eb37de66a24486bcff7f40145ae72c
+msgid "OpenLDAP"
+msgstr ""
+
+#: ../../25.10/index.md:367 ca8c87665302465b9d438def5c1b9f41
+msgid ""
+"Updated from 2.6.9 to 2.6.10, which contains various bugfixes. See the "
+"[2.6 series upstream release "
+"notes](https://git.openldap.org/openldap/openldap/-/blob/OPENLDAP_REL_ENG_2_6/CHANGES)"
+msgstr ""
+
+#: ../../25.10/index.md:369 65ebf3557070475fb288354895eaa7ca
+msgid "OpenSSH"
+msgstr ""
+
+#: ../../25.10/index.md:371 aa4d20615003439ca5e811c0d22598ed
+#, python-brace-format
+msgid ""
+"Updated to the new major 10.0 upstream release, which among other things "
+"now uses a hybrid post-quantum algorithm by default for key agreement. It"
+" also adds support for glob patterns in “Authorized{Keys,Principals}File”"
+" and `Match version/sessiontype/command` stanzas inside `ssh[d]_config`, "
+"e.g. \"Match version OpenSSH_10.*\". And adds support for FIDO tokens "
+"that return no attestation data."
+msgstr ""
+
+#: ../../25.10/index.md:373 8ad307f4fb274c9795400c0762576fe5
+msgid "Breaking changes"
+msgstr ""
+
+#: ../../25.10/index.md:375 d1a190639c6942c2b41833818b0ac08d
+msgid "Removes support for the weak DSA signature algorithm."
+msgstr ""
+
+#: ../../25.10/index.md:376 47e5c2c90c32404da3aa5a2b11f2a8f8
+msgid ""
+"Announces itself as \"SSH-2.0-OpenSSH_10.0\". Do not match on "
+"“OpenSSH_1*”."
+msgstr ""
+
+#: ../../25.10/index.md:378 e1745145b6ce439a8da7657c5aad6f44
+msgid ""
+"For more please see the [full release "
+"notes](https://www.openssh.com/txt/release-10.0)"
+msgstr ""
+
+#: ../../25.10/index.md:380 ee5c03d4b2d84baf9971b7db824e4ae0
+msgid "PHP"
+msgstr ""
+
+#: ../../25.10/index.md:382 4038e4701ac24839828995473b203e5c
+msgid ""
+"Upgrade to the 8.4.11 upstream version. The upgrade mostly improves "
+"stability and security, fixing crashes and leaks. It brings fixes for a "
+"few CVEs (CVE-2025-1735, CVE-2025-6491, CVE-2025-1220)."
+msgstr ""
+
+#: ../../25.10/index.md:384 9fdf95e561814e789832ce004756d69c
+msgid ""
+"For more read the [upstream "
+"changelog](https://www.php.net/ChangeLog-8.php#8.4.11) since the former "
+"version in Plucky that was 8.4.5"
+msgstr ""
+
+#: ../../25.10/index.md:386 e8855ee6684d43eeb3a51d03bc3b0b3c
+msgid "PostgreSQL"
+msgstr ""
+
+#: ../../25.10/index.md:388 52ca6f64344c4490bacea2f988a88b43
+msgid ""
+"PostgreSQL stayed on version 17, but received the stable updates (which "
+"we also backport regularly) and now is on 17.6."
+msgstr ""
+
+#: ../../25.10/index.md:390 f5badbb89a95460a8b5ce094f76f1b28
+msgid "A dump/restore is not required for those running 17.X."
+msgstr ""
+
+#: ../../25.10/index.md:392 a157c19715ce4dc19bb681af530877c2
+msgid ""
+"If you have self-referential foreign key constraints on partitioned "
+"tables, it may be necessary to recreate those constraints to ensure that "
+"they are being enforced correctly."
+msgstr ""
+
+#: ../../25.10/index.md:394 f30f7f8f821f4ab3b69bc5e62d956be6
+msgid ""
+"If you have any BRIN numeric_minmax_multi_ops indexes, it is advisable to"
+" reindex them after updating."
+msgstr ""
+
+#: ../../25.10/index.md:396 05f2fb1489b444bb85abd6b9692dd34e
+msgid ""
+"For more details check the upstream release notes for "
+"[17.5](https://www.postgresql.org/docs/release/17.5/) and "
+"[17.6](https://www.postgresql.org/docs/release/17.6/)."
+msgstr ""
+
+#: ../../25.10/index.md:398 8c4121b5b33f4f2a8721474be8ad4a5a
+msgid "QEMU"
+msgstr ""
+
+#: ../../25.10/index.md:400 d349a65c044345fc92264951b0ac7d5c
+msgid ""
+"The [QEMU](https://qemu.org/) package was updated to version 10.1.0. Here"
+" are the changes since Ubuntu 25.04."
+msgstr ""
+
+#: ../../25.10/index.md:402 8776ae4bf180499ab093edc2d6d6d39b
+msgid ""
+"Arm is able to emulate Secure EL2 physical and virtual timers as well as "
+"architectural features  `FEAT_AFP, FEAT_RPRES, FEAT_XS` and even more by "
+"10.1"
+msgstr ""
+
+#: ../../25.10/index.md:403 9f124456f9dc409ca0ae73151032b8e1
+msgid ""
+"Arm's virt board can configuring a larger PCIe MMIO regions via `highmem-"
+"mmio-size`"
+msgstr ""
+
+#: ../../25.10/index.md:404 05009962c1464fcf937231d29b213819
+msgid "RISC-V got various improvements like"
+msgstr ""
+
+#: ../../25.10/index.md:405 d30818d3634a4312bc6773054cdcd295
+msgid "support for Smdbltrp, Ssdbltrp and Smrnmi extensions"
+msgstr ""
+
+#: ../../25.10/index.md:406 3990fcc3bb4f4cd29360fedff0fc678c
+msgid "Add 'sha' support"
+msgstr ""
+
+#: ../../25.10/index.md:407 ce73c32b5e824a0a841f940a6a10a027
+msgid ""
+"Support of the [RVA23 Profile](https://riscv.org/ecosystem-"
+"news/2025/04/risc-v-rva23-a-major-milestone/)"
+msgstr ""
+
+#: ../../25.10/index.md:408 23163834dd474c6ebf84e63e5d487ed0
+msgid "s390x added support for generation 17 mainframe CPUs and virtio-mem"
+msgstr ""
+
+#: ../../25.10/index.md:409 8cfa86c4ba024195bf2b6056d8ccaff8
+msgid "s390x Control program identification data can now be retrieved via QOM"
+msgstr ""
+
+#: ../../25.10/index.md:410 ef58577ad1974758b4a08ee905de1bcf
+msgid "x86 emulation got a performance boost handling string instructions"
+msgstr ""
+
+#: ../../25.10/index.md:411 baa7d0959986415985c5efbdc07c60ca
+msgid "x86 furthermore got more recent CPU types like ClearwaterForest"
+msgstr ""
+
+#: ../../25.10/index.md:412 9e9fbf6fab174fe5822581ee25090c3d
+msgid "`virtio-scsi` has gained true multiqueue support"
+msgstr ""
+
+#: ../../25.10/index.md:413 4c194ef17d1f4f3d81c87426af68a30f
+msgid "Support for Intel ® TDX included"
+msgstr ""
+
+#: ../../25.10/index.md:414 6d08f099c8df445c83f56dd0e70dae31
+msgid "Support for starting a TDX or SEV-SNP virtual machine from an IGVM file."
+msgstr ""
+
+#: ../../25.10/index.md:415 f2bb933328194b61af929dc9d1b06a05
+msgid ""
+"Support for VFIO on TDX and SNP virtual machines and many more vfio "
+"improvements."
+msgstr ""
+
+#: ../../25.10/index.md:416 bd52c763715c40ecb394695d1ca655cd
+msgid ""
+"32 bit hosts never could never provide the atomicity requirements of "
+"64-bit guests. From 10.0, QEMU has disabled configuration of 64-bit "
+"guests on 32-bit hosts."
+msgstr ""
+
+#: ../../25.10/index.md:418 7fda46c906294c50b431d0a49e942ae9
+msgid ""
+"It is important to note that very old machine types have been deprecated "
+"for a while and now finally have been removed upstream and in Ubuntu."
+msgstr ""
+
+#: ../../25.10/index.md:419 c9ec1351335a4fd3a4e371b31d609e11
+msgid ""
+"x86 dropped every type <= 2.5 which translates to anything <=xenial. That"
+" implies that you can migrate your older guests e.g. from trusty up to "
+"24.04 LTS (Noble Numbat) or 25.04 (Plucky Puffin). The former giving "
+"another 4 + 5  +5 (basic, pro, legacy) years of support. But then after "
+"way more than a decade, guests would need to be [bumped to a newer "
+"machine type which is generally recommended "
+"regularly](https://documentation.ubuntu.com/server/explanation/virtualisation"
+"/upgrading-the-machine-type-of-your-vm/)."
+msgstr ""
+
+#: ../../25.10/index.md:420 02da64432cd5497593903153cffd9135
+msgid ""
+"On s390x the cleanup was a bit more aggressive - with <=4.1 and thereby "
+"<=eoan gone. This is a slightly shorter timeline, but still all the 5+5+5"
+" years of support of an Ubuntu LTS plus the 4 years between focal and "
+"noble and thereby quite a long time until you need to consider updating "
+"your guest to a newer machine type."
+msgstr ""
+
+#: ../../25.10/index.md:421 72af74d1d60840b0a8e8f3502e562591
+msgid ""
+"On ppc64 no Ubuntu related machine type was dropped yet, on arm we didn't"
+" yet need to introduce them."
+msgstr ""
+
+#: ../../25.10/index.md:423 9a10da6c8a5c46b6924f98ae181daf21
+msgid ""
+"For more details, please see related upstream changelogs and the general "
+"log on removed features:"
+msgstr ""
+
+#: ../../25.10/index.md:424 bafa95ab239e44feb1e8c43c3395dd15
+msgid "[10.0 Changelog](https://wiki.qemu.org/ChangeLog/10.0)"
+msgstr ""
+
+#: ../../25.10/index.md:425 1a69ea5101ee47f1bc5d81bd4a1d04f2
+msgid ""
+"[Removed Features](https://qemu-project.gitlab.io/qemu/about/removed-"
+"features.html)"
+msgstr ""
+
+#: ../../25.10/index.md:427 fe833cd22b8140b4bf80913bb3430481
+msgid "Samba"
+msgstr ""
+
+#: ../../25.10/index.md:429 45be685fa3084bc49710b85623bcee94
+msgid "Samba has been updated to the new upstream 4.22 version."
+msgstr ""
+
+#: ../../25.10/index.md:431 df24bfa484ee4d6c9a2a9cb64989278d
+msgid "New features:"
+msgstr ""
+
+#: ../../25.10/index.md:432 029680a6efab45288d4150fbb692fa8b
+msgid "SMB3 Directory Leases"
+msgstr ""
+
+#: ../../25.10/index.md:433 1a42ab674d9d4d409628004c3453f4a0
+msgid "Netlogon Ping over LDAP and LDAPS"
+msgstr ""
+
+#: ../../25.10/index.md:434 11035fcc3fb3463c9c9e871eb9dd64a6
+msgid "Experimental Himmelblaud Authentication in Samba"
+msgstr ""
+
+#: ../../25.10/index.md:435 880625a74614490da0ad7de7e7509bbd
+msgid "AD DC schema upgrade and provision performance improvements"
+msgstr ""
+
+#: ../../25.10/index.md:437 2d7487752fa44bde8ee8fb8c1039e161
+msgid "Removed features:"
+msgstr ""
+
+#: ../../25.10/index.md:438 111cb4ca3da44c3db1c3bbd01ab5fd47
+msgid "`nmbd proxy logon`"
+msgstr ""
+
+#: ../../25.10/index.md:439 bda7022721044bd7967a68570632cf58
+msgid "`cldap port`"
+msgstr ""
+
+#: ../../25.10/index.md:440 27e880ac4ab24fa2ae5d8b030f0a4324
+msgid "`fruit:posix_rename`"
+msgstr ""
+
+#: ../../25.10/index.md:442 56b4dabae92544ccb9ea822dc8c79b16
+msgid ""
+"Please refer to the upstream release notes for details: "
+"https://www.samba.org/samba/history/samba-4.22.0.html"
+msgstr ""
+
+#: ../../25.10/index.md:445 7d1df91354d44a17a2f775fc25bdc321
+msgid "Strongswan"
+msgstr ""
+
+#: ../../25.10/index.md:446 6c16f0fd3be045ffb677680410723fbc
+msgid ""
+"Strongswan was upgraded to v6.0.1, following upstream in **dropping the "
+"NTRU post-quantum encryption algorithm**. See upstream changelogs for the"
+" full listing of changes:"
+msgstr ""
+
+#: ../../25.10/index.md:447 662ceadd3b7d4672b7465707dc103388
+msgid "https://github.com/strongswan/strongswan/releases/tag/5.9.14"
+msgstr ""
+
+#: ../../25.10/index.md:448 8f8a04e1deec4ee88ce493a0f8348249
+msgid "https://github.com/strongswan/strongswan/releases/tag/6.0.0"
+msgstr ""
+
+#: ../../25.10/index.md:449 48f95389fb44411e8c7b90a42572105b
+msgid "https://github.com/strongswan/strongswan/releases/tag/6.0.1"
+msgstr ""
+
+#: ../../25.10/index.md:451 19a7a56354564a168e6f90e0c5c19c7e
+msgid "Intel® QuickAssist Technology (Intel® QAT)"
+msgstr ""
+
+#: ../../25.10/index.md:453 5f5637e1acd944779832ca751da778db
+msgid ""
+"Intel® QAT components have been updated to their most recent versions. "
+"Those are:"
+msgstr ""
+
+#: ../../25.10/index.md:455 362010c52e1249d7a749f8e4859ce984
+msgid ""
+"qatlib : 25.08.0 For more information, visit the project’s[ "
+"repo](https://github.com/intel/qatlib?tab=readme-ov-file#features)."
+msgstr ""
+
+#: ../../25.10/index.md:457 8e9faec189e54ead83981745ea97a62b
+msgid ""
+"qatengine : updated to 2.0.0 For more information, visit the project’s[ "
+"repo](https://github.com/intel/QAT_Engine/blob/master/docs/features.md)."
+msgstr ""
+
+#: ../../25.10/index.md:459 c54f6fa1a20745fbb84d12a2cc92379d
+msgid ""
+"qatzip : updated to 1.3.1 For more information, visit the project’s[ "
+"repo](https://github.com/intel/QATzip?tab=readme-ov-file#features)."
+msgstr ""
+
+#: ../../25.10/index.md:462 0f19e821ff3d4229ac73e7d06c6c651d
+msgid "sos (sosreport)"
+msgstr ""
+
+#: ../../25.10/index.md:464 ca4d3f48f15a4e5ca80191a9397d5e3e
+msgid "`sos` was updated to version 4.10.0. Key updates below"
+msgstr ""
+
+#: ../../25.10/index.md:466 44fa52ee66294a56a835965fc448acd4
+msgid ""
+"The temporary directory has now been changed from `/tmp` to `/var/tmp`. "
+"This follows changed in systemd-tmpfiles and the cleaning of `/var/tmp`, "
+"this aligns with other distros."
+msgstr ""
+
+#: ../../25.10/index.md:467 56a40230d14c42ca9346d39376b1122b
+msgid ""
+"`sos clean` now cleans the sos concurrently, improving the speed of "
+"cleaning."
+msgstr ""
+
+#: ../../25.10/index.md:468 4e6dc7dc4cec4c278311ea88001d6505
+msgid ""
+"Many new additional plugins include `authd`, `charmed_mysql`, `helm`, "
+"`opensearch`, `pulseaudio` and `valkey`"
+msgstr ""
+
+#: ../../25.10/index.md:469 a942afa5d92f46e69280451b262569d3
+msgid "Many other plugins have also been updated."
+msgstr ""
+
+#: ../../25.10/index.md:471 290bf944f49d4d88ab92ab9bd1d3fb71
+msgid ""
+"Upstream release notes can be viewed on the [sos project "
+"GitHub](https://github.com/sosreport/sos/releases/tag/4.10.0)"
+msgstr ""
+
+#: ../../25.10/index.md:473 9dd394fc02ba4ac3ada50e72cbc1a081
+msgid "Subiquity"
+msgstr ""
+
+#: ../../25.10/index.md:475 7a8504f817644cb6a31acffa422fe4fe
+msgid ""
+"Please see the [25.10 Release "
+"Notes](https://github.com/canonical/subiquity/releases/tag/25.10) post on"
+" GitHub."
+msgstr ""
+
+#: ../../25.10/index.md:477 d6bd7a640a514b528fc59f56e6d2ae6d
+msgid "Valkey"
+msgstr ""
+
+#: ../../25.10/index.md:479 0b0ff246a711450bb791b2cc8db8c0f9
+msgid ""
+"Valkey was updated to version 8.1, starting with 8.1.1. This includes "
+"additional significant performance and efficiency improvements, without "
+"any backwards-incompatible changes to commands and responses. For more "
+"information on the new version, see the [Valkey 8.1 blog post "
+"](https://valkey.io/blog/valkey-8-1-0-ga/). Release notes are available "
+"on the [Valkey project GitHub ](https://github.com/valkey-"
+"io/valkey/releases/tag/8.1.1)."
+msgstr ""
+
+#: ../../25.10/index.md:481 4212094ff9554ae68507a7c3a61c682b
+msgid ""
+"Additionally, now that Redis has been updated to 8.0, **Valkey no longer "
+"acts as a drop-in replacement**. Therefore, the valkey-redis-compat "
+"package has been removed. If you are planning to swap from Redis to "
+"Valkey, **make sure to do so prior to upgrading**."
+msgstr ""
+
+#: ../../25.10/index.md:483 57da450378024a3f9291b2e60644f347
+msgid "OpenStack"
+msgstr ""
+
+#: ../../25.10/index.md:485 5baccc6f8c75407589e7f2d3359e3d05
+msgid ""
+"OpenStack has been updated to the [2025.2 (Flamingo) "
+"](https://releases.openstack.org/flamingo/) release. This includes "
+"packages for Aodh, Barbican, Ceilometer, Cinder, Designate, Glance, Heat,"
+" Horizon, Ironic, Keystone, Magnum, Manila, Masakari, Mistral, Neutron, "
+"Nova, Octavia, Swift, Vitrage, Watcher and Zaqar."
+msgstr ""
+
+#: ../../25.10/index.md:487 2489ca89274141bcafd5aba3daba161e
+msgid ""
+"This release is also provided for Ubuntu 24.04 LTS via the Ubuntu Cloud "
+"Archive."
+msgstr ""
+
+#: ../../25.10/index.md:489 d4a0fa2b0bd142aeb3a39096231eb1d9
+msgid ""
+"The Flamingo release significantly strengthens OpenStack's security "
+"posture with new confidential computing features in Nova (SEV-ES support,"
+" one-time passthrough devices), credential rotation capabilities in "
+"Magnum, and bring-your-own encryption keys in Manila. The Eventlet "
+"Removal is still underway, already being removed across multiple core "
+"services including Ironic, Barbican, Heat, modernizing OpenStack's "
+"asynchronous operations foundation for long-term sustainability."
+msgstr ""
+
+#: ../../25.10/index.md:491 6b0e1477f193445cbcaef34cec230916
+msgid "Ceph"
+msgstr ""
+
+#: ../../25.10/index.md:493 67835b9b7218494a8ce66b092a81061a
+msgid "Open vSwitch (OVS) and Open Virtual Network (OVN)"
+msgstr ""
+
+#: ../../25.10/index.md:494 2c2f9cd3bbcf4dd0b4e79fde2674b427
+msgid ""
+"OVS was updated to 3.6.0 and OVN was updated 25.09.0. Please refer to the"
+" upstream NEWS files  for more information about individual features:"
+msgstr ""
+
+#: ../../25.10/index.md:495 13334bbe2a094e06b931ddfe8744c013
+msgid "[OVS 3.6.0](https://github.com/openvswitch/ovs/blob/v3.6.0/NEWS)"
+msgstr ""
+
+#: ../../25.10/index.md:496 2524bbc08fa24dae97794eb27f87a9be
+msgid "[OVN 25.09.0](https://github.com/ovn-org/ovn/blob/v25.09.0/NEWS)"
+msgstr ""
+
+#: ../../25.10/index.md:498 e4c332144bab49aa9c46ec3e483a30e6
+msgid "Platforms"
+msgstr ""
+
+#: ../../25.10/index.md:500 a493fdaaf69d408b999ea4d5d977c42e
+msgid "GRUB2"
+msgstr ""
+
+#: ../../25.10/index.md:502 b0503227746f435babaf9528edfbbbb0
+msgid ""
+"We’ve started shipping a pre-release beta of GRUB 2.14 as the bootloader."
+" Everything should work smoothly, but if you notice anything strange, "
+"please file a bug report and let us know!"
+msgstr ""
+
+#: ../../25.10/index.md:504 8a7874256ff64c41b62ef29b0e10d531
+msgid "Public Cloud / Cloud images"
+msgstr ""
+
+#: ../../25.10/index.md:506 ../../25.10/index.md:703
+#: 0fba8fb44fa84e94a8b85ccc6e9c389b 18fad9acc09b48a883f50663906e8a6b
+msgid "Microsoft Azure"
+msgstr ""
+
+#: ../../25.10/index.md:508 b6dff2a0d8ec4aaebabc468966977baa
+msgid ""
+"Ubuntu images on Microsoft Azure now include azure-vm-utils package, "
+"which provides consistent disk naming across SCSI and NVMe devices, "
+"improved handling for accelerated networking (MANA and Mellanox), and "
+"removes the need for custom udev or Netplan configurations."
+msgstr ""
+
+#: ../../25.10/index.md:510 47d7a4205a8e497badb8c432b02a0cbc
+msgid "How to report any issues resulting from these changes"
+msgstr ""
+
+#: ../../25.10/index.md:512 f43a2b7a5e84490b83610a63e436c006
+msgid "Raspberry Pi 🍓"
+msgstr ""
+
+#: ../../25.10/index.md:514 0bdab7d7f3f64c7cbf6324d721a03013
+msgid ""
+"A new layout of the boot partition is introduced to enhance the "
+"reliability of the boot process ([LP: "
+"#2116266](https://launchpad.net/bugs/2116266)). This will automatically "
+"\"test\" new boot assets written to the boot partition before committing "
+"them as the current \"known good\" set. See the [call for "
+"testing](https://discourse.ubuntu.com/t/call-for-testing-a-b-boot-on-"
+"raspberry-pi/64173) for more information, or [the blog "
+"post](https://waldorf.waveform.org.uk/2025/pull-yourself-up-by-your-"
+"bootstraps.html) covering the feature for the full details (including "
+"advice on how to opt-out of this feature, where required)"
+msgstr ""
+
+#: ../../25.10/index.md:516 fcb6906c4d3a4ff8b345c8bd3a752abd
+msgid ""
+"Please note that, due to the new boot process, the boot firmware on your "
+"Pi *must* be up to date. On the Pi 3, 3+, and Zero 2W, the boot firmware "
+"is in the image itself, and so is guaranteed to be up to date. On the Pi "
+"5, all boot firmware since release are compatible. However, on the Pi 4 "
+"your boot firmware must be dated no earlier than 2022-11-25. To check "
+"this, run `sudo rpi-eeprom-update`. If your firmware is dated earlier "
+"than this, using Ubuntu 24.04 LTS (Noble Numbat) or later, run `sudo rpi-"
+"eeprom-update -a` and reboot."
+msgstr ""
+
+#: ../../25.10/index.md:518 f6768d5aca66471a8adc28c0025a27fe
+msgid ""
+"The Ubuntu desktop images for Raspberry Pi are now based upon the "
+"\"desktop-minimal\" seed rather than \"desktop\" ([LP: "
+"#2103808](https://launchpad.net/bugs/2103808)). This greatly reduces the "
+"default set of applications installed on the images (saving approximately"
+" 777MB of space on the uncompressed image, and thus on user's systems). "
+"The list of applications removed from the image is:"
+msgstr ""
+
+#: ../../25.10/index.md:520 c33b8aa1620c41d4a4a2b029bc5aef7e
+msgid "deja-dup (backup service)"
+msgstr ""
+
+#: ../../25.10/index.md:521 ac3de6a7701344afa8ac19716ccd41c6
+msgid "file-roller (archive handler)"
+msgstr ""
+
+#: ../../25.10/index.md:522 5210c30c0ad4469eb89fa6d68f3b609c
+msgid "gnome-calendar"
+msgstr ""
+
+#: ../../25.10/index.md:523 c894df52c8de4bb3ad3525fc0bfcf87e
+msgid "gnome-snapshot (camera application)"
+msgstr ""
+
+#: ../../25.10/index.md:524 57bd791e152d4cd7a8c7bb5f047a87db
+msgid "libreoffice-*"
+msgstr ""
+
+#: ../../25.10/index.md:525 b6cd319e2aa24ddbb5cf5d33be592408
+msgid "remmina (remote desktop client)"
+msgstr ""
+
+#: ../../25.10/index.md:526 11c9285299774232b794df2bea2d1e9c
+msgid "rhythmbox (music player)"
+msgstr ""
+
+#: ../../25.10/index.md:527 9ab4787bf44545e2b73762431e4f4326
+msgid "shotwell (photo catalogue)"
+msgstr ""
+
+#: ../../25.10/index.md:528 5f02810986704fd2a36bd7c2c0149dde
+msgid "simple-scan (flat-bed scanner application)"
+msgstr ""
+
+#: ../../25.10/index.md:529 81c314a4b4c641e08ff00c7c5149c0de
+msgid "thunderbird (email client)"
+msgstr ""
+
+#: ../../25.10/index.md:530 572dbf1b92444a0bbb98c13f958b5d7f
+msgid "totem (video player)"
+msgstr ""
+
+#: ../../25.10/index.md:531 08bdad552edd4c36aca225ba8aab48a4
+msgid "transmission-gtk (bittorrent client)"
+msgstr ""
+
+#: ../../25.10/index.md:533 3d88272d02ac42ff8a38995847f4ac36
+msgid ""
+"The applications mentioned above will *not* be automatically removed for "
+"upgraders as the `ubuntu-desktop` meta-package remains manually installed"
+" in this circumstance. If you wish to remove these applications (in "
+"bulk), you may do so with: `sudo apt purge ubuntu-desktop --autoremove`. "
+"If you wish to keep specific applications, simply \"install\" them with "
+"apt first (which will mark them as \"manually installed\", excluding them"
+" from automatic removal)."
+msgstr ""
+
+#: ../../25.10/index.md:535 f5d4434dba4c4d58a82b15a0ce14fcbc
+msgid ""
+"The creation of the swap-file on the desktop images is now handled by "
+"[cloud-init](https://cloudinit.readthedocs.io/en/latest/) ([LP: "
+"#2116275](https://launchpad.net/bugs/2116275)). You may customize the "
+"size of the swapfile by editing user-data on the boot partition prior to "
+"first boot"
+msgstr ""
+
+#: ../../25.10/index.md:537 b7bc2f087dc441d2a0eff315f29c3f58
+msgid "IBM Z and LinuxONE (s390x)"
+msgstr ""
+
+#: ../../25.10/index.md:539 421030bc30c0484b84120c58f9c775eb
+msgid ""
+"With every new Ubuntu release, the s390-tools package got upgraded to "
+"it's latest available release v2.38 ([LP: "
+"#2115416](https://launchpad.net/bugs/2115416)), that now includes support"
+" to provide Topology-Map information to user-space ([LP: "
+"#2098361](https://launchpad.net/bugs/#2098361)), support to convert LUKS2"
+" volume from AES keys to retrievable PAES keys ([LP: "
+"#2117450](https://launchpad.net/bugs/#2117450)) as well as Control "
+"Program Identification (CPI) hardening for SEL (Security Enhanced Linux) "
+"guests ([LP: #2118866](https://launchpad.net/bugs/#2118866))."
+msgstr ""
+
+#: ../../25.10/index.md:541 2240e3b407454052b799e2d08694cdb0
+msgid ""
+"Further support and enhancements were done in the virtualization stack "
+"with the implementation of virsh hypervisor-cpu-models in libvirt ([LP: "
+"#2027925](https://launchpad.net/bugs/#2027925), performance enhanced "
+"refresh PCI translation in qemu ([LP: "
+"#2049699](https://launchpad.net/bugs/#2049699)) and kernel ([LP: "
+"#2049700](https://launchpad.net/bugs/#2049700)), the implementation of "
+"Control Program Identification (CPI) in qemu ([LP: "
+"#2118769](https://launchpad.net/bugs/#2118769)) and the new reporting of "
+"vfio-ap configuration changes with CHSC Store Event Information in KVM, "
+"kernel ([LP: #2118771](https://launchpad.net/bugs/#2118771)) and qemu "
+"([LP: #2119160](https://launchpad.net/bugs/#2119160))."
+msgstr ""
+
+#: ../../25.10/index.md:543 c6fd969f26754c40b01f12416b70f806
+msgid ""
+"Significant effort was spent to enable Ubuntu for the latest IBM Z (z17) "
+"and LinuxONE (LinuxONE 5) hardware generations, with support in glibc "
+"([LP: #2117398](https://launchpad.net/bugs/#2117398)), and the tool-"
+"chain, namely:"
+msgstr ""
+
+#: ../../25.10/index.md:544 cb10d64f55844d029fc204ad818abb14
+msgid "gcc ([LP: #2117410](https://launchpad.net/bugs/#2117410))"
+msgstr ""
+
+#: ../../25.10/index.md:545 8e2b1400bca54c87b4ca1e3a1636765f
+msgid "llvm ([LP: #2117411](https://launchpad.net/bugs/#2117411)) and"
+msgstr ""
+
+#: ../../25.10/index.md:546 2c69f1a0d30e4751b06e7947b0f43781
+msgid ""
+"valgrind ([LP: #2116735](https://launchpad.net/bugs/#2116735) and [LP: "
+"#2119288](https://launchpad.net/bugs/#2119288))"
+msgstr ""
+
+#: ../../25.10/index.md:548 110229c613c6471992a229f953584171
+msgid "Another big area of enhancements is cryptography:"
+msgstr ""
+
+#: ../../25.10/index.md:549 74ad53be839e4939aca4ecc6dcc8be36
+msgid ""
+"with the upgrade to opencryptoki v3.25 ([LP: "
+"#2116720](https://launchpad.net/bugs/#2116720)) there is now also"
+msgstr ""
+
+#: ../../25.10/index.md:550 aea6cdabf55a4431bfab81c9b98c2769
+msgid ""
+"support for ep11 token based import and export of secure key objects "
+"([LP: #2117436](https://launchpad.net/bugs/#2117436))"
+msgstr ""
+
+#: ../../25.10/index.md:551 c6e3bc95ed5f47ebaafd1c0ee3e7a8a1
+msgid ""
+"the new tools p11kmip that allows to import/export PKCS #11 keys from to "
+"a KMIP server ([LP: #2117449](https://launchpad.net/bugs/#2117449))"
+msgstr ""
+
+#: ../../25.10/index.md:552 47a6816e64b946e4b14dbb9ee58c0d75
+msgid ""
+"and basic support for AES-GCM in CCA tokens ([LP: "
+"#2117451](https://launchpad.net/bugs/#2117451)) In addition several "
+"cryptography packages were updated, like:"
+msgstr ""
+
+#: ../../25.10/index.md:554 2cdba2ab3fe6414daeb1c6f7bad920e4
+msgid ""
+"openssl-ibmca to v2.5.0 ([LP: "
+"#2116709](https://launchpad.net/bugs/#2116709))"
+msgstr ""
+
+#: ../../25.10/index.md:555 e6464c7ab24c4b07a7b2f550c7087c1f
+msgid ""
+"openssl-pkcs11-sign-provider to v1.0.2 ([LP: "
+"#2116721](https://launchpad.net/bugs/#2116721))"
+msgstr ""
+
+#: ../../25.10/index.md:556 7ba1376030ca4fd1bd91a00e23f065ca
+msgid "libzpc to v1.4.0 ([LP: #2116711](https://launchpad.net/bugs/#2116711))"
+msgstr ""
+
+#: ../../25.10/index.md:557 b6245fb64ab34197a95f93529bec45a8
+msgid ""
+"libica4 to v4.4.1 ([LP: #2116716](https://launchpad.net/bugs/#2116716)) "
+"and"
+msgstr ""
+
+#: ../../25.10/index.md:558 82e5a1e3354e41ee828908aa7ff2db70
+msgid "cryptsetup to v2.8.0 ([LP: #2116736](https://launchpad.net/bugs/#2116736))"
+msgstr ""
+
+#: ../../25.10/index.md:559 c88ff2203d964413a2457886ebedcebb
+msgid ""
+"The kernel also comes with new PHMAC support for MSA 11 HMAC ([LP: "
+"#2096891](https://launchpad.net/bugs/#2096891))."
+msgstr ""
+
+#: ../../25.10/index.md:561 372fe3ffa3054412a47e4165caf5f5de
+msgid "Finally further tools were updated, like the"
+msgstr ""
+
+#: ../../25.10/index.md:562 13b14da772c0443f82cf012f76829954
+msgid ""
+"smc-tools to v1.8.5, used for shared memory communication cards ([LP: "
+"#2119285](https://launchpad.net/bugs/#2119285))"
+msgstr ""
+
+#: ../../25.10/index.md:563 16892efc554d4ab9a3b6b8b47228ad47
+msgid ""
+"libzdnn to v1.1.2, for neuronal network usage with IBM Z hardware support"
+" ([LP: #2116713](https://launchpad.net/bugs/#2116713)) and the"
+msgstr ""
+
+#: ../../25.10/index.md:564 fec94c9ea7b64c978afb92223fe540fe
+msgid ""
+"qclib to v2.5.1, that allows to query s390x hardware data ([LP: "
+"#2116708](https://launchpad.net/bugs/#2116708))"
+msgstr ""
+
+#: ../../25.10/index.md:566 60312cff77a9449b9f0a39999c928261
+msgid "IBM POWER (ppc64el)"
+msgstr ""
+
+#: ../../25.10/index.md:568 a1528cd1fd994e9abc6cc3e3df59171c
+msgid "RISC-V"
+msgstr ""
+
+#: ../../25.10/index.md:570 95659f518b4b442a9365af044132d84d
+msgid ""
+"Ubuntu 25.10 targets the RVA23S64 ISA profile. Systems that don't satisfy"
+" this requirement cannot run Ubuntu 25.10. RVA20 hardware will continue "
+"to be supported by Ubuntu 24.04 LTS."
+msgstr ""
+
+#: ../../25.10/index.md:572 07c5d4fe674349ca9130632cd9336cd9
+msgid ""
+"If you’d like to try it out in a VM, please refer to this guide https"
+"://canonical-ubuntu-boards.readthedocs-hosted.com/en/latest/how-to/qemu-"
+"riscv/"
+msgstr ""
+
+#: ../../25.10/index.md:575 cbe87dc9001143cdb02aa7975b00b508
+msgid "Known Issues"
+msgstr ""
+
+#: ../../25.10/index.md:577 79b34b1c434a43ee85d7e88ec778bfa2
+msgid ""
+"As is to be expected with any release, there are some significant known "
+"bugs that users may encounter with this release of Ubuntu. The ones we "
+"know about at this point (and some of the workarounds) are documented "
+"here, so you don't need to spend time reporting these bugs again:"
+msgstr ""
+
+#: ../../25.10/index.md:579 ebe8bbd7ad6d453da0446ca941dbf3a7
+msgid "General"
+msgstr ""
+
+#: ../../25.10/index.md:581 615ce611ce894b68b21f1c31effbfe8d
+msgid ""
+"Offline installs ticking the box for Nvidia drivers result in Nouveau "
+"drivers being installed instead - to work around, install online or "
+"update drivers after install.  ([LP: "
+"#2127099](https://bugs.launchpad.net/ubuntu/+source/nvidia-graphics-"
+"drivers-580/+bug/2127099))"
+msgstr ""
+
+#: ../../25.10/index.md:582 d580a93e238b420496d5f7fc57b38d94
+msgid ""
+"There is a bug ([LP: #2104316](https://bugs.launchpad.net/ubuntu-power-"
+"systems/+bug/2104297)) in the *beta* images that prevents netboot "
+"installs in some scenarios."
+msgstr ""
+
+#: ../../25.10/index.md:583 4898b35ed2be47e5a340be4bfc76495b
+msgid ""
+"It has been reported that cloud-init may fails to upgrade properly in the"
+" Oracular to Pluck upgrade path, see [LP: "
+"#2104316](https://bugs.launchpad.net/ubuntu-power-systems/+bug/2104297)."
+msgstr ""
+
+#: ../../25.10/index.md:584 d6e0fbfcff6a40649187a05552b2d88c
+msgid ""
+"The Live Session of the new Ubuntu Desktop installer is not localized. It"
+" is still possible to perform a non-English installation using the new "
+"installer, but internet access at install time is required to download "
+"the language packs. ([LP: #2013329](https://bugs.launchpad.net/ubuntu-"
+"release-notes/+bug/2013329))"
+msgstr ""
+
+#: ../../25.10/index.md:585 ebd964cc03c44c80aab403d35027325f
+msgid ""
+"ZFS with Encryption on Ubuntu 24.10 will [fail to activate the cryptoswap"
+" "
+"partition](https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/2084089)."
+"  This affects both new installs and upgrades.  We expect to address this"
+" post-release with an archive update."
+msgstr ""
+
+#: ../../25.10/index.md:587 e4194e51d24c4f15a0d77956207aac71
+msgid ""
+"Some particular hardware (e.g. Thinkpad x201) might have issues ([general"
+" freeze](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2084055), "
+"[`desktop-security-center` not launching](https://github.com/canonical"
+"/desktop-security-center/issues/81)), when booted without `nomodeset` "
+"(Safe graphics). Follow these steps if you encounter such an issue:"
+msgstr ""
+
+#: ../../25.10/index.md:589 49197889c9634d67a6f036d7903881c0
+msgid ""
+"At the GRUB boot menu, press `e` (keep `Shift` pressed during early boot "
+"if the menu doesn't show up)."
+msgstr ""
+
+#: ../../25.10/index.md:591 6888b55ca62344fcb9d7541439772b70
+msgid "Add `nomodeset` to `linux` line, like the example below:"
+msgstr ""
+
+#: ../../25.10/index.md:597 0b4c450740a24b22ba07aa445420c054
+msgid "Press `Ctrl-x` to continue the boot process"
+msgstr ""
+
+#: ../../25.10/index.md:599 9a057b6e0fd7430092dbf5689807d1e0
+msgid ""
+"After installation is complete, reboot, use `nomodeset` again, like the "
+"example below:"
+msgstr ""
+
+#: ../../25.10/index.md:605 eb7c7c33ceb741cf944587c53649e813
+msgid ""
+"Add `nomodeset` to the GRUB config file, `/etc/default/grub`, like the "
+"example below:"
+msgstr ""
+
+#: ../../25.10/index.md:611 7d17ff570263480fb5c0766aa1ebd3c1
+msgid "Finally, make the change take effect:"
+msgstr ""
+
+#: ../../25.10/index.md:616 1dfe8a68e2cd4f97808fa5677bd5d76d
+msgid ""
+"flatpak is failing to install applications due to missing or incorrect "
+"AppArmor rules in the profile for fusermount3. Please see "
+"https://bugs.launchpad.net/ubuntu-release-notes/+bug/2122161 for details."
+msgstr ""
+
+#: ../../25.10/index.md:618 cc091653efe347ec87eac9651a34e6e4
+msgid "Linux kernel"
+msgstr ""
+
+#: ../../25.10/index.md:620 be55ac218b0b4e248a1acd0dbe222756
+msgid ""
+"There is an AppArmor issue where confined profiles may unexpectedly seem "
+"to apply to another process and restrict things like \"`<tool> > "
+"output.log`\" from working inside questing LXD containers. See "
+"https://bugs.launchpad.net/ubuntu-release-notes/+bug/2121552 for more "
+"details."
+msgstr ""
+
+#: ../../25.10/index.md:624 5afaf6e547fc4e909e11c6dd723c27ac
+msgid ""
+"Screen reader support is present with the new desktop installer, but is "
+"incomplete ([LP: #2061015](https://launchpad.net/bugs/2061015), [LP: "
+"#2061018](https://launchpad.net/bugs/2061018), [LP: "
+"#2036962](https://launchpad.net/bugs/2036962), [LP: "
+"#2061021](https://launchpad.net/bugs/2061021))"
+msgstr ""
+
+#: ../../25.10/index.md:626 5fdcce3701134e5190bf59ce33d81269
+msgid ""
+"You will perhaps experience crashes trying to use the snap-store on "
+"Qualcomm Snapdragon X Elite hardware ([LP: "
+"#2127161](https://bugs.launchpad.net/ubuntu/+source/mesa/+bug/2127161))"
+msgstr ""
+
+#: ../../25.10/index.md:628 bc132e8baf0f49bcb42e4796712227af
+msgid ""
+"OEM installs are not supported yet ([LP: "
+"#2048473](https://launchpad.net/bugs/2048473))"
+msgstr ""
+
+#: ../../25.10/index.md:630 f52402f9a1b049aca15c201a257d2930
+msgid ""
+"GTK4 apps (including the desktop wallpaper) do not display correctly with"
+" VirtualBox or VMWare with 3D Acceleration ([LP: "
+"#2061118](https://launchpad.net/bugs/2061118))."
+msgstr ""
+
+#: ../../25.10/index.md:632 216c496aef624723874b9fd91b080fcc
+msgid ""
+"**Incompatibility between TPM-backed Full Disk Encryption and Absolute:**"
+" TPM-backed Full Disk Encryption (FDE) has been introduced to enhance "
+"data security. However, it's important to note that this feature is "
+"incompatible with Absolute (formerly Computrace) security software. If "
+"Absolute is enabled on your system, the machine will not boot post-"
+"installation when TPM-backed FDE is also enabled. Therefore, disabling "
+"Absolute from the BIOS is recommended to avoid booting issues."
+msgstr ""
+
+#: ../../25.10/index.md:633 ec31fe0a185f46fa9bc62e5df32347a0
+msgid ""
+"**Hardware-Specific Kernel Module Requirements for TPM-backed Full Disk "
+"Encryption:** TPM-backed Full Disk Encryption (FDE) requires a specific "
+"kernel snap which may not include certain kernel modules necessary for "
+"some hardware functionalities. A notable example is the `vmd` module "
+"required for NVMe RAID configurations. In scenarios where such specific "
+"kernel modules are indispensable, the hardware feature may need to be "
+"disabled in the BIOS (such as RAID) to ensure the continued availability "
+"of the affected hardware post-installation. If disabling in the BIOS is "
+"not an option, the related hardware will not be available post-"
+"installation with TPM-backed FDE enabled."
+msgstr ""
+
+#: ../../25.10/index.md:634 d5cfed7c059541c393bc0c5d93b47f3e
+msgid ""
+"[FDE specific bug "
+"reports](https://bugs.launchpad.net/bugs/+bugs?field.searchtext=&orderby=-importance&field.status%3Alist=NEW&field.status%3Alist=CONFIRMED&field.status%3Alist=TRIAGED&field.status%3Alist=INPROGRESS&field.status%3Alist=FIXCOMMITTED&field.status%3Alist=INCOMPLETE_WITH_RESPONSE&field.status%3Alist=INCOMPLETE_WITHOUT_RESPONSE&assignee_option=any&field.assignee=&field.bug_reporter=&field.bug_commenter=&field.subscriber=&field.tag=fde&field.tags_combinator=ANY&field"
+".status_upstream-empty-"
+"marker=1&field.has_cve.used=&field.omit_dupes.used=&field.omit_dupes=on&field.affects_me.used=&field.has_patch.used=&field.has_branches.used=&field.has_branches=on&field.has_no_branches.used=&field.has_no_branches=on&field.has_blueprints.used=&field.has_blueprints=on&field.has_no_blueprints.used=&field.has_no_blueprints=on&search=Search)."
+msgstr ""
+
+#: ../../25.10/index.md:636 17ce091fd9294d3386ada10e28383952
+msgid ""
+"Installing `ubuntu-fonts-classic` results in a non-Ubuntu font being "
+"displayed ([LP#2083683](https://bugs.launchpad.net/bugs/2083683)). To "
+"resolve this, install `gnome-tweaks` and set ‘Interface Text’ to "
+"‘Ubuntu’."
+msgstr ""
+
+#: ../../25.10/index.md:638 3e5ced300a0c45329e2f8dff3f0ef30c
+msgid ""
+"Wayland desktop performance using the Nvidia driver is still suboptimal. "
+"Work is underway to resolve this in 26.04 "
+"([LP#2081140](https://bugs.launchpad.net/bugs/2081140))."
+msgstr ""
+
+#: ../../25.10/index.md:640 15da42ca2dc5457cafda08e42445202b
+msgid ""
+"There is no simple way to customize the login screen ([upstream "
+"issue](https://gitlab.gnome.org/GNOME/gnome-control-"
+"center/-/issues/2185)). As a workaround, you can copy your personal "
+"monitor settings to the login screen with:"
+msgstr ""
+
+#: ../../25.10/index.md:644 7fa5149aecc44e5cb4a1b3097daf32f1
+msgid ""
+"and (at your own risk) you can copy all your other personal settings to "
+"the login screen with:"
+msgstr ""
+
+#: ../../25.10/index.md:651 86b953e6375e4d59994614878f477451
+msgid "rabbitmq-server"
+msgstr ""
+
+#: ../../25.10/index.md:653 54509aba7a704158bc5122f80d089cb2
+msgid ""
+"Certain version hops may be unsupported due to feature flags, raising "
+"questions about how Ubuntu will maintain this package moving forward. We "
+"are currently exploring the use of snaps as a potential solution to "
+"enable smoother upgrades. For more information please read [LP: "
+"#2074309](https://launchpad.net/bugs/2074309)."
+msgstr ""
+
+#: ../../25.10/index.md:655 a62462275f574b5c998a23b95d3a532f
+msgid "Openstack"
+msgstr ""
+
+#: ../../25.10/index.md:657 da4737cc764d491c9da48c2e6e7b12cb
+msgid ""
+"Currently, Nova Compute is non-functional because of a python3.13 "
+"incompatibility "
+"([LP:#2103413](https://bugs.launchpad.net/ubuntu/+source/nova/+bug/2103413))."
+" The Openstack team and Upstream work on it and it will be resolved via "
+"an SRU later."
+msgstr ""
+
+#: ../../25.10/index.md:660 c564c93ea8ad44b09fd5ae0f69a1f380
+msgid "The Ubuntu Cloud Archive is not affected by this bug."
+msgstr ""
+
+#: ../../25.10/index.md:664 fe7b5abd76d849a6b499960471fa1128
+msgid ""
+"On systems booting via U-Boot, U-Boot should be updated to the current "
+"Plucky version before installation as subiquity does not run flash-kernel"
+" and grub-update during the installation. So for first boot the device-"
+"tree from U-Boot will be used."
+msgstr ""
+
+#: ../../25.10/index.md:666 b850a0a2c3444c86820a29b960bdd689
+msgid ""
+"In some situations, it is acceptable to proceed with an offline "
+"installation when the mirror is inaccessible. In this scenario, it is "
+"advised to use:"
+msgstr ""
+
+#: ../../25.10/index.md:673 5e0adadc691041d6a93bbc5ff1530da3
+msgid ""
+"Network interfaces left unconfigured at install time are assumed to be "
+"configured via dhcp4. If this doesn't happen (for example, because the "
+"interface is physically not connected) the boot process will block and "
+"wait for a few minutes ([LP: "
+"#2063331](https://bugs.launchpad.net/subiquity/+bug/2063331)). This can "
+"be fixed by removing the extra interfaces from `/etc/netplan/50-cloud-"
+"init.conf` or by marking them as `optional: true`. Cloud-init is disabled"
+" on systems installed from ISO images, so settings will persist."
+msgstr ""
+
+#: ../../25.10/index.md:675 3f50e9557c0a4ab792224e508a2c3e67
+msgid ""
+"Installing to a remote NVMe drive using NVMe over TCP firmware support "
+"can result in an unbootable system. A workaround exists using an "
+"autoinstall directive. Alternatively, the configuration on the target "
+"system can be manually fixed post installation before rebooting to the "
+"target system. More information at [LP: "
+"#2127072](https://bugs.launchpad.net/bugs/2127072)."
+msgstr ""
+
+#: ../../25.10/index.md:677 dadc0f3cbc554c02bf1e4608e181bd33
+msgid "Raspberry Pi"
+msgstr ""
+
+#: ../../25.10/index.md:679 c44d194e90844edb90673572a60b41d9
+msgid ""
+"The new gnome-initial-setup has issues preventing it from working "
+"properly:"
+msgstr ""
+
+#: ../../25.10/index.md:680 28c9c345a6e04ac2acfed8deec2e9f92
+msgid ""
+"Time zone input dropdown can \"wobble\" ([LP: "
+"#2084611](https://launchpad.net/bugs/2084611))"
+msgstr ""
+
+#: ../../25.10/index.md:681 11bc1a67f1d345248b478a26186faa95
+msgid ""
+"The hostname change is mandatory ([LP: "
+"#2093132](https://launchpad.net/bugs/2093132))"
+msgstr ""
+
+#: ../../25.10/index.md:683 66bcf34b3a844ce08df8b59cff28fe98
+msgid ""
+"During boot on the server image, if your `cloud-init` configuration (in "
+"`user-data` on the boot partition) relies upon networking (importing SSH "
+"keys, installing packages, etc.) you *must* ensure that at least one "
+"network interface is required (`optional: false`) in `network-config` on "
+"the boot partition. This is due to netplan changes to the wait-online "
+"service (~~[LP: #2060311](https://launchpad.net/bugs/2060311)~~)"
+msgstr ""
+
+#: ../../25.10/index.md:685 11b1ad1a370846ebabb7a8edb52a41bb
+msgid ""
+"The seeded totem video player will not prompt users to install missing "
+"codecs when attempting to play a video requiring them ([LP: "
+"#2060730](https://launchpad.net/bugs/2060730))"
+msgstr ""
+
+#: ../../25.10/index.md:687 339330dc2c1e428d998f4e1a19500990
+msgid ""
+"With the removal of the `crda` package in 22.04, the method of setting "
+"the wifi regulatory domain (editing `/etc/default/crda`) no longer "
+"operates. On server images, use the `regulatory-domain` option in the "
+"Netplan configuration. On desktop images, append "
+"`cfg80211.ieee80211_regdom=GB` (substituting `GB` for the relevant "
+"country code) to the kernel command line in the `cmdline.txt` file on the"
+" boot partition  ([LP: #1951586](https://launchpad.net/bugs/1951586))."
+msgstr ""
+
+#: ../../25.10/index.md:689 7a1dcc81665c4193a4d10bbe135d1856
+msgid ""
+"The power LED on the Raspberry Pi 2B, 3B, 3A+, 3B+, and Zero 2W currently"
+" goes off and stays off once the Ubuntu kernel starts booting ([LP: "
+"#2060942](https://launchpad.net/bugs/2060942))"
+msgstr ""
+
+#: ../../25.10/index.md:691 49b1c123771e4fd1a562d94ab1b62746
+msgid ""
+"Colours appear incorrectly in the Ubuntu App Centre ([LP: "
+"#2076919](https://launchpad.net/bugs/2076919))"
+msgstr ""
+
+#: ../../25.10/index.md:693 dca2fd9cf6314d8cb305a25bde04e865
+msgid ""
+"On server images, re-authentication to WiFi APs when regulatory domain is"
+" set result in `dmesg` spam to the console ([LP: "
+"#2063365](https://launchpad.net/bugs/2063365))"
+msgstr ""
+
+#: ../../25.10/index.md:695 cff55f39446044e4b5b3aea29312ebdf
+msgid ""
+"On the Pi Zero 2W, the release image contains a bug in the Bluetooth "
+"components of the firmware package. This is due to be fixed in an SRU "
+"([LP: #2127041](https://launchpad.net/bugs/2127041))"
+msgstr ""
+
+#: ../../25.10/index.md:697 de710cb709e8469aba365a8cc19eaf7e
+msgid "Google Compute Platform"
+msgstr ""
+
+#: ../../25.10/index.md:699 617550fa380644749a4e573d4a34e6a4
+msgid "Google cloud's ssh-in-browser is broken in 25.10"
+msgstr ""
+
+#: ../../25.10/index.md:701 c0560a5e42fc42ceb1ca9823617c3b5a
+msgid ""
+"[ssh-in-browser](https://cloud.google.com/compute/docs/ssh-in-browser) "
+"(i.e. the SSH button in the console GUI) does not work in Questing 25.10."
+" This is because the capability relies on older `ssh` algorithms "
+"(`diffie-hellman-group-exchange-sha256` and `diffie-hellman-"
+"group14-sha1`) which have now been deprecated in 25.10 ([LP: "
+"#2127982](https://bugs.launchpad.net/cloud-images/+bug/2127982))."
+msgstr ""
+
+#: ../../25.10/index.md:705 8f86c5ac41ba410db9941558655e8d83
+msgid ""
+"When inspecting system logs with journalctl, users may encounter a denied"
+" log entry relating to systemd-detect-virt. There is no known impact on "
+"functionality "
+"(LP:#[2124958](https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/2124958))."
+msgstr ""
+
+#: ../../25.10/index.md:708 48d87488058f42598cff069b04743df2
+msgid "AWS"
+msgstr ""
+
+#: ../../25.10/index.md:710 30ffa3514061417da2842569d379a3a1
+msgid "Nothing yet."
+msgstr ""
+
+#: ../../25.10/index.md:712 df23503790e3436db40c0b423e24b402
+msgid "s390X"
+msgstr ""
+
+#: ../../25.10/index.md:714 8fc84d7ffd82471f9c7fbc26aed31f2e
+msgid ""
+"During upgrade from Ubuntu Server 25.04 (Plucky Puffin) to Ubuntu 25.10 "
+"(Questing Quokka) one may notice the following error with kdump-tools:"
+msgstr ""
+
+#: ../../25.10/index.md:721 cb83e8a097d041cf8f0bed4b5875e81c
+msgid "This is likely due to a race condition."
+msgstr ""
+
+#: ../../25.10/index.md:723 920a38be216f475480314a995ec2ab49
+msgid ""
+"One may proceed and complete the upgrade, but at the end of the process "
+"the system needs to be manually rebooted. The bug is tracked here: [LP: "
+"#2126934](https://launchpad.net/bugs/2126934)"
+msgstr ""
+
+#: ../../25.10/index.md:726 14ce00726f9d4a73b12ac10ac1d17498
+msgid "Official flavors"
+msgstr ""
+
+#: ../../25.10/index.md:728 362ff0a56ff649a8b6ccfd411b8e4a1d
+msgid "Find the release notes for the official flavors at the following links:"
+msgstr ""
+
+#: ../../25.10/index.md:730 38dff873f3c14280bf76bc53ba90078e
+msgid ""
+"[Edubuntu Release "
+"Notes](https://discourse.ubuntu.com/t/edubuntu-25-10-released/)"
+msgstr ""
+
+#: ../../25.10/index.md:731 65027fa24ebb4644ba4e8dbab12980e4
+msgid ""
+"[Kubuntu Release "
+"Notes](https://wiki.ubuntu.com/QuestingQuokka/ReleaseNotes/Kubuntu)"
+msgstr ""
+
+#: ../../25.10/index.md:732 590a16759cc04f51876b0c71a11006e2
+msgid ""
+"[Lubuntu Release Notes](https://lubuntu.me/lubuntu-25-10-questing-quokka-"
+"released/)"
+msgstr ""
+
+#: ../../25.10/index.md:733 1678d7e1283146318df48e146feb65bf
+msgid ""
+"[Ubuntu Budgie Release Notes](https://ubuntubudgie.org/2025/10/ubuntu-"
+"budgie-25-10-release-notes/)"
+msgstr ""
+
+#: ../../25.10/index.md:734 944ee2cbe8864f1ba741791faf60dac1
+msgid ""
+"[Ubuntu MATE Release Notes](https://ubuntu-mate.org/blog/ubuntu-mate-p-p"
+"-release-notes/)"
+msgstr ""
+
+#: ../../25.10/index.md:735 94c555bcdd924233a83bf0f3c6bc9bfb
+msgid ""
+"[Ubuntu Studio Release Notes](https://discourse.ubuntu.com/t/ubuntu-"
+"studio-25-10-release-notes/)"
+msgstr ""
+
+#: ../../25.10/index.md:736 4664346dbeb9419fb2f83b8b6c2a7720
+msgid ""
+"[Ubuntu Unity Release Notes](https://ubuntuunity.org/posts/ubuntu-"
+"unity-2504-released/)"
+msgstr ""
+
+#: ../../25.10/index.md:737 6c8b53e03aae4593b0df8102602bfc37
+msgid ""
+"[Xubuntu Release Notes](https://wiki.xubuntu.org/releases/25.10/release-"
+"notes)"
+msgstr ""
+
+#: ../../25.10/index.md:738 371477c66e7a4fcbb880f581898d4e40
+msgid ""
+"[Ubuntu Kylin Release "
+"Notes](https://ubuntukylin.com/news/ubuntukylin2510-en.html)"
+msgstr ""
+
+#: ../../25.10/index.md:739 586883af99584c1f84942fb506cf600f
+msgid "[Ubuntu Cinnamon Release Notes](https://ubuntucinnamon.org/?p=1406)"
+msgstr ""
+
+#: ../../25.10/index.md:742 76d6b40c26274105a09db10478522505
+msgid "More information"
+msgstr ""
+
+#: ../../25.10/index.md:744 97d1e0a6a6eb4b07bec1fc0a7024fa54
+#, python-brace-format
+msgid ""
+"Refer to {ref}`release-policy-and-schedule` and {ref}`project-and-"
+"community`."
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/25.10/schedule.po
+++ b/docs/locale/ja/LC_MESSAGES/25.10/schedule.po
@@ -1,0 +1,510 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../25.10/schedule.md:2 7e92e6781b9343fb8ddc623fffe1d0d7
+msgid "Ubuntu Questing Quokka Release Schedule"
+msgstr ""
+
+#: ../../25.10/schedule.md 4124aec2db8f41b092a0d95df233a36e
+#: c7f0e91ff11744fa9c45f8c8bc24e2c8 e1a2c36c4942406193ba8d12604722ab
+msgid "Week"
+msgstr ""
+
+#: ../../25.10/schedule.md 0ff87b004ecc4b239f5e5d612be23f95
+#: 55a13263f3ec401ba32555df812fbd02 5d0632582a3546c6855c202dd14fd7d0
+msgid "Date (Thursday)"
+msgstr ""
+
+#: ../../25.10/schedule.md 4b68e710358748f2ab97eb34205633af
+#: def521eff852424dbd577c4fd73d96ba
+msgid "25.10 events"
+msgstr ""
+
+#: ../../25.10/schedule.md 28e6913e0e5144f492d0d539c31f0eac
+#: 5348b1b3af5840ccab5498b8696d4d80 e18855c4f28d4a679b228c0d58c5534c
+msgid "**April 2025**"
+msgstr ""
+
+#: ../../25.10/schedule.md 069142a512444581bb2b6b602bc0e82f
+#: 294b5f7e70da4bf0a5977ec792970e57 8f01b111adc6480a8064107ddb831f54
+msgid "1"
+msgstr ""
+
+#: ../../25.10/schedule.md 8072bc2e6e8248d58edd3b0a83aebff6
+#: a6664d4a4eb24372b263e4e7d1178e7e d76920f1660a4b64a22fbbb93b088432
+msgid "April 24"
+msgstr ""
+
+#: ../../25.10/schedule.md 077fa4d5d95f4d569444f3c40bf6da57
+#: db446be147104b458aaaea80c93b808a
+msgid "Toolchain Uploaded"
+msgstr ""
+
+#: ../../25.10/schedule.md 1a3de0d91e7a49b183475dd4b85d2a5b
+#: 50f72a6c02994ef6904e7d890764fa5c c76ebbf1d0bb4582a3c3d7f6cd5475fc
+msgid "**May 2025**"
+msgstr ""
+
+#: ../../25.10/schedule.md 01a32e5bfd92422b8bc5e9db7d74f2d7
+#: a959082ba18b4998b42404e2413d8048 a9796ae59b0b4f9381935821ac03d0e2
+msgid "2"
+msgstr ""
+
+#: ../../25.10/schedule.md 3783c532e3794a03a91aad4882490215
+#: 63027a6da41e4a7c9c504ec1208feb43 67e4d069a5d54d3895c0936026269a88
+msgid "May 01"
+msgstr ""
+
+#: ../../25.10/schedule.md 588e07f3eda7428584b32914c6348140
+#: 858ca7329b2a41cf832164e4ee49918c ff9517734a4d4c86b5c02eab029e6602
+msgid "3"
+msgstr ""
+
+#: ../../25.10/schedule.md 13d029060b1544b7b4a9545909798cf6
+#: 1c8db1a789e44de2a40bb032e1c9c790 27a61f71cc574b4ea3da831d99d0723a
+msgid "May 08"
+msgstr ""
+
+#: ../../25.10/schedule.md 5cfcf72f633b46538150528fea46df8f
+#: 6c7a622d87c44f859aee534fa47de7e7 ec3ae89dd77345b4b22ac1ab704826b9
+msgid "4"
+msgstr ""
+
+#: ../../25.10/schedule.md cc1fafe7c1b34042852b584834130e9f
+#: cc545512320c4ab89027ba910d95ca85 d370487fd6ec4fc58935390978254ccd
+msgid "May 15"
+msgstr ""
+
+#: ../../25.10/schedule.md 080f2c8a57a14f2eb9fe4f9c5b11d0ec
+#: 7fadbecc0f5843128495324327d9549e fffb9a143b3f4df7afa45d76887bbb4e
+msgid "5"
+msgstr ""
+
+#: ../../25.10/schedule.md 5170002bf63f40f48ebf80a37487310a
+#: 98815974572045ffb6fb22802e32cbb9 d85de95e52c5488a9bed5fcf0a3a8b09
+msgid "May 22"
+msgstr ""
+
+#: ../../25.10/schedule.md 0bf211acb97d4c848818b4bf42e643e1
+#: 5bbe85fa27364bd08ca86c939a822a8d bfa6a1125f124634a28573561f7850d0
+msgid "6"
+msgstr ""
+
+#: ../../25.10/schedule.md 64572c0bb7be4fe896870c81f44387f5
+#: b4fb2b36247f4350a04bfa5a70166fb5 b819da64b1c8495da00d5855459b5c43
+msgid "May 29"
+msgstr ""
+
+#: ../../25.10/schedule.md 95acbb4a2ad94e3fab67d35b57fbbe05
+#: bdf86e04a2cc47498f5f3a390a7a57d4
+msgid "Questing Snapshot 1"
+msgstr ""
+
+#: ../../25.10/schedule.md 4780779ce69547349302f48faa9bae2a
+#: 78f8315e1d5747a8a3915ca1f8773981 e54a24ee51db41c4a09a3c1e470fe0e7
+msgid "**June 2025**"
+msgstr ""
+
+#: ../../25.10/schedule.md 1d513843e422429cb84693d2bf2219c8
+#: 3d44c7519c924e30b09f9416704da3d6 cf78ab90027545b986f56d229efcf8be
+msgid "7"
+msgstr ""
+
+#: ../../25.10/schedule.md bae888e00732449c9cb414e1e3adf0a5
+#: c2a2d21ba10a49279aa95998a9fe633a c3a8b48d0872479cb4853cb93de1c9d4
+msgid "June 05"
+msgstr ""
+
+#: ../../25.10/schedule.md 4abe83701d254b8c8097626064fe64ac
+#: cb28ab7c39224dc6a2b9d5c24de500d4 f12086dc96324c97a29e94b05c1b3874
+msgid "8"
+msgstr ""
+
+#: ../../25.10/schedule.md 2d4ccacfb3d9432ab631086044069e01
+#: 48abe2a2131b445581d9e8a73d945b5e 4bf83db500e0416baa77f210e6e78ee0
+msgid "June 12"
+msgstr ""
+
+#: ../../25.10/schedule.md 3b7a9909bb37401fb47ffc8936325daf
+#: 44fc9177d9d1489fb220130ecff9b9cf de08f4f561bb434fbf92143c992be426
+msgid "9"
+msgstr ""
+
+#: ../../25.10/schedule.md 54ffcb6dcdbc47e3b00c4708e2682cd4
+#: 7e337d1768f4483198e2c4fbe508a1bc 90e53189eeff42bcb08b2362cac65cfe
+msgid "June 19"
+msgstr ""
+
+#: ../../25.10/schedule.md 3157bde0c8d143e7b77a35c0e6d98460
+#: 59488ee514bb432cac186260c90425ba 6a25ce375d9b4156b5021683ffb16b56
+msgid "10"
+msgstr ""
+
+#: ../../25.10/schedule.md 4ec48bb6112841b19528e8facd932b7b
+#: f5e774d3af5d428eb429365bc9e76a1b f9c40b7ee42841d2887e9f4128110022
+msgid "June 26"
+msgstr ""
+
+#: ../../25.10/schedule.md 600f9d38a0b04f0dbfddca66bddb1202
+#: ac6eb865643b4fc3a2b793e2c075839d
+msgid "Questing Snapshot 2"
+msgstr ""
+
+#: ../../25.10/schedule.md 42d34b64a2da4b08b2d57b8a9acf64c0
+#: 593f18b5218a4067a3ccfb384d1dbbbc 85c0b6a87f4c4309a6d92ee98bc1677b
+msgid "**July 2025**"
+msgstr ""
+
+#: ../../25.10/schedule.md 3430795d337c463c8fb60c2d40771211
+#: c3196ea28c214de282aca74549e5e7f4 daa3b3157a8c49ab886b72a44e8be99c
+msgid "11"
+msgstr ""
+
+#: ../../25.10/schedule.md 8d9b317ba05e450bad220b941de77db3
+#: e614e224382746c6a9754dd291bdc9bb f7414354926d4db1bb55bdc8b5c0b323
+msgid "July 03"
+msgstr ""
+
+#: ../../25.10/schedule.md 25dcb075dc9b408ab6cbe19582d60092
+#: 4b60a71f65cd45d19578b2a2253de3e4 b290d4cc534e4871bd5f39f06669e818
+msgid "12"
+msgstr ""
+
+#: ../../25.10/schedule.md 6120f2b0bc834272b72ae30a8c49f0fd
+#: 734ab2da242c4fcd94ba6fe7da710ed5 cefb6455cc9941d09f3b9b98eaf1feac
+msgid "July 10"
+msgstr ""
+
+#: ../../25.10/schedule.md b66da47b17c34ce9acd244600d26731d
+#: d73e9d2f28e44d2eba52df8604de0067 ff2f1ddb8d4e4e6eb281d8feda1a90d9
+msgid "13"
+msgstr ""
+
+#: ../../25.10/schedule.md 42ae0f01ce314c9fb27ed2bfd5f56dc8
+#: 62a40bd8f58b4f3a94cb134b0e9c7168 ac8ee277e3e44c63b9feb80fb48a882b
+msgid "July 17"
+msgstr ""
+
+#: ../../25.10/schedule.md 56c653063ed948eabbb10eee5074d6a6
+#: 8b0949fbe41542bcb7352443200ae462 c3c05450f1fa47c38ef5eeddc4e49073
+msgid "14"
+msgstr ""
+
+#: ../../25.10/schedule.md 17bb01cd0c7a4fa3b0c8c994e4fdeeca
+#: a35287622c0d4d1898732f51e3c70403 dc18fc226cfb4d3db9c8cb56c6503fa9
+msgid "July 24"
+msgstr ""
+
+#: ../../25.10/schedule.md 1a6814fb65ff44c1a8edbcf055d33577
+#: 83f72a6f943d413bb27a06259f102420 d6a5bffc22ce407ea4a8a5b08d86defb
+msgid "15"
+msgstr ""
+
+#: ../../25.10/schedule.md 092a73e8e7e24f90851f5842225e90d7
+#: 5bbc44cb3ef1475896db4e88dead86f9 c9f4668fe8e549eca9b1e902e1f4df31
+msgid "July 31"
+msgstr ""
+
+#: ../../25.10/schedule.md c9f89dd3a38e4f06b2788e81188dd6b2
+#: ed33a300970f487fa5abb3dacbf9773b
+msgid "Questing Snapshot 3"
+msgstr ""
+
+#: ../../25.10/schedule.md 66a90c2b1ec34c4497fe35015bb41e25
+#: 82bdab2d63c64a2697e24ca5b180f7fc 91245a4bd69f4bc4a4b272dc67e49547
+msgid "**August 2025**"
+msgstr ""
+
+#: ../../25.10/schedule.md bb1be42bbdbe4dd38ec5b8ea6ea6bc59
+#: dffad2df8e8f4d11a84f9f20f7cfb566 ece9838160944f01ac98d95009b07597
+msgid "16"
+msgstr ""
+
+#: ../../25.10/schedule.md 30c7108924904adeb1429d856c5885d4
+#: 47b53094fa4144c19d53f2256ea6e8b2
+msgid "August 04"
+msgstr ""
+
+#: ../../25.10/schedule.md 1f990899b57644ee8541ff008bd64d11
+#: cd07fbd287cb4508ac61c8d138b93e4e
+msgid ""
+"[Debian Import Freeze](https://canonical-ubuntu-project.readthedocs-"
+"hosted.com/release-team/freezes/#debian-import-freeze)"
+msgstr ""
+
+#: ../../25.10/schedule.md 3415eafe222749afabd5c67d85792955
+#: 88f57f1d6227474b9cd469170d2d6820 e4631a6aa7d64dfdb32b361c4a9cd433
+msgid "17"
+msgstr ""
+
+#: ../../25.10/schedule.md 52b86d1b750a494b8f6790da2e84a511
+#: a0d20877d863410ea9d0a19dd9e2e826 da5c92a58afb412f9f04d17bbeca482b
+msgid "August 14"
+msgstr ""
+
+#: ../../25.10/schedule.md 05517cb56bac488ab5ec224837d03c7a
+#: 9f118a0531b343229fd3f782d5510fa0
+msgid "[Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze)"
+msgstr ""
+
+#: ../../25.10/schedule.md 4608f8f88f204a4cb1152e5b00da6be4
+#: 461a38de1f43448cb82e5722e1bf8651 8577e17efb4e48b991e9ff9e43a61ec2
+msgid "18"
+msgstr ""
+
+#: ../../25.10/schedule.md 2c1580b0badb4563889f48e86dfad409
+#: 3c74b243833349119a7b6d9fae51fcf7 79720a42a152418191db207383e1a132
+msgid "August 21"
+msgstr ""
+
+#: ../../25.10/schedule.md 23d260fc0d5745138cb42d827c8bf048
+#: c095ab9c1a28467eb4ea5ac1335e2893 ca36de04906a47bfa48907c6da23ef96
+msgid "19"
+msgstr ""
+
+#: ../../25.10/schedule.md 0448dd1ac15d4ae0a6af2765b0b690c3
+#: 4ffd8bb16b014426b65d774b098daf6b d404823713b849aa88779343b29477ae
+msgid "August 28"
+msgstr ""
+
+#: ../../25.10/schedule.md 31812ce21795474cb925b84272156731
+#: 59a8d4db02f44bc9a06ee0a89f7ef71b
+msgid "Questing Snapshot 4"
+msgstr ""
+
+#: ../../25.10/schedule.md 13402b08b3624634be4396eac0ae80f7
+#: 46e16d8268db489fa67ee1a2d22df4d1 a0c882da1dbc423698d1b3c6a8e8fd13
+msgid "**September 2025**"
+msgstr ""
+
+#: ../../25.10/schedule.md 2965acb5e9d54cbe934f9bc4e456904f
+#: db412960b4bb4f3a891d52b547942891 df810f2a6b5b475783f305b9924aa56e
+msgid "20"
+msgstr ""
+
+#: ../../25.10/schedule.md 39e51ab78f0f4b1d95a98fb3cb8893e8
+#: 6f011744d0694e88add0e1eee5b6bf02 e6e62d5d782646038fd6649903a0f8d6
+msgid "September 04"
+msgstr ""
+
+#: ../../25.10/schedule.md 487f46c269914321ae1d50570ad3c9df
+#: ff0fbf02de0f4d4c8d39df27b50c1977
+msgid ""
+"[User Interface Freeze](https://canonical-ubuntu-project.readthedocs-"
+"hosted.com/release-team/freezes/#user-interface-freeze)"
+msgstr ""
+
+#: ../../25.10/schedule.md 6da25287807e439aa9c131ded575e8e3
+#: 80d47a146c35454a93ba620789283bfc f41af4f60d464358b221e47feacad54a
+msgid "21"
+msgstr ""
+
+#: ../../25.10/schedule.md 0b27987b929e496a83a43bbfc2a764c2
+#: b2c845f8d37e4888adf53134b401141d c9c7d4b5943244188374b09ad4ba509d
+msgid "September 11"
+msgstr ""
+
+#: ../../25.10/schedule.md efb11a80c75843ebb3791926716d8a02
+#: f10ff7c81f0c42c4b3694d988ffa4eaf
+msgid ""
+"[Documentation String Freeze](https://canonical-ubuntu-project"
+".readthedocs-hosted.com/release-team/freezes/#documentation-string-"
+"freeze), [Kernel Feature Freeze](https://canonical-ubuntu-project"
+".readthedocs-hosted.com/release-team/freezes/#kernel-feature-freeze)"
+msgstr ""
+
+#: ../../25.10/schedule.md 63d48ebc2cd84c898e568b722472adb0
+#: 7ef2777b5344493c958926a567ea0a91 8607783929444d7989083a78bea4522e
+msgid "22"
+msgstr ""
+
+#: ../../25.10/schedule.md 96398146ddae40e7882e06dd31071e33
+#: e30377b4016c48d69733d0a2aba9e758
+msgid "September 15 (Monday)"
+msgstr ""
+
+#: ../../25.10/schedule.md 591e98abb16240a6a08644a6077adb80
+#: 77d43dcdc32b499aa8ab40798da2cabb
+msgid ""
+"[Beta Freeze](https://canonical-ubuntu-project.readthedocs-hosted.com"
+"/release-team/freezes/#beta-freeze), [Hardware Enablement Freeze](https"
+"://canonical-ubuntu-project.readthedocs-hosted.com/release-team/freezes"
+"/#hardware-enablement-freeze), ISO Testing Week (mandatory)"
+msgstr ""
+
+#: ../../25.10/schedule.md 6f56dbe60e434ca38fdab6840875c9ea
+#: aa5a18f190a94b52b790f2544c058f96
+msgid "⠀"
+msgstr ""
+
+#: ../../25.10/schedule.md 222c0e16d9854d23a683e9e196c20379
+#: 298d24be0a294acfbfad6c29ee936f34 7d413be3a85740d99ef4126a00a931bf
+msgid "September 18"
+msgstr ""
+
+#: ../../25.10/schedule.md 100c8c7c85bc4f889101777bb572cdcb
+#: 458c212c6df0490e83a4fa488f1f533b
+msgid "Questing Beta (mandatory)"
+msgstr ""
+
+#: ../../25.10/schedule.md 97d3f90831514433aa0eabce174e49f1
+#: b2457bd9cb9f48bb826d165bb537a93d bdaff0913214451d959fe1fb4715c150
+msgid "23"
+msgstr ""
+
+#: ../../25.10/schedule.md 3915f551ca1449e8a57ff3c5a958443e
+#: deefb15efc6549769d344dc49e20567a f81544fcb87e429b814dd5f83502e88e
+msgid "September 25"
+msgstr ""
+
+#: ../../25.10/schedule.md 5e5f01277f2646fba3456f79dda80994
+#: ba71e05ab0da45629abe03f45976c32f
+msgid ""
+"[Kernel Freeze](https://canonical-ubuntu-project.readthedocs-hosted.com"
+"/release-team/freezes/#kernel-freeze), [Non Language Pack Translation "
+"Deadline](https://wiki.ubuntu.com/NonLanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../25.10/schedule.md 54105883588b4b8eab2cc089aa84d790
+#: 9ce276f5059c4fd985afb9724bbca5ce bb6d865f95cb43228e22debbf45c1b06
+msgid "**October 2025**"
+msgstr ""
+
+#: ../../25.10/schedule.md 1d429b34153742578d245f46b78a9dc0
+#: b8db17fe3c16485f8e973e07dba10301 dbef8c07edef4643a00e7de5a6991798
+msgid "24"
+msgstr ""
+
+#: ../../25.10/schedule.md 14df550e4cc44dc8a73c19cf13dcef47
+#: 208156abbcbb4f3cbfba1f53552f7f4d 72fa2051745443c08b5d9abe96f2c3f8
+msgid "October 02"
+msgstr ""
+
+#: ../../25.10/schedule.md 58f52b45d49b49ebbe50dccbfd4be49a
+#: 80c9ad8fa6414d938488ea712f69f975
+msgid ""
+"[Final Freeze](https://canonical-ubuntu-project.readthedocs-hosted.com"
+"/release-team/freezes/#final-freeze), [Release Candidate](https"
+"://canonical-ubuntu-project.readthedocs-hosted.com/release-team/freezes"
+"/#release-candidate), [Language Pack Translation Deadline](https"
+"://canonical-ubuntu-project.readthedocs-hosted.com/release-team/freezes"
+"/#language-pack-translation-deadline)"
+msgstr ""
+
+#: ../../25.10/schedule.md 06abae9f1bdd48329905a0adb2469795
+#: 381ac273d1ab4a24b0ca335707ca240b ac125b37f6454de7ae4db62f1df00ac6
+msgid "25"
+msgstr ""
+
+#: ../../25.10/schedule.md 0ec44fb206f44579858ad4db3a9a7a71
+#: 6ecc2159c6224f4a90a4fae8ed5963a1 a59405c7cd4b488898a1509d7385a9ad
+msgid "October 09"
+msgstr ""
+
+#: ../../25.10/schedule.md 711a0788cbc94b828a8aec4a22a5abfc
+#: f00bd8f6a7f244c5af0454b134805ec3
+msgid "Questing [Final Release](https://wiki.ubuntu.com/FinalRelease)"
+msgstr ""
+
+#: ../../25.10/schedule.md:41 c72805cf34c54e3ba9968c624874cf1f
+msgid "Planned and potentially disruptive archive-wide activities"
+msgstr ""
+
+#: ../../25.10/schedule.md:43 e9d018fdb9af4a6e97c88825ec3b27fe
+msgid ""
+"If you're planning a change that might have a disruptive effect on the "
+"archive - e.g. transitions or switches of important defaults (such as "
+"compiler versions) - list it here."
+msgstr ""
+
+#: ../../25.10/schedule.md 0d1ca14e0bb6433ba28f07688d47581c
+msgid "Planned activity"
+msgstr ""
+
+#: ../../25.10/schedule.md 8fd5d392aaf248b5b328c66b749cfbad
+msgid "boost1.88"
+msgstr ""
+
+#: ../../25.10/schedule.md 15e89a3a92dc419ab0f09042dc1a0c18
+msgid "libxml2 2.14.x"
+msgstr ""
+
+#: ../../25.10/schedule.md b451d9eadeb34d7da7346d62f322dcf0
+msgid ""
+"binutils 2.45, Chrony/NTS time-daemon ([LP: "
+"#2111342](https://bugs.launchpad.net/ubuntu/+bug/2111342))"
+msgstr ""
+
+#: ../../25.10/schedule.md 07ba309604c64a638b089b534dc46ff5
+msgid ""
+"openssl 3.5.0 ([LP: "
+"#2110006](https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/2110006))"
+msgstr ""
+
+#: ../../25.10/schedule.md 0228c2b635c14b0d99e2d48d86b8e542
+msgid "GCC 15"
+msgstr ""
+
+#: ../../25.10/schedule.md 34e7d30a027f42098f609e6918a3561e
+msgid "August 07"
+msgstr ""
+
+#: ../../25.10/schedule.md 5cad1803ecf54f879aaf796efd939da2
+msgid "[GNOME 49 Beta](https://release.gnome.org/calendar/)"
+msgstr ""
+
+#: ../../25.10/schedule.md 4bc9782b68a247679fb12db58c27fe4b
+msgid "Raise ISA level for riscv64, archive rebuild (@xypron)"
+msgstr ""
+
+#: ../../25.10/schedule.md 85754dcf47774ba694dc6f3e2fc060f4
+msgid "[GNOME 49.0](https://release.gnome.org/calendar/)"
+msgstr ""
+
+#: ../../25.10/schedule.md:81 b5f5a5ecd4dc485cb28f1f9e270ea086
+msgid "Ubuntu Questing Quokka Release Task Signup Sheet"
+msgstr ""
+
+#: ../../25.10/schedule.md:83 8c70ea5290514a32bf97e5aab14b5adc
+msgid "This signup sheet is to be used for planning release milestone tasks."
+msgstr ""
+
+#: ../../25.10/schedule.md:121 d4b03d10e11f4ac0b70d4912bd8c30fe
+msgid ""
+"When the archive is frozen, all members of the release team are expected "
+"to participate in bug fix reviews."
+msgstr ""
+
+#: ../../25.10/schedule.md:123 25b36f012e854bb3a478c4228183edf2
+msgid ""
+"After [Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), all "
+"members of the Release Team are expected to participate in Feature Freeze"
+" Exception reviews in their particular area of expertise."
+msgstr ""
+
+#: ../../25.10/schedule.md:125 2e1c469231b64e17be1594f426c539aa
+msgid ""
+"After [Final Beta](https://wiki.ubuntu.com/FinalBetaRelease), all members"
+" of the Release Team are expected to participate in bug fix reviews in "
+"their particular area of expertise."
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/26.04/changes-since-previous-interim.po
+++ b/docs/locale/ja/LC_MESSAGES/26.04/changes-since-previous-interim.po
@@ -1,0 +1,2932 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../26.04/changes-since-previous-interim.md:6
+#: 17357184c614421fb0504020141b2527
+msgid "Ubuntu 26.04 LTS changes since 25.10"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:8
+#: c0b095b3f7e946f491b6a0deab811d2e
+msgid ""
+"If you're upgrading to Ubuntu 26.04 LTS from the previous interim "
+"release, Ubuntu 25.10 (Questing Quokka), the following changes apply to "
+"you."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:11
+#: 75545d05824d49c798b295db9b06dc5b
+#, python-brace-format
+msgid ""
+"Ubuntu 26.04 LTS is currently in development, scheduled to be released in"
+" April 2026. See the {ref}`release schedule <resolute-raccoon-schedule>`."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:14
+#: 7d5100f489c440edad242b1cc656369f
+msgid "New features and improvements"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:16
+#: 9979259e6d6344ef9c5c5a1dcd3b936a
+msgid "System features"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:18
+#: b803f42448324ed48c585707b717e74d
+msgid "cloud-init v. 26.1"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:20
+#: 0b35531b9a7d4e259feccbab99762851
+msgid "Cloud-init features introduced beyond v. 25.3 in Questing:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:22
+#: 7e15b7d4301a4fceb540763058058ef3
+msgid "Add support for s390x platform detection on LXD"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:23
+#: 39de96fe84ec4456980d6fa1e570fb01
+msgid "Add support for Tilaa cloud platform detection."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:24
+#: 73ac5aaa3f0e45b98d1f95613f6cd373
+msgid "Fix LXD Snap installs on Plucky and newer"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:25
+#: 20b3c763688f4cc4a584cf0e9bbaa504
+msgid ""
+"Scaleway cloud to support exposing regions and availability zones, drop "
+"private IP handling"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:26
+#: 7c0937587cfd4164844beff08d06cd9b
+msgid "Add network v1 support for bonds, bridges and VLANs"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:27
+#: 0701c402122b4b418dab2733b6304243
+msgid ""
+"Allow `network-config` to express `allow_accept_ra` for bonds, bridges "
+"and VLANsOpenStack `network_data.json` support of bond names"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:29
+#: ac6ebf0a1afb4929a8e7852b8a0fe53b
+msgid ""
+"See [cloud-init’s release notes for more "
+"details](https://github.com/canonical/cloud-init/releases)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:31
+#: 16005dca21a7436cb83e642561288d87
+msgid "fwupd"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:33
+#: 1cdce1d67fff4186834e9ce2b02211c6
+msgid ""
+"Systems running TPM/FDE will now prompt for the recovery key before "
+"firmware updates that may require the recovery key upon reboot."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:35
+#: fed1e39288844532aad1625dd2d2706c
+msgid "Linux kernel 7.0 🐧"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:37
+#: 06d4dc56f3a0412aab14af4f227ad817
+msgid ""
+"`cgroupfs` is now mounted with "
+"`nsdelegate,memory_recursiveprot,memory_hugetlb_accounting`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:39
+#: 50c2c22fced0414294628d5b90229055
+msgid "Netplan v1.1.2 🌐"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:41
+#: ../../26.04/changes-since-previous-interim.md:45
+#: ../../26.04/changes-since-previous-interim.md:66
+#: ../../26.04/changes-since-previous-interim.md:498
+#: ../../26.04/changes-since-previous-interim.md:593
+#: ../../26.04/changes-since-previous-interim.md:692
+#: ../../26.04/changes-since-previous-interim.md:720
+#: 0b6fca65436a44faa6df9d1f34742bd4 4b8267c33a4d4e29afeb9140930dfdea
+#: 5ae72570388e4f74a518404a0e3562b5 6a13b0ceace14d2698c217053ec0aed1
+#: 7d1bd1fd28de4d2cb59a51e26c23257b 9e85bc2a8861460c9d7da615f8f8b14c
+#: c65f891a3ec9421ab4c6b90ac6c0a809
+msgid "..."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:43
+#: 9d00ec207b5f46aba3b721ac71d4e69e
+msgid "Package Management: APT 3.0"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:47
+#: 36fc10acf5e0403caac8489abb3b96dc
+msgid "sudo-rs"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:49
+#: 5516f46d595d42d4ba5e738e4573c37c
+msgid ""
+"Password feedback is now enabled by default in order to improve the user "
+"experience of `sudo`. If the previous behavior is preferred, password "
+"feedback can be disabled using the following steps:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:52
+#: b92c537c109f49728beb555409683211
+msgid "Edit sudoers using `sudo visudo` in the terminal"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:53
+#: 92892567762f486c88e661f5ad03ed45
+msgid "Add the option `Defaults !pwfeedback` to the configuration file"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:55
+#: 8225de71b2274859b3fdd7a47121c39f
+msgid "systemd 259.5"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:57
+#: 8c14cb954dad46499b6cdc241200bfaa
+msgid ""
+"The `systemd` service manager has been updated to version 259. For a "
+"complete list of changes, see the "
+"[changelog](https://github.com/systemd/systemd/releases/tag/v259)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:59
+#: 72d829a6617941d4801de2772e6df95a
+msgid "Also, refer to the removed and deprecated functionality:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:61
+#: a8c5925a25644f4296a96143828db378
+#, python-brace-format
+msgid "{ref}`cgroup-v1-removed`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:62
+#: aa4b1cf492514b09afd18c9a3a77b1c2
+#, python-brace-format
+msgid "{ref}`system-v-scripts-deprecated`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:64
+#: 8ca5b7cd0b6e4684b8b6e0dbb55e63cb
+msgid "TPM/FDE"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:68
+#: 48b492ca34bd4f60be65e0228d045ed6
+msgid "Ubuntu Insights integration with the release upgrader"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:70
+#: 7219cbad2b3e4d798ce2992d87040981
+msgid ""
+"When Ubuntu Insights is available and configured, the release upgrader "
+"will now use Ubuntu Insights at the end of a release upgrade to generate "
+"a report based on the existing consent state. Note, this change does not "
+"prevent the Ubuntu Report-based collection that may be triggered by a "
+"release upgrade."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:72
+#: 31dad597d4014115a8c489290b39da16
+msgid ""
+"This change only affects Desktop and WSL since presently, these are the "
+"only platforms that include Ubuntu Insights."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:75
+#: 36cc06c5c46d44c89598b82c5220392f
+msgid "IBM Z and LinuxONE (s390x)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:77
+#: a6771fb7afd847cd922afdc7c82a183c
+msgid ""
+"The following provides an overview of selected and significant s390x-"
+"specific enhancements and improvements that landed in Ubuntu Server 26.04"
+" for IBM Z and LinuxONE."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:79
+#: 14fa3c7d4ef84e899b4f0995d3b0b095
+msgid ""
+"On the IBM Z (s390s) architecture, the architectural level set (ALS) was "
+"raised to build for IBM Z generation z15 (LinuxONE Emperor III) with the "
+"`march=z15` and `mtune=z16` compiler options ([LP: "
+"#2126577](https://launchpad.net/bugs/2126577)). This brings performance "
+"improvements on the later generations"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:81
+#: 7d39fa58ceb845209c2c47858cdae4d7
+#, python-brace-format
+msgid "{ref}`ibm-z14-support-removed`."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:83
+#: b2d8794fad59467981752da1ae6579ad
+msgid ""
+"With every new Ubuntu Server release the `s390-tools` package was "
+"gradually upgraded to its latest available release v2.41 ([LP: "
+"#2141945](https://launchpad.net/bugs/2141945)), that now:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:85
+#: d14b5d4785054130aec0f79fa896a6ef
+msgid ""
+"adds a `udev` rule to set `none` as default I/O scheduler for `virtio-"
+"blk` devices ([LP: #2138886](https://launchpad.net/bugs/2138886))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:86
+#: 188ac2458a554585a2ee6a818e135e25
+msgid ""
+"adds a `udev` rule to disable the `rotational` attribute for `virtio-blk`"
+" (especially important for swapping or paging) ([LP: "
+"#2138887](https://launchpad.net/bugs/2138887))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:87
+#: 62f4e5f0f2354a52ab99cf8c298f8b59
+msgid ""
+"introduces the new `pvverify` tool, that allows to verify host key "
+"documents in the context of Secure Execution (SE) ([LP: "
+"#2138888](https://launchpad.net/bugs/2138888))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:88
+#: 24a1a241ea2c42a7b48f8956ca725d74
+msgid ""
+"and the `pvimg info` command was enhanced to display additional SE image "
+"information ([LP: #2141952](https://launchpad.net/bugs/2141952))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:90
+#: fcb384e74ca4487aa789642f170b0632
+msgid ""
+"KVM enhancements arrived by adding zVDT Parallel Sysplex support ([LP: "
+"#2142654](https://launchpad.net/bugs/2142654)) and by rewriting `gmap` "
+"using MMU notifiers ([LP: #2142682](https://launchpad.net/bugs/2142682))."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:92
+#: 1eec81987f624900b522061a899d6975
+msgid ""
+"In the area of cryptography the following updates and improvements "
+"happened:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:94
+#: 89e04538306846be9dc9ebbffbdbda4a
+msgid ""
+"`zkey` support for `dm-integrity` with HMAC was added to the `s390-tools`"
+" package ([LP: #2096889](https://launchpad.net/bugs/2096889)) and to the "
+"kernel ([LP: #2138650](https://launchpad.net/bugs/2138650))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:95
+#: 99faa7d2358c4e5a9699fd5bff94c0f3
+msgid ""
+"PHMAC was added to `cryptsetup` ([LP: "
+"#2138512](https://launchpad.net/bugs/2138512)), and required also "
+"`systemd` ([LP: #2138511](https://launchpad.net/bugs/2138511)) updates."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:96
+#: d397723f775942299f72a9f3565308e3
+msgid ""
+"The default use of clear keys by PAES and PHMAC in-kernel crypt modules "
+"was disabled ([LP: #2139610](https://launchpad.net/bugs/2139610)), but "
+"they can still be explicitly allowed with a module parameter."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:97
+#: b00d062884954d80be03ec531edca098
+msgid ""
+"An overwrite function was added to the `zcrypt` driver, allowing the "
+"configuring of the device driver on a per APQN basis ([LP: "
+"#2138854](https://launchpad.net/bugs/2138854))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:98
+#: d4d2062617994277b1b92db207bfdf29
+msgid ""
+"The upgrade to `opecryptoki` v3.26 ([LP: "
+"#2135123](https://launchpad.net/bugs/2135123)) added ML-KEM and ML-DSA "
+"support for `ep11` token ([LP: "
+"#2138514](https://launchpad.net/bugs/2138514)) and `cca` token ([LP: "
+"#2138515](https://launchpad.net/bugs/2138515)) and BLS support for `ep11`"
+" token ([LP: #2138804](https://launchpad.net/bugs/2138804))."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:99
+#: 71fba745f066497fbfb384566bcac689
+msgid ""
+"The upgrade of `libzpc` to v1.4.1 ([LP: "
+"#2136312](https://launchpad.net/bugs/2136312)) removed a protected key "
+"verification pattern mismatch, now allowing to support Live Guest "
+"Relocation ([LP: #2140342](https://launchpad.net/bugs/2140342))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:101
+#: 327ca297387d4ea8a835fa711cc5b81b
+msgid ""
+"The kernel also received selected improvements, like support for 128 KB "
+"tape block sizes ([LP: #2141569](https://launchpad.net/bugs/2141569)) and"
+" support for dynamic (de)configuration of hot-pluggable memory ([LP: "
+"#2142862](https://launchpad.net/bugs/2142862))."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:103
+#: 88e29dd03a114a11a6649691e8365fc0
+msgid ""
+"Finally several packages were updated to their latest upstream version to"
+" pick up s390x-specific upstream fixes and improvements. For example:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:105
+#: 5f0c94eca5334bac90865f7b3c92cea8
+msgid ""
+"`valgrind`, for full z17 support ([LP: "
+"#2139096](https://launchpad.net/bugs/2139096))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:106
+#: 3f1265cabd8d42c998c35580de54497e
+msgid ""
+"`libdfp`, mainly fixes ([LP: "
+"#2122325](https://launchpad.net/bugs/2122325))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:107
+#: 69251ad92187473aabce8cf8cce1c416
+msgid ""
+"`smc-tools` for fixes and additional statistics output ([LP: "
+"#2142098](https://launchpad.net/bugs/2142098))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:109
+#: a585a3843501406f808b5ea6dfda557d
+msgid "Desktop features"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:111
+#: 42119a9143ca488a9218fadadea737a6
+msgid "GNOME 50"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:113
+#: f208359672064d19b66aaf1960a6b5e7
+msgid "The GNOME desktop environment has been updated to version 50."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:115
+#: db0af5d29ff3459e8a204cdc70d71ec1
+msgid "GStreamer 1.28"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:117
+#: 141e5521b77c40ad873c2a46a0e17415
+msgid ""
+"The GStreamer multimedia framework has been updated to [version "
+"1.28](https://gstreamer.freedesktop.org/releases/1.28/)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:119
+#: 3ca6c8e263644d3bb1372b29730bab33
+msgid "Added graphical Ubuntu Insights management controls to Settings"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:121
+#: b8e1841683724041a70def4a24520b5e
+msgid ""
+"Graphical controls to finely control Ubuntu Insights consent states as "
+"well as to preview reports have been added to Settings. They can be found"
+" under *Privacy & Security* within the *Telemetry* panel, which also "
+"replaces the *Diagnostics* panel."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:123
+#: f051e3a3312b4c10a0d99e93d3b20e1b
+msgid "Prompt for Ubuntu Insights consent on release upgrades"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:125
+#: 425fab5eea6b4574976bdc4ef761609c
+msgid ""
+"After a release upgrade, you'll be prompted for consent to collect system"
+" information via Ubuntu Insights. This prompt only appears if Ubuntu "
+"Insights consent isn't already set or if it's deemed necessary to re-"
+"prompt due to any other reason."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:127
+#: f5f85411ec3e42bd94bb7c4931db249e
+msgid ""
+"This change is part of creating a new release upgrade mode for GNOME "
+"Initial Setup."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:129
+#: 1ab55980055f441a8009e5db7e0354a6
+msgid "Server features"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:131
+#: a7af3c9a15ef477fa6ab2268ad9257ea
+msgid "Chrony 4.8"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:133
+#: fb8fe46f68bf4ce0b911b37cf7415597
+msgid ""
+"Chrony was updated to version 4.8, which adds support for limiting the "
+"selection of unreachable sources, fixes `refclock` handling on newer "
+"kernels and more."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:135
+#: 571340554ce34b948254f6df07f8abb1
+msgid ""
+"For more information about the 4.8 release or all the other changes since"
+" version 4.5 that was in Noble please have a look at [Chrony’s news "
+"page](https://chrony-project.org/news.html)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:137
+#: 8b1b270d89ec4abaad651ef814b5514a
+msgid "Exim4"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:139
+#: 6a77ddc9f33d452ab2a6d78843dbea78
+msgid ""
+"The Exim4 update to 4.99.1 improves handling many messages to a single "
+"host by using fewer forks & execs. New options like `dkim_verify_minimal`"
+" avoid calling the DKIM ACL after the first good verify and fix various "
+"bugs."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:141
+#: 52a8da7eb1cf4bf79e8f9b526fdd613d
+msgid ""
+"For a detailed list of changes please refer to the [upstream "
+"changelog](https://github.com/Exim/exim/blob/master/doc/doc-"
+"txt/ChangeLog#L84). The minor .1 in 4.99.1 ensures that recent re-"
+"occurring security issues of CVE-2025-26794 and CVE-2025-67896 are closed"
+" right away."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:143
+#: 1c9be2af5ffc44b2a5ad617bd72304a3
+msgid "Kerberos"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:145
+#: cf1b4a72a5fd4c9faa13b7a798562754
+msgid ""
+"Kerberos has been configured to observe the `/etc/krb5.conf.d/` directory"
+" by default. This introduces support for third-party packages that need "
+"to add Kerberos configuration."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:147
+#: 40149322faf149de914f2dcc959f0ba5
+msgid ""
+"If you have existing configuration snippets in `/etc/krb5.conf.d/`, but "
+"do not include them, they will now be included in the `krb5.conf` file."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:148
+#: f3c45d4ea9af498681ee317bf0d118dc
+msgid ""
+"If you already include `/etc/krb5.conf.d/` in your `krb5.conf` file, "
+"either active or commented out, no changes will be made."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:149
+#: 9dddd372ed994b5f97e2be6dc6ba687a
+msgid ""
+"If your existing `krb5.conf` file is a symbolic link, no changes will be "
+"made."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:151
+#: fe85e3ecc79045e99eeaad926781b8a4
+msgid ""
+"MIT Kerberos and Heimdal are both supported, but use different orderings "
+"for the include directive. MIT Kerberos uses alphanumerical order, while "
+"Heimdal uses the unpredictable order of the `readdir()` system call ([LP:"
+" "
+"#2140967](https://bugs.launchpad.net/ubuntu/+source/heimdal/+bug/2140967))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:153
+#: bd811833c1a2413ca96be6d5ebf8e963
+msgid "`multipath-tools` 0.12.2"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:155
+#: 5b698df25cf94241aea373e848cea3d8
+msgid ""
+"Updated from version 0.11.1 to 0.12.2. See the 0.12 series in the "
+"[upstream changelog](https://github.com/opensvc/multipath-"
+"tools/blob/0.12.2/NEWS.md)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:157
+#: bdd63110b22240f2a1ded97d89e4710f
+msgid "OpenLDAP"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:159
+#: 7fa99a9e07514d79b3c37a4aaa908c73
+msgid "New version [2.6.10](https://launchpad.net/ubuntu/+source/openldap)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:161
+#: 5f18de702029433ba29ccd10866bb43c
+msgid ""
+"Running in [AppArmor enforce "
+"mode](https://documentation.ubuntu.com/server/how-to/security/apparmor/) "
+"now."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:162
+#: 61996b09f0054bf0960f962cc6ab5853
+msgid ""
+"Added patch to support changing `pbkdf2` iteration count (see task "
+"[#2125685](https://bugs.launchpad.net/ubuntu/+source/openldap/+bug/2125685))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:164
+#: fd6a67ab1d5f45b4af75043c17ec77f0
+msgid ""
+"See the [2.6 series upstream release "
+"notes](https://git.openldap.org/openldap/openldap/-/blob/OPENLDAP_REL_ENG_2_6/CHANGES)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:166
+#: f8262f0f90c9443997cc80c9c8f717f6
+msgid "PHP 8.5.2"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:168
+#: b839270ad15140e9a64cd9e6888e6301
+msgid ""
+"PHP was updated to the 8.5.2 upstream version. Among other enhancements "
+"and bugfixes, the highlighted changes are:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:170
+#: d22cfd5881e94350bfe786290163e76b
+msgid "A new URI Extension"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:171
+#: 8278942103734073b8f10649202f896d
+msgid "The Pipe Operator"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:172
+#: 59187ded0f574f4d99b567432d704f17
+msgid "Clone With functionality"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:173
+#: cf79f06e07ec46e1a64b3ad3210e7c56
+msgid "The `#[\\NoDiscard]` Attribute"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:174
+#: 4d0974ef78de4bdbb7753809a130a0b3
+msgid "Closures and First-Class Callables in Constant Expressions"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:175
+#: ce1276cb972d495996aca34bcc9c4354
+msgid "Persistent `cURL` Share Handles"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:176
+#: 9d95751a19264294bc3fa3b6d72b9692
+msgid "`array_first()` and `array_last()` functions"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:178
+#: ../../26.04/changes-since-previous-interim.md:624
+#: ../../26.04/changes-since-previous-interim.md:702
+#: 5f89a1c99a8a4a46a000d2c80a2877bc 9a32cd8c37b2477da987453a70fc9d8a
+#: f9ab1a211cf444ab9fba060076b4c8cf
+msgid ""
+"Other breaking changes and new features can be seen in the [full upstream"
+" changelog](https://www.php.net/ChangeLog-8.php#PHP_8_5)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:180
+#: 8b1200f723854fd29d2fe49fcb085e86
+msgid "Samba 4.23"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:182
+#: 33ccc6ff89da44c3b5ea9db633bc63c1
+msgid "Samba has been updated to the new upstream 4.23 version."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:184
+#: 59ce6e00820f447fab45bbb2bd9a861d
+msgid "New features and important changes in 4.23:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:186
+#: 398a420ff5fc4869b26676fbaf8c47e1
+msgid "SMB3 Unix Extensions enabled by default"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:187
+#: 197a81fc985749ac98a8b43c6f471479
+msgid ""
+"NetBios is disabled by default in the configuration file "
+"`/etc/samba/smb.conf` for fresh installs"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:190
+#: 5dddb08b05ce49e3b8607a67befb442c
+msgid "SSSD"
+msgstr ""
+
+#: ../../reuse/26.04/sssd-2.12-features.txt:2 cd99a47c2ae84bacb441bd694253bb66
+msgid "SSSD has been updated to version 2.12."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:195
+#: 556c20017cb24719854072d305defbf4
+#, python-brace-format
+msgid "See also {ref}`26.04-sssd-changes`."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:197
+#: ../../26.04/changes-since-previous-interim.md:615
+#: 36f874cd3c6c40f88dc411efaa62f047 9b33e5d1db9f4db484c320439470d2c9
+msgid "Other changes of importance are listed upstream:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:199
+#: ../../26.04/changes-since-previous-interim.md:617
+#: 1a38eb8ce705425fb1e18c3907d0ded8 1ee9be7587b64938aef0d00d8e7b292c
+msgid "https://sssd.io/release-notes/sssd-2.11.0.html"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:200
+#: ../../26.04/changes-since-previous-interim.md:618
+#: 077e1183e71145e39babb757912b361e 96c46bf109a74dcfa024e77e57101d50
+msgid "https://sssd.io/release-notes/sssd-2.12.0.html"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:202
+#: e0d7517e6e314521939acdfe42ef212a
+msgid "Squid"
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-features.txt:2 8f67ccc2bcfe41a3ac9824d84596698c
+msgid ""
+"Squid was updated to upstream version 7.2. Coming from version 6, the "
+"main new options are:"
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-features.txt:4 9cdded77e3d24ca4a0ad602f56187871
+msgid "Add `tls_key_log` directive to log TLS master keys."
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-features.txt:6 ea2009b92222430cb15ae5cabbb75f4d
+msgid ""
+"Add `key-extras` format to external ACL helpers to pass transaction "
+"details."
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-features.txt:8 6c5748f74a3146c4a5c0e8ec0b0666e9
+msgid "Add `doh_query` directive to send DNS queries over HTTPS."
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-features.txt:10 afc61e3a03224ce4aeb7e81a052f2ddd
+msgid ""
+"Add `cache_peer` option `tls-client-cert-switch` to select client "
+"certificates dynamically."
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-features.txt:12 a795a4f7aa1641eeacb8b145788a8dbf
+msgid ""
+"Several bugfixes for crash scenarios are also included in this major "
+"release."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:207
+#: f5b4a2394ec74d9ba4edb7f8928785d0
+#, python-brace-format
+msgid "See also {ref}`26.04-squid-removals`."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:209
+#: ../../26.04/changes-since-previous-interim.md:632
+#: 887e622323554ab394e58225f25f4220 aee413df0e084a7190a7251c6289a9ee
+msgid ""
+"For a list of all changes and fixes, please check the [upstream releases "
+"page](https://github.com/squid-cache/squid/releases)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:211
+#: d047d3b2cd024f5cbdc1bf0c35348659
+msgid "SoS (`sosreport`)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:213
+#: f72a92a4b80e4e30b1603fdd5f727f1d
+msgid ""
+"SoS was updated to 4.10.2. This upgrade introduces new plugins and also "
+"adds new features to existing plugins."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:215
+#: c17e4bf9fb3a49b48f61478674d5e7f4
+msgid ""
+"For more information see the "
+"[4.10.1](https://github.com/sosreport/sos/releases/tag/4.10.1) and "
+"[4.10.2](https://github.com/sosreport/sos/releases/tag/4.10.2) upstream "
+"release notes."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:217
+#: be80defb66474df29aa3904fcdab5d12
+msgid "Colored output with `strace` 6.19"
+msgstr ""
+
+#: ../../reuse/26.04/strace-6.19.txt:2 d8ac68c1039f4ea3ac7bc258992d3aac
+msgid ""
+"[`strace`](https://strace.io/) now supports colored output (configurable "
+"with `--color=...`, `STRACE_COLORS=...` and `NO_COLOR=1`)."
+msgstr ""
+
+#: ../../reuse/26.04/strace-6.19.txt:4 95a5d17adbb146a88b661e687f07ee64
+msgid "![Sample colored output](/images/strace-color.png)"
+msgstr ""
+
+#: ../../reuse/26.04/strace-6.19.txt:4 9b3c122804674aef898a60f560c3faa9
+msgid "Sample colored output"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:222
+#: 50c5c49c0902489bbdaea413f905d623
+msgid "Container stack"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:224
+#: 579d0296ebbe4091ba8176255a0a659d
+msgid ""
+"For the `containerd` and `runc` packages, we established a pattern to "
+"either keep the regular updates to the latest version or to opt for "
+"slower, more stable updates throughout the time the release is active. "
+"For more please read [Ubuntu Server Gazette - Issue 8 - Containers: "
+"Steady paths for agile stacks](https://discourse.ubuntu.com/t/ubuntu-"
+"server-gazette-issue-8-containers-steady-paths-for-agile-stacks/68680)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:226
+#: 7d09ccc04dd543a4952c5132687f785e
+msgid "containerd 2.2.2"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:228
+#: 71b4f070018c419d8d4f9c51c2485986
+msgid ""
+"The `containerd` packages (`src:containerd-app`, `src:containerd-stable`)"
+" were updated to version 2.2.2 Version 2 includes the stabilization of "
+"new features added in the last 1.x release as well as the removal of "
+"features which were deprecated in 1.x, meaning you should expect breaking"
+" changes here."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:230
+#: 0ec8218fe94942e2836c6c777a756ab3
+msgid ""
+"For further details on such changes, please refer to the `containerd` 2.0"
+" [upstream release "
+"notes](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md)"
+" and check the notes for [individual point "
+"releases](https://github.com/containerd/containerd/releases)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:232
+#: d4193a1fd9154b0b834398e33f28c01c
+msgid "runc 1.4.0"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:234
+#: 1b74ac60c78f4a18b252341934a9c35e
+msgid ""
+"The `runc` package (`src:runc-app`) was updated to version 1.4.0. The "
+"most noteworthy change here is that the handling of `pids.limit` has been"
+" updated to match the newer guidance from the OCI runtime specification. "
+"In particular, now a maximum limit value of 0 will be treated as an "
+"actual limit (it will be treated the same as a limit value of 1). We only"
+" expect users that explicitly set `pids.limit` to 0 will see a behavior "
+"change."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:236
+#: a50aa17e89e44ba08527b5ced02a96eb
+msgid ""
+"For more details on this new release, please [check the upstream release "
+"notes](https://github.com/opencontainers/runc/releases/tag/v1.4.0)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:238
+#: 70233f49e91e4c7e8f21eb6e634ce0a0
+msgid "Docker 29"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:240
+#: 8f524105dd494c078b4b969620fa4681
+msgid ""
+"[docker.io](http://docker.io) was updated to version 29. This release "
+"includes several improvements and breaking changes."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:242
+#: 46496507b1f0446db842f27d153196ee
+msgid ""
+"There is a new experimental support for `nftables` which can be enabled "
+"by setting Docker daemon’s firewall-backend option to `nftables`."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:244
+#: 62d2cd2c1bcb4077bca6f01874b27958
+msgid ""
+"The `containerd` image store is now the default for **fresh installs**. "
+"This doesn’t apply to daemons configured with `userns-remap` or for users"
+" upgrading from a previous [docker.io](http://docker.io) version."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:246
+#: 931ea26b59c24753897075221a2f2f50
+msgid ""
+"For a comprehensive list of changes, please check the [upstream release "
+"notes](https://docs.docker.com/engine/release-notes/29/)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:248
+#: 6fe2744bbe8d4274b4e194451bb1cab6
+msgid "Virtualization stack"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:250
+#: e2b9f010589e40f5ade8194e2f998c8e
+msgid ""
+"The virtualization stack got various updates and to provide more "
+"flexibility an additional hardware enablement option was added that will "
+"in addition allow to switch to the virtualization stack of the following "
+"interim releases while otherwise staying on the LTS."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:254
+#: 7602e2548fea4c0c975a6bebfa8d268b
+msgid "libvirt"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:256
+#: 4c80ca4634fa47298606c6597c2df8cb
+msgid ""
+"The libvirt package was upgraded to version 12.0.0. Here is the important"
+" changes since Ubuntu Questing:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:258
+#: db5e3fd5d7cc44e995dc2b24c5878f8e
+msgid "Several new features have been added into the `bhyve` driver:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:260
+#: 50d64ed707cd4f05b3e0f0707dbbe28c
+msgid ""
+"Experimental NAT networking support using the Packet Filter (`pf`) "
+"firewall."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:262
+#: 067a8a285e2248c7bfbea992704b2fd4
+msgid ""
+"Querying domain block, interface, and memory statistics. Not all "
+"statistics fields are supported though."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:264
+#: 8f49b0846272448d81022a4a6c8b6dfa
+msgid "SLIRP networking support"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:266
+#: 710e9f3e782347f6af042f7333474785
+msgid "NVMe device support"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:268
+#: de96df9f08df452880652f34af8a7fe4
+msgid "`virtio-scsi` support"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:270
+#: a134c288cbb04595837a4dc7163294f2
+msgid "Initial ARM64 support"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:272
+#: e8308e35a3404348b3549b1feb8c7a48
+msgid "Multi-GPU: Add support for NUMA affinity of PCI devices"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:274
+#: e42b111b88bb471880ffb9f015b4e225
+msgid ""
+"To support NVIDIA Multi-Instance GPU (MIG) configurations, `libvirt` now "
+"handles QEMU’s `acpi-generic-initiator` device internally. MIG enables "
+"partitioning a physical GPU into multiple isolated instances, each "
+"associated with one or more virtual NUMA nodes."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:276
+#: b3fafa8e821b4c9c8f90132b7b724e8c
+msgid "Hyper-V:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:278
+#: c3aa9d0ffd31430c83b19ee39c9cb1bb
+msgid "Introduce Hyper-V host-model mode"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:280
+#: 678281785df04f039106fd849d2ee033
+msgid "Hyper-V `virttype` support for Qemu domains"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:282
+#: 0b9a68d3bb7241bb89228b7ca5645f3f
+msgid ""
+"For more details, please see the [upstream "
+"changelog](https://libvirt.org/news.html#v12-0-0-2026-01-15)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:284
+#: 8f3c59185195442aaa0c07b39e633a63
+msgid "Some additional notable changes:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:286
+#: bfb5561e787d440b9bb4b01cb2983f3f
+msgid ""
+"The detection of the CPU MSR (Model Specific Register) features has been "
+"improved by enabling the `msr` kernel module load and fixing `vmx-*` "
+"features detection issue."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:288
+#: 828258de377f4cf181927ba6fb0ce616
+msgid "Use `sysusers` to manage users and groups"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:290
+#: 4528102372bf4cada8fef6d287b51ac9
+msgid "QEMU"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:292
+#: 77e7879a84f9419b8959778244b1dda5
+msgid ""
+"The QEMU package was upgraded to version 10.2.1. Here is the important "
+"changes since Ubuntu Questing:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:294
+#: c067297db3ee4695a115b0601314e1ba
+msgid ""
+"Upgrading Windows 11 makes the VM stop working and to fix this issue and "
+"ensure the migration path, we added new machine types for Resolute and "
+"old Ubuntu releases:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:296
+#: 6ecc81db0a45459dab19513fa0c0a8fb
+msgid ""
+"`pc-i440fx-questing-v2` Ubuntu 25.10 PC v2 (i440FX + PIIX, + 10.1 "
+"machine, 1996)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:298
+#: bad576446f864ea381c8ad3c9cd576c9
+msgid ""
+"`pc-i440fx-noble-v2`   Ubuntu 24.04 LTS PC v2 (i440FX + PIIX, `arch-caps`"
+" fix, 1996)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:300
+#: 3248c0e00c3f4710831dbe9e21c052af
+msgid ""
+"`pc-q35-noble-v2`      Ubuntu 24.04 LTS PC v2 (Q35 + ICH9, `arch-caps` "
+"fix, 2009)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:302
+#: ea719811c135470fa31d075092f504d1
+msgid "Other notable new features:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:304
+#: a2cf73f561a14e7fa77be6dc62e7edde
+msgid "ARM"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:306
+#: ed6425c3cda84b29bcb9952d27622882
+msgid "New board model: `amd-versal2-virt`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:308
+#: 3a182182f0e94afc8544751b863dc744
+msgid ""
+"New CPU architectural features emulated: `FEAT_TCR2`, `FEAT_CSSC`, "
+"`FEAT_SCTLR2`."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:310
+#: 85aa507797b24357b2bc038faa111968
+msgid "RISC-V"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:312
+#: a81683dedc9f4e60ac82661b99b2330c
+msgid "Add `riscv64` to `FirmwareArchitecture`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:314
+#: 0a6230e5b6cf4c96a7d825c13a929027
+msgid "Update OpenSBI to v1.8.1"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:316
+#: 093d5378b8a14b63a05c0546d4ffccd3
+msgid "Implement MonitorDef HMP API"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:318
+#: badb2fd4c5094a85b26a9d3c986cb5ef
+msgid "X86"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:320
+#: cff12d58484a479bb2c52326a52eb72d
+msgid ""
+"Support for a new accelerator, MSHV, which lets you create VMs from a "
+"Hyper-V guest without using nested virtualization."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:322
+#: 7c7e9b45f9d94b64a4ecfccfcb275092
+msgid "Migration:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:324
+#: de60175f24ec47e4a08ca88ee2bb47da
+msgid "Supported new `cpr-exec` migration mode"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:326
+#: 7357a93272824e78bd617a250a585429
+msgid "Supported `mapped-ram` on snapshot save/load"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:328
+#: 31e5ecd956a64a1c9ea40bfd0d126a68
+msgid ""
+"For more details, please see related upstream "
+"[changelog](https://wiki.qemu.org/ChangeLog/10.2) and the general log on "
+"[removed features](https://qemu-project.gitlab.io/qemu/about/removed-"
+"features.html)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:330
+#: 685700ed0f8a4c60b3b1638e639737bc
+msgid "EDK2"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:332
+#: 4e9eb6a9667046858381f1b2ccbecd65
+msgid ""
+"The package has been updated to version **2025.11**. Below are the most "
+"significant changes since Ubuntu Questing:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:334
+#: 8391e72fe371497fa44bff1e4acbfc19
+msgid "OVMF packaging rework"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:336
+#: c14e3307b202467cbd0b743fdac70a01
+msgid "OVMF has been split into the following packages:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:338
+#: f4265664f96947d9843d767454748e7f
+msgid "`ovmf-generic`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:340
+#: 22271d23419e4ab784b93a32575294bf
+msgid "`ovmf-amdsev`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:342
+#: 877cc3e2c5d04e4a85c50b60846ee16d
+msgid "`ovmf-inteltdx`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:344
+#: 2e31250685284bc2a7677c3b5c12d034
+msgid ""
+"The `ovmf` package is now a **metapackage** that depends on the above "
+"variants. This allows users to install only the OVMF firmware compatible "
+"with their CPU."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:347
+#: 365ad357b7a740888f78a908b3b0e5e4
+msgid "`ovmf-inteltdx` changes"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:349
+#: 266c53bba8494bda812e9a3cdbe67188
+msgid "`OVMF.inteltdx.fd` has been removed."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:351
+#: 406633336073432fa68ff7bdc51bf35b
+msgid "`OVMF.inteltdx.secboot.fd` has been renamed to `OVMF.inteltdx.ms.fd`."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:353
+#: 9f7ff87a8b8c450caab721a05da59d5e
+msgid "Removed components"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:355
+#: fc33186cf4354da7b6b86e143ab1544f
+msgid "`qemu-efi-arm`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:357
+#: 0f639b6c270d4214ba0dde50cf398020
+msgid "`ovmf-ia32`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:359
+#: 860a06d747a04b2f9a530ae18e570ef6
+msgid "The `loongarch64` target is no longer built."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:361
+#: d3563c881d4a451abbd339854d42ae6c
+msgid "Secure Boot improvements"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:363
+#: 0c9e83a29c0548df8b3a3f0bfd66bca0
+msgid "NX is now enabled in all Secure Boot variants."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:365
+#: cecc9b7880e9468abca7c4aaabbffc54
+msgid "The `strictnx` variant has been dropped."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:367
+#: 29e3f5d6fff842098e7d348b9614d99d
+msgid "New package"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:369
+#: ef6459cd62c749a8adbc9ef5f78cb758
+msgid "Introduced `ovmf-legacy`, providing `OVMF.legacy.fd` with PVSCSI support."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:371
+#: b9d1141d2005474fa707359afc2d343c
+msgid ""
+"Further details on new features and bug fixes are available in the "
+"upstream changelogs:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:373
+#: 846f3f752b7942c2ba4057ad7f6fe8ff
+msgid "[edk2-stable202505](https://github.com/tianocore/edk2/releases/tag/edk2-stable202505)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:375
+#: 12d01a2bfb264dcd9e5a64ed097c76a1
+msgid "[edk2-stable202508](https://github.com/tianocore/edk2/releases/tag/edk2-stable202508)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:377
+#: f528192c29b4412c888040c7df2d68c9
+msgid "[edk2-stable202511](https://github.com/tianocore/edk2/releases/tag/edk2-stable202511)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:379
+#: 7f9f3d35e1ce4cda82fb9b8197cc475f
+msgid "DocumentDB"
+msgstr ""
+
+#: ../../reuse/26.04/documentdb-0.108-0-features.txt:2
+#: 64655096dd504b3ba1a3fc295650a635
+msgid ""
+"DocumentDB is now available in Ubuntu, starting with version 0.108-0. It "
+"is a powerful, scalable, MongoDB compatible open-source document database"
+" built for modern applications, built on PostgreSQL. For more information"
+" see [documentdb.io](https://documentdb.io/)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:384
+#: b14662d88af745edb4b1193b1e97c12b
+msgid "MariaDB is fully supported"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:386
+#: 59edc28384da445e9cbbdfbab988e1d8
+msgid ""
+"MariaDB was updated to the latest LTS version 11.8.6. For more "
+"information on the MariaDB LTS, see the [upstream release "
+"notes](https://mariadb.com/docs/release-notes/community-server/11.8)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:389
+#: 3c4ce7c4fb9847f2b496e582e95860c7
+msgid ""
+"Starting with 26.04, MariaDB will now be provided with [full support in "
+"Ubuntu "
+"main](https://bugs.launchpad.net/ubuntu/+source/mariadb/+bug/2122095)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:391
+#: 105c7c5e659849088cd2e4b00d45bdf4
+msgid ""
+"MariaDB was updated to the latest LTS version 11.8.6. For more "
+"information on the MariaDB LTS, [see the upstream release "
+"notes](https://mariadb.com/docs/release-notes/community-server/11.8)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:393
+#: 002e95db88ac434ebb8dee053ea33501
+msgid "The MySQL and MariaDB servers are mutually exclusive on Ubuntu for now."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:395
+#: 36487a0386ea4021ba10a700f6554e76
+msgid "MySQL"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:397
+#: e1d552a615a446f6b32d9554fc5ae090
+msgid ""
+"MySQL’s current LTS version 8.4 is provided in Ubuntu 26.04 LTS, starting"
+" with version 8.4.8. Future security fixes will be provided by 8.4.x "
+"version updates. For more information see the [upstream release "
+"notes](https://dev.mysql.com/doc/relnotes/mysql/8.4/en/)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:399
+#: eddb53cb53f74d558946585ad9dce9c0
+msgid "MySQL Shell"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:401
+#: d93553a9989b441894285affa5e5fba5
+msgid ""
+"MySQL Shell was updated to the latest LTS version, 8.4.8, to match "
+"MySQL’s version. See the [upstream release "
+"notes](https://dev.mysql.com/doc/relnotes/mysql-shell/8.4/en/) for more "
+"information."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:403
+#: ec72852064d945a7b80b716af9db873f
+msgid "Percona Toolkit"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:405
+#: 708a8e2ecadd497f90063ce84ded8498
+msgid ""
+"Percona Toolkit was updated to the latest version, 3.7.1, and now "
+"includes additional tools for managing your MySQL, MariaDB, or PostgreSQL"
+" server. This includes `pt-galera-log-explainer`, `pt-k8s-debug-"
+"collector`,  and `pt-pg-summary` among others."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:407
+#: 7bebf1aa640643a8935019e3cdb35ec6
+msgid "PostgreSQL"
+msgstr ""
+
+#: ../../reuse/26.04/postgresql-18-features.txt:2
+#: 341a74a4efda4b6ca159e3e95ef2fd1b
+msgid ""
+"PostgreSQL was updated to version 18. This new version improves "
+"performance for workloads of all sizes through a new I/O subsystem that "
+"has demonstrated up to 3× performance improvements when reading from "
+"storage, and also increases the number of queries that can use indexes. "
+"This release makes major-version upgrades less disruptive, accelerating "
+"upgrade times and reducing the time required to reach expected "
+"performance after an upgrade completes. Developers also benefit from "
+"PostgreSQL 18 features, including virtual generated columns that compute "
+"values at query time, and the database-friendly `uuidv7()` function that "
+"provides better indexing and read performance for UUIDs. PostgreSQL 18 "
+"makes it easier to integrate with single-sign on (SSO) systems with "
+"support for OAuth 2.0 authentication."
+msgstr ""
+
+#: ../../reuse/26.04/postgresql-18-features.txt:4
+#: f5bac69059384daf9e7cb9797d2640ac
+msgid ""
+"For further information, check the [upstream release "
+"announcement](https://www.postgresql.org/about/news/postgresql-18-released-3142/)"
+" and the [upstream release "
+"notes](https://www.postgresql.org/docs/18/release-18.html)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:412
+#: ce1153df6b274201ad0602f4d2c3a029
+msgid "Valkey"
+msgstr ""
+
+#: ../../reuse/26.04/valkey-9.0-features.txt:2 3067150c175740a688988d1772e0793a
+msgid ""
+"Valkey was updated to version 9.0, starting with 9.0.3. This includes "
+"various features and improvements beyond 8.x, such as atomic slot "
+"migrations and hash field expiration."
+msgstr ""
+
+#: ../../reuse/26.04/valkey-9.0-features.txt:4 4962e65f1658491493d630f60f223760
+msgid ""
+"For more information on the new version, see the [Valkey 9 blog "
+"post](https://valkey.io/blog/introducing-valkey-9/). Release notes are "
+"available on the [Valkey project GitHub](https://github.com/valkey-"
+"io/valkey/releases)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:417
+#: 0358e2304d1d4ee7b9c5c06078632c5c
+msgid "fence-agents"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:419
+#: 693d006fb20848b4821a9059cc2bc8c9
+msgid ""
+"`fence-agents` is updated to version 4.17.0. This version includes a few "
+"new agents, like `aws_vpc_net` and `hetzner_cloud`, and enhancements to "
+"the existing ones."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:421
+#: 9a845d19943f409fa0dec90b8960243b
+msgid ""
+"In terms of security, the `azure_arm` agent replaced the dependency on "
+"`msrestazure` (deprecated) to `azure-identity`."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:423
+#: 20c1b7b0ac614ac18b11b1bfe87b4b8c
+msgid ""
+"For a list of all changes, please refer to the [upstream "
+"changes](https://github.com/ClusterLabs/fence-"
+"agents/compare/v4.16.0...v4.17.0)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:425
+#: 5d94049959fa4a46a18153e5cd31ded5
+msgid "resource-agents"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:427
+#: 8305f23ed7414e10b4e94d1bc8614d33
+msgid ""
+"`resource-agents` is updated to version 4.17.0. This version includes "
+"several new agents, like `aws-datasync-*` and `tickle-*`, and "
+"enhancements to the existing ones."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:429
+#: 8793e7dced3c483b972b1c46eeb870cd
+msgid ""
+"For a list of all changes, please refer to the [upstream release "
+"notes](https://github.com/ClusterLabs/resource-"
+"agents/blob/main/ChangeLog)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:431
+#: 0bffe6e6dc884e1ca73d2f58e5ea6ff3
+msgid "HAProxy"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:433
+#: 5aa5b9278872451fb4a5ae44b7f39b87
+msgid ""
+"HAProxy was updated to the latest upstream LTS release, 3.2, which "
+"introduces performance and efficiency improvements, faster and more "
+"reliable QUIC protocol support, and more. For further details on this new"
+" release, please check the HAProxy 3.2 [upstream "
+"announcement](https://www.mail-"
+"archive.com/haproxy@formilux.org/msg45917.html)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:435
+#: ../../26.04/changes-since-previous-interim.md:650
+#: a77d39a7a0f84f51a50d3ad9b9d1e572 e788ce20447a42f789d8e5cb57c04390
+msgid "Microsoft Azure"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:437
+#: 87c433ee8ae142249128b5174ac3f1d9
+msgid ""
+"The `walinuxagent` package was updated to version `2.15.0.1`. This "
+"release brings several improvements to the Microsoft Azure Linux Guest "
+"Agent since Ubuntu Questing:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:439
+#: 9abaeaffacd544618a7550044e4b8054
+msgid "Extension Security"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:440
+#: f5c04c6993ad46319ac0bf4286d78168
+msgid ""
+"Introduced support for extension signature validation and policy "
+"enforcement to improve the security of VM extensions."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:442
+#: 6bf15d45eef04482ba3a9fc7063cd26d
+msgid "Memory Management"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:443
+#: 97e7b527622a4e1ab5dfd0dfd3288bde
+msgid ""
+"Implemented memory quota management using cgroups to ensure the agent "
+"maintains a predictable resource footprint."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:445
+#: 64370d84248e47d6b11060eb4c410a0c
+msgid "Enhanced Reliability"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:446
+#: cbd2fa501c19485b8b52b1f7757526c3
+msgid ""
+"Improved telemetry and retry strategies for extension artifact downloads,"
+" along with more robust log collection handling."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:448
+#: abf1df87aa1549bb9195a41590a7285c
+msgid "Documentation"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:449
+#: 7771836bcfe644148117f406d4c40f21
+msgid ""
+"Added a new `waagent` manpage for better local access to command-line "
+"documentation."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:451
+#: a5a771050fda4af684fa45e67f597402
+msgid ""
+"To overcome the former issues around password-changing functionality it "
+"will now utilize sha512_crypt of python3-passlib to be compatible with "
+"python 3.13 that removed crypt."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:453
+#: 42b0bac4dffc4f2e8afda8e0024def04
+msgid ""
+"For further details on the changes in this update, please refer to the "
+"upstream release notes:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:455
+#: 126495b8ab2845ec866a95f0971c4907
+msgid "[v2.12.0.2](https://github.com/Azure/WALinuxAgent/releases/tag/v2.12.0.2)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:456
+#: 76fecf514a1c4ab9b7a59f6020e986ad
+msgid "[v2.13.1.1](https://github.com/Azure/WALinuxAgent/releases/tag/v2.13.1.1)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:457
+#: 779a8a420fcc403e9feec7d5a30ae798
+msgid "[v2.14.0.1](https://github.com/Azure/WALinuxAgent/releases/tag/v2.14.0.1)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:458
+#: 4c8b7a092d214facba48c3c1b9bec1c8
+msgid "[v2.15.0.1](https://github.com/Azure/WALinuxAgent/releases/tag/v2.15.0.1)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:460
+#: b3bf98e226c14c04a66a6af8663963df
+msgid "OpenStack 2026.1 Gazpacho"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:462
+#: 6d33ee10dcb74c7dac321ff9ebe48cde
+msgid ""
+"OpenStack has been updated to the [2026.1 "
+"Gazpacho](https://releases.openstack.org/gazpacho/index.html) release. "
+"Gazpacho is a [SLURP](https://releases.openstack.org/) release, "
+"supporting direct upgrades from the previous SLURP release (2025.1 "
+"Epoxy). This includes packages for Aodh, Barbican, Ceilometer, Cinder, "
+"Designate, Glance, Heat, Horizon, Ironic, Keystone, Magnum, Manila, "
+"Masakari, Mistral, Neutron, Nova, Octavia, Placement, Swift, Watcher, and"
+" Zaqar."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:464
+#: f614449052b54939a52f10b2a2dd6ce1
+msgid "Eventlet migration"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:465
+#: 9497a97f835345889068ff73212fdb77
+msgid ""
+"Multiple projects completed or advanced the migration from Eventlet to "
+"native Python threading, including Cyborg, Designate, Manila (technology "
+"preview), Nova (experimental), and Watcher. This long-running effort "
+"modernizes OpenStack's concurrency model for long-term sustainability. "
+"Operators should review per-service concurrency configuration before "
+"upgrading."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:467
+#: bb54ca6430224da482e9dda3e00c6331
+msgid "Nova (Compute)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:468
+#: b5a3103fb1144ce8876f40563698eaae
+msgid ""
+"Parallel live migrations improve memory transfer speed via multi-"
+"connection support. `IOThread` is now enabled by default for QEMU "
+"instances, offloading disk I/O from vCPU threads. Live migration of "
+"instances with vTPM devices is now supported in host secret security "
+"mode. The volume-attach API is asynchronous starting from microversion "
+"2.101, and UEFI firmware selection is now delegated to `libvirt`. Full "
+"OpenAPI schema coverage has been achieved across all Nova API endpoints."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:470
+#: 9a1ac92a07ac478e97ff72043d5621d7
+msgid "Neutron (Networking)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:471
+#: 100181ec17434cfcacaeea6151e8b8d7
+msgid ""
+"A new network IP availability details API extension provides richer "
+"subnet and allocation pool usage information. OVN BGP capabilities have "
+"been integrated into the Neutron OVN driver, and ML2/OVN now supports "
+"North/South routing for external (SR-IOV, bare metal) ports as well as "
+"allowed address pairs with virtual MAC addresses. Additional OVN "
+"configuration options improve scalability."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:473
+#: 24ef70e703704e7eaa3bd45e2a4da986
+msgid "Ironic (Bare Metal)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:474
+#: 5e6e1e22a9ec4093bb58c4ddb87213ba
+msgid ""
+"NFS and CIFS/SMB transport protocols are now supported for Redfish "
+"Virtual Media boot. Two new deploy interfaces have been added: "
+"`autodetect` (selects the best interface automatically) and `noop` (marks"
+" nodes active without deploying an OS). A new standalone networking "
+"service enables physical switch management without Neutron, and "
+"VXLAN/Geneve overlay networks are now supported for bare metal nodes."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:476
+#: df62bcdbd5bc4b4e9f05001d07146d60
+msgid "Manila (Shared File Systems)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:477
+#: aaae4f247ef04833ac5ce4d572cf3363
+msgid ""
+"QoS type support allows administrators to define throughput and IOPS "
+"limits via share type extra-specs or dedicated QoS type entities. Share "
+"replica metadata, custom export locations during share management, and "
+"new back-end drivers for HPE Alletra MP B10000 are included."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:479
+#: a93a384646db4999b86b3f4d94ef65b7
+msgid "Horizon (Dashboard)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:480
+#: f51996e4a5c9438eb022f7e690d27d83
+msgid ""
+"Live migration with Nova microversion 2.30 is now supported, and the Key "
+"Pairs page has been rewritten from AngularJS to Python/Django. A new "
+"configuration option avoids full container listings in the Swift panel, "
+"reducing resource consumption."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:482
+#: 4c14a25ac58744998ea6bebfcf11b15a
+msgid ""
+"For the full list of [upstream release "
+"highlights](https://releases.openstack.org/gazpacho/highlights.html), see"
+" the OpenStack 2026.1 Gazpacho documentation."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:484
+#: 26e4769b26f2428c94091ac5e5327868
+msgid "Development features"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:486
+#: 0c2fa4f43bfd4c71b695b90724a2ab62
+msgid "Toolchain upgrades 🛠️"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:488
+#: 509c8a7eb7064b4c933bb1f405820509
+msgid "`glibc` 2.42 now ships non-UTF8 encodings as `libc-gconv-modules-extra`."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:489
+#: 6f9256c806b244fd92491d5dfde09017
+msgid "LLVM 21 is the default LLVM toolchain."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:490
+#: 05a6302b9b914f9bb27ad266c9e4106a
+msgid "Rust 1.93.1 is the default Rust toolchain."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:492
+#: d4f83346bcec46d1a82a3289ba2cc0b3
+msgid "OpenJDK"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:494
+#: d4a910c3e8b647af95bf2494bc2259e0
+msgid ""
+"OpenJDK 25 package is the default and is TCK (Technology Compatibility "
+"Kit) certified on AMD64, ARM64, S390X, PPC64EL. The Java TCK is the most "
+"comprehensive test suite that covers all aspects of Java SE specification"
+" including language features, libraries and APIs. This guarantees "
+"interoperability and conformance to standard."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:496
+#: 4b1841ab7b0649108ada70a1359322dd
+msgid ".NET"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:500
+#: cd4a34eb139b45e8b904adf7ea93a178
+msgid "Rust + cargo-auditable"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:502
+#: 41bba53a5dfb445985b3817ee951d29d
+msgid ""
+"Rust packages built on Launchpad now have opt-in [cargo-"
+"auditable](https://github.com/ubuntu/ubuntu-release-notes) support. If "
+"enabled, binaries will include JSON-formatted metadata in a header "
+"section of the binary expressing the dependencies used to compile the "
+"binary. If a CVE is discovered in a popular Rust crate, this dependency "
+"metadata lets users and sysadmins immediately check if a binary is "
+"compromised."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:506
+#: 6344dbfa03154666a938248dbccc1d59
+#, python-brace-format
+msgid ""
+"For example, the dependency metadata for {manpage}`sudo-rs(1)` looks like"
+" this:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:538
+#: 95fbf850221a48bfb3d33bd07a5ced47
+msgid "Pretty printed"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:539
+#: bdd0e8ab5437419ab510a8705e6cd504
+msgid ""
+"This has been pretty-printed for ease of readability. In real life the "
+"data is minified and compressed."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:542
+#: 626072a25619413a8ed0b2994539907b
+msgid ""
+"We have enabled cargo-auditable support for a few well-known Rust "
+"packages:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:543
+#: cf2e141941b74b1ab7f3c417a3291db3
+msgid "`alacritty`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:544
+#: 41a57ef48478468cbc5d369b22c4ff18
+msgid "`bat`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:545
+#: f8e1cfbbcda349a3830f05fbea9792d6
+msgid "`du-dust`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:546
+#: 992bae2a817340ccb302f9a32c55d60e
+msgid "`eza`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:547
+#: b15a128f68ef472080333c34b9541f76
+msgid "`fd-find`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:548
+#: 136ebd0f537a45349a5dea628628f553
+msgid "`hyperfine`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:549
+#: 332c3434d2ce4766843c7c70dc556764
+msgid "`ripgrep`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:550
+#: f27528019da34c9ca98e828c93aeb81e
+msgid "`sd`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:551
+#: 90fce22088da42b980d4fbbe3540ab57
+msgid "`sudo-rs`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:553
+#: d456dfc2fab7481d835a6d14de897151
+msgid ""
+"We encourage developers to turn on cargo-auditable support for their own "
+"packages!"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:555
+#: 7d434ace7bf24e0582f93e8a4c14b98a
+msgid ""
+"For more information, including how to opt in, see the [Ubuntu project "
+"documentation](https://documentation.ubuntu.com/project/contributors"
+"/language-specific/rust/cargo-auditable/)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:557
+#: 7b1f3feea95d4d449b97a1a597f1615c
+msgid "Backwards-incompatible changes"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:559
+#: 35061dd50fc2412fa712243f016a2a25
+msgid "System changes"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:562
+#: c6536deda1ee418ab3ed9be1acd3ad67
+msgid "`cgroup` v1 support has been removed"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:564
+#: 31ecc6075f2f48daacc3ea191569164c
+msgid ""
+"`systemd` version 259 no longer supports `cgroup` v1 (`legacy` and "
+"`hybrid`) hierarchies. As a result:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:566
+#: fcb0a95fc0034744a6c1851bbf12d1a8
+msgid ""
+"Ubuntu installations running `cgroup` v1 will not be allowed to upgrade "
+"to Ubuntu 26.04 LTS."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:567
+#: 26af900097e045b1ae1c507fec5db90e
+msgid ""
+"Ubuntu 26.04 LTS container workloads will not run on a host booted with "
+"`cgroup` v1."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:568
+#: 09f7393bed9b49748ae43cc12f708ace
+msgid ""
+"Ubuntu 26.04 LTS hosts do not support container workloads that require "
+"`cgroup` v1: for example, Ubuntu earlier than 18.04 LTS."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:570
+#: 66513c21b9f24bcbb9473b8355fa7104
+msgid ""
+"This change was made in `systemd` version 258. See the "
+"[changelog](https://github.com/systemd/systemd/releases/tag/v258) for "
+"more information."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:572
+#: fc1daae39bc14568834f071b2b7571a9
+msgid "Removable media are mounted under `/run/media`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:574
+#: dd7d0736cf2b4ecaad267a4b29e07f38
+msgid ""
+"In previous Ubuntu releases, removable media were mounted under the "
+"`/media` directory. Starting with Ubuntu 26.04 LTS, `/run/media` is now "
+"the mount directory instead. This has several benefits:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:576
+#: 5487c9b4e627483f962f80afe30e5dd1
+msgid "Better support for read-only root file systems"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:577
+#: 7f6a3a124ffa416795c9b8793b5002bd
+msgid "Better alignment with other distributions and upstream defaults"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:578
+#: e869cce955984ba1923a2b4e21af8f7c
+msgid ""
+"Not requiring special cleanup routines because `/run` is hosted on a "
+"virtual memory file system (`tmpfs`)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:580
+#: 0c299dc4af5f4fdda3ba7cba2da47990
+msgid ""
+"If you rely on the specific directory path for media access, check that "
+"your setup still works. For example, test your existing scripts."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:582
+#: 0eac7aed3e1e45968adf13aa42ce4301
+msgid "[LP#2130110](https://bugs.launchpad.net/ubuntu/+source/udisks2/+bug/2130110)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:585
+#: e0dff5df975c42ffb7e0f64a77e5df69
+msgid "Ubuntu no longer supports IBM Z generations z14 or older"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:587
+#: 5a848351f5c74027a8e56ba9f5441316
+msgid ""
+"On the IBM Z (s390s) architecture, the architectural level set (ALS) was "
+"raised to build for IBM Z generation z15 ([LP: "
+"#2126577](https://launchpad.net/bugs/2126577)). As a result, Ubuntu 26.04"
+" LTS no longer works on IBM Z generations z14 (LinuxONE II) or older. You"
+" can't install Ubuntu 26.04 LTS on this hardware or upgrade to it. The "
+"`ubuntu-release-upgrader` prevents you from performing the upgrade."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:589
+#: c2a036339ad94ce5a86543a353825cd2
+msgid ""
+"IBM Z generation z14 (LinuxONE II) is still supported by Ubuntu Server "
+"24.04 LTS for up to 15 years in total."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:591
+#: 2ca4979f97364d149503afc4d2460b61
+msgid "Desktop changes"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:595
+#: bd3501ae72254990ab40185280daabfe
+msgid "Server changes"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:597
+#: 4bc900fcf2154d9181a51f1fb936d2d0
+msgid "TLS 1.0 and 1.1 disabled in Apache"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:599
+#: c651ef179b4d4cc3b869d9173c54383d
+msgid ""
+"The Debian changes for the new version of Apache have disabled TLS 1.0 "
+"and 1.1, following RFC 8996. These should be already disabled by default "
+"in OpenSSL, and now Apache follows the same. See [the fixed "
+"bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=943415)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:601
+#: 536b9cd18ed24b4eb060f838c7622e9b
+msgid "NFS"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:603
+#: 4e69e68183c74b339b49f18f6048b37d
+msgid ""
+"The `blkmapd` and `nfs-blkmap` services have been removed. From the "
+"`NEWS` file:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:605
+#: 888d076c05fc4b8eb132b52d4eb6d132
+msgid ""
+"pNFS block layout is deprecated in favor of pNFS SCSI layout. This is  "
+"because block layout could easily result in data loss, as documented in "
+"<https://linux-nfs.org/wiki/index.php/PNFS_block_server_setup>."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:607
+#: 62b0bf1197904329bdbfbb5508e7fdb5
+msgid ""
+"Users of pNFS are advised to move to the revised SCSI/NVMe layouts  that "
+"are safe to use and don't require the use of blkmapd."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:610
+#: 5ccbb5a3e5344609aa4a97253fd278b8
+msgid "Breaking changes in SSSD"
+msgstr ""
+
+#: ../../reuse/26.04/sssd-2.12-changes.txt:2 23f14178de3247f78b0c7c083d9e0dda
+msgid ""
+"SSSD now runs under user `sssd` (instead of `root`). Make sure that "
+"`sssd` can still access secrets or integrations from its new user."
+msgstr ""
+
+#: ../../reuse/26.04/sssd-2.12-changes.txt:4 8e945b81d12e4a6c8faf33ee4ba5511b
+msgid ""
+"The implicit files provider and domain was removed: see "
+"<https://sssd.io/docs/files-provider-deprecation.html>."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:620
+#: 6630e95801674bd0bf144e9983f0fb98
+msgid "Breaking changes in PHP"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:622
+#: f4432aaab4874d4b932c9dad7a131095
+msgid ""
+"It is no longer possible to use `array` and `callable` as class alias "
+"names in `class_alias()`."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:627
+#: a3315f5b44024913a8b422440942de9a
+msgid "Removed options and directives in Squid"
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-removals.txt:2 9bf54fd27a3749b8b187e48eb2701cad
+msgid "Some directives and options were removed in Squid 7.2:"
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-removals.txt:4 4d7b82dfdbaa4efea5a5260e50663ba2
+msgid "Removed `client_delay_access` directive."
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-removals.txt:6 cab7cfe9b6a441568bc2fbbd3dd2074f
+msgid "Removed `ftp_epsv` directive."
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-removals.txt:8 790a4524cafd46299ff7ae982f44b695
+msgid "Removed `cache_peer` option `no-netdb-exchange`."
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-removals.txt:10 6262af3c170c400897e41753216aa677
+msgid ""
+"Removed `client_persistent_connections` and "
+"`server_persistent_connections` directives."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:634
+#: 1124968c159a47e99c9c19741d70f4cb
+msgid "Kerberos removes deprecated algorithms from its default lists"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:636
+#: 655d8663a7dc439ea166d977df004b05
+msgid ""
+"MIT Kerberos no longer includes the `arcfour-hmac-md5` and the `des3-cbc-"
+"sha1` algorithms in its default encryption algorithm list (the `openssh` "
+"and `krb5` lists). They are weak, deprecated algorithms. Before, `krb5` "
+"would include them in its default algorithm lists when users do not "
+"specify a list with algorithms to be used."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:638
+#: c57679786bcf4cf4b6332ff5fb2a6d17
+msgid ""
+"Note that we did not remove support for those algorithms. Instead we just"
+" dropped them from the default list that the client will try in case the "
+"user do not specify any algorithms in their configuration file in the "
+"`permitted_enctypes` directive in the `libdefaults` section in "
+"`/etc/krb5.conf`."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:640
+#: d60393dd6a7b471ab5443dff3e94de27
+msgid "PostgreSQL is no longer available on i386"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:642
+#: a0a27a045344491a87f00d9d47b5efca
+msgid ""
+"PostgreSQL 18 in Ubuntu 26.04 LTS no longer builds for the i386 "
+"architecture. Therefore, it no longer produces the `libpq-dev` and "
+"`libpq5` binary packages for that architecture. This means that any "
+"package depending on those libraries will also not be available in i386."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:644
+#: 6980cb24eae440bda6bb97e6ef0dcd54
+msgid ""
+"See [LP: #2142320](https://bugs.launchpad.net/ubuntu-release-"
+"notes/+bug/2142320) for more information."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:646
+#: 7555f7527a5d44e0afc0b8545a3c7dd6
+msgid "Replaced agents in `resource-agents`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:648
+#: 9208167d710e49a2b8a3e2b7e609d680
+msgid ""
+"The `oracledb` and `zabbixagent` agents were replaced by the `oracle` and"
+" `zabbix-agent`, respectively. You might need to adjust your existing "
+"configuration."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:652
+#: 8911cd65131b47da8c671da1ffd8ad2e
+msgid ""
+"`Azure Disk Encryption` (ADE) is scheduled for retirement on September "
+"15, 2028. A number of packages were historically pre-installed on Azure "
+"images to allow the enablement of ADE without requiring additional "
+"package installations. Due to its impending retirement, Ubuntu on Azure "
+"will no longer maintain the enablement of ADE without additional package "
+"installations. Accordingly, the following packages have been removed from"
+" one or more Ubuntu image-lines on Azure:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:654
+#: b9e4421baba94c29881120c234969890
+msgid "`python3-parted`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:655
+#: 67a213e5c1414f2e9055c4bbba8f4c39
+msgid ""
+"This package is largely unsupported by its maintainers, imposing a "
+"potential security risk into the future. Its only known use was for the "
+"enablement of ADE. It is no longer pre-installed on any Ubuntu image on "
+"Azure."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:657
+#: ad8dfab516cf46fbb8e6b91f2a1bce9c
+msgid "`python3-six`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:658
+#: 514affd7d2b24164afe177791e02f6c1
+msgid ""
+"The only known use of this package was for the enablement of ADE. It is "
+"no longer pre-installed on any Ubuntu image on Azure."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:660
+#: 6db0658e725b4c0c8fcfc146d89bddd8
+msgid "`lsscsi`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:661
+#: 37b681f190c1488e8dd4145b63d98d56
+msgid ""
+"This package was initially introduced to support ADE. It has been removed"
+" from all minimal Ubuntu image-lines to maintain the minimal footprint "
+"assertion. However, it remains a pre-installed package for all non-"
+"minimized Ubuntu images on Azure since it is a valuable debugging tool "
+"for individual instances and server deployments."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:669
+#: 91fcfc6cd91f46f8af7fbf810c4b37c8
+msgid "Removed features in OpenStack"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:671
+#: 8549ac753afd4415ac87ddfd3223fe02
+msgid "The Manila V1 API and the Manila shell utility have been removed."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:673
+#: 46505ad23422438cb08228460b26e7d1
+msgid ""
+"For details, see the Manila [release "
+"highlights](https://releases.openstack.org/gazpacho/highlights#manila) "
+"and [release "
+"notes](https://docs.openstack.org/releasenotes/manila/2026.1.html)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:679
+#: 822529dd0e5a45c0a3df3a13739a3dfc
+msgid "Deprecated features"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:681
+#: 98082a9b66924e0494bc202b942097ba
+msgid "System deprecations"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:684
+#: 211a9e2033374900be2286466b9e414c
+msgid "Legacy System V service scripts are deprecated"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:686
+#: d465af902b7b412c828d12e6dd9a59e4
+msgid ""
+"Ubuntu 26.04 LTS is the last release that supports System V service "
+"scripts compatibility in `systemd`. Migrate your legacy System V scripts "
+"to native `systemd` unit files."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:688
+#: 7ad1cdfbcfbf45a09cda6f67b0185a4e
+msgid ""
+"`systemd` version 260 [has already dropped "
+"support](https://github.com/systemd/systemd/releases/tag/v260), so this "
+"change will take effect in Ubuntu 26.10."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:690
+#: ff8800830e864cababe45eb8a591eacc
+msgid "Desktop deprecations"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:694
+#: ba0aed8637b745928f5315c30d06ff68
+msgid "Server deprecations"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:696
+#: b1185d38770e44339a5081d451f4b419
+msgid "PHP"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:698
+#: 5feafc7052264766a2f92e475310c6ff
+msgid "Deprecation of the backtick operator"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:699
+#: 4b7016438218455f8001874f8dec1e99
+msgid ""
+"Non-canonical cast names (boolean), (integer), (double), and (binary) "
+"have been deprecated. (bool), (int), (float), and (string) need to be "
+"used instead."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:700
+#: 6704809d826c4ad186b76ff90f30123f
+msgid ""
+"Using null as an array offset or when calling array_key_exists() is now "
+"deprecated - now an empty string is needed."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:716
+#: 57cb856cb1f44797a2d1d81099960e14
+msgid "Bug fixes"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:718
+#: c36375d5078e4174b44e53d4ade50cd6
+msgid "Desktop fixes"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:722
+#: 7f25e5f9697c4a9e97b3c633e43584ab
+msgid "Server fixes"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:724
+#: 095b4ae19dc3414eb81d5e07a52c52a7
+msgid "Apache 2.4.65"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:726
+#: 9abc6891163d4d20bcebbbb795128062
+msgid ""
+"Apache has been updated to upstream version 2.4.65. For more details, see"
+" the [upstream release "
+"notes](https://www.apachelounge.com/Changelog-2.4.html)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:728
+#: 3aae7388029c4b5398c4fb67f10f162c
+msgid "Nginx 1.28.2"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:730
+#: 71c4b532f5b5414fb405596dcefee8e1
+msgid ""
+"Nginx was updated to version 1.28.2, which includes fixes for various "
+"bugs. See the [1.28 series upstream release "
+"notes](https://nginx.org/en/CHANGES-1.28)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:732
+#: 4940d6cc10a44977b59a259ac0b104d5
+msgid "Django 5.2.9"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:734
+#: fc966348fd9f420b970096f0231fedaa
+msgid ""
+"Django was updated to LTS version 5.2.9. For more information, see the "
+"[Django 5.2 release "
+"notes](https://docs.djangoproject.com/en/6.0/releases/5.2/)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:736
+#: 6a031bc5fb744a3ea1b8ec47fc37c4a2
+msgid "OpenSSH 10.2"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:738
+#: 582f5bd7f44c49f5b7473ffc9f336676
+msgid ""
+"OpenSSH was updated to version 10.2, which is a bugfix release on top of "
+"10.1 present in the Ubuntu Questing 25.10 release."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:740
+#: 2f09416ac1cb4a779b55c8b36bba8db9
+msgid ""
+"As per RFC 8732, gss-group14-sha1- and gss-gex-sha1- are considered "
+"deprecated algorithms and should not be used. Therefore, we dropped those"
+" deprecated algorithms from the Ubuntu GSS-API support patch. This does "
+"not mean those algorithms are no longer supported. Instead, they were "
+"removed from the default list that the client or the server will try for "
+"GSS key exchange in case the user does not specify any algorithms in "
+"their configuration file."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:742
+#: b69b6ea6b5dc410d800e44f7e63f34af
+msgid "Dovecot 2.4.2"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:744
+#: 7a1f24e4efd541879b35a65a9e1891c2
+msgid ""
+"Updated to 2.4.2. See the [upstream "
+"announcement](https://dovecot.org/mailman3/archives/list/dovecot@dovecot.org/thread/XTMMPVQ3QKQMYDZ3CZZCXPNHN7OXKS3L/)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:746
+#: 5e34e4baddff4ebb81314e7eaf9f3f27
+msgid "Postfix 3.10.6"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:748
+#: 41467415656949dea6f16c6cc595b073
+msgid ""
+"Postfix was updated to version 3.10.6. See the [upstream "
+"announcement](https://www.postfix.org/announcements/postfix-3.10.6.html)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:750
+#: c927aeb8e30c406a80bc3031136b802b
+msgid ""
+"A noteworthy change in the packaging of Postfix is that **by default it "
+"is no longer installed in a `chroot`, and only limited `chroot` support "
+"is available from now on**."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:752
+#: 659afde6899b42249a85c0d31cef9390
+msgid "`unbound` 1.24.2"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:754
+#: 12e7bcd2a64d43e9a0f9849af5a6607d
+msgid ""
+"Update to version 1.24.2. See the [upstream "
+"changelog](https://github.com/NLnetLabs/unbound/releases/tag/release-1.24.2)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:771
+#: 3f92edda433d4e08a6a8587ce16b10fd
+msgid "Known issues"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:773
+#: 45457aa1330b493697a46c063f19cb25
+msgid ""
+"As is to be expected with any release, there are some significant known "
+"bugs that users may encounter with this release of Ubuntu. The ones we "
+"know about at this point (and some of the workarounds) are documented "
+"here, so you don’t need to spend time reporting these bugs again:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:775
+#: af11957db1b84ff7a117f43349e2552f
+msgid "System issues"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:777
+#: a7281383365d41cf9106b84dbf7f28ef
+msgid "Hardware requiring `nomodeset`"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:779
+#: 37cc8e10b30742ceb7a8458d95775df4
+msgid ""
+"Some particular hardware (e.g. Thinkpad x201) might have issues ([general"
+" freeze](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2084055), "
+"[`desktop-security-center` not launching](https://github.com/canonical"
+"/desktop-security-center/issues/81)), when booted without `nomodeset` "
+"(Safe graphics). Follow these steps if you encounter such an issue:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:781
+#: 7aaf753783d94b849b0caa9f24a7c0de
+msgid ""
+"At the GRUB boot menu, press `e` (keep `Shift` pressed during early boot "
+"if the menu doesn’t show up)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:782
+#: 92aa799a2589411bb9501da7450d0f42
+msgid "Add `nomodeset` to `linux` line, like the example below:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:788
+#: 1fc30294d1714fe09ab39ecff24e1567
+#, python-brace-format
+msgid "Press {kbd}`Ctrl-x` to continue the boot process"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:789
+#: d45186fa14e74ce892ddee706eee0941
+msgid ""
+"After installation is complete, reboot, use `nomodeset` again, like the "
+"example below:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:795
+#: eba5927be38a40c5bb667acbf8f01569
+msgid ""
+"Add `nomodeset` to the GRUB config file, `/etc/default/grub`, like the "
+"example below:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:801
+#: 26f6b8a285004e66a143545714294937
+msgid "Finally, run `sudo update-grub` to make the change take effect."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:809
+#: 6d9d989877e84e138185b718a5ab62f3
+msgid "Raspberry Pi"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:811
+#: 76b48bbbc9c34f9b8d5ee4898a2ecf3a
+msgid ""
+"The new `gnome-initial-setup` has issues preventing it from working "
+"properly:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:812
+#: 3f393b5f4b634f95ba20cedc4a1819c0
+msgid ""
+"The selected key layout does not persist ([LP: "
+"#2127782](https://launchpad.net/bugs/2127782))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:813
+#: 22b375b69caa43f48dfaaae85148160d
+msgid ""
+"Time zone input dropdown can \"wobble\" ([LP: "
+"#2084611](https://launchpad.net/bugs/2084611))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:814
+#: b89d49c8140f44aba038e3743ec2ff66
+msgid ""
+"The hostname change is mandatory ([LP: "
+"#2093132](https://launchpad.net/bugs/2093132))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:816
+#: 0fb56788d6f445deb5191a03c2a31b03
+msgid ""
+"During boot on the server image, if your `cloud-init` configuration (in "
+"`user-data` on the boot partition) relies upon networking (importing SSH "
+"keys, installing packages, etc.) you *must* ensure that at least one "
+"network interface is required (`optional: false`) in `network-config` on "
+"the boot partition. This is due to Netplan changes to the `wait-online` "
+"service (~~[LP: #2060311](https://launchpad.net/bugs/2060311)~~). "
+"Furthermore, a current issue may cause `cloud-init` to run before the "
+"network is ready ([LP: #2144891](https://launchpad.net/bugs/2144891))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:818
+#: cc44dc16927f497e90ecf5c30a550bb4
+msgid ""
+"With the removal of the `crda` package in 22.04, the method of setting "
+"the WiFi regulatory domain (editing `/etc/default/crda`) no longer "
+"operates. On server images, use the `regulatory-domain` option in the "
+"Netplan configuration. On desktop images, append "
+"`cfg80211.ieee80211_regdom=GB` (substituting `GB` for the relevant "
+"country code) to the kernel command line in the `cmdline.txt` file on the"
+" boot partition  ([LP: #1951586](https://launchpad.net/bugs/1951586))."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:820
+#: 021d724410a14527b9072056d7a6c6eb
+msgid ""
+"Colors appear incorrectly in the Ubuntu App Center ([LP: "
+"#2076919](https://launchpad.net/bugs/2076919))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:822
+#: cb50876262624602a16e987d701a58fe
+msgid ""
+"On server images, re-authentication to WiFi APs when regulatory domain is"
+" set result in `dmesg` spam to the console ([LP: "
+"#2063365](https://launchpad.net/bugs/2063365))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:824
+#: 86b635eea28e4d73a4a2a5b1bfa7bdd5
+msgid "Netboot installs"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:826
+#: a072cac92a23411eb0c3f342881d030d
+msgid ""
+"There is a bug ([LP: #2104316](https://bugs.launchpad.net/ubuntu-power-"
+"systems/+bug/2104297)) in the *beta* images that prevents netboot "
+"installs in some scenarios."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:828
+#: 6ebb0753e5124d938b5015afb5b1af0f
+msgid "cloud-init upgrade"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:830
+#: 33c829b81d6e4e2191c4be16daec8993
+msgid ""
+"It has been reported that cloud-init may fail to upgrade properly in the "
+"Oracular to Plucky upgrade path, see [LP: "
+"#2104316](https://bugs.launchpad.net/ubuntu-power-systems/+bug/2104297)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:832
+#: e5b888467e0a4d4980d53aaa1f6bda3a
+msgid "ZFS with cryptoswap"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:834
+#: 7eacfac008964f74a41f64e2d984232c
+msgid ""
+"ZFS with Encryption on Ubuntu 24.10 will [fail to activate the cryptoswap"
+" "
+"partition](https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/2084089)."
+"  This affects both new installs and upgrades.  We expect to address this"
+" post-release with an archive update."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:836
+#: fe98ba751379456797875c7ada887d5e
+msgid "I/O scheduler"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:838
+#: baf09f176f574460bf3ebcc7717d9baf
+msgid ""
+"A bug prevents the I/O scheduler from being reset to “none” ([LP: "
+"#2083845](https://bugs.launchpad.net/bugs/2083845)): the fix is already "
+"in Linux v6.11.2, and will be part of the first SRU kernel."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:840
+#: d5d22cb4a10a44dbb47fed1046baed69
+msgid "FAN networking"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:842
+#: 3c01dd956440437b9f32c4abd2789577
+msgid ""
+"Support for FAN networking has been dropped in the 6.11 release kernel. "
+"It will be re-introduced in the next 6.11 kernel update shortly."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:846
+#: 0ed27bc304e746a8a4e90cdcf3ec4dd0
+msgid "Desktop issues"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:848
+#: 082d26374fa94fecb83e8d73296d64c8
+msgid "Localization"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:850
+#: ffd8486c87eb4aa7b368125205ef5d7e
+msgid ""
+"The Live Session of the new Ubuntu Desktop installer is not localized. It"
+" is still possible to perform a non-English installation using the new "
+"installer, but internet access at install time is required to download "
+"the language packs. ([LP: #2013329](https://bugs.launchpad.net/ubuntu-"
+"release-notes/+bug/2013329))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:852
+#: 2bf302647cbe40d993f444fda750c459
+msgid "Screen reader support"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:854
+#: 0b7ec5efcb36411aab5ebaef771c2acd
+msgid ""
+"Screen reader support is present with the new desktop installer, but is "
+"incomplete ([LP: #2061015](https://launchpad.net/bugs/2061015), [LP: "
+"#2061018](https://launchpad.net/bugs/2061018), [LP: "
+"#2036962](https://launchpad.net/bugs/2036962), [LP: "
+"#2061021](https://launchpad.net/bugs/2061021))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:856
+#: 6d19b052a3304eabaa245b688df1d248
+msgid "OEM installs"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:858
+#: f82ce683332740198712c57ab407cd76
+msgid ""
+"OEM installs are not supported yet. ([LP: "
+"#2048473](https://launchpad.net/bugs/2048473))"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:860
+#: 36ed8b88a0ad4610ac4069172834fadd
+msgid "Virtualized GTK 4 apps"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:862
+#: cc6872ef9cac440097f6a98125c8e051
+msgid ""
+"GTK 4 apps (including the desktop wallpaper) do not display correctly "
+"with VirtualBox or VMWare with 3D Acceleration ([LP: "
+"#2061118](https://launchpad.net/bugs/2061118))."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:864
+#: 8f35639920d54a81a90bc121e4a1b59d
+msgid "Limitations of TPM-backed full disk encryption"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:866
+#: 703c13bea3ec407aa32788faef648b89
+msgid ""
+"TPM-backed full disk encryption (TPM/FDE) has been introduced to enhance "
+"data security. The following are its known issues and limitations as of "
+"the Ubuntu 26.04.0 LTS release:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:868
+#: 258498d0437c45a494617d00daa2b1cf
+msgid ""
+"Some potentially eligible systems might be detected as **ineligible** for"
+" TPM/FDE."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:870
+#: 90fe26c83e83463f85d0c911bb85b7bb
+msgid ""
+"If you **forget the passphrase or PIN** and you boot your system with the"
+" recovery key, you can't remove or replace the passphrase or PIN anymore."
+" On subsequent boots, you have to continue using your recovery key."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:872
+#: 533ff8edcaa74c8e914ef29570dea865
+msgid "**Disk re-encryption** is currently not supported."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:874
+#: af8cc3531390420faa3633478ed65e47
+msgid ""
+"Certain **self-healing and reparation options** for defective systems "
+"after installation are currently missing."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:876
+#: 5e9ab0d38a7240d19b69ca5c3710350b
+msgid ""
+"TPM/FDE requires a specific kernel snap which may not include certain "
+"**kernel modules** necessary for some hardware functionalities. A notable"
+" example is the `vmd` module required for **NVMe RAID** configurations."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:878
+#: f96bb5ca72c84b7cbfd7954aeca8d06b
+msgid ""
+"In scenarios where such specific kernel modules are needed, you might "
+"have to disable the hardware feature (such as RAID) in the firmware to "
+"ensure the continued availability of the affected hardware post-"
+"installation. If disabling in the firmware is not an option, the related "
+"hardware will not be available post-installation with TPM/FDE enabled."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:880
+#: 32b58734bfc54dd091bba14f73c39e91
+msgid ""
+"**Nvidia drivers** are the only out-of-tree kernel drivers supported by "
+"TPM/FDE. You can't install other third-party drivers using DKMS."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:882
+#: 28ec6d2d8b4149439773c79baa105fcc
+msgid ""
+"For other known issues, see [FDE specific bug "
+"reports](https://bugs.launchpad.net/bugs/+bugs?field.searchtext=&orderby=-importance&field.status%3Alist=NEW&field.status%3Alist=CONFIRMED&field.status%3Alist=TRIAGED&field.status%3Alist=INPROGRESS&field.status%3Alist=FIXCOMMITTED&field.status%3Alist=INCOMPLETE_WITH_RESPONSE&field.status%3Alist=INCOMPLETE_WITHOUT_RESPONSE&assignee_option=any&field.assignee=&field.bug_reporter=&field.bug_commenter=&field.subscriber=&field.tag=fde&field.tags_combinator=ANY&field"
+".status_upstream-empty-"
+"marker=1&field.has_cve.used=&field.omit_dupes.used=&field.omit_dupes=on&field.affects_me.used=&field.has_patch.used=&field.has_branches.used=&field.has_branches=on&field.has_no_branches.used=&field.has_no_branches=on&field.has_blueprints.used=&field.has_blueprints=on&field.has_no_blueprints.used=&field.has_no_blueprints=on&search=Search)."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:884
+#: ddc41587eb9d4d3c979b5cf25d9e3a42
+msgid "Resuming from suspend on Nvidia"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:886
+#: e48806c8f09a49b58b88f4d1c80db034
+msgid ""
+"Resuming from suspend on Nvidia desktops (where Nvidia is the primary GPU"
+" so generally not laptops)  will exhibit visual corruption and freezes "
+"using the default Wayland session  "
+"([LP#1876632](https://bugs.launchpad.net/bugs/1876632)). If you need "
+"suspend/resume support then the simplest solution is to select ‘Ubuntu on"
+" Xorg’ at the login screen."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:888
+#: a93f38b5628e493caa328939e0d68724
+msgid "Classic fonts"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:890
+#: 3dd748653b0e4da38d42c24141669b3b
+msgid ""
+"Installing `ubuntu-fonts-classic` results in a non-Ubuntu font being "
+"displayed ([LP#2083683](https://bugs.launchpad.net/bugs/2083683)). To "
+"resolve this, install `gnome-tweaks` and set ‘Interface Text’ to "
+"‘Ubuntu’."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:892
+#: 7d63e829bad44a949d4920e56304da45
+msgid "Server issues"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:894
+#: b49f72f1d7ee41c8a422c8e0fe0fb9c1
+msgid "Apache2 security hardening breaks the `mod-php` JIT"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:896
+#: 897e5938dec84f37ae49939228ab0e12
+msgid ""
+"The Apache2 `systemd` service unit now sets the "
+"`MemoryDenyWriteExecute=yes` option by default as a security hardening "
+"measure. This prevents simultaneously writable and executable memory "
+"mappings. However, it breaks PHP's JIT compiler when using the "
+"`libapache2-mod-php` module, producing warnings such as the following:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:902
+#: 70f3ef25c889465f8e426bcd150e5000
+msgid ""
+"We recommend that you switch from `mod-php` to the `php-fpm` service, "
+"which isn't affected by the change."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:904
+#: 71052c4fb6434d79a8a2f28f4b752757
+msgid ""
+"If you want to continue using `mod-php`, override the setting by editing "
+"the Apache2 `systemd` unit:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:906
+#: ed3105e267a94a2fa3b6da44b2404739
+msgid "Open the editor:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:912
+#: 9b83c863e76d4a2faeb3e9660b3d7b53
+msgid "Uncomment and edit the following line and save:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:919
+#: 37268c44267548d8a1d08458b472f7a6
+msgid "Restart Apache2:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:925
+#: 16d05d327067405b8ba6f07e19c430b7
+msgid ""
+"See [LP: #2144455](https://bugs.launchpad.net/ubuntu-release-"
+"notes/+bug/2144455) and the [systemd.exec "
+"documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#MemoryDenyWriteExecute=)"
+" for more information."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:936
+#: 0647c22747dd46d8adb80cc7022261be
+msgid "Installer"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:938
+#: 7fdf773adc7948c5812f8c69827c19e7
+msgid ""
+"On systems booting via U-Boot, U-Boot should be updated to the current "
+"Plucky version before installation as subiquity does not run flash-kernel"
+" and grub-update during the installation. So for first boot the device-"
+"tree from U-Boot will be used."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:940
+#: ab271c3db7f64f768cdab4b37a906694
+msgid ""
+"In some situations, it is acceptable to proceed with an offline "
+"installation when the mirror is inaccessible. In this scenario, it is "
+"advised to use:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:947
+#: 1839f016de1e4c0286f55d58e9bc21a3
+msgid ""
+"Network interfaces left unconfigured at install time are assumed to be "
+"configured via dhcp4. If this doesn’t happen (for example, because the "
+"interface is physically not connected) the boot process will block and "
+"wait for a few minutes ([LP: "
+"#2063331](https://bugs.launchpad.net/subiquity/+bug/2063331)). This can "
+"be fixed by removing the extra interfaces from `/etc/netplan/50-cloud-"
+"init.conf` or by marking them as `optional: true`. Cloud-init is disabled"
+" on systems installed from ISO images, so settings will persist."
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:949
+#: 6fb3b2ac3b5c4997a0232121fccb0343
+msgid "Official flavors"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:951
+#: a6c25c8aa9c9473cb6eb7ac113b437d5
+msgid "Find the release notes for the official flavors at the following links:"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:953
+#: 58c97cb2218f47a2b96977c31d6b5eac
+msgid ""
+"[Edubuntu Release Notes](https://discourse.ubuntu.com/t/edubuntu-26-04"
+"-beta-released/)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:954
+#: 302f34561c284c498618671da158b687
+msgid ""
+"[Kubuntu Release "
+"Notes](https://wiki.ubuntu.com/PluckyPuffin/ReleaseNotes/Kubuntu)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:955
+#: 2e82334ee69341aeb1547a6cde6999f5
+msgid "[Lubuntu Release Notes](https://lubuntu.me/lubuntu-25-04-p-p-released/)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:956
+#: 15857e441a7b43c5ac13029b2b7a3237
+msgid ""
+"[Ubuntu Budgie Release Notes](https://ubuntubudgie.org/2025/04/ubuntu-"
+"budgie-25-04-release-notes/)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:957
+#: 9ffe24a10de944ff8cd8266fa5a9a836
+msgid ""
+"[Ubuntu MATE Release Notes](https://ubuntu-mate.org/blog/ubuntu-mate-p-p"
+"-release-notes/)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:958
+#: e4e88af3453d473d9c7d87a86437262a
+msgid ""
+"[Ubuntu Studio Release Notes](https://discourse.ubuntu.com/t/ubuntu-"
+"studio-26.04-release-notes/)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:959
+#: 706505049eaf41c090fc70bed6393be3
+msgid ""
+"[Ubuntu Unity Release Notes](https://ubuntuunity.org/posts/ubuntu-"
+"unity-2504-released/)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:960
+#: dea94dd5c88b41959bd066d208b4aa2f
+msgid ""
+"[Xubuntu Release Notes](https://wiki.xubuntu.org/releases/25.04/release-"
+"notes)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:961
+#: e38a70862bf940a390c3b5e2fe47dcfd
+msgid ""
+"[Ubuntu Kylin Release "
+"Notes](https://ubuntukylin.com/news/ubuntukylin2504-en.html)"
+msgstr ""
+
+#: ../../26.04/changes-since-previous-interim.md:962
+#: 4872ed7379ad4cacb2db1d89404f80b8
+msgid "[Ubuntu Cinnamon Release Notes](https://ubuntucinnamon.org/?p=1348)"
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/26.04/index.po
+++ b/docs/locale/ja/LC_MESSAGES/26.04/index.po
@@ -1,0 +1,164 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../26.04/index.md:17
+msgid "Summary for LTS users"
+msgstr ""
+
+#: ../../26.04/index.md:17
+msgid "Changes since 25.10"
+msgstr ""
+
+#: ../../26.04/index.md:17
+msgid "Release schedule"
+msgstr ""
+
+#: ../../26.04/index.md:6 bcd40810eb1644b09c59608ef38bfa38
+msgid "Ubuntu 26.04 LTS release notes"
+msgstr ""
+
+#: ../../26.04/index.md:8 73c0ce58f3a64747b3f5a82d794fb008
+msgid "23 April 2026"
+msgstr ""
+
+#: ../../26.04/index.md:11 78ac5da426d0470e9cf79339c17885b7
+msgid ""
+"These release notes cover new features and changes in Ubuntu 26.04 LTS "
+"(Resolute Raccoon)."
+msgstr ""
+
+#: ../../26.04/index.md:14 54075724dc074398a651d6a8e4e8f5aa
+#, python-brace-format
+msgid ""
+"Ubuntu 26.04 LTS is currently in development, scheduled to be released in"
+" April 2026. See the {ref}`release schedule <resolute-raccoon-schedule>`."
+msgstr ""
+
+#: ../../26.04/index.md:26 c9d0b3fe2f264c04bead9111a1e278b7
+msgid "Changes since your version of Ubuntu"
+msgstr ""
+
+#: ../../26.04/index.md:28 99e628eb09d04f63b9364572c2b41c65
+msgid ""
+"The majority of Ubuntu users upgrade every two years, following LTS "
+"releases. Other users prefer the more frequent interim releases that come"
+" out every six months."
+msgstr ""
+
+#: ../../26.04/index.md:30 aa2d368f04db4557909a3ba43df414ff
+msgid "Find the news that are relevant to your system:"
+msgstr ""
+
+#: ../../26.04/index.md:38 204bb0744a6946908d33d2ae699f0bb5
+msgid "For Ubuntu LTS users"
+msgstr ""
+
+#: ../../26.04/index.md:40 59873d044de042db96a6a8d4783ed5f7
+msgid ""
+"If you're upgrading **from Ubuntu 24.04 LTS (Noble Numbat)**, read an "
+"overview of the major changes between the two LTS releases."
+msgstr ""
+
+#: ../../26.04/index.md:47 64c438f8cbe74aacadd10979f350cceb
+msgid "For Ubuntu interim users"
+msgstr ""
+
+#: ../../26.04/index.md:49 f4d86c3804b04d928a134e08669a79a1
+msgid ""
+"If you're upgrading **from Ubuntu 25.10 (Questing Quokka)**, read a "
+"detailed list of changes since the previous interim release."
+msgstr ""
+
+#: ../../26.04/index.md:53 da3f0747e671406982b60bcbf5434d5a
+msgid "Upgrading from older releases"
+msgstr ""
+
+#: ../../26.04/index.md:56 4522a53b18464d30943392f479a8bde2
+msgid ""
+"If you're currently using an older Ubuntu LTS or interim release, such as"
+" Ubuntu 22.04 LTS or 25.04, you must first upgrade to either Ubuntu 24.04"
+" LTS or 25.10 before you can proceed to 26.04 LTS."
+msgstr ""
+
+#: ../../26.04/index.md:59 c6a027319d5f4cce85e2b3f98553743b
+msgid "Support lifespan"
+msgstr ""
+
+#: ../../26.04/index.md:61 44369ccf10024e60945f3b77b156e12a
+msgid ""
+"Ubuntu 26.04 LTS is designated as a long-term support release. This means"
+" it will continue to receive security updates and critical bug fixes for "
+"five years. Ubuntu 26.04 LTS will be supported until April 2031."
+msgstr ""
+
+#: ../../26.04/index.md:63 16b1e0ab0e204d9790d4b6e90c71ff4c
+msgid ""
+"With an Ubuntu Pro subscription, access to ESM (Expanded Security "
+"Maintenance) updates will be available for ten years."
+msgstr ""
+
+#: ../../26.04/index.md:65 f47294e40047421187e66c1835ed4826
+#, python-brace-format
+msgid "See our {ref}`release-policy-and-schedule`."
+msgstr ""
+
+#: ../../26.04/index.md:67 3310219115cb4aad84f5a3109b2fc6d3
+msgid "Requirements and compatibility"
+msgstr ""
+
+#: ../../26.04/index.md:69 8ad67e6d4673424ab9bc20aaf1120edb
+msgid ""
+"Ubuntu Desktop 26.04 LTS requires a 2 GHz dual-core processor or better, "
+"a minimum of 6 GB RAM and 25 GB of free storage space for a comfortable "
+"experience."
+msgstr ""
+
+#: ../../26.04/index.md:71 2b9a77bdb3884107bc7cc841c26090f3
+msgid ""
+"Although it's possible to install Ubuntu Desktop on systems with lower "
+"specifications, we recommend using an [Ubuntu "
+"flavor](https://ubuntu.com/desktop/flavors) instead in that case. For "
+"example, you can install [Xubuntu](https://xubuntu.org/) or "
+"[Lubuntu](https://lubuntu.me/) on systems with 2 GB RAM or more."
+msgstr ""
+
+#: ../../26.04/index.md:73 21ed049059b94810844912de9599583d
+msgid ""
+"Requirements for Ubuntu Server 26.04 LTS [scale with your specific use "
+"case](https://ubuntu.com/server/docs/reference/installation/system-"
+"requirements/), starting as low as 1.5 GB RAM and 4 GB of storage space."
+msgstr ""
+
+#: ../../26.04/index.md:75 d216f9439067467cbe240443fbaed041
+msgid ""
+"For ISO-based installs, you will need a USB port or DVD drive for the "
+"installation media. Alternatively, Ubuntu Server is also available as "
+"pre-built images for cloud, virtualized, and bare-metal environments, "
+"which utilize their own deployment mechanisms."
+msgstr ""
+
+#: ../../26.04/index.md:79 22dc8bc9146640d58d6dec0ce1b6f743
+msgid ""
+"While an internet connection is recommended for updates and additional "
+"software, it is not required for the initial installation."
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/26.04/schedule.po
+++ b/docs/locale/ja/LC_MESSAGES/26.04/schedule.po
@@ -1,0 +1,592 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../26.04/schedule.md:2 1c5d8d7be26d4b558b801e16b516720b
+msgid "Ubuntu Resolute Raccoon Release Schedule"
+msgstr ""
+
+#: ../../26.04/schedule.md:9 0010cee823cc43e9a9f90fde6ca24b4a
+msgid "**木 19th  2月 2026**"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 ../../26.04/schedule.md:11
+#: 203c03f9838f4fe7b1f87904058a6f44 fc72ea6dca1945b99fc322456f019c9a
+msgid ""
+"[Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), Debian Import "
+"Freeze"
+msgstr ""
+
+#: ../../26.04/schedule.md:9 bd4e3bc28b6a487b8ef61dc86039496a
+msgid "**木 26th  3月 2026**"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 ../../26.04/schedule.md:11
+#: 11b15dc16a634b7b89d15974b5946afb 9b0b5bc20a594917bb6e43e143060e06
+msgid "Beta (mandatory)"
+msgstr ""
+
+#: ../../26.04/schedule.md:9 4da22e7ec6a549e693d88dad1380107e
+msgid "**木 23rd  4月 2026**"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 ../../26.04/schedule.md:11
+#: 56b7b8b4eef9495b9580e910e0913503 9fb51d06d63345bf85f41c5ad21adb79
+msgid "[Final Release](https://wiki.ubuntu.com/FinalRelease)"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 25c7acd802284720ac99ec9a4b89a487
+#: e17b8989da054fc5ac68f6048052fed9
+msgid "Week"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 dca2d98bc0474478a82a8abff47a15d9
+#: f5b499706bdf405e9a3327ab9f0ed346
+msgid "Date (Thursday)"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 323fbb84e82140a5935f5655f66c2ec7
+msgid "26.04 events"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 1e5baeab9fee495c9d8f57276f99bdee
+#: f7a3bd28daed4a6197e2e0df5905ef0e
+msgid "**October 2025**"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 99bba6f2baa44df595f81d137793e24f
+#: afbf787eca504b668bf3dd1b04cfcebc
+msgid "1"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 28006431ba054796b37772fed4e05ce0
+#: bb962610f6d04d6684ee7d5a882fe155
+msgid "October 16"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 39777d2b6f4a4af49ef6df1f101a5254
+msgid "Toolchain Uploaded"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 cc4b24060b014d64b9d09718da147e14
+#: fa7d5aeaa4054723b2d0ea2eb711b734
+msgid "2"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 b1e1bd5e8d524ad2a6c1fc8c790764a5
+#: c06456526d2f4f6bb7b5774bfb8623e2
+msgid "October 23"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 33fcfb1f4ca14829a7e81ae52b1e8fa0
+#: a3bd96213f28447fb1c259faba535957
+msgid "3"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 20b14fbd92374f3a880172083eb289e6
+#: 349bb51715734205ad8218b8e2922cee
+msgid "October 30"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 c85b3dae674c40d5b43a07db021a2cd8
+#: fceeb7028d8e45aa81a17e5dd33e3ba6
+msgid "**November 2025**"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 b6694490238942a1b78c39e17094f63a
+#: f442d0788f874e52a49e58d6d2f3222d
+msgid "4"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 2baa2fa38cde4a53a600e4e791e5c96f
+#: c3945536680f4f28a4d8aa68a318df0e
+msgid "November 06"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 5c26dbc4a88b449b899f810e73cdc86f
+#: a1888b586f634752ab6c541254c5a2f5
+msgid "5"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 ad7b38f086014e2c950e2f2ff1fc851f
+#: bd62a8a85a084c3db228d648b08a1359
+msgid "November 13"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 887384c109a7443cb1921fba754e3b87
+#: c0c7dd437a1940ef9497eeed72967b55
+msgid "6"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 96382fabeebb4d4b979c6fd5e24d921d
+#: a93f95510dc64c688575133b6c3e65aa
+msgid "November 20"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 64542b8da2064badb62d222ea7de035c
+#: 74c67de99e7840d29cb494fb5583b7e9
+msgid "7"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 5e8080fd0f104a7db387ab5a633c1e25
+#: e8de1dcd8ccd424795a7bc76150ab0b8
+msgid "November 27"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 e82f7d689dc941ce8d9258ec8e1b177b
+msgid "Resolute Snapshot 1"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 cfa24fd7a87d4c5194ebb57c5fdc3134
+#: ed2bf5ad350c4f678a45cbdcc8531dc2
+msgid "**December 2025**"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 1ef04bc2746d43e483f86f441dff1a6f
+#: 8d22566ab9d247e0925d71de1b48d5a9
+msgid "8"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 774e1eed63804bb6bced384cb456e554
+#: b7c0949ad88f47beaea34400601a48e2
+msgid "December 04"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 1badd7e029714cb7848c1c8951703a38
+#: ba259b3730444a2db3b14023819eec92
+msgid "9"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 28ab623d08e64c7b9b45832488789739
+#: f7eb26c59bba41b08a057b9bdd94ac52
+msgid "December 11"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 ae1afa25ad4e4a0392876012f58a0fe1
+msgid "Resolute Snapshot 2"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 14e37b343edc48a5b373d51b26d56602
+#: 5566d37f82634556b48f0cf3f15e7d42
+msgid "10"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 a1b3173ec4004b2db971ab0125b6d768
+#: cacef1dfde70433ea96885ea8bfa46fa
+msgid "December 18"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 54c690e252af4e4dbb7961bd7d6455d8
+#: af2cbccc1ba949958c3fee9269d8eeea
+msgid "11"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 a9ef7505d0884e0a954d1ad884c670ba
+#: daaf8673f40f4f6d97a206313976a187
+msgid "December 25"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 5d9097f64ee846c89a306a9d286ed7a3
+#: 9ac706ac244a4a4a86bc72b9d9256ef9
+msgid "**January 2026**"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 4127b7162ec843b28d52bfcddc275208
+#: badb4a64db69481a9893596a73b2689a
+msgid "12"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 74971b249f59436b845c6e8c4dd39d26
+#: bb3db14153a44fe3add2c551d20d1c81
+msgid "January 01"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 332ebb430acc4ff89dbde5c43494c4cf
+#: ec51be7a8934460a893bffea76d1564d
+msgid "13"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 12cebc51534f4776b7db8ae251b71737
+#: 3cd96964786b4bbda6ec1ac9f085552f
+msgid "January 08"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 53fbc5cb0c0e433e8f95ef310548d0c1
+#: 60fd62964f1c4001ac2a1033f00ca20d
+msgid "14"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 12b2a7f07b8b49dc8a4d4a2707d67a64
+#: af4c86279d5b42409f5840bd036c07b9
+msgid "January 15"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 5aee6335354345a38fd40300355a0f85
+#: 6c7ce93821804748b641ac29ea08e8cf
+msgid "15"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 cc5eca456a734da5a50b13e7faf38164
+#: de9f3fe525e24b40ba16c813be74d865
+msgid "January 22"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 a4ffe48c6146437084e27f368b35508b
+#: f19c3ee7c57d482a882d482bb7ca1e88
+msgid "16"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 1f568657bf284e24a39bd26276da2254
+#: c24d920715524cb98ddbcb1e253fd51a
+msgid "January 29"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 2d9de4446db34abc8a99cf5662bcda24
+msgid "Resolute Snapshot 3"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 0398b8e386494cc8a75c2e92dd31296f
+#: f79962b5935d474187bfafa6ac46fc70
+msgid "**February 2026**"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 3c2c42051d224a1c8d6210f5faa431d1
+#: 7d03cb4969084177b6b562b2d0544e32
+msgid "17"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 7d26bb218b83427c8c454fbc010ab895
+#: ca4cd52cc8804483a3d44cdc63602ba6
+msgid "February 05"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 08c66932bbab46c2b3a421c18c1d2705
+#: 8cbda6da21374bc4ae641bd384888751
+msgid "18"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 3319ecfb8ea24a98b705b68a8944e107
+#: ea15a83f8d0a4b3aadf0e20bee664484
+msgid "February 12"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 59aa16b5f7174af5bbeb5e44a16a94ef
+#: a4134ad69b024d8ea9cbb60ac4dec79d
+msgid "19"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 2a371ac9c3fe4a5eae47489e7d8786de
+#: 44b23669456d4ecea8f61461dc569260
+msgid "February 19"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 436e9e4311bf46dcb7263fcc1e780914
+#: 85d675815a554ec7ad44676b7aa6c29d
+msgid "20"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 2c00ad010dc14ca0ad6234a47be6882c
+#: 2d6bafc3c7e2431fa5a8c16083fc1e4a
+msgid "February 26"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 000ebce70bca4d9c931d435a283f80e3
+msgid "Resolute Snapshot 4"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 5729e3d58df54753b31184e72d432634
+#: 8a3d54b4af5c4d0b8415264ea4a35f04
+msgid "**March 2026**"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 0abe9fbfbe0f4a4ba8e1ffa01c6ba0f9
+#: ffde4c39a51a48d8949ad6a1e4d11289
+msgid "21"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 ad15018054c44372940679aaa677b9fa
+#: c3df2af0b8054eeb86d6423c23d5eaba
+msgid "March 05"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 452b912c13a14617842ebbd9581b6431
+#: 5d29a5b29ee840bc9870da27a3023c0d
+msgid "22"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 213e6a31d9934e559aceba469bd6f5c3
+#: db9ad55cfc5b4855b40734ffe315c575
+msgid "March 12"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 7c896c84fe4e4c708b7941d27c2f5b2e
+msgid "[User Interface Freeze](https://wiki.ubuntu.com/UserInterfaceFreeze)"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 090c0da64ca543428045ba66ee7a9a48
+#: 8660042aec8345fd88bb00a8da99129f
+msgid "23"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 20ecc83ab34b4a3daf4cc6dd6efea3ad
+#: e48ab23a8ef545d7a2c104652f78f0ea
+msgid "March 19"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 432e2914a62f4dab950bec015cb585b3
+msgid ""
+"[Documentation String "
+"Freeze](https://wiki.ubuntu.com/DocumentationStringFreeze), [Kernel "
+"Feature Freeze](https://wiki.ubuntu.com/KernelFeatureFreeze)"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 1199b4309379499a8f420c1695e65f3e
+#: 5b89206d76594d458bb42f6d8757c96c
+msgid "24"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 51ab4bc356c04e3d9d310a0da13ebf79
+msgid "March 23 (Monday)"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 0860a5c892134f78b1aa5a354954de7c
+msgid ""
+"[Beta Freeze](https://wiki.ubuntu.com/BetaFreeze), [Hardware Enablement "
+"Freeze](https://wiki.ubuntu.com/HardwareEnablementFreeze), ISO Testing "
+"Week (mandatory)"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 524041c51c9c4e0b85d80785d7c44e9e
+msgid "⠀"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 22315c01f1d14a52a8e761ff9ae1b0bc
+#: 70641259719942ab833300d54be1d1ac
+msgid "March 26"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 8bb8a811ef764db2a89b263f00b215ad
+#: c7b554a884194b8695140a83b92caf6e
+msgid "**April 2026**"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 ba3c4bbedf204ff28aa923b7fc795cd3
+#: c2f09c5cbb2d4a57902ed13afb26543b
+msgid "25"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 91022633114a45cb82e9694071f89de5
+#: bb8e55a474c14c2fb35ec4f9e9d5ed4a
+msgid "April 02"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 7c3a79d3e4d94e3dbbe2aa33317fefde
+#: d30a790de93345a78c7168f4d42a8bb7
+msgid "26"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 ca5dd4886c154750aa50a54e825c0c50
+#: f8c17aebb51b4011a8f238c4bc94ef99
+msgid "April 09"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 ac9dc4ffa8ac4a50826914e9a7539cb1
+msgid ""
+"[Kernel Freeze](https://wiki.ubuntu.com/KernelFreeze), [Non Language Pack"
+" Translation "
+"Deadline](https://wiki.ubuntu.com/NonLanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 24175bac70784359a8605794186aed30
+#: ea8df0d738434d45878e203e8a269556
+msgid "27"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 03cffdf74ab04fa5bfed2f62c2a6ddec
+#: 6a72b0b41172403384628d9645937c01
+msgid "April 16"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 13e6a34fbac8494ab90dcf0c5dd0e9f1
+msgid ""
+"[Final Freeze](https://wiki.ubuntu.com/FinalFreeze), [Release "
+"Candidate](https://wiki.ubuntu.com/ReleaseCandidate), [Language Pack "
+"Translation "
+"Deadline](https://wiki.ubuntu.com/LanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 5d9ed68488f34c0ea44806f9077c4b80
+#: da1ac3e955cb46d5948b180a24aa5403
+msgid "28"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 4a56ad641b3244c1924fd68885874fa0
+#: 90f4c8acc61c4a3c82d140987db1536e
+msgid "April 23"
+msgstr ""
+
+#: ../../26.04/schedule.md:61 6a2bf840522245bb9279ff680c4bd856
+msgid "Planned and potentially disruptive archive-wide activities"
+msgstr ""
+
+#: ../../26.04/schedule.md:63 3716912569aa44fea84fc3257b9490e9
+msgid ""
+"If you’re planning a change that might have a disruptive effect on the "
+"archive - e.g. transitions or switches of important defaults (such as "
+"compiler versions) - list it here."
+msgstr ""
+
+#: ../../26.04/schedule.md:6 4d50499ccd2c4dfebc899f8a8a2671eb
+msgid "Planned activity"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 7bc0555dd5ce4d62a4896b52ca379b43
+msgid "Python 3.14 as a supported version"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 9ad5a8d3576d4ac29e485c38a34b940b
+msgid "enable autosync from Debian"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 b370d7a3ec7f495897851acd2f954139
+msgid "Golang 1.25 transition"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 677b3865b40b417897d94e2d649443a2
+msgid "binutils 2.46"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 f1274d7eb2874334ac3f0f2f595e7217
+msgid "GNOME 50 alpha"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 297625fd2a5b461aa0b583e162b2fb61
+msgid "Python 3.14 as the default version"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 41dfb0bd2cab4b2183e5279fd2529ec4
+msgid "PHP 8.5"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 99d8b0ed752147dfac76467888ce17db
+msgid "GNOME 50 beta"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 bc976f0f64f04c4e951384bc879906ce
+msgid ""
+"GCC 16 as optional, Rust 1.93 transition (tentative), Java 25 default "
+"(tentative)"
+msgstr ""
+
+#: ../../26.04/schedule.md:103 53b961a91d1c48e4a462efa430f125df
+msgid "Ubuntu Resolute Raccoon Release Task Signup Sheet"
+msgstr ""
+
+#: ../../26.04/schedule.md:105 53e1f05264f342e8ab5ddd1d6f90abae
+msgid "This signup sheet is to be used for planning release milestone tasks."
+msgstr ""
+
+#: ../../26.04/schedule.md:107 d7bbd2138d6b46e7a32b5b6c8755213d
+msgid ""
+"The Alpha and Beta 1 milestones have been replaced with [Testing "
+"Weeks](https://lists.ubuntu.com/archives/ubuntu-"
+"release/2018-April/004434.html), which are organized ad hoc at this "
+"point."
+msgstr ""
+
+#: ../../26.04/schedule.md:6 8d247e0a81994f8c8536fa2655f2f8f4
+msgid "Milestone"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 a9b2437f0b364dc4aadd0815a304120a
+msgid "Date"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 2041a3b7c41e4f62a104af83d2c6bd7f
+msgid "Image (Nusakan) Engineering"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 e69b2699bab3413f8dac760c7e3f3577
+msgid "Checklist Tracking"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 2ec0b90f14e94df781a9e9e59cea9a36
+msgid "Announcement Email"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 f5f77bac23ef46f59313dad9653731a8
+msgid "Feature Freeze"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 0c6f3433bcc2471d937ab65437d5dd97
+#: 12c319bec58e4ec8bf7e33ff1e9aa2aa 2a948d4de0264dfc84a9b2b852abda4e
+#: 3be4949cd9304038a000700f095c9867 8f0ab6c408f141e0bfbd3e74376d771f
+#: af57642130f244cdbeab3d6871adbeee
+msgid "n/a"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 84c50fce80e74107a50bb97160efc1a3
+#: 8eace1a9135742cd96f9a7029ffebf93 a06b979a07fe4a7fbf0c779ae4249ea0
+#: b7cb787227164c63947242e6eabd325f e4118614949c45eb9c1f96804937fa8a
+#: ea43f3355684468bbe62ac4bc3d28ba0
+msgid "@utkarsh"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 cbe9fed560bc41d093dee6b2dfee32a5
+msgid "UI Freeze"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 cd8ae2f26e4a4799b2a508a712aed53f
+msgid "Doc String Freeze"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 96b17d508e5b47bd80462147988da26d
+msgid "26.04 Beta"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 6f097da61df842218d725db591aa1087
+msgid "26.04 Release"
+msgstr ""
+
+#: ../../26.04/schedule.md:6 58fc54637c574223b3f12fe625e3837c
+msgid "April 23 2026"
+msgstr ""
+
+#: ../../26.04/schedule.md:117 8f4da0c67b6a4f018fd9d84ada49e302
+msgid ""
+"When the archive is frozen, all members of the release team are expected "
+"to participate in bug fix reviews."
+msgstr ""
+
+#: ../../26.04/schedule.md:119 12b04e19feec48e389d49fefcabd3748
+msgid ""
+"After [Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), all "
+"members of the release team are expected to participate in Feature Freeze"
+" Exception reviews in their particular area of expertise."
+msgstr ""
+
+#: ../../26.04/schedule.md:121 65cb8ecdad9640a294b125ad4210e9b5
+msgid ""
+"After [Final Beta](https://wiki.ubuntu.com/FinalBetaRelease), all members"
+" of the release team are expected to participate in Bug fix reviews in "
+"their particular area of expertise."
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/26.04/summary-for-lts-users.po
+++ b/docs/locale/ja/LC_MESSAGES/26.04/summary-for-lts-users.po
@@ -1,0 +1,2064 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../26.04/summary-for-lts-users.md:6 47f7bbe8f6b24a8a90d85c0813e50936
+msgid "Ubuntu 26.04 LTS summary"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:8 41f1ff562c12455bb2b2392c9a52ffd7
+msgid ""
+"If you’re upgrading **from Ubuntu 24.04 LTS (Noble Numbat)**, you receive"
+" the changes that happened in all the interim releases between Ubuntu "
+"24.04 LTS and 26.04 LTS, as well as the most recent changes since Ubuntu "
+"25.10."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:10 6fffb859297e43c1af337b61a6a6396f
+#, python-brace-format
+msgid ""
+"For details, see the complete interim release notes: {ref}`24.10 "
+"<ubuntu-24.10-release-notes>`, {ref}`25.04 <ubuntu-25.04-release-notes>` "
+"and {ref}`25.10 <ubuntu-25.10-release-notes>`. Finally, review the latest"
+" {ref}`ubuntu-26.04-lts-changes-since-25.10`."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:12 957523735670415599db1b5f89ee4999
+msgid "The following is an overview of the major changes."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:14 5da9bdfd5291489391558767e8fb4a70
+msgid "Desktop"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:16 dadab1b4099b4ecfa6e4f489eb2d5cca
+msgid "Updated applications"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:18 34cd928eb7664bce8f36391b9e7c7207
+msgid ""
+"Firefox 🔥🦊 has been updated [to version 149](https://www.firefox.com/en-"
+"US/firefox/148.0/releasenotes/) / [150](https://www.firefox.com/en-"
+"US/firefox/148.0/releasenotes/)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:19 2c2e6955968d48d9859b4d7dd917c98c
+msgid ""
+"LibreOffice 📚 has been updated from version 24.2 [to "
+"25.8](https://wiki.documentfoundation.org/ReleaseNotes/25.8)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:20 67d33c4762fe494ea08c4662fe93f750
+msgid ""
+"Thunderbird 🌩️🐦 has been updated [to version 140 "
+"\"Eclipse\"](https://blog.thunderbird.net/2025/07/welcome-to-"
+"thunderbird-140-eclipse/)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:21 54673e4f67e4416899743f7784b88186
+msgid ""
+"GNU Image Manipulation Program 🖼️ has received a major update from "
+"version 2.10 [to "
+"3.0](https://www.gimp.org/news/2025/03/16/gimp-3-0-released/)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:23 340498dc81c44bbbb6be876b874299fd
+msgid "GNOME 50"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:25 c1029c72f70a411eb782177d54a6cd77
+msgid ""
+"The GNOME desktop environment has been updated from version 46 to 50. "
+"Major highlights:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:27 d20125b74989436296b34c9ec802c3e8
+#, python-brace-format
+msgid ""
+"You can now set an application to start automatically after login in "
+"{menuselection}`Settings --> Apps`."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:28 21560493283b4448865e24e343204fd5
+msgid "Fractional scaling factors are now optimized so as to minimize blur."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:29 0870a7a767e44c548f1f9aefc96664c4
+msgid ""
+"The default monospace font size has been reduced to match the default "
+"user interface font size. The monospace font is used in terminals and "
+"similar applications."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:30 534c45e026244249bb5074b916d998bc
+msgid ""
+"The [Sysprof](https://apps.gnome.org/Sysprof/) app is installed by "
+"default as a new system utility. This makes it easier to discover "
+"performance issues in your apps."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:35 7cdebc62968c4d3f9473dffe94041b64
+msgid ""
+"For details, see the upstream release notes: [GNOME "
+"47](https://release.gnome.org/47/), [GNOME "
+"48](https://release.gnome.org/48/), [GNOME "
+"49](https://release.gnome.org/49/) and [GNOME "
+"50](https://release.gnome.org/50/)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:37 542dbab2c65e4bbebbd95aa1c4db4af5
+msgid "New document viewer"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:41 314f53f2b6684fd092f32f2edb0f66b5
+msgid ""
+"The Document Viewer app for viewing PDFs is now provided by Papers "
+"instead of Evince. Papers started with the Evince codebase but it has "
+"been updated to use GTK4 and partially rewritten in Rust."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:43 c936d370ed0e4d9eafcc99f54742cfad
+msgid "New image viewer"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:47 48e4a541b11849af9debc261d65efa5f
+msgid ""
+"The Image Viewer app is now provided by "
+"[Loupe](https://apps.gnome.org/Loupe/) instead of Eye of GNOME (EOG). "
+"Loupe is written in Rust and powered by the "
+"[Glycin](https://gitlab.gnome.org/GNOME/glycin) library."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:49 6ff097682f3946d0908ab918494d4e02
+msgid "New terminal emulator"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:53 5b421510d3ea41d3b35736794cc3b678
+msgid ""
+"The Terminal app is now provided by "
+"[Ptyxis](https://gitlab.gnome.org/chergert/ptyxis/-/blob/main/README.md?ref_type=heads)"
+" instead of GNOME Terminal."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:55 4ac2bf384d08409f8a2447fce44f892c
+msgid "New default video player"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:57 2779aebcb93847599a5c21e378056c30
+msgid ""
+"The default video player is now "
+"[Showtime](https://apps.gnome.org/Showtime/), replacing Totem."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:59 139c1b19b0354c81a510cabbf37e0f34
+msgid "New video and audio thumbnailers"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:61 eba9db04b9194432abd5d54093d4759d
+msgid ""
+"Previously, video and audio thumbnails were generated by the Totem video "
+"thumbnailer. Now, the [`gst-thumbnailers`](https://salsa.debian.org"
+"/gnome-team/gst-thumbnailers) project handles the same functionality."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:63 8daca7218a6c4ab287eca2b3481a7ad1
+msgid ""
+"The new thumbnailers are written using the Rust GStreamer bindings and "
+"rely on the [Glycin](https://gitlab.gnome.org/GNOME/glycin) library for "
+"image handling. They do a better job at finding \"interesting\" frames "
+"than the previous Totem thumbnailers."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:65 5be9d62ec7784acc9f1dfeabc2f33570
+msgid "Tracker Miners updated to LocalSearch"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:67 310e87f0f77a4bafbbea6db685747310
+msgid ""
+"The Tracker Miners indexer has been renamed to LocalSearch. See the "
+"[upstream announcement](https://blogs.gnome.org/carlosg/2024/07/14"
+"/goodbye-tracker-hello-tinysparql-and-localsearch/). Ubuntu 26.04 LTS "
+"ships a substantial update of this tool from version 3.8.2 to 3.11."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:69 9f2a1d63a02b4e6ca6c7b741ce29bf2b
+#, python-brace-format
+msgid ""
+"For LocalSearch to be able to index audio files, video files, ISO files "
+"and certain zip-compressed office files, you need to select "
+"{guilabel}`Install third-party software for graphics and Wi-Fi hardware "
+"and additional media formats` during the Ubuntu installation. You can "
+"also install the extractors manually after installation with the "
+"following command:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:75 902b57318b1f4639b3dd1d8537f99df8
+msgid "Wayland session"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:79 9c16726fcad0422eb96e96646117d665
+msgid ""
+"The *Ubuntu Desktop* session now runs only on the Wayland back end, "
+"because GNOME Shell can [no longer run as an X\\.org "
+"session](https://discourse.ubuntu.com/t/ubuntu-25-10-drops-support-for-"
+"gnome-on-xorg/62538)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:81 d8427af7c73644259fa1c10d3532779f
+msgid ""
+"You can still run applications developed for X\\.org through the XWayland"
+" compatibility layer."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:83 0f82375e7f954f49a9e6b4a8b9445c74
+msgid ""
+"Other desktop sessions, such as [KDE on X11](https://kde.org/), "
+"[Xfce](https://www.xfce.org/), [MATE](https://mate-desktop.org/), "
+"[`i3`](https://i3wm.org/) and many others, can still be launched using an"
+" X\\.org session."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:85 198da4ffb9524866926392addb2fa414
+msgid "Machines using Nvidia graphics now fully support Wayland."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:87 8c22f59b719e4d9a95e8ce54050ebc3e
+msgid "Software & Updates app"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:89 55b4cbdfd5654486b502cf69371a44e4
+msgid ""
+"Ubuntu Desktop no longer includes the Software & Updates settings app by "
+"default. For more details, see [the Discourse "
+"announcement](https://discourse.ubuntu.com/t/why-we-re-saying-goodbye-to-"
+"software-updates/76783)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:91 7b3a2ed67bb640b5ae076edc0eca8cba
+msgid ""
+"The app is still available in the Ubuntu repository and it's been updated"
+" to use the GTK 4 toolkit."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:93 bb0c5affe15b448bb7e42720924851a0
+msgid "You can install the app manually with the following command:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:99 fd17785624284539a0a17c3f2fcd1841
+msgid "App Center enhancements"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:103 f169bbe48f6f471ca07d6082f8a6ec29
+msgid "The App Center now includes improvements, including:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:105 f348c10b093740328c7eb612a0c8c744
+msgid "Installs in progress"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:106 92e4188ebed345caac6ad97eec271341
+msgid "Improved self-update handling"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:107 fd03b1a7d9b3401cb2b8a6a6fa875958
+msgid "Messaging for running snaps"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:108 4b4536dfea31442ab06cd7baaaaa3911
+msgid "Direct uninstall of snaps from the manage page"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:109 2cb283612bb9409d84bf16d03169b997
+msgid "Scrolling support for touch screens"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:110 7a93e0a6cd4d47a1bb7d570b76c0abf8
+msgid "Third party Deb installation"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:112 59e326c5081b46a8aca84a7ecd696125
+msgid "Security Center"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:116 b9bb4404a4a64c368e2ce8cc316c31fc
+msgid ""
+"A new Security Center is included. It features the ability to easily "
+"enable or disable a new experimental [permissions "
+"prompting](https://discourse.ubuntu.com/t/ubuntu-desktop-s-24-10-dev-"
+"cycle-part-5-introducing-permissions-prompting/47963/1) feature for Home "
+"directory permissions."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:118 3d1c1cdec5984298803df06faeb7adc9
+msgid "Permission prompting"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:122 8573cee603e74b338eeb1c0c1228bfa6
+msgid ""
+"Prompting is also supported by an additional seeded snap, `prompting-"
+"client`, for permissions prompt handling."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:124 cf7af1863d8e4d34ad750cd1ae910d69
+msgid "Better power optimization"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:128 2a9d4e366b6f4c209726ab1b523414b0
+msgid ""
+"Power Profiles Manager [has been improved and "
+"optimized](https://gitlab.freedesktop.org/upower/power-profiles-"
+"daemon/-/releases/#0.23) to support better newer hardware features "
+"(especially AMD), can now support multiple optimization drivers and is "
+"now battery-aware to automatically increase the optimization levels when "
+"running on battery only."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:130 13e1d3d899a84c3db58b6a990f3c8851
+msgid "Performance improvements in Windows games"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:134 a3f2abdf33004ed892f39c97b74b319f
+msgid ""
+"A new NTSYNC driver that emulates WinNT sync primitives is available, "
+"delivering better performance potential for Windows games running on Wine"
+" and Proton (Steam Play)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:136 86e08bfb33e842a39ba94632385b82c2
+msgid "New ARM64 Desktop image"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:140 3479f6ad0b6b44cc9654faabcbff0450
+msgid ""
+"There is now an official generic ARM64 Desktop ISO targeting VMs, ACPI + "
+"EFI platforms and Snapdragon based WoA devices."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:142 663bb84f7cb94aef90bd5930f3cafea5
+msgid ""
+"Initial hardware enablement work for the Snapdragon X Elite platform is "
+"included in the Desktop ISO."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:144 d924533f7b57456f9b84636657e2e69b
+msgid "Dual boot enhancements"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:148 e5ad98e446604269a261e441e476a2be
+msgid ""
+"Improved dual boot user experience, with a focus on BitLocker protected "
+"Windows systems:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:150 1f17f4bf0a224a5ebaee6eaca58cf576
+msgid ""
+"Added the option to install Ubuntu alongside existing BitLocker "
+"partitions if enough unallocated  space (or a sufficiently large and "
+"resizable partition) is available"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:151 2847fbc5ba784e73b14dd535c2cf1fa6
+msgid ""
+"Made encrypted installations and other 'advanced options' available for "
+"dual boot scenarios"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:153 097cfe308b8549f5a0762ee6d9d88799
+msgid "JPEG XL support"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:157 60853b1352414ecd84cbf8c1c504e7ee
+msgid ""
+"The JPEG XL format is now supported without needing to install any "
+"additional packages"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:159 bd1692f0ce0042a3b0160f0d8a8fb07f
+msgid "VA-API accelerated video encoding and decoding by default"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:161 589f781b588c4a54a19c94638d8507e1
+msgid ""
+"By default, hardware-accelerated video encoding and decoding are now "
+"provided for AMD and Intel users via the Video Acceleration API (VA-API)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:163 7160c0d6526d4c7a94ecb5bf115beb5d
+msgid "Updated optional media codecs"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:167 9e21b63c74f44c38979d84ab0d7bdb22
+msgid ""
+"The additional packages that you can enable during the Ubuntu "
+"installation have been updated. The updated package set now includes the "
+"non-free AAC codec for supported Bluetooth headsets."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:169 3e178e7574dd437ca655868a55bfe569
+#, python-brace-format
+msgid ""
+"To install these codecs, select {guilabel}`Install third-party software "
+"for graphics and Wi-Fi hardware and additional media formats` in the "
+"Ubuntu installer."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:171 705cd13b64eb4effb57cf942fa09a029
+msgid "New update notifications"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:175 bea54ce39c1f4e80a62da96dbf9f1695
+msgid ""
+"When system updates are available, the Software Updater window no longer "
+"pops up unprompted, stealing the keyboard focus. Instead, a notification "
+"shows up with options to open the Software Updater or to install all "
+"updates directly."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:177 cc49617a9c994678969036d620ed9bf6
+msgid ""
+"An icon in the system tray reminds you that updates are available even "
+"after dismissing the notification. It also provides a quick way to apply "
+"all the updates or inspect them in the Software Updater."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:179 f363d9d21d794f62b201557ce2e1b6dd
+msgid "Installer accessibility"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:183 fb7e20449a3246009c5a07f636943361
+msgid ""
+"The Ubuntu installer has received plenty of accessibility fixes for "
+"screen reader users."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:185 3fa6735ee1374730bf10969e840d7ac2
+msgid "Ubuntu Insights"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:189 7d6bd168280c49af8cd947df0d0940c7
+msgid ""
+"[Ubuntu Insights](https://github.com/ubuntu/ubuntu-insights) is being "
+"developed as a replacement for [Ubuntu Report](https://github.com/ubuntu"
+"/ubuntu-report) and gives you more control over the non-personally "
+"identifying system metrics that you choose to share with Canonical. The "
+"metrics collection is opt-in."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:192 29d6bc9d70654ae7839e12005008678c
+msgid ""
+"Any consent that you previously granted to Ubuntu Report will not be "
+"carried over to Ubuntu Insights."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:196 62dc1dfa01bf44799b04c04d7f789a8e
+msgid "Server"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:199 69e79b9d7990459fb1a0856d586f0c54
+msgid "OpenSSH"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:201 a29b6c1029854b4b8969eff1e26e13a1
+msgid ""
+"The upgrade from Ubuntu 24.04 LTS, which had OpenSSH 1:9.6p1, to OpenSSH "
+"1:10.2p1 includes major changes. Note the following:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:203 f00e9a6d256b4d24a608bb7296e99807
+msgid "Deprecation warning for SHA1 SSHFP DNS records"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:204 229ac815f78d497aa5b8c6b264284a1e
+msgid ""
+"Add a warning when the connection negotiates a non-post quantum key "
+"agreement algorithm."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:205 766ec4a98e334a9f8948314a79f9f693
+msgid "Removes support for the weak DSA signature algorithm."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:206 bf5e1b496b174fae9ec5e9ca101baae1
+msgid ""
+"New `PerSourcePenalties` option that will penalise client addresses that "
+"for some reason do not complete authentication. New in version 9.8."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:207 d296a0bdc61a4fbe8de7fcb1498a68f1
+msgid ""
+"Support for a new hybrid post-quantum key exchange algorithm, called "
+"“mlkem768x25519-sha256”. Described in "
+"https://datatracker.ietf.org/doc/html/draft-kampanakis-curdle-ssh-pq-"
+"ke-03, it’s available by default. New in version 9.8."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:208 b5106a42db8f44259a564b3d1ce9df32
+msgid ""
+"New match option invalid-user, which can be used when the target username"
+" is not valid"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:209 044b4dbfa6774375bbbd5f570d095bfa
+msgid ""
+"New `sshd.service` alias to `ssh.service`. Both names can now be used in "
+"`systemctl` commands."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:210 5043b9ee7b38418e892cab49bcf593cb
+msgid ""
+"New binary packages called `openssh-client-gssapi` and `openssh-server-"
+"gssapi`. This is in preparation for a future split of the GSSAPI "
+"authentication mechanism into separate packages in the near future. For "
+"now, they just pull in their non-gssapi counterparts, if installed. See "
+"https://lists.debian.org/debian-devel/2024/04/msg00044.html for the "
+"detailed plan."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:211 90f1b9c7f975490da68091ec9959a69d
+msgid "Host DSA keys are no longer generated."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:212 f129ebdfe4f94502851916aadfc581e6
+msgid ""
+"Starting with 1:9.6p1-3ubuntu17, openssh server no longer reads "
+"`~/.pam_environment` of the target system upon login. See [LP: "
+"#2059859](https://bugs.launchpad.net/ubuntu/+source/openssh/+bug/2059859/)"
+" for details."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:214 1908bac3ba8f446da997ebbcbf5174d1
+msgid ""
+"For full upstream release notes for all releases, please consult "
+"https://www.openssh.org/releasenotes.html"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:216 0259fbd69c504041a1876b0bb3403824
+msgid "Chrony"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:218 3abc387de5d34585a082e6b3570f3109
+msgid ""
+"Chrony is now used as the default time daemon replacing `systemd-"
+"timesyncd` for new installations."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:220 2af0fa1a9b2440a7b4cafc88015c8209
+msgid ""
+"To migrate existing systems after the upgrade to Ubuntu 26.04 LTS, use "
+"the following commands:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:227 560800a7c1c14a9abbc67ffe75f3d355
+msgid "NTS (authenticated & encrypted NTP) by default uses Ubuntu time servers."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:229 2631a2ec4add48a59f58ec7a72cb4e81
+msgid ""
+"Ubuntu's NTP servers are defined in a [new "
+"snippet](https://discourse.ubuntu.com/t/improving-chrony-time-source-"
+"configuration-in-ubuntu/47850) in `/etc/chrony/sources.d/ubuntu-ntp-"
+"pools.sources`."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:231 0d5ed7a46dbd4a82aea42ba20fd80d72
+msgid ""
+"If you edited `/etc/chrony/chrony.conf`, ensure that the servers defined "
+"in `/etc/chrony/sources.d/ubuntu-ntp-pools.sources` are not used twice."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:233 c4c7a009af4d4f8f8249347d2d875bfd
+msgid ""
+"Specific release notes since Chrony version 4.5, which was found in "
+"Ubuntu 24.04 LTS, are at <https://chrony-"
+"project.org/news.html#_27_aug_2025_chrony_4_8_released>."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:235 1952c665109c4228bc2f93efd5238732
+msgid "ClamAV"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:237 468d4b005f5f4298a5f853a077c01c98
+msgid "Updated to 1.4.3 with many new features"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:239 ba054538338a4dbd8942102513c4c65c
+msgid "Scanning attachments found in Microsoft OneNote section files"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:240 5dd6c0ffe11c44849240c7e1004aa16f
+msgid "Extracting Universal Disk Format (UDF) partitions"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:241 8911525a5f53479198385a3f4980b864
+msgid "Extracting embedded images in HTML CSS `<style>` blocks"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:242 96052857ff1d475da0be6321a759f10b
+msgid "Extracting `alz` and `lha`/`lzh` archives"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:243 94f2bcdc2261434eaacfc54815fdecc3
+msgid "Toggle for image fuzzy hashing"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:244 1554553d9b6e4bb0829a8db38af7a12d
+msgid "Improvements for VBA extraction in office documents"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:245 44cea170966f4076b64a21fc2ffcd72f
+msgid "Custom clean file cache size with `--cache-size` (uses more RAM)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:246 a76e6bb9e24945389e6807948a1df6eb
+msgid "A `systemd.timer` unit for running `freshclam`"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:247 17da65efdd47458ba362eea3ece86eed
+msgid "Better limit handling for large files"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:248 8cb3ed05e2654ecf8a2c3294effa89b8
+msgid "Client certificates for authentication to a private Freshclam mirror"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:249 ddc4366aec36467396f4ff0a2d6d6792
+msgid "Virus database minimal age"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:251 0607f56589b44acd907d464a719cd461
+msgid ""
+"For complete details of all changes leading up to 1.4.3, please see the "
+"upstream release notes at <https://blog.clamav.net/>."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:253 99cd7f8363e54ad4b6c84c2f40550b9a
+msgid "Django"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:257 dd45beb6cfcf407da69b51a087d0fba2
+msgid ""
+"Django has been updated to the latest LTS release 5.2 from 4.2, which "
+"includes many new features and bug fixes. All Django middleware provided "
+"in Ubuntu has also been updated to be compatible with the new version. "
+"See the [5.0 release "
+"notes](https://docs.djangoproject.com/en/5.2/releases/5.0/) for features "
+"and updates added with the major version change and the [5.2 release "
+"notes](https://docs.djangoproject.com/en/5.2/releases/5.2/) for the "
+"changes made leading up to the LTS release."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:259 22eb068a1f4b457c855b8c3b25db526e
+msgid "PHP"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:261 44f73bc0ae5f432ab3427fd92a78c7c5
+msgid ""
+"PHP was updated to version 8.5. Among other enhancements and bugfixes, "
+"the highlighted changes since Ubuntu Noble 24.04 are:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:263 5875ff53bc7c49b9891eb4492010d20b
+msgid "Property hooks"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:264 ebc03cca40b64b36a94fb1036f664064
+msgid "Asymmetric visibility"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:265 4a2440a6b9c74115a78f7d46eddf6629
+msgid "Updated DOM API"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:266 433f0eab5109491cbdb979d919dc2e9f
+msgid "A new URI Extension"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:267 fbef2b6a552b423f8bd77c94be9f6864
+msgid "The Pipe Operator"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:268 dfcf597521134457814fd6c47a463ca7
+msgid "Clone With functionality"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:269 f4b41578622846bc9912c88d4fe1998b
+msgid "The `#[\\NoDiscard]` Attribute"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:270 9f7c459b10614798b9da810ecaf623a8
+msgid "Closures and First-Class Callables in Constant Expressions"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:271 39cbb9516f7a4395be5a9f1f7b575766
+msgid "Persistent `cURL` Share Handles"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:272 48c1a9ffa08d49b9b3c2bec2dbe3b7bd
+msgid "`array_first()` and `array_last()` functions"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:274 33173546c13942b8920399e416cf8967
+msgid ""
+"For more details, breaking changes and other features, see the upstream "
+"release notes:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:276 e7fd8817d1844ed8a31d2d48ff93b906
+msgid "[PHP 8.4](https://www.php.net/releases/8.4/en.php)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:277 a98f1f791b8e4ca1ada677d96b1123f5
+msgid "[PHP 8.5](https://www.php.net/releases/8.5/en.php)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:279 5094ef106c9a4772acb0d93396fb1bcc
+msgid "Dovecot"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:281 d35176731b234ec3958ce87c82e2d896
+msgid ""
+"Updated to 2.4.2. Version 2.4 introduced many changes to the Dovecot "
+"configuration format!"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:283 2a52cd1693fe4006a0b4c7d85f45361b
+msgid ""
+"Coming from Ubuntu 24.04 LTS, please follow [dovecot’s 2.3 upgrade "
+"documentation](https://doc.dovecot.org/2.4.2/installation/upgrade/2.3-to-2.4.html)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:285 01f5c34aca39445d83671f75a6f3e8df
+msgid ""
+"When you’re coming from other versions, follow [the upgrade "
+"overview](https://doc.dovecot.org/2.4.2/installation/upgrade/overview.html)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:287 e87b8d87a6614c6b990bf55d92936a46
+msgid "Postfix"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:289 b5e852714ba341ce9856b7d4ccbc654a
+msgid ""
+"Specific release notes for major version releases since Ubuntu 24.04 LTS "
+"(Noble Numbat) are:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:291 3bba7e85033645aab52822b64a6ef91f
+msgid "3.9.0: https://www.postfix.org/announcements/postfix-3.9.0.html"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:292 4fc50d7eb80e47d897906672970c9751
+msgid "3.10.0: https://www.postfix.org/announcements/postfix-3.10.0.html"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:294 da6ef9610ba7482f9b9c431e6e0cde37
+msgid ""
+"A noteworthy change in the packaging of Postfix is that **by default it "
+"is no longer installed in a `chroot`, and only limited `chroot` support "
+"is available from now on**."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:296 6b4c5bdb977747e3882caf597b6c2404
+msgid "RabbitMQ"
+msgstr ""
+
+#: ../../reuse/26.04/rabbitmq-upgrade.txt:2 5d2736c4b6d14e27ba0029513036a160
+msgid ""
+"RabbitMQ is not directly upgradable due to feature flags. To mitigate "
+"this, some manual steps are needed. For more information please read "
+"<https://discourse.ubuntu.com/t/ubuntu-server-gazette-issue-12-upgrading-"
+"rabbitmq-across-ubuntu-releases/77271>."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:301 5ecff433b04244e3b281662c20bad6fd
+msgid "Samba"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:303 f2031285ce5a40978f5f6759ccee83a3
+msgid ""
+"Samba has been updated to the new upstream 4.23 version. Changes since "
+"Ubuntu Noble 24.04:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:305 d7f08476123b4d81b4a44a12d0a75792
+msgid "SMB3 Unix Extensions enabled by default"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:306 3d1207d8cd844122b49f3cfdc42b2040
+msgid ""
+"NetBios is disabled by default in the configuration file "
+"/etc/samba/smb.conf for fresh installs"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:307 23b3419e16d44641a30bba4d84a9131c
+msgid "SMB3 Directory Leases"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:308 8cbfa28c90894a1d89e3b369eb3cd1bc
+msgid "Netlogon Ping over LDAP and LDAPS"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:309 343e666ecafc4ce4b3059c5539f1ec31
+msgid "Experimental Himmelblaud Authentication in Samba"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:310 e4a0a671f0734f96ba1b8f14fe8439ab
+msgid "AD DC schema upgrade and provision performance improvements"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:311 9001940357f245069b4f3590fdb4ada7
+msgid ""
+"LDAP TLS/SASL [channel binding "
+"support](https://www.samba.org/samba/history/samba-4.20.3.html)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:312 b2fb9d08766f4d6caea6080fdab928ff
+msgid "Group Managed Service Accounts"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:313 ac8b70bc1ec1430cbd508305ea25897f
+msgid "Samba can now claim Functional Level 2012R2 support"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:314 d5ee46355b09481585b5d2383385f364
+msgid "Some Samba public libraries made private by default"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:315 c0d6ede681bf44ea862f7de4bc7823b1
+msgid "Samba AD will rotate expired passwords on smartcard-required accounts"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:316 53ffb9c25bf9410a9a0d57ec60b21e37
+msgid "Automatic keytab update after machine password change"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:318 8e6834edf7ee4103bdd9bf4ef97aa153
+msgid "Removed features:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:320 7fde0bef7f5e46d4936962197e11e461
+msgid "`nmbd proxy logon`"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:321 b5f6a84a1e24445cb801b75bbb395483
+msgid "`cldap port`"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:322 bfabf45f894b4675986a1ca39a414bed
+msgid "`fruit:posix_rename`"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:324 9ff7769eb9994dd5ae13a837800e1580
+msgid "Packaging changes when upgrading from Ubuntu Noble 24.04:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:326 e213d6662a9c4f50a6d6a69c270dce19
+msgid ""
+"samba-vfs-modules: the VFS modules from this package were moved to the "
+"samba package, with the exception of the Ceph module, which got its own "
+"package: samba-vfs-ceph. The samba-vfs-modules package is now just a "
+"transitional package, and it can be safely removed after the release "
+"upgrade."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:327 bae693f07bc5444a9d9b1b7f0e46cd5a
+msgid ""
+"samba-vfs-modules-extra: this package used to contain the GlusterFS VFS "
+"module. This module was moved to a new package called samba-vfs-"
+"glusterfs, and samba-vfs-modules-extra became a transitional package. It "
+"can also be safely removed after the release upgrade."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:328 d7b3cafc4cf44294bf825c1ea27eee84
+msgid "The dumpmscat binary is no longer built"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:330 fc75bb3b10f74d6ba9671c33a02595fe
+msgid "Samba upstream release notes since Ubuntu 24.04 LTS (Noble Numbat):"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:332 597871a5861242628f4bc8744feba837
+msgid "[https://www.samba.org/samba/history/samba-4.20.0.html](https://www.samba.org/samba/history/samba-4.20.0.html)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:333 47d1aeb6b09543b38342292636c56cee
+msgid "[https://www.samba.org/samba/history/samba-4.21.0.html](https://www.samba.org/samba/history/samba-4.21.0.html)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:334 44fec79b461845bdbec90225cd954864
+msgid "[https://www.samba.org/samba/history/samba-4.22.0.html](https://www.samba.org/samba/history/samba-4.22.0.html)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:335 38993e1e7a614577acab7478b746c531
+msgid "[https://www.samba.org/samba/history/samba-4.23.0.html](https://www.samba.org/samba/history/samba-4.23.0.html)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:337 9544355ffc974b6cb3e0c50608a8c238
+msgid "Samba on i386"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:339 19b93bc55e444272b8f7bcd6ab84435c
+msgid ""
+"Samba version 4.21.x added a dependency to the python3-samba package: "
+"python3-cryptography. Unfortunately, python3-cryptography was last built "
+"for i386 for Ubuntu Bionic 18.04, and is no longer available for that "
+"architecture, making this new dependency unsatisfiable."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:341 cdfa06759c8e46428150f6bc881615c9
+msgid ""
+"For Ubuntu Plucky 25.04 and later, the python3-samba package is no longer"
+" built for i386. Please see [LP: "
+"#2099895](https://bugs.launchpad.net/ubuntu/+source/samba/+bug/2099895) "
+"for details. The main consequence is that the samba-tool script (part of "
+"that package) is no longer available for i386."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:343 e5cb9f8aa7c84442a9aaa0e63a328b05
+msgid "Upgrading an AD/DC from previous Ubuntu releases"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:345 67dbdf5c4fe842b7b82b051cec1f6d53
+msgid ""
+"If you have deployed a Samba Active Directory Domain Controller *without*"
+" having installed the `samba-ad-dc` package, you should install it before"
+" doing a release upgrade to Ubuntu 26.04 LTS (Resolute Raccoon). If "
+"`samba-ad-dc` is not installed prior to the release upgrade, the Active "
+"Directory Domain Controller functionality will not work on the upgraded "
+"system due to many missing components."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:347 e6cd72270448465cb37115e79591b9de
+msgid ""
+"See [LP: "
+"#2101838](https://bugs.launchpad.net/ubuntu/+source/samba/+bug/2101838) "
+"for more information"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:349 7eca5643809445acab9d56bbe76dd3e0
+msgid "Squid"
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-features.txt:2 fd9661b7c4584c3682059051671c7e6b
+msgid ""
+"Squid was updated to upstream version 7.2. Coming from version 6, the "
+"main new options are:"
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-features.txt:4 546d5b53b5f9446297406a27139b8b67
+msgid "Add `tls_key_log` directive to log TLS master keys."
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-features.txt:6 80e80b37358d4729b4d3a0df3161cf96
+msgid ""
+"Add `key-extras` format to external ACL helpers to pass transaction "
+"details."
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-features.txt:8 d280ae869eb3446ca238f5eabec57505
+msgid "Add `doh_query` directive to send DNS queries over HTTPS."
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-features.txt:10 050f7a48d781455ea6c5de833eab88bc
+msgid ""
+"Add `cache_peer` option `tls-client-cert-switch` to select client "
+"certificates dynamically."
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-features.txt:12 ae188960cd7e463683a3df4c39695ba9
+msgid ""
+"Several bugfixes for crash scenarios are also included in this major "
+"release."
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-removals.txt:2 99ac4b372ee14375a69f3b77e437450d
+msgid "Some directives and options were removed in Squid 7.2:"
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-removals.txt:4 75feb185af3c453ea1cb59fc1cab50f9
+msgid "Removed `client_delay_access` directive."
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-removals.txt:6 54e09ffc147149718edda88092d205aa
+msgid "Removed `ftp_epsv` directive."
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-removals.txt:8 4d08df61fdd34949b70c4ce6864c13a5
+msgid "Removed `cache_peer` option `no-netdb-exchange`."
+msgstr ""
+
+#: ../../reuse/26.04/squid-7.2-removals.txt:10 31a76e7681cf434b9525a2611e1fbdac
+msgid ""
+"Removed `client_persistent_connections` and "
+"`server_persistent_connections` directives."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:357 b83484fa6ea740638d2e5dea5b4613af
+msgid ""
+"For a list of all changes and fixes, please check the [upstream releases "
+"page](https://github.com/squid-cache/squid/releases)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:359 358039c8d0af4b02940f1de2231f35da
+msgid "SSSD"
+msgstr ""
+
+#: ../../reuse/26.04/sssd-2.12-features.txt:2 9fdfc21aea4145b09ab789c349812f12
+msgid "SSSD has been updated to version 2.12."
+msgstr ""
+
+#: ../../reuse/26.04/sssd-2.12-changes.txt:2 48708513721e4006a7e3c2b0d531c9fc
+msgid ""
+"SSSD now runs under user `sssd` (instead of `root`). Make sure that "
+"`sssd` can still access secrets or integrations from its new user."
+msgstr ""
+
+#: ../../reuse/26.04/sssd-2.12-changes.txt:4 c9272b6df34a469aa0e68bb266f8422e
+msgid ""
+"The implicit files provider and domain was removed: see "
+"<https://sssd.io/docs/files-provider-deprecation.html>."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:367 9865940c95f64e02886b2ee3263ef970
+msgid "https://sssd.io/release-notes/sssd-2.10.0.html"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:368 7442957762304e3ea891116b80c46f5f
+msgid "https://sssd.io/release-notes/sssd-2.11.0.html"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:369 8a40bc9d24e54ba9837440bbf4ad5996
+msgid "https://sssd.io/release-notes/sssd-2.12.0.html"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:371 7b072f26763246de8ed8e02f375a2ae0
+msgid "strace"
+msgstr ""
+
+#: ../../reuse/26.04/strace-6.19.txt:2 3e53ff7e193d4722b539a42ce85206c2
+msgid ""
+"[`strace`](https://strace.io/) now supports colored output (configurable "
+"with `--color=...`, `STRACE_COLORS=...` and `NO_COLOR=1`)."
+msgstr ""
+
+#: ../../reuse/26.04/strace-6.19.txt:4 0be6a880434146c4940d32a81649546f
+msgid "![Sample colored output](/images/strace-color.png)"
+msgstr ""
+
+#: ../../reuse/26.04/strace-6.19.txt:4 e6f01770a3ee41fe870520edf3c53dd7
+msgid "Sample colored output"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:376 0d44fec81b4844169a4dbf05c786ed16
+msgid "HAProxy"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:380 ff590a25884d4339bcf41f0cebbe5f2c
+msgid ""
+"HAProxy was updated to the latest upstream LTS release, 3.2, which "
+"introduces performance and efficiency improvements, faster and more "
+"reliable QUIC protocol support, and more. For further details on this new"
+" release, please check the HAProxy 3.2 [upstream "
+"announcement](https://www.mail-"
+"archive.com/haproxy@formilux.org/msg45917.html)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:382 47c3b55f80ed433bbcfc99e9b8029b4d
+msgid ""
+"For users coming from HAProxy 2, breaking changes include detection of "
+"accidental multiple commands sent to the Runtime API, rejecting the "
+"enabled keyword for dynamic servers, stricter parsing of non-standard "
+"URIs and renaming of `tune.ssl.ocsp-update` to `tune.ocsp-update`."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:384 88679e8454ec42c295520d5a1ca632ce
+msgid ""
+"You can learn more at [Announcing HAProxy "
+"3.0](https://www.haproxy.com/blog/announcing-haproxy-3-0). A complete "
+"list of changes is available in the [upstream "
+"changelog](https://www.haproxy.org/download/3.0/src/CHANGELOG)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:386 e330e45708c3405581f9f4ed22b25513
+msgid "DocumentDB"
+msgstr ""
+
+#: ../../reuse/26.04/documentdb-0.108-0-features.txt:2
+#: f7a86e50abcf441d953bf54b5d1f77eb
+msgid ""
+"DocumentDB is now available in Ubuntu, starting with version 0.108-0. It "
+"is a powerful, scalable, MongoDB compatible open-source document database"
+" built for modern applications, built on PostgreSQL. For more information"
+" see [documentdb.io](https://documentdb.io/)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:393 80a508b94cf24c60a696f6f19ec0f1b5
+msgid "MySQL"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:397 e0ceed44840c4fae8e770109d94ca849
+msgid ""
+"MySQL was updated from 8.0 to 8.4 LTS, starting with 8.4.8 in Ubuntu "
+"26.04 LTS. This is MySQL's first official long term support release, "
+"including various internal improvements, new features, and some important"
+" configuration changes."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:399 c7736152a65b471c9f8a049a5bba2d27
+msgid ""
+"Upstream release notes are available in the [Mysql 8.4 documentation "
+"library](https://dev.mysql.com/doc/relnotes/mysql/8.4/en/). For more "
+"information about the transition from MySQL 8.0 to 8.4, see the [MySQL "
+"8.4 overview](https://dev.mysql.com/doc/refman/8.4/en/mysql-"
+"nutshell.html)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:401 b98650fcfa524fcaa35ae3a0e3dd899d
+msgid ""
+"Due to upstream policy, support for 32-bit MySQL Server has been removed."
+" However, Ubuntu will continue to provide a MySQL client and client "
+"library for 8.4 on armhf and i386."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:403 90ac3c84841f4351a349ccefc734c9a9
+msgid "MySQL Shell"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:407 c8f5051f35bf48e3bba82781dd0e46df
+msgid ""
+"MySQL Shell was updated from major version 8.0 to 8.4 to coincide with "
+"MySQL 8.4. It adds support for MySQL 8.4 servers, and provides additional"
+" improvements for interacting with MySQL 8.0 servers. For a list of "
+"features, see the [MySQL Shell 8.4 "
+"documentation](https://dev.mysql.com/doc/mysql-shell/8.4/en/). Release "
+"notes for MySQL Shell 8.4 can be found "
+"[here](https://dev.mysql.com/doc/relnotes/mysql-shell/8.4/en/)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:409 4d4069e83b814ddd90a35350770d0fc5
+msgid "PostgreSQL"
+msgstr ""
+
+#: ../../reuse/26.04/postgresql-18-features.txt:2
+#: 4f96d2b24b704f98bff3a7c4c2b05d5e
+msgid ""
+"PostgreSQL was updated to version 18. This new version improves "
+"performance for workloads of all sizes through a new I/O subsystem that "
+"has demonstrated up to 3× performance improvements when reading from "
+"storage, and also increases the number of queries that can use indexes. "
+"This release makes major-version upgrades less disruptive, accelerating "
+"upgrade times and reducing the time required to reach expected "
+"performance after an upgrade completes. Developers also benefit from "
+"PostgreSQL 18 features, including virtual generated columns that compute "
+"values at query time, and the database-friendly `uuidv7()` function that "
+"provides better indexing and read performance for UUIDs. PostgreSQL 18 "
+"makes it easier to integrate with single-sign on (SSO) systems with "
+"support for OAuth 2.0 authentication."
+msgstr ""
+
+#: ../../reuse/26.04/postgresql-18-features.txt:4
+#: 9482a18ea07b4b08ba4f23c833298dff
+msgid ""
+"For further information, check the [upstream release "
+"announcement](https://www.postgresql.org/about/news/postgresql-18-released-3142/)"
+" and the [upstream release "
+"notes](https://www.postgresql.org/docs/18/release-18.html)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:416 e3fd51596a69438fa089f4c935ac118d
+msgid "Valkey"
+msgstr ""
+
+#: ../../reuse/26.04/valkey-9.0-features.txt:2 b568e9bde8924521bcdd2beb16bc2079
+msgid ""
+"Valkey was updated to version 9.0, starting with 9.0.3. This includes "
+"various features and improvements beyond 8.x, such as atomic slot "
+"migrations and hash field expiration."
+msgstr ""
+
+#: ../../reuse/26.04/valkey-9.0-features.txt:4 51db1a9bbaae4c6896870c3c43da0192
+msgid ""
+"For more information on the new version, see the [Valkey 9 blog "
+"post](https://valkey.io/blog/introducing-valkey-9/). Release notes are "
+"available on the [Valkey project GitHub](https://github.com/valkey-"
+"io/valkey/releases)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:423 02c0bcdb35504c0da4d466178af427bc
+msgid "Container stacks"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:427 78e97d6f6ef64a6da2d08054cf6243c4
+msgid ""
+"For the `containerd` and `runc` packages, we established a pattern to "
+"either keep the regular updates to the latest version or to opt for "
+"slower, more stable updates throughout the time the release is active. "
+"For more please read [Ubuntu Server Gazette - Issue 8 - Containers: "
+"Steady paths for agile stacks](https://discourse.ubuntu.com/t/ubuntu-"
+"server-gazette-issue-8-containers-steady-paths-for-agile-stacks/68680)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:429 3e0dc306c8a8401a9318491622cd98d5
+msgid "High availability and clustering"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:431 33ad4e92d5004dd2a832495de914e82a
+msgid ""
+"The **`kpartx-boot`** package has been discontinued to align with Debian."
+" Originally introduced to support `dmraid` booting, its functionality is "
+"preserved, as the `kpartx` package now includes everything previously "
+"provided by `kpartx-boot`."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:436 0e05ec839e69452bb394fb832b90e3d8
+msgid ""
+"The **`dmraid`** package has been removed. The rationale for its removal "
+"is outlined in bug [LP#2073677](https://bugs.launchpad.net/bugs/2073677),"
+" primarily due to its removal from Debian unstable and minimal upstream "
+"support. If you require this functionality, consider using alternatives "
+"like `mdadm`."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:441 86b0e630f5884e65a2b40f64ce706fa9
+msgid ""
+"Pacemaker was updated to version 3. All new features and breaking changes"
+" are described in the [upstream release "
+"notes](https://projects.clusterlabs.org/w/projects/pacemaker/pacemaker_3.0_changes/)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:443 e7662d3bb53149fea0653df291f1c7a6
+msgid "Development"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:445 56a6a453950b4520a526dea1105f4b77
+msgid ""
+"GCC 🐄 has been updated from version 14 to 15.2, `binutils` from 2.42 to "
+"2.45, and `glibc` from 2.39 to 2.42."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:446 b5d89de36145439c82a536e96dfe4c50
+msgid ""
+"Python 🐍 has been updated from version 3.12 to 3.13.9, while 3.14 is also"
+" available."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:447 55c62a4559b14a9aa3a71582354fb20b
+msgid "LLVM 🐉 has been updated from version 18 to 21."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:448 581849b049c3442a926595e7de3f48a1
+msgid ""
+"Rust 🦀 has been updated from version 1.75 to 1.93, while 1.91 and 1.92 "
+"are also available."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:449 6c847e737f0d40b29830bc814138b782
+msgid "Golang 🐀 has been updated from version 1.22 to 1.25."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:450 1c0edd0d0aaa444aa4811e37547a1c1e
+msgid "Zig ⚡ is now available in Ubuntu. It defaults to version 0.14.1."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:451 5707b6af66954bde9e6207b39e95eb5d
+msgid ""
+"OpenJDK has been updated from version 21 to 25, while LTS versions 8, 11,"
+" 17, 21 are also available. OpenJDK 26, and OpenJDK 27 previews are also "
+"included."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:452 412182deacdd4d10ada6f80eea8d7152
+msgid "Ubuntu Toolchains has a new [homepage](https://ubuntu.com/toolchains)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:454 bd5d981feae640cab898cbb02a6c4c0d
+msgid "OpenJDK 25 and TCK certification"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:458 2eb82edf04844d7eac572f65718bf06f
+msgid ""
+"OpenJDK 25 package is available and is TCK (Technology Compatibility Kit)"
+" certified on AMD64, ARM64, S390X, PPC64EL. The Java TCK is the most "
+"comprehensive test suite that covers all aspects of Java SE specification"
+" including language features, libraries and APIs. This guarantees "
+"interoperability and conformance to standard."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:460 bfe45abf9f244fb9a50f944ba6f5e9d1
+msgid "OpenJDK 21 and TCK certification"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:464 e8beb0163fee48daba5b76e3c4fdeec0
+msgid ""
+"OpenJDK 21 and OpenJDK 17 packages are now TCK (Technology Compatibility "
+"Kit) certified on AMD64, ARM64, s390x, ppc64el. The Java TCK is the most "
+"comprehensive test suite that covers all aspects of Java SE specification"
+" including language features, libraries and APIs. This guarantees "
+"interoperability and conformance to standard."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:466 a6d383dcc47341e39f206bdbf785c3d3
+msgid "Spring® snaps"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:470 ec67b69d451844879969aacfb746e966
+msgid ""
+"We are excited to announce the [devpack-for-spring](https://snapcraft.io"
+"/devpack-for-spring) snap and a set of Spring® [content "
+"snaps](https://snapcraft.io/devpack-for-spring-manifest) that will serve "
+"as development tools for Spring® projects."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:472 ced41d74bece4f88bc35c7774221f23b
+msgid ""
+"Developers can now quickly build Ubuntu ROCK images for their Java "
+"applications using the [Gradle and Maven plugins for "
+"Rockcraft](https://github.com/rockcrafters/java-rockcraft-plugins)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:474 3b13bfa3c2a34339a39865f557d1b96f
+msgid "GraalVM snap"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:478 4741a79a078d4ff58a31465938674329
+msgid ""
+"GraalVM Community Edition for JDK versions 21, 24 and 25 is now available"
+" as a [snap](https://snapcraft.io/graalvm-jdk). Java developers now have "
+"a choice to build and deploy their applications with standard OpenJDK, "
+"with OpenJDK-CRaC or as a GraalVM native image."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:481 cc833f425d1f4a949d4af4a3def5467c
+msgid ".NET 10"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:483 ba9e4d06dbcc48a3a295c6fd46f0c839
+msgid ".NET has been updated from version 8 to 10."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:485 bc419747523348b88e1987c84279c8cc
+msgid ""
+"We have also expanded .NET support to the IBM Power platform, further "
+"broadening the platform’s reach."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:487 86d5335574d742a7ac0ff1bc82f27036
+msgid ".NET snap"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:491 57628a1856fa4cc29d7b2fd7976120de
+msgid ""
+"We are excited to introduce the new and improved [.NET "
+"Snap](https://snapcraft.io/dotnet), allowing developers to seamlessly "
+"install any supported version of .NET on any Ubuntu system."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:493 4720e3a7d30444b5ac6964f53df078cd
+msgid "PowerShell snap on more architectures"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:497 d4f2d8168db242fb86de1b011e341466
+msgid ""
+"Support for the PowerShell snap has been expanded to include the `arm64`,"
+" `s390x`, and `ppc64el` architectures, broadening its availability across"
+" platforms."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:500 870f73ab3d6e4118b44ddb20c685cba9
+msgid "Enterprise"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:502 e0fbbe16589845c18d8303f64a9df1fd
+msgid "Updated `authd`"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:504 e60660cb44ea4266950d6e2b0793594f
+msgid ""
+"[authd](https://github.com/ubuntu/authd), Ubuntu's cloud authentication "
+"solution, has been updated:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:506 60c90f8d50b14bf99c79d4f1cab513aa
+msgid "Many fixes and improvements to the EntraID provider"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:507 62fef7098517419ca5a2a170dec7be74
+msgid "New Google provider"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:508 a874f5e798b1416b8ef5e5f4acac1a2f
+msgid "Supports device registration with EntraID"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:509 7616cebeadb3440dafbd0c1393e813e2
+msgid "authctl is a new command line tool to manage authd"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:510 97cd9d67833a4fcbbc3971dfb4f6a69c
+msgid "Many improvements and important bug fixes such as UID/GID handling"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:512 b1f6913cbcce47a09bad59e49baa07bc
+msgid "New `authd` documentation"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:514 d77f6a7966214f8e87086fd04d2b4433
+msgid ""
+"New [authd "
+"documentation](https://documentation.ubuntu.com/authd/en/stable/) has "
+"been published."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:516 44e8fcf9d8084b1c9c38c73212bfe011
+msgid "Updated ADSys"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:518 cec610c5c5f54773b4aa671e46beee98
+msgid ""
+"The Active Directory Group Policy client for Ubuntu supports the latest "
+"Polkit and comes with improvements and bug fixes to certificates "
+"enrollment."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:521 1bf7b5c17553424c913876ccff647ce5
+msgid "Cloud"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:524 74a0c81fe77c4b4080a6f0a7040ddd15
+msgid "Security"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:526 1fd03cf7ba064305a894fd125a0e33fb
+msgid "New AppArmor sandboxing profiles"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:530 5a51339d2a5849238ebc31492656e270
+msgid ""
+"As part of a profile writing effort to improve overall system security, "
+"the AppArmor package now includes many new profiles for applications. "
+"This improved sandboxing can help mitigate the impact of any exploit in "
+"the confined applications."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md 6167cbfaffee4f7e81db6d11fb4ac33e
+msgid "Report bugs"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:533 0f1f72075a174f5eaad6a71d924c8895
+msgid ""
+"These profiles may cause breakage for unanticipated uses of those "
+"applications, and we encourage users to file a bug on "
+"[Launchpad](https://bugs.launchpad.net/ubuntu/+source/apparmor/+filebug) "
+"for AppArmor-induced breakage in common use cases. When AppArmor denies "
+"an action, it usually generates a log entry describing the denial, which "
+"will help us investigate the bug, but which can also be used to add "
+"additional rules for customization or to work around the denials. "
+"AppArmor log entries can be read in the auditd logs, if auditd is "
+"installed, or in the `syslog` otherwise. [This "
+"page](https://gitlab.com/apparmor/apparmor/-/wikis/denial_quick_guide) "
+"describes how the information contained in the denial log can be used to "
+"update a local override."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:536 5eff1b3ba0634b68875ebe61c16605dc
+msgid "TPM-backed full-disk encryption"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:540 da39f6c7390744809dc81e14d79665ae
+msgid ""
+"New [TPM-backed disk encryption](https://canonical-ubuntu-desktop-"
+"documentation.readthedocs-hosted.com/en/latest/explanation/hardware-"
+"backed-disk-encryption/) is available for Ubuntu Desktop. Its features "
+"include:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:542 531d79d2f4b74f9c9befdb36238ef580
+msgid "Passphrase support and management"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:543 a471bc38bbfa4876bc324a93379785fb
+msgid "Regeneration of the recovery key"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:544 4f5e2e45922745b9a532d5195bd95ce1
+msgid "Better integration with firmware updates"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:546 b914ababc4444bc8b6b5752a4dc93788
+msgid ""
+"For details, see [Hardware-backed disk "
+"encryption](https://documentation.ubuntu.com/desktop/en/latest/explanation"
+"/hardware-backed-disk-encryption/) in the Ubuntu Desktop documentation."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:548 4810e746e35946878b03b7d37084bd84
+msgid "cargo-auditable"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:552 54e6a6a8a44c48a7acb8fb6d703359ce
+msgid ""
+"Rust packages built on Launchpad now have opt-in support for [cargo-"
+"auditable](https://github.com/ubuntu/ubuntu-release-notes). If enabled, "
+"binaries will include JSON-formatted metadata in a header section of the "
+"binary expressing the dependencies used to compile the binary. If a CVE "
+"is discovered in a popular Rust crate, this dependency metadata lets "
+"users and sysadmins immediately check if a binary is compromised."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:556 a9e89368bb6d410cadc09b220fb2ecc5
+msgid ""
+"For details, see the [Ubuntu project "
+"documentation](https://documentation.ubuntu.com/project/contributors"
+"/language-specific/rust/cargo-auditable/)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:558 c404b50763d44e80857743d5e85c889a
+msgid "Hardware support"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:560 6b474690128c4e9997392d8f40d931f7
+msgid "NVIDIA Dynamic Boost"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:564 e35b2f5b52484bddb29dacf82df213ce
+msgid ""
+"This release enabled NVIDIA Dynamic Boost by default on supported laptops"
+" with NVIDIA GPUs."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:566 6a6513bcbf3142eca93a4cb85304f38e
+msgid ""
+"NVIDIA Dynamic Boost is a feature of the NVIDIA drivers that dynamically "
+"shifts power between CPU and GPU depending on the workload on the system."
+" While gaming, this allows extracting more performance by granting more "
+"power to the GPU."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:568 b42fce3b0dba4605af9c041756b45414
+msgid ""
+"Dynamic Boost will be active only when the laptop is powered by AC and "
+"there is enough load on the GPU. It will not be engaged when the system "
+"is running on battery."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:570 8cbe8d80aacd43d6904ba1d616a73db0
+msgid ""
+"For more details refer to [NVIDIA's "
+"documentation](https://download.nvidia.com/XFree86/Linux-x86_64/570.133.07/README/dynamicboost.html)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:572 0be6f14c531e47d981051f9b31962bcc
+msgid "Support for new Intel® integrated and discrete GPUS"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:576 9ffba88454b5482d905825690156d216
+msgid ""
+"This release brings full support for Intel® Core™ Ultra Xe2 integrated "
+"Intel® Arc™ graphics, and Intel® Arc™ B580 and B570 “Battlemage” discrete"
+" GPUs. Moreover, the following features are also included:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:579 f6cec648cec747bebb6f7cdced2c80f0
+msgid ""
+"Improved GPU and CPU ray tracing rendering performance in applications "
+"with Intel Embree support, such as Blender (v4.2+). Ray tracing hardware "
+"acceleration on the GPU improves frame rendering by 20-30%, due to a 2-4x"
+" speed-up for the ray tracing component."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:580 613e4a49e537489dba739c47fac3aab5
+msgid ""
+"Full hardware accelerated video encoding of AVC, JPEG, HEVC, and AV1 on "
+"“Battlemage” devices."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:581 4d960b4c0572468899b11beb0d87c109
+msgid "Introduction of the new CCS optimization in Intel® Compute Runtime."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:582 03bd7667c8f947378e3a178341ae1975
+msgid "Enable debugging support for Intel Xe GPUs."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:583 a178c7939fb941f393fabad21da042e3
+msgid ""
+"oneAPI Level Zero Ray Tracing improves AI/ML workload speeds via Embree "
+"on SYCL"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:585 db1195850e724e95b4b0ef97ac4e1de9
+msgid "Suspend with Nvidia"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:589 fdcec3c423164d36902e28afa5fea8fd
+msgid ""
+"Suspend-resume support is now enabled in the proprietary Nvidia driver so"
+" as to prevent corruption and freezes when waking an Nvidia desktop."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:591 f5a4ff188ae3438faacde7029cf16f81
+msgid "ARM desktop platforms"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:595 64852304119046119f683f6a49e85de8
+msgid ""
+"The `linux-generic` kernel for ARM64 provides broader compatibility for "
+"ARM64 desktop platforms that utilize UEFI for booting "
+"([LP#2121352](https://bugs.launchpad.net/ubuntu/+source/linux-"
+"signed/+bug/2121352))."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:597 b596a345948d4501b7af34ae47a0d6db
+msgid "A new boot layout for Raspberry Pi"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:601 ac8ca435a8bf4580a017a46bb55fc8f6
+#, python-brace-format
+msgid ""
+"A new layout of the boot partition is introduced to enhance the "
+"reliability of the boot process ([LP: "
+"#2116266](https://launchpad.net/bugs/2116266)). This will automatically "
+"\"test\" new boot assets written to the boot partition before committing "
+"them as the current \"known good\" set. See the [call for "
+"testing](https://discourse.ubuntu.com/t/call-for-testing-a-b-boot-on-"
+"raspberry-pi/64173) for more information, or [the blog "
+"post](https://waldorf.waveform.org.uk/2025/pull-yourself-up-by-your-"
+"bootstraps.html) covering the feature for the full details (including "
+"advice on how to opt-out of this feature, where required). The {manpage"
+"}`piboot-try(1)` man-page may also be consulted for advanced operations."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:604 cc6770502eab450a828aa9ccbfb519a7
+msgid ""
+"Please note that, due to the new boot process, the boot firmware on your "
+"Pi *must* be up to date."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:606 dbd233ff717443b4b8b5acb56d84f450
+msgid "For Pi 3, 3+, and Zero 2W"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:607 7cbdb2ac7a8346399b292c8c98b214c2
+msgid "No action required, the boot firmware is in the image itself."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:609 609d4cb0a4a24be3a0eb4d9fa01907be
+msgid "For Pi 4"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:610 38f0497a4f6e47c19b03784059a43c35
+msgid ""
+"Your boot firmware *must* be dated no earlier than **2022-11-25**. To "
+"check, run `sudo rpi-eeprom-update`. If your firmware is dated earlier, "
+"using Ubuntu 24.04 LTS (Noble Numbat) or later, run `sudo rpi-eeprom-"
+"update -a` and reboot."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:612 f42ffa2454f54cdcb8fe9b81e1159dd4
+msgid "For Pi 5"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:613 c13f2401ab2748c99f5977152a164ba1
+msgid ""
+"No action required, all firmware since release of the platform are "
+"compatible."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:616 9aaadb143ca940f1a32ed2f7402f05c0
+msgid "Raspberry Pi is based on the minimal image"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:620 bb8a4afc74ce48c883cf30c339752fdb
+msgid ""
+"The Ubuntu desktop images for Raspberry Pi are now based upon the "
+"`desktop-minimal` seed rather than `desktop` ([LP: "
+"#2103808](https://launchpad.net/bugs/2103808)). This greatly reduces the "
+"default set of applications installed on the images (saving approximately"
+" 777MB of space on the uncompressed image, and thus on user's systems)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md f75cf057b9084019a9eb8a05e2934b02
+msgid "The list of applications removed from the image"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:624 dd5a93464cc34f25952ae70ad14ef37d
+msgid "`deja-dup` (backup service)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:625 2509994beae5442483fc4e0e2237e174
+msgid "`file-roller` (archive handler)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:626 979e3e25e5e544ed98fcbb7a1bc24b2f
+msgid "`gnome-calendar`"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:627 57820d4e165c4e679cc33571a9ed0c76
+msgid "`gnome-snapshot` (camera application)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:628 f153bfdc6fec46d79649e6a6b65854d2
+msgid "`libreoffice-*`"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:629 e2ef9747c54b40c691f6c20e3de75f80
+msgid "`remmina` (remote desktop client)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:630 5c7fe523799246888aff93304d0eff23
+msgid "`rhythmbox` (music player)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:631 cc70bd34d5fd457e83f6506a95fd8764
+msgid "`shotwell` (photo catalogue)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:632 343e8cef112d4dd8bb0600f282bc0f00
+msgid "`simple-scan` (flat-bed scanner application)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:633 fa502ef3e8fd41018558157e41991fdb
+msgid "`thunderbird` (email client)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:634 f3194f37687f4b07828c22e4b551cc9a
+msgid "`showtime` (video player)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:635 205434f04c444d1dbd3f7f5a4d88e572
+msgid "`transmission-gtk` (bittorrent client)"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:638 4d7f8606ed524ba9a249a3aad9148f33
+msgid ""
+"The applications mentioned above will *not* be automatically removed for "
+"upgraders as the `ubuntu-desktop` meta-package remains manually installed"
+" in this circumstance. If you wish to remove these applications (in "
+"bulk), you may do so with:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:647 eb6d4881a8894eac8f986951a5701ce9
+msgid ""
+"If you wish to keep specific applications, simply \"install\" them with "
+"`apt` first. This marks them as \"manually installed\", excluding them "
+"from automatic removal."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:649 99b1a7f5c4374d3194aa371c4e5376f6
+msgid "Swap is created with `cloud-init` on Raspberry Pi"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:653 43a38a3c544c4294bb19d039a3c2f1a6
+msgid ""
+"The creation of the swap file on the desktop images is now handled by "
+"[`cloud-init`](https://cloudinit.readthedocs.io/en/latest/) ([LP: "
+"#2116275](https://launchpad.net/bugs/2116275)). You may customize the "
+"size of the swap file by editing `user-data` on the boot partition prior "
+"to first boot (commented examples are included in the image)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:655 b888f09402014b8a8bb91c88932bc1cf
+msgid "New RISC-V requirements"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:659 8ce60d477cd64f3dbc03131ca23d901d
+msgid ""
+"The RISC-V version of Ubuntu 26.04 LTS only supports hardware that "
+"implements the RVA23S64 ISA profile. You can't run Ubuntu 26.04 LTS on "
+"systems that don't satisfy this requirement. Ubuntu 24.04 LTS continues "
+"to support boards with the earlier RVA20 processor cores."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:661 a0caf303f20b456daf784f6d18970e1d
+msgid ""
+"As of April 2026, no RVA23S64 hardware is available yet. The only "
+"supported RISC-V platform is the QEMU virtualization with the `-cpu "
+"rva23s64` CPU profile."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:663 4cb6eb4331144663bca835f535365157
+msgid "IBM Z requirements raised to z15"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:667 842f62ca20c14f16a7ec7c705727ad14
+msgid ""
+"On the IBM Z (s390s) architecture, Ubuntu 26.04 LTS now requires the z15 "
+"architectural level at minimum. As a result, you can't install Ubuntu "
+"26.04 LTS on IBM Z generation z14 (LinuxONE II) or older."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:669 a0c194807121457fbdadcdd736868ae1
+msgid ""
+"The performance on IBM Z generation z15 (LinuxONE III) and newer has "
+"improved."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:671 df6b389ff136401b9cc146d51b313da0
+msgid "For more information, refer to the following release notes:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:673 c92a855b23714081a18d1bf65c542dab
+#, python-brace-format
+msgid "{ref}`ibm-z15-level`"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:674 dee7c69c7e4a43229214f3ee1ce37cd9
+#, python-brace-format
+msgid "{ref}`ibm-z14-support-removed`"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:676 61bb78119c53411cbb9aaea2f0740b02
+msgid "Common changes"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:678 794fa247027d45a4a7e4008cf1970435
+msgid "`sudo-rs`"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:682 c5563ed4fe054221be1b78adb1885488
+msgid "The `sudo-rs` tool is now the default `sudo` provider."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:684 f1f67430e4184b58b6d0c2e9aa8545ea
+msgid ""
+"The `sudo` tool (the original `sudo` maintained by Todd C. Miller) has "
+"been renamed to `sudo.ws`. Additionally, the `sudo-ldap` package has been"
+" removed: please switch to using LDAP authentication via PAM."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:686 c031b349e6144740ab4b308ef15198d4
+msgid ""
+"See [Ubuntu Server Docs](https://documentation.ubuntu.com/server/how-"
+"to/security/user-management/#sudo-rs) for configuring your default `sudo`"
+" provider and for the differences between `sudo-rs` and `sudo.ws`."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:689 e634b4505c684a48a620d88690de02a7
+msgid "`rust-coreutils`"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:693 42325e3664ab43d7a138a91f72a96443
+msgid ""
+"The core utilities of the operating system are now provided by the "
+"[`rust-coreutils`](https://launchpad.net/ubuntu/+source/rust-coreutils) "
+"package. Among other things, this brings significant performance "
+"improvements, such as in the `base64` tool."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:695 2d199f51199a43749f9de04cd89a8c6e
+msgid ""
+"Since `rust-coreutils` are not necessarily fully compatible yet, we "
+"continue to provide the classic GNU utilities as well. You can switch "
+"back and forth between them."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:698 aca40fae86894a43b8b6d7ea61f6aada
+msgid "Linux kernel 7.0"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:700 0816e6dedae24016b7eba602c45c4331
+msgid "The Linux kernel has been updated from version 6.8 to 7.0."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:702 891b6b01ec0b4cf58e452b267e6c6693
+msgid ""
+"Crash dumps are now [enabled by "
+"default](https://documentation.ubuntu.com/server/how-to/software/kernel-"
+"crash-dump/#kdump-enabled-by-default) for desktop and server "
+"installations."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:707 4330b6f1bfa44b9b8a5dbf00d979b45a
+msgid ""
+"Kernel developers can now make use of a [new scheduling "
+"system](https://canonical.com/blog/crafting-new-linux-schedulers-with-"
+"sched-ext-rust-and-ubuntu), `sched_ext`, which provides a mechanism to "
+"implement scheduling policies as eBPF programs. This enables developers "
+"to defer scheduling decisions to standard user-space programs and "
+"implement fully functional hot-swappable Linux schedulers, using any "
+"language, tool, library, or resource accessible in user-space."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:712 8ecfe6b31adf48d3b1706c250749d113
+msgid ""
+"After the generic kernel gained the ability to [tune responsiveness at "
+"boot time](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2051342),"
+" the `linux-lowlatency` binary package has been retired in favor of a "
+"combination of `linux-generic` and a new user-space `lowlatency-kernel` "
+"package, responsible of tuning the GRUB command line."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:717 598d392e601746d798a09913d82d2b36
+msgid "`systemd` 259"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:719 2df0063f597141058aa7ff0e53167df7
+msgid "The `systemd` service manager has been updated from version 255 to 259."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:721 bc7ece6c5174465aa5a89d184c0abaad
+msgid ""
+"Ubuntu 26.04 LTS is the last release that supports System V service "
+"scripts compatibility in `systemd`. Migrate your legacy System V scripts "
+"to native `systemd` unit files."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:723 dc9fe621a01b44ea8d7a81abb6f8990e
+#, python-brace-format
+msgid ""
+"Support for `cgroup` version 1 (`legacy` and `hybrid` hierarchies) has "
+"been removed. For details, see {ref}`cgroup-v1-removed`."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:728 faba3bef23e94c98b8da169571c8b058
+msgid ""
+"Ubuntu now comes with the upstream `tmp.mount` unit by default. As a "
+"result, the `/tmp` directory is now a `tmpfs` file system by default."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:733 66479a68500b45f5a16f3c97f8e6b267
+msgid "Netplan 1.2"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:735 63e80d24a690419596ffb15294402887
+msgid "The Netplan network manager has been updated from version 1.0 to 1.2."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:737 bba30f1855714dd7b5f203312eaff173
+msgid ""
+"Netplan introduces a custom `systemd-networkd-wait-online` logic, waiting"
+" for link-local addresses and one routable interface, as described in the"
+" [specification](https://discourse.ubuntu.com/t/spec-definition-of-an-"
+"online-system/27838)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:742 d8606c35fd0e4467a1b76ebc2f81bd45
+msgid ""
+"Besides improvements to the `embedded-switch-mode` setting for SR-IOV "
+"devices, Netplan introduces a parser flag to skip broken configurations "
+"and fixes for ProtonVPN and Microsoft Azure Linux."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:747 fdffb03a998946f19ea15dcb5c83cec5
+msgid ""
+"Adding support for `wpa-psk-sha256` WiFis and allowing to configure "
+"**routing-policy** on the NetworkManager backend (LP: "
+"[#2086544](https://launchpad.net/bugs/2086544))."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:752 c1aa7906a8c4462e9ee55a8a91f6d6c6
+msgid "Adds support non-standard OVS setups, e.g. inside snap environments."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:757 4b368d22e25346f285cb9e0b75e5af3a
+msgid "Package Management: APT 3"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:759 6129b49bc7f04088b10f3d8d59709f73
+msgid "APT has been updated from version 2.7 to 3.1."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:761 b515d3eebc2146e5bf702124f71953b2
+msgid ""
+"The new dependency solver is now automatically used if the classic solver"
+" cannot find a solution to either find a solution or add more context to "
+"the failure, and in other cases to [evaluate its "
+"performance](https://discourse.ubuntu.com/t/evaluating-the-new-apt-"
+"solver-in-25-04/55618)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:763 757f9d67f5ba4dbca64942a18a0bd341
+msgid ""
+"APT has switched from GnuTLS and gcrypt to the OpenSSL library for TLS "
+"connections and file hashing, which should improve compatibility and "
+"reduces the footprint of minimal installations."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:765 0e602c5c313a4d02ae3c90601f5997ae
+msgid ""
+"An automatic pager has been added to `apt(8)` for commands such as show "
+"and list, similar to `git log` and `journalctl`."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:767 8125b7e438ff47dabe39a71b3125cca2
+msgid ""
+"The `apt-key` command has been removed. Signature verification now makes "
+"direct use of `gpgv`. Some packages and system administration scripts may"
+" need adjustment for managing keys directly, advice can be found in the "
+"`apt-secure(8)` manual page."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:769 a403d57171f44504931d2f9312850a4b
+msgid "Dracut"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:773 4c8dad1976334278b6f1ebac32530aae
+msgid ""
+"Ubuntu now uses Dracut as its default initial ramdisk infrastructure, "
+"replacing `initramfs-tools`. Dracut uses `systemd` in the initial ramdisk"
+" and supports new features like Bluetooth and NVM Express over Fabrics "
+"(NVMe-oF)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:775 d1bc7ee7f3544c90962d647ddbd95fd1
+msgid ""
+"The original `initramfs-tools` remains supported and you can switch "
+"between the two implementations if required."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:777 2da5d494f7894e91a144d4fb581e0327
+msgid ""
+"For details about the switch, see [the "
+"specification](https://discourse.ubuntu.com/t/spec-switch-to-"
+"dracut/54776)."
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:780 31c4b07ef0ae49aba25e828139a610cf
+msgid "More details"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:782 b20ba741bf834e8d9d5764b188464777
+msgid ""
+"For a complete list of changes in Ubuntu 26.04 LTS, refer to the "
+"following documents, depending on the Ubuntu release that you're "
+"upgrading from:"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:784 1a6175672aa240cb84567ce21d0999d2
+#, python-brace-format
+msgid "{ref}`ubuntu-24.10-release-notes`"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:785 349347de02004865aaa5fb46b1f02442
+#, python-brace-format
+msgid "{ref}`ubuntu-25.04-release-notes`"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:786 1845beae9bc6420c9f69e491c28255a0
+#, python-brace-format
+msgid "{ref}`ubuntu-25.10-release-notes`"
+msgstr ""
+
+#: ../../26.04/summary-for-lts-users.md:787 f2ca78f724604299a8e0c19467b1b5dc
+#, python-brace-format
+msgid "{ref}`ubuntu-26.04-lts-changes-since-25.10`"
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/26.10/index.po
+++ b/docs/locale/ja/LC_MESSAGES/26.10/index.po
@@ -1,0 +1,38 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../26.10/index.md:8
+msgid "Release schedule"
+msgstr ""
+
+#: ../../26.10/index.md:2 2c8c7e420533462aae150252247cb1bb
+msgid "Ubuntu 26.10 release notes"
+msgstr ""
+
+#: ../../26.10/index.md:4 57ff1da2f2b64b0891eafa3a41cc89c4
+msgid "Ubuntu 26.10 (S S) is currently in development."
+msgstr ""
+
+#: ../../26.10/index.md:6 0052e5529d6f44198e5653fe161027c3
+msgid "For the release schedule of Ubuntu 26.10, refer to:"
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/26.10/schedule.po
+++ b/docs/locale/ja/LC_MESSAGES/26.10/schedule.po
@@ -1,0 +1,493 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../26.10/schedule.md:2 a63e7677a4434cc4bd9441dcccd48c23
+msgid "Ubuntu S S Release Schedule"
+msgstr ""
+
+#: ../../26.10/schedule.md c88921be152f425e80ccbf3430ee8c6e
+#: d744616c350d4eb3bc5e41ac57885674
+msgid "Week"
+msgstr ""
+
+#: ../../26.10/schedule.md 103b32ae152e4afab474fbf152d5dcb3
+#: 16ac1e59a67b426bbfec8b6ab9f595b7
+msgid "Date (Thursday)"
+msgstr ""
+
+#: ../../26.10/schedule.md bfcca7737c7c4832ae2d791f3443425b
+msgid "26.10 events"
+msgstr ""
+
+#: ../../26.10/schedule.md 18e7d88fa58e470ca1c29af64d91fe99
+#: 55f35943c02b4becbd5a720e50a621e1
+msgid "**April 2026**"
+msgstr ""
+
+#: ../../26.10/schedule.md d5e4ed70d7cc47c097bcab425d52d96a
+#: eab1e8abc3ef4cbd831ca46fab105d05
+msgid "1"
+msgstr ""
+
+#: ../../26.10/schedule.md 1276453cfd5e4ed6b8197342c55fc593
+#: 4771e60425f7447098560b6cdc1a3a78
+msgid "April 30"
+msgstr ""
+
+#: ../../26.10/schedule.md b0b25a4c12e24c7785bb7c119f1a256a
+msgid "Toolchain Uploaded"
+msgstr ""
+
+#: ../../26.10/schedule.md 26529fa65d7a4caaa61e2e71e4c3d45f
+#: 28ce19b696dd41188a83c08da6e8a71e
+msgid "**May 2026**"
+msgstr ""
+
+#: ../../26.10/schedule.md 6b3047ff54fa4def91c9a9cb84c16f03
+#: cf73b9d57d8543b8afcf7f697be52622
+msgid "2"
+msgstr ""
+
+#: ../../26.10/schedule.md 031cd52afa534ddc8aec8960e2949096
+#: cfd35b2ebd654645ac45ff50fe8a128e
+msgid "May 07"
+msgstr ""
+
+#: ../../26.10/schedule.md 089b7de4de3c47008b386f06fe832816
+#: 6acf0711128841cc9b895bb1012a0c99
+msgid "3"
+msgstr ""
+
+#: ../../26.10/schedule.md 9f1a2cc605f24ba48ab8d740a2a44d30
+#: ae51aaef0ce4428b8e6004add1077fad
+msgid "May 14"
+msgstr ""
+
+#: ../../26.10/schedule.md 32b80f424ff24a98bf674108e829e90b
+#: 8bf07de9dcc84c10b357a5696208d975
+msgid "4"
+msgstr ""
+
+#: ../../26.10/schedule.md 89541a25da3440f3b89394aace5b06c4
+#: aa22fc494d814581b6c5b6414eae9f46
+msgid "May 21"
+msgstr ""
+
+#: ../../26.10/schedule.md 8c334219b28344f3a8b3b26183a16ae0
+#: e55263da69d84f4f8d832d43b1cadff6
+msgid "5"
+msgstr ""
+
+#: ../../26.10/schedule.md 01a72769da204add90ed34da9a1fcf19
+#: 359812e691c24ee0afa83ffbe75a34ba
+msgid "May 28"
+msgstr ""
+
+#: ../../26.10/schedule.md 17565bf064674e7e94a3a50b33e6dc64
+#: f322b6ba8d4b48d09144bd6f0f0ee701
+msgid "**June 2026**"
+msgstr ""
+
+#: ../../26.10/schedule.md 917b7bd9f5f0453aa421a5ae64af7f1d
+#: f3b056263d5d403c877d07d205e0d09d
+msgid "6"
+msgstr ""
+
+#: ../../26.10/schedule.md be5d89c6c44348408954f64301be59d7
+#: febe407682e04d899836a8c4b7036b17
+msgid "June 04"
+msgstr ""
+
+#: ../../26.10/schedule.md 72304e2572804013986526f5169e9083
+#: a5e258eb0dac4eb088b97e064246ea02
+msgid "7"
+msgstr ""
+
+#: ../../26.10/schedule.md 1e44157d1a0948bc98d243d9c80a637b
+#: 84a053550b754c4cbf65ba7095da51a5
+msgid "June 11"
+msgstr ""
+
+#: ../../26.10/schedule.md 2a5a3ff5b4f7452aafa7b3bc53f6af16
+#: adc588760c774812b52ad15675209e46
+msgid "8"
+msgstr ""
+
+#: ../../26.10/schedule.md 484964a25c234f7c90b9d30e63f751bf
+#: 496e96ca950a4d85a2b1a5d6fa31fd4a
+msgid "June 18"
+msgstr ""
+
+#: ../../26.10/schedule.md 756db176253f40739738490a95431759
+#: f79b736a914e49bf9063f97e2a40d76e
+msgid "9"
+msgstr ""
+
+#: ../../26.10/schedule.md 1829565b5cb54059ae32ca42c32dbeb5
+#: e86d25cdfea34b8386e85d322dd7ed59
+msgid "June 25"
+msgstr ""
+
+#: ../../26.10/schedule.md 07c126dbea7446feab5c1f0c5f67e89d
+#: e21c2f0242674a98880599f254fd391f
+msgid "**July 2026**"
+msgstr ""
+
+#: ../../26.10/schedule.md 44666027fc534c6ebf4a763e4d3696c4
+#: e1ac2afa87084791be0400653ea5c82c
+msgid "10"
+msgstr ""
+
+#: ../../26.10/schedule.md 7b5a9d2a51184105bfd7b5943e373140
+#: d93d572b2e9347fcb2383a47d2267b8c
+msgid "July 02"
+msgstr ""
+
+#: ../../26.10/schedule.md 20bc7bf838f341f3962a93b89fd4085e
+#: 6bd0c6b4847e4064911dd46648358c7f
+msgid "Ubuntu Testing Week (optional)"
+msgstr ""
+
+#: ../../26.10/schedule.md 8cd842e0792f479996d1a1f9ee2b6d41
+#: b1778c318d0c4cb582e006b2c0e69202
+msgid "11"
+msgstr ""
+
+#: ../../26.10/schedule.md 206026cb39f847d58452488db1b57efb
+#: 5fa64a22cbf747d6ad48e620ae24c677
+msgid "July 09"
+msgstr ""
+
+#: ../../26.10/schedule.md 6ff554a8e0974f34b3a39cac223c50c0
+#: 7e45ea6485c84a53a58967547be3ad56
+msgid "12"
+msgstr ""
+
+#: ../../26.10/schedule.md 2cc3c24e59e6460882fa0590599c9043
+#: 526e3a8c4e994e3dbeb2a961f45e57af
+msgid "July 16"
+msgstr ""
+
+#: ../../26.10/schedule.md 441794f043aa4f02ba32971e91f3dfdd
+#: 861e153b8317411698c106e311e216a7
+msgid "13"
+msgstr ""
+
+#: ../../26.10/schedule.md 8827c5176b2348ce8c71e691d7fac1b9
+#: fd5da5a9fd92403d8bfd04b392522436
+msgid "July 23"
+msgstr ""
+
+#: ../../26.10/schedule.md 8bf79dc5ee494707b8996eb7eef21bb8
+#: cc8542a4abc1430c9779d35ae4e43a6f
+msgid "14"
+msgstr ""
+
+#: ../../26.10/schedule.md 23b8632e96df4519804150ef008dd65b
+#: 50410563f8a4413c95ec0543940c9a4c
+msgid "July 30"
+msgstr ""
+
+#: ../../26.10/schedule.md b944a7b97ce84e78b138e61204e368de
+#: e7d01681b7de40968b377f5ef7d4d2bb
+msgid "**August 2026**"
+msgstr ""
+
+#: ../../26.10/schedule.md b0cec464a0134833900235e49744ca79
+#: dd7fcf4e2e8b4d77b647a9afcf5ef1ee
+msgid "15"
+msgstr ""
+
+#: ../../26.10/schedule.md 3c4a88227e464cc38db91c0650298b5b
+#: 91f12d74484b4576b4f7427207e1b0bf
+msgid "August 06"
+msgstr ""
+
+#: ../../26.10/schedule.md 6ad51ce13e42462d8b0a2b4b630fd57d
+#: 83d0e107df2b426a852a1cb74d0f1def
+msgid "16"
+msgstr ""
+
+#: ../../26.10/schedule.md 49acbc665e9e4d67a4c790c4a8196d06
+#: bfcbd1ccaba54d809d50b2738420fc04
+msgid "August 13"
+msgstr ""
+
+#: ../../26.10/schedule.md 6d4e35e3467a4deb929b786e70f488a0
+#: b0fa96cf951b4def92c8c4e2beea6574
+msgid "17"
+msgstr ""
+
+#: ../../26.10/schedule.md 98ea934488cf45f18a534cf6fe4e72f3
+#: aaa9927d75f149c586886f2062d12559
+msgid "August 20"
+msgstr ""
+
+#: ../../26.10/schedule.md f4fa10f7418541d290f1ba91367cb576
+msgid ""
+"[Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), Debian Import "
+"Freeze"
+msgstr ""
+
+#: ../../26.10/schedule.md 2fd9d66c47a14b9783b5cfd952b853a0
+#: 43389db1243a497990888db4cb22fbed
+msgid "18"
+msgstr ""
+
+#: ../../26.10/schedule.md 75a8dd09fc4c42a4b0b0250d84e02250
+#: 8988cb3835294474954fcd6b1ea9ef11
+msgid "August 27"
+msgstr ""
+
+#: ../../26.10/schedule.md 26eefa9646b043a9b7d8bd40b14035db
+#: 8096e884a83941ba88fd81240a31a8e5
+msgid "**September 2026**"
+msgstr ""
+
+#: ../../26.10/schedule.md 638f7bf0bf454cb7bcc490004878cdf4
+#: 6d29c939114e43daba509beb7eb2ca6a
+msgid "19"
+msgstr ""
+
+#: ../../26.10/schedule.md 1803f794d2a9472b97261d67e50e1363
+#: a1807c5ed7c045b6a720836e05ad0dc7
+msgid "September 03"
+msgstr ""
+
+#: ../../26.10/schedule.md 7d62b8a8f036430182d6bc6cec9cc830
+#: aad1d110281246419835c88e086c6945
+msgid "20"
+msgstr ""
+
+#: ../../26.10/schedule.md 0eff9ef29d9246e089f79758dc120742
+#: a31831d89f944df8bb7e87f0b76071bc
+msgid "September 10"
+msgstr ""
+
+#: ../../26.10/schedule.md f315e37c58c841ca9ebf483c67e8b389
+msgid "[User Interface Freeze](https://wiki.ubuntu.com/UserInterfaceFreeze)"
+msgstr ""
+
+#: ../../26.10/schedule.md 88816b72fe5848a2befc4b90a996cc2c
+#: 98092d451ecb4d1a9a8e7b27e22a9292
+msgid "21"
+msgstr ""
+
+#: ../../26.10/schedule.md 0e488fed8ad24eca9552d36fbcc73e7a
+#: 325e1c1fa49946a2ac88d61a3e875299
+msgid "September 17"
+msgstr ""
+
+#: ../../26.10/schedule.md d499b976ab8f4bd3ae667a036a323b8c
+msgid ""
+"[Documentation String "
+"Freeze](https://wiki.ubuntu.com/DocumentationStringFreeze), [Kernel "
+"Feature Freeze](https://wiki.ubuntu.com/KernelFeatureFreeze)"
+msgstr ""
+
+#: ../../26.10/schedule.md d20843a4ef4b4e8c97f23d40401461b6
+#: de3975672b0f4c7aba719afbac724c81
+msgid "22"
+msgstr ""
+
+#: ../../26.10/schedule.md 207005bd3cd24f38a6977e54d598a098
+msgid "September 21 (Monday)"
+msgstr ""
+
+#: ../../26.10/schedule.md f13878a6fc8542dfb043d99ab3bb58ef
+msgid ""
+"[Beta Freeze](https://wiki.ubuntu.com/BetaFreeze), [Hardware Enablement "
+"Freeze](https://wiki.ubuntu.com/HardwareEnablementFreeze)"
+msgstr ""
+
+#: ../../26.10/schedule.md 019a9b47b42c4381a6e0aee18fe4987f
+msgid "⠀"
+msgstr ""
+
+#: ../../26.10/schedule.md 9795a2e1656c4251afd718ea04ac1f26
+#: a449d2d194d347f8bcb37fbc17a32608
+msgid "September 24"
+msgstr ""
+
+#: ../../26.10/schedule.md aeef3490e6884bb9801db3a582403b1c
+msgid "Beta (mandatory)"
+msgstr ""
+
+#: ../../26.10/schedule.md 01911e08544245ca80a70d91d5cda144
+#: af0485492c2a467193d590cbdac19a53
+msgid "**October 2026**"
+msgstr ""
+
+#: ../../26.10/schedule.md 0a7e39b66e6a46aba53dc0e8e0d78b5c
+#: 62aef0df733944fdbcbd881bf6d28d94
+msgid "23"
+msgstr ""
+
+#: ../../26.10/schedule.md ad2b151efec5475481b03fb03a2bf133
+#: fd2521b0a5d0463dbc73ce70a78e7ae0
+msgid "October 01"
+msgstr ""
+
+#: ../../26.10/schedule.md 3faf934f66b6417d979e80de059748e4
+msgid ""
+"[Kernel Freeze](https://wiki.ubuntu.com/KernelFreeze), [Non Language Pack"
+" Translation "
+"Deadline](https://wiki.ubuntu.com/NonLanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../26.10/schedule.md 7f92545b75e5420fa6829fcf2c63e48c
+#: d00293fc68ce48058e5b2469e14154e4
+msgid "24"
+msgstr ""
+
+#: ../../26.10/schedule.md 0a770562330f4b1cb9fe88b2e0fca818
+#: ecb9256b76fb44f78cfde40789e1ba73
+msgid "October 08"
+msgstr ""
+
+#: ../../26.10/schedule.md e6598e6e147f42ceaa0b80159f0fd02a
+msgid ""
+"[Final Freeze](https://wiki.ubuntu.com/FinalFreeze), [Release "
+"Candidate](https://wiki.ubuntu.com/ReleaseCandidate), [Language Pack "
+"Translation "
+"Deadline](https://wiki.ubuntu.com/LanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../26.10/schedule.md 2d27e5a6c6ce45fc983b4cc8d705d749
+#: 7810ce5f435e4d3ba8e355f13c7bfeb5
+msgid "25"
+msgstr ""
+
+#: ../../26.10/schedule.md af5f192440ab465cba8ea04ac39a478a
+#: bf913d1948ef47b5928f99995753f0d3
+msgid "October 15"
+msgstr ""
+
+#: ../../26.10/schedule.md 3a27d227f77a463fad153cc875af188e
+msgid "[Final Release](https://wiki.ubuntu.com/FinalRelease)"
+msgstr ""
+
+#: ../../26.10/schedule.md:43 1eb5e0df9d1940419126692f3eab93af
+msgid "Planned and potentially disruptive archive-wide activities"
+msgstr ""
+
+#: ../../26.10/schedule.md:45 187c6d393851481e8f410f4bf327530d
+msgid ""
+"If you're planning a change that might have a disruptive effect on the "
+"archive - e.g. transitions or switches of important defaults (such as "
+"compiler versions) - list it here."
+msgstr ""
+
+#: ../../26.10/schedule.md 4ff4115e0dee4656bac01601f849ab0d
+msgid "Planned activity"
+msgstr ""
+
+#: ../../26.10/schedule.md:82 510baefdb7dd430caa8bcc24376c7e61
+msgid "Ubuntu S S Release Task Signup Sheet"
+msgstr ""
+
+#: ../../26.10/schedule.md:84 c1cde72fcd834825aca64f9797e5561c
+msgid "This signup sheet is to be used for planning release milestone tasks."
+msgstr ""
+
+#: ../../26.10/schedule.md:86 5620fde50aaa418a8175a6d172452b75
+msgid ""
+"The Alpha and Beta 1 milestones have been replaced with [Testing "
+"Weeks](https://lists.ubuntu.com/archives/ubuntu-"
+"release/2018-April/004434.html), which are organized ad hoc at this "
+"point."
+msgstr ""
+
+#: ../../26.10/schedule.md 5360eb4ef5e943afb5179b49bcaed810
+msgid "Milestone"
+msgstr ""
+
+#: ../../26.10/schedule.md 423bbaea6fe54891b87770ae87f4d2da
+msgid "Date"
+msgstr ""
+
+#: ../../26.10/schedule.md ff22f321cd694f3baf30a3d012d9d64c
+msgid "Image (Nusakan) Engineering"
+msgstr ""
+
+#: ../../26.10/schedule.md 24b254b7b6484e8a9d061cff54627e5e
+msgid "Checklist Tracking"
+msgstr ""
+
+#: ../../26.10/schedule.md 6cbe3acd2a5944c29a4fe5987d038c59
+msgid "Announcement Email"
+msgstr ""
+
+#: ../../26.10/schedule.md 03fc6e1296ca4a5ea615f84dde890df3
+msgid "Feature Freeze"
+msgstr ""
+
+#: ../../26.10/schedule.md 7293fb4621ea453595a06f19f88570c3
+#: 75f2099a046749bc806812d8a1eacd54 9c7a4fab34134d9199bd4af9cc4308cf
+#: ee37166fbff94225ac84a554a40c9564 f79e2b0b96a14e4b87eb02421831014d
+msgid "n/a"
+msgstr ""
+
+#: ../../26.10/schedule.md 7eacff01391147418aa8a528f97abb3e
+msgid "UI Freeze"
+msgstr ""
+
+#: ../../26.10/schedule.md 61274347d50f4477b317a259a3240532
+msgid "Doc String Freeze"
+msgstr ""
+
+#: ../../26.10/schedule.md 1554d26b563d42eb9c23c28497f4e332
+msgid "26.10 Beta"
+msgstr ""
+
+#: ../../26.10/schedule.md 944134b85d6b461e8d8c9e49a41a9d8e
+msgid "Final Freeze"
+msgstr ""
+
+#: ../../26.10/schedule.md 573dbb11a19c453babd487814872d6ce
+msgid "26.10 Release"
+msgstr ""
+
+#: ../../26.10/schedule.md c9c80c27dc2c47e1bf13d86a63b2585a
+msgid "October 15 2026"
+msgstr ""
+
+#: ../../26.10/schedule.md:97 afd0a1dd739b4b7cb19d0f1bcd42224d
+msgid ""
+"When the archive is frozen, all members of the release team are expected "
+"to participate in bug fix reviews."
+msgstr ""
+
+#: ../../26.10/schedule.md:99 c2133fa5a239432788bc283bf060c8a9
+msgid ""
+"After [Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), all "
+"members of the release team are expected to participate in Feature Freeze"
+" Exception reviews in their particular area of expertise."
+msgstr ""
+
+#: ../../26.10/schedule.md:101 4d847d06b3304b97a84acbdd3f1e8d61
+msgid ""
+"After [Final Beta](https://wiki.ubuntu.com/FinalBetaRelease), all members"
+" of the release team are expected to participate in Bug fix reviews in "
+"their particular area of expertise."
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/27.04/schedule.po
+++ b/docs/locale/ja/LC_MESSAGES/27.04/schedule.po
@@ -1,0 +1,509 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../27.04/schedule.md:2 5fc65236b2dc474c8a91773aaba25972
+msgid "Ubuntu T T Release Schedule"
+msgstr ""
+
+#: ../../27.04/schedule.md 1bf0b546f5fc47f8bf93bc06b07498ed
+#: 63130fbd66704e7f8195df252c9669c2
+msgid "Week"
+msgstr ""
+
+#: ../../27.04/schedule.md 18476d5a4b7a4adb883592e26ddcf3e6
+#: 268fc4ffc89741d184242fc2e89aa713
+msgid "Date (Thursday)"
+msgstr ""
+
+#: ../../27.04/schedule.md b412f15b17a442669b825e484475f5b1
+msgid "27.04 events"
+msgstr ""
+
+#: ../../27.04/schedule.md a852d26f83314d64bc361ee594a5846f
+#: b401fdf1924649679ff9d0171ab0e59c
+msgid "**October 2026**"
+msgstr ""
+
+#: ../../27.04/schedule.md 472de431494749ee9010aa200a0c4862
+#: 67d7619983a74a4a89804b18d6530ccd
+msgid "1"
+msgstr ""
+
+#: ../../27.04/schedule.md 3356979d8f1e43c1bdf930ea56e4aa3a
+#: 3716ead9a0924b0db30acfaea27b990b
+msgid "October 22"
+msgstr ""
+
+#: ../../27.04/schedule.md 1f8a9d06c2474959a6f7b88cd94167a5
+msgid "Toolchain Uploaded"
+msgstr ""
+
+#: ../../27.04/schedule.md 1aa0bdcdb39d43ffa6e857b58b62b2c4
+#: 963937253bb34fef861ccc99b3b4f7d7
+msgid "2"
+msgstr ""
+
+#: ../../27.04/schedule.md a12e7cc5cd9f4daca4327bbca0b5b3ae
+#: aef4ee29a5f040c6a6ad72a44f33c014
+msgid "October 29"
+msgstr ""
+
+#: ../../27.04/schedule.md 1b7a054bb9124244915237006c4b3355
+#: e1399a526559458b83e02674987c104d
+msgid "**November 2026**"
+msgstr ""
+
+#: ../../27.04/schedule.md 4d0f7b58b7a04e01be3e50f3240fce74
+#: f43d7f49fc5d4e5ca1700135a250de2a
+msgid "3"
+msgstr ""
+
+#: ../../27.04/schedule.md 8a69391ede7b4c50a55a43e858f26d69
+#: 9e60bf36a83642bb89356f5dd155c9fd
+msgid "November 05"
+msgstr ""
+
+#: ../../27.04/schedule.md 635a10f63e1942cf87a7b67d644ae630
+#: f7136f005b5148a680fcdbcafc19c213
+msgid "4"
+msgstr ""
+
+#: ../../27.04/schedule.md 70cf63b616cb4bc7b948460b78a223d1
+#: c65a4cdb2ab64432aeb1d1bd43863a5c
+msgid "November 12"
+msgstr ""
+
+#: ../../27.04/schedule.md 4b9e623769234c5bb7ab5577fe6723c7
+#: d0757a3671104cfe9953410e8a2fd145
+msgid "5"
+msgstr ""
+
+#: ../../27.04/schedule.md 06cf8016e71f453180b1ce095ca3a75e
+#: 93a7867e5aeb4a9da79117bfabd04543
+msgid "November 19"
+msgstr ""
+
+#: ../../27.04/schedule.md a29feda0a1e645de86c17dab92aa503e
+#: eec821f83cf841ef87c62e92b7ba9a82
+msgid "6"
+msgstr ""
+
+#: ../../27.04/schedule.md 2186384bed1c43009de2cac69cb2d317
+#: 55458bd144084382a7fda23b69222941
+msgid "November 26"
+msgstr ""
+
+#: ../../27.04/schedule.md 3c75f0168e0f42d69fc8335cd41942ac
+#: e02e71946d134a6aa180ba72465d5c68
+msgid "**December 2026**"
+msgstr ""
+
+#: ../../27.04/schedule.md 14f89ab555684e9e8053cda716207925
+#: 2819ae7c4fec43368d52046211b9c844
+msgid "7"
+msgstr ""
+
+#: ../../27.04/schedule.md 6cdd92adefcd49ff99f097f00aadfbe9
+#: cc24af30837649b0b2b09bfd4a517afa
+msgid "December 03"
+msgstr ""
+
+#: ../../27.04/schedule.md 5749c0497f9d4c3392fddc7f7c5c3633
+#: aa051a4a880b4bca88656fb4d2ef9170
+msgid "8"
+msgstr ""
+
+#: ../../27.04/schedule.md 27a1e490001c4f208490451393b6f553
+#: 860aafae28f84a568c94216a4df94c4c
+msgid "December 10"
+msgstr ""
+
+#: ../../27.04/schedule.md 4787f694ad874ff796ba609de07f3a7b
+#: c9e881ce9cb642558f78cc93810ac355
+msgid "9"
+msgstr ""
+
+#: ../../27.04/schedule.md 4685379ef5234c6db1dfc47e2d04b3e9
+#: e7c2914dd3714b988c8135cf155ebe63
+msgid "December 17"
+msgstr ""
+
+#: ../../27.04/schedule.md 1c57f80962934e1e8fc3a0a8b1a055e9
+#: 4e0f2cb9ac8f4235ba82c28a20f7119e
+msgid "10"
+msgstr ""
+
+#: ../../27.04/schedule.md 3a6fb2b32b18401ca0641f2b9face83c
+#: 8b925d5c2a6e4098ab4d4b9afa1eae75
+msgid "December 24"
+msgstr ""
+
+#: ../../27.04/schedule.md 7cb9a4bbaa8d48238cdf26e9f5289b78
+#: 7e9525f0459e4cc9a57a1cb9b0382366
+msgid "Ubuntu Testing Week (optional)"
+msgstr ""
+
+#: ../../27.04/schedule.md 2d281d34bb6044678395a6896b842ce1
+#: c973bc1893c9414692925fe9e119c45d
+msgid "11"
+msgstr ""
+
+#: ../../27.04/schedule.md 5960ed8e524448c3928277bd174eaa48
+#: 8d7a170cfdcb4951be92197a94022292
+msgid "December 31"
+msgstr ""
+
+#: ../../27.04/schedule.md 8c215f9af23d46099459ec7892a7a737
+#: a67bd925768843b39a94739ce40021d7
+msgid "**January 2027**"
+msgstr ""
+
+#: ../../27.04/schedule.md 41e6574bd9af4569a2b627e2b875c274
+#: 4db37eecaa2149af924b96d93f20641d
+msgid "12"
+msgstr ""
+
+#: ../../27.04/schedule.md 4986192a92644cdbadd5bd745bff06d6
+#: 8f3bd6a2e6944ae98b6aefa3351b0629
+msgid "January 07"
+msgstr ""
+
+#: ../../27.04/schedule.md a1c98d9791e049b98503aaedb6b2ba81
+#: fdf7504e5b0e4a30acc32f37e603b35d
+msgid "13"
+msgstr ""
+
+#: ../../27.04/schedule.md 7d59c8ff396b46dba1abb2b84549a0d6
+#: b68dd83dea9e45c6851436664f6e51a2
+msgid "January 14"
+msgstr ""
+
+#: ../../27.04/schedule.md 294ae6ae1349431d9f1f7b42209735f7
+#: 55b1973cf19b43b2943f4cd062131cc5
+msgid "14"
+msgstr ""
+
+#: ../../27.04/schedule.md 2a573e4e69c749489aeef492b0ae14ad
+#: 5e2c2faabcea462691c157417e0832f2
+msgid "January 21"
+msgstr ""
+
+#: ../../27.04/schedule.md 9db49dfd28a54badb06927d948e7cd3c
+#: d599282c4366409ea88a5d3ff9cd86fe
+msgid "15"
+msgstr ""
+
+#: ../../27.04/schedule.md 579648f9ed2943c8bb3f912d47476b5f
+#: 6cb084801f904279b44268a0230683ef
+msgid "January 28"
+msgstr ""
+
+#: ../../27.04/schedule.md 01fb1518a3894ef98196ec73deafdcf1
+#: abc692b50d044fe09e0646816820b78c
+msgid "**February 2027**"
+msgstr ""
+
+#: ../../27.04/schedule.md e2def005c9804cc08aa8e805f82e3fee
+#: e3e704c9b8964992bfc334a96c96affd
+msgid "16"
+msgstr ""
+
+#: ../../27.04/schedule.md 2a7e9f0849ec4bad8948cb6d3f3f2a54
+#: db7861cff9e645d7aca9ade14220bd5e
+msgid "February 04"
+msgstr ""
+
+#: ../../27.04/schedule.md 128c19f30c43469ebb059826386e861c
+#: 279828d15f0e47e0af07e94b86397e23
+msgid "17"
+msgstr ""
+
+#: ../../27.04/schedule.md a8844fce206f487a810a21b7f27c4add
+#: e63094472379420b89de23e13e61369b
+msgid "February 11"
+msgstr ""
+
+#: ../../27.04/schedule.md 89220a732187417ea18f40d8ea339514
+#: e91b20e9b54642a382ac17e116700398
+msgid "18"
+msgstr ""
+
+#: ../../27.04/schedule.md 4de11f4863bc4f9bbddbf260821d57e1
+#: e3526a5755c5437d8376c2da0890b880
+msgid "February 18"
+msgstr ""
+
+#: ../../27.04/schedule.md 884d96f1bd1d4a1e82c2dcc65be60893
+#: f007fa04e80447e98a0d70cad0ef5841
+msgid "19"
+msgstr ""
+
+#: ../../27.04/schedule.md c84b23f6492b4e5280719b04a6b65c2a
+#: d9b7df05468049c19ead2b2602f1f5ed
+msgid "February 25"
+msgstr ""
+
+#: ../../27.04/schedule.md a925f0c47e0840e28e11a8446a25ceee
+msgid ""
+"[Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), Debian Import "
+"Freeze"
+msgstr ""
+
+#: ../../27.04/schedule.md b1a8bcf790a94dc4a6bad1b128e5cfab
+#: e554063005264501abc22b87725483fd
+msgid "**March 2027**"
+msgstr ""
+
+#: ../../27.04/schedule.md 00f88eb31c5d4b0ca5546bfda2803f69
+#: 7803a79e845e436a977feb235bf73243
+msgid "20"
+msgstr ""
+
+#: ../../27.04/schedule.md 68a5068ceaf1442a82d3e70e101668cd
+#: b11b60df82d54393848d7f0729993822
+msgid "March 04"
+msgstr ""
+
+#: ../../27.04/schedule.md 4757e1ef62c6436c9a18e87d66708c1c
+#: 5acb86a29e194d1f9bfe487b37a10f4a
+msgid "21"
+msgstr ""
+
+#: ../../27.04/schedule.md c954d7b0620642a081ccea3ee4b7f186
+#: fda5f0d69d7b4522bc9df2c5e98cf4df
+msgid "March 11"
+msgstr ""
+
+#: ../../27.04/schedule.md a5716c67c10f40c39c7a13dcbf082796
+#: c794b6ca469c46d1a77d57922a22200c
+msgid "22"
+msgstr ""
+
+#: ../../27.04/schedule.md 5c8a6fd08b294983972732a4d9df2144
+#: c599d0a1f8a447e6863953845d6ecb5e
+msgid "March 18"
+msgstr ""
+
+#: ../../27.04/schedule.md a94e31cc3a8a475b9bd88b624aba01f1
+msgid "[User Interface Freeze](https://wiki.ubuntu.com/UserInterfaceFreeze)"
+msgstr ""
+
+#: ../../27.04/schedule.md e3908f6a55e04fdab22f0f18ec1f8b5e
+#: ea8f38f7f7144a53a4beffca691c51c8
+msgid "23"
+msgstr ""
+
+#: ../../27.04/schedule.md 24143e7ee30243d794e73b77497bac8c
+#: 45c7cd2efe6844a9962e4e740153f321
+msgid "March 25"
+msgstr ""
+
+#: ../../27.04/schedule.md f72a58d539974d49be922d3a35ba91ce
+msgid ""
+"[Documentation String "
+"Freeze](https://wiki.ubuntu.com/DocumentationStringFreeze), [Kernel "
+"Feature Freeze](https://wiki.ubuntu.com/KernelFeatureFreeze)"
+msgstr ""
+
+#: ../../27.04/schedule.md 42906325203142ac833f650fcdfde9d7
+#: 4fe2ade062c643d0a97556c649e91af0 e0ba0b47253d43bfb774a48e4ff6856e
+msgid "24"
+msgstr ""
+
+#: ../../27.04/schedule.md 3e10ad41adcc4115b73cbd8e396f86e3
+msgid "March 29 (Monday)"
+msgstr ""
+
+#: ../../27.04/schedule.md 02f4708978e44a358b9b6ab782b4b978
+msgid ""
+"[Beta Freeze](https://wiki.ubuntu.com/BetaFreeze), [Hardware Enablement "
+"Freeze](https://wiki.ubuntu.com/HardwareEnablementFreeze)"
+msgstr ""
+
+#: ../../27.04/schedule.md 6438662d9ce349ccb73b174d082f9fd3
+#: d35f0fd9cc75452c85203f0e54c12f02
+msgid "**April 2027**"
+msgstr ""
+
+#: ../../27.04/schedule.md 11f0184fc05c4b6abcb020cdc341431d
+#: 8c399a14dd074e61be5eb47227391eb1
+msgid "April 01"
+msgstr ""
+
+#: ../../27.04/schedule.md e5c9de06e1424ac896ac8dbf9028bb7a
+msgid "Beta (mandatory)"
+msgstr ""
+
+#: ../../27.04/schedule.md 40badb7c08384363a82092a770baca9b
+#: be5860e538e84f38b1df1d98dc15dd6a
+msgid "25"
+msgstr ""
+
+#: ../../27.04/schedule.md 3d27edd4e22148c28da5f0d4fb5b8414
+#: 78e3f4efd5eb4a62a58cb950d85d1d0d
+msgid "April 08"
+msgstr ""
+
+#: ../../27.04/schedule.md 23a881513b8b4c0d84e4ebbed17148cb
+msgid ""
+"[Kernel Freeze](https://wiki.ubuntu.com/KernelFreeze), [Non Language Pack"
+" Translation "
+"Deadline](https://wiki.ubuntu.com/NonLanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../27.04/schedule.md acae1277005746ebbe4cf3fd8e76203a
+#: f08636dee6b44b41b86ee77fe8bdd807
+msgid "26"
+msgstr ""
+
+#: ../../27.04/schedule.md 1922184d1acc4327ab555afe994e2720
+#: 1e9e785d71264a16aa99bb7415d8ed31
+msgid "April 15"
+msgstr ""
+
+#: ../../27.04/schedule.md ea6d5b97f83d4fa4be6d1bc7f360fb95
+msgid ""
+"[Final Freeze](https://wiki.ubuntu.com/FinalFreeze), [Release "
+"Candidate](https://wiki.ubuntu.com/ReleaseCandidate), [Language Pack "
+"Translation "
+"Deadline](https://wiki.ubuntu.com/LanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../27.04/schedule.md 9fc7149eec0046a6944dd8e70fe4768e
+#: f923181b21ea459696b6ba94b26a47aa
+msgid "27"
+msgstr ""
+
+#: ../../27.04/schedule.md baa1003ab3b94e9d8506b21b7dc5ca4e
+#: ee39faabec874591b239705c236d9d9d
+msgid "April 22"
+msgstr ""
+
+#: ../../27.04/schedule.md fe3ca20309554369be7ab78e5f940c1a
+msgid "[Final Release](https://wiki.ubuntu.com/FinalRelease)"
+msgstr ""
+
+#: ../../27.04/schedule.md:44 b5a803c3b7454548a286d4b2a6000b1b
+msgid "Planned and potentially disruptive archive-wide activities"
+msgstr ""
+
+#: ../../27.04/schedule.md:46 f9865ab6f9d247418c09b7833f80b017
+msgid ""
+"If you’re planning a change that might have a disruptive effect on the "
+"archive - e.g. transitions or switches of important defaults (such as "
+"compiler versions) - list it here."
+msgstr ""
+
+#: ../../27.04/schedule.md a101e23c568a41b8b2c0c80c600337dd
+msgid "Planned activity"
+msgstr ""
+
+#: ../../27.04/schedule.md:85 6011f6814ead41d19159254c3ba912bf
+msgid "Ubuntu T T Release Task Signup Sheet"
+msgstr ""
+
+#: ../../27.04/schedule.md:87 75acb933ca1d43f5bbc13ac657df8e7b
+msgid "This signup sheet is to be used for planning release milestone tasks."
+msgstr ""
+
+#: ../../27.04/schedule.md:89 1081fb91e2984e08b9ea1cb4d797db62
+msgid ""
+"The Alpha and Beta 1 milestones have been replaced with [Testing "
+"Weeks](https://lists.ubuntu.com/archives/ubuntu-"
+"release/2018-April/004434.html), which are organized ad hoc at this "
+"point."
+msgstr ""
+
+#: ../../27.04/schedule.md 18bfaeefbb2343bea33f430bbb1fba02
+msgid "Milestone"
+msgstr ""
+
+#: ../../27.04/schedule.md 6b98fb7737a344aabd1dac96156fe75a
+msgid "Date"
+msgstr ""
+
+#: ../../27.04/schedule.md 27357993f9884060a1e5db4f3e91039f
+msgid "Image (Nusakan) Engineering"
+msgstr ""
+
+#: ../../27.04/schedule.md 08d1abfddc3b472f8e51ae35cf304818
+msgid "Checklist Tracking"
+msgstr ""
+
+#: ../../27.04/schedule.md c8180f0f992548ccbbee0cc1d05b7c31
+msgid "Announcement Email"
+msgstr ""
+
+#: ../../27.04/schedule.md 47d6305aaed74b249b22e508f1189e3d
+msgid "Feature Freeze"
+msgstr ""
+
+#: ../../27.04/schedule.md 0008e80095d845ffab282830448945d2
+#: 5af19484d3ae4aa28ea450d1b75cef06 88b18bf2c7594b82ab8e326937cd1cec
+#: b334759e91e2497687fb87910fa7963d eedeb3256fd04b3f9b8b0076b822f991
+msgid "n/a"
+msgstr ""
+
+#: ../../27.04/schedule.md 636e2059aa064f208619dabdbba0e5f2
+msgid "UI Freeze"
+msgstr ""
+
+#: ../../27.04/schedule.md 47b53191866b4e668b082a416497517b
+msgid "Doc String Freeze"
+msgstr ""
+
+#: ../../27.04/schedule.md d3067d283946458ab4310e82c6da3334
+msgid "27.04 Beta"
+msgstr ""
+
+#: ../../27.04/schedule.md 450141426d9f4439a1981944580b4d7f
+msgid "Final Freeze"
+msgstr ""
+
+#: ../../27.04/schedule.md 7ef96353abdc45588c2446c0d36f0083
+msgid "27.04 Release"
+msgstr ""
+
+#: ../../27.04/schedule.md 354ad96e5c2e4fbf84a092d230c2aa19
+msgid "April 22 2027"
+msgstr ""
+
+#: ../../27.04/schedule.md:100 0643429d53c84a398acb9419ffac3d97
+msgid ""
+"When the archive is frozen, all members of the release team are expected "
+"to participate in bug fix reviews."
+msgstr ""
+
+#: ../../27.04/schedule.md:102 2420c9e13b5748eb877667466f0bba01
+msgid ""
+"After [Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), all "
+"members of the release team are expected to participate in Feature Freeze"
+" Exception reviews in their particular area of expertise."
+msgstr ""
+
+#: ../../27.04/schedule.md:104 614f689677314150915b0735f626da59
+msgid ""
+"After [Final Beta](https://wiki.ubuntu.com/FinalBetaRelease), all members"
+" of the release team are expected to participate in Bug fix reviews in "
+"their particular area of expertise."
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/27.10/schedule.po
+++ b/docs/locale/ja/LC_MESSAGES/27.10/schedule.po
@@ -1,0 +1,493 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../27.10/schedule.md:2 56f0a329616b48158f52051641ec00bf
+msgid "Ubuntu U U Release Schedule"
+msgstr ""
+
+#: ../../27.10/schedule.md d2ec41ef7a3444bca75ed0a26bf0b75b
+#: db31bc0ff67445e2bba822243549c15e
+msgid "Week"
+msgstr ""
+
+#: ../../27.10/schedule.md 9a9ae53e82b04f658db79f0eb1db67e9
+#: 9e1aca3edde342bb9c9215bb97d4f061
+msgid "Date (Thursday)"
+msgstr ""
+
+#: ../../27.10/schedule.md 0ab1315bf2354be984f8c065d1bef8fb
+msgid "27.10 events"
+msgstr ""
+
+#: ../../27.10/schedule.md 44e86a36510c4d6fbb1c30e64cb86f0d
+#: 60bf4f71999c4011a77bc6ecdfb0c6dd
+msgid "**April 2027**"
+msgstr ""
+
+#: ../../27.10/schedule.md a529c92d11fd4623b5b17e7755fe1dd2
+#: cbf6f003f81948038e46973046540395
+msgid "1"
+msgstr ""
+
+#: ../../27.10/schedule.md 237d3689331844a7b8f25b133a3c8ff4
+#: 338f5139356f475fbeb2e608cef0d34f
+msgid "April 29"
+msgstr ""
+
+#: ../../27.10/schedule.md 6a825a6cc199440e80f6eaa238cdd013
+msgid "Toolchain Uploaded"
+msgstr ""
+
+#: ../../27.10/schedule.md 2d9f58247a1f437d9c1458d351383bf9
+#: d2df88d75f6f48a7a969792d2ec42f3b
+msgid "**May 2027**"
+msgstr ""
+
+#: ../../27.10/schedule.md 985c992f66b34744a2464070fa9f7266
+#: a8f65017c16a4085803f74993af4bd21
+msgid "2"
+msgstr ""
+
+#: ../../27.10/schedule.md bcfec5bc9c9b49ae870038d2c6548eb5
+#: dc81ae4bb685422c837eca4689c8a27d
+msgid "May 06"
+msgstr ""
+
+#: ../../27.10/schedule.md 650d05623062455daf18795822598499
+#: e2366f52a542405f8ea686b7abb5a8fd
+msgid "3"
+msgstr ""
+
+#: ../../27.10/schedule.md 1a9623e3099a4b22b8a5ceebcb8744df
+#: e09a0b6fc8914e3e9a473936c6623962
+msgid "May 13"
+msgstr ""
+
+#: ../../27.10/schedule.md 24a4f9cf342e4850a9e67ae4ee611e36
+#: 7b7a6bfaa2754321adc8afe9b2822787
+msgid "4"
+msgstr ""
+
+#: ../../27.10/schedule.md ddeb5055996e4372b36d47b2343b8fb5
+#: f350c7d99a9b4213b3e1e7a85fa671da
+msgid "May 20"
+msgstr ""
+
+#: ../../27.10/schedule.md 2516042d167b4b1180ef9cddec3ab835
+#: 768f4088bb7f497b8fe7a79c3280a4fa
+msgid "5"
+msgstr ""
+
+#: ../../27.10/schedule.md 06b4e22471fe4939a80524b9668f8efe
+#: 3953563675de4274b19286f7d57a8329
+msgid "May 27"
+msgstr ""
+
+#: ../../27.10/schedule.md 47e106d56374464c9f85e5b481158433
+#: d6bc39458e1b4f518d32c191bf0f1cdb
+msgid "**June 2027**"
+msgstr ""
+
+#: ../../27.10/schedule.md 12771d816a3c411ab48f4af40068e6df
+#: f87705cdd567449c9680c246d141ba17
+msgid "6"
+msgstr ""
+
+#: ../../27.10/schedule.md 3cd8149832ba4b64906187bf88350a00
+#: 78bd2eb25c8f435fbb5df7ad1025aaa2
+msgid "June 03"
+msgstr ""
+
+#: ../../27.10/schedule.md 385bf650de104063b1e789c6389e22a5
+#: 6a0a2db375d74dfb9686ade1884e5a07
+msgid "7"
+msgstr ""
+
+#: ../../27.10/schedule.md 35d7f5b5480b40999d8e8fcb86a27adc
+#: 731c2aae6271461ea5e874bb135d9e5a
+msgid "June 10"
+msgstr ""
+
+#: ../../27.10/schedule.md ea70a680be1347679e5298cab37c7a0f
+#: fb3a9f4627d447fc8850b0b6ae776e37
+msgid "8"
+msgstr ""
+
+#: ../../27.10/schedule.md 72c42319eaf542618219ffcb3bcfb9f6
+#: df7bce5ae00943279b915f0e218db0b7
+msgid "June 17"
+msgstr ""
+
+#: ../../27.10/schedule.md 4efd1326f0e84a11aa5cdd87c791546c
+#: ff1077ce43514ca5b1ec91e11a8bbf90
+msgid "9"
+msgstr ""
+
+#: ../../27.10/schedule.md a195568824064bc2b6cc02c6543ef36d
+#: e572ae3a577b48b7983a469bc2d120cc
+msgid "June 24"
+msgstr ""
+
+#: ../../27.10/schedule.md d535fb47cbeb4e3489200f3926f05c5d
+#: fb490c8489674c39a5bf8e00848fd1ae
+msgid "**July 2027**"
+msgstr ""
+
+#: ../../27.10/schedule.md 6eaf1dee62e84448b37a91ecbc7011f2
+#: fc2df79fdc654503911cc4423e3fa53f
+msgid "10"
+msgstr ""
+
+#: ../../27.10/schedule.md 81a147d5f15a4893887840a2bd0fe2f2
+#: ce23c56824364ce9988cbabb06779631
+msgid "July 01"
+msgstr ""
+
+#: ../../27.10/schedule.md 170e17d8bc3f40b6a542c492ffe3d18c
+#: c076f01b100b4fc8bdac29932b2faa85
+msgid "Ubuntu Testing Week (optional)"
+msgstr ""
+
+#: ../../27.10/schedule.md 0c3ea652aa004126bb59078165d3c5f4
+#: 2e3fc07a544745fc9f7da05f1692bae9
+msgid "11"
+msgstr ""
+
+#: ../../27.10/schedule.md 3a8cd85b8b5548bda6c563ddaa57ee1d
+#: 43c361e433b04177997e5234f6454a91
+msgid "July 08"
+msgstr ""
+
+#: ../../27.10/schedule.md 92c5c633a6e94bd181e8e72407312e06
+#: 9da4ce0b0f384dae95bdd93fa17e0570
+msgid "12"
+msgstr ""
+
+#: ../../27.10/schedule.md 50f1100fbcbf4828a61664c98d7c7cd3
+#: d433712ff8d3402ea0c5c0701e9218cb
+msgid "July 15"
+msgstr ""
+
+#: ../../27.10/schedule.md a7e8c947086544f191deaa146ea91a1b
+#: c84e3714a39e4d378f418c73d3cbc6c0
+msgid "13"
+msgstr ""
+
+#: ../../27.10/schedule.md 1beaf18ed44c4eea90aba457bd2ffb7a
+#: e722083c255f4a059ca126a9677e9357
+msgid "July 22"
+msgstr ""
+
+#: ../../27.10/schedule.md 48ed79dde7e74cdb9448f69597c06bd7
+#: bcd86579163e464c9147c1450533b9e4
+msgid "14"
+msgstr ""
+
+#: ../../27.10/schedule.md 6689443ee8b14a2c918eaaeb9ef9ccca
+#: bb3969dc6c6347fea1bdba6e446a8509
+msgid "July 29"
+msgstr ""
+
+#: ../../27.10/schedule.md 2f10e5ed57c548e69b6414cb891d619e
+#: 33371ce623e74fecb923390be3ea52a1
+msgid "**August 2027**"
+msgstr ""
+
+#: ../../27.10/schedule.md 1b4b4e7c1b0d4162827c6b4e207739a9
+#: b3207f1ee9254e7ba396266df5e41943
+msgid "15"
+msgstr ""
+
+#: ../../27.10/schedule.md ae11edec022740a7bf3f0d46eb8b2034
+#: d5227cca5fb94de78dd5559fd440221c
+msgid "August 05"
+msgstr ""
+
+#: ../../27.10/schedule.md a1a5b8cf33a240fa81d3224c4117010c
+#: ff8b268900614bc08bdc14626f07bb31
+msgid "16"
+msgstr ""
+
+#: ../../27.10/schedule.md 95cf9057669f4c3286e19e84bfce324d
+#: b95d21049c2c4f29a9b46c756feeb830
+msgid "August 12"
+msgstr ""
+
+#: ../../27.10/schedule.md 1ec94f9108a74c39a7564ca45c6f8bc0
+#: e11b2e7505da4389bc5ddef44d0eb339
+msgid "17"
+msgstr ""
+
+#: ../../27.10/schedule.md df169af7cda744a8b78267404141bc8f
+#: e40014bb4458498ca963c351709efd46
+msgid "August 19"
+msgstr ""
+
+#: ../../27.10/schedule.md 0221a8d42c7d4317acf84b9b55adca75
+msgid ""
+"[Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), Debian Import "
+"Freeze"
+msgstr ""
+
+#: ../../27.10/schedule.md 2236c3cba3e745bf91b30f3c0da20074
+#: 2eda115f5a30483f8c8b6fe64942c65e
+msgid "18"
+msgstr ""
+
+#: ../../27.10/schedule.md 36644a06d24849a092e1b3bb3613d9f5
+#: b2653a12222f4ae7b5f49d2fb80b83d1
+msgid "August 26"
+msgstr ""
+
+#: ../../27.10/schedule.md 6c57008a382d425d8c2b0d3647e0696d
+#: abc045b482da4ab9ae882d47568d2b3a
+msgid "**September 2027**"
+msgstr ""
+
+#: ../../27.10/schedule.md 55ad2ac579cd4698ae849b89d7c2d41e
+#: 89ae2178de5e44bf9eeebcc9e90878a9
+msgid "19"
+msgstr ""
+
+#: ../../27.10/schedule.md 28ac78e7f3bb4f1097c960148a75bf79
+#: 8526d3e455b04270a0daae7a6ebe7e8e
+msgid "September 02"
+msgstr ""
+
+#: ../../27.10/schedule.md 56c90dceaf1a43919b168c2d1e9c9e2b
+#: f5a0107f46884f9fb5c6775d3d32c720
+msgid "20"
+msgstr ""
+
+#: ../../27.10/schedule.md 57e0c7f6d9c745149a8f1cf2c638a817
+#: ec3a990f44de4caca3f8da9ce8b1b6c9
+msgid "September 09"
+msgstr ""
+
+#: ../../27.10/schedule.md de4f2dec2b4f43f2bc2163f138c197f2
+msgid "[User Interface Freeze](https://wiki.ubuntu.com/UserInterfaceFreeze)"
+msgstr ""
+
+#: ../../27.10/schedule.md 518d6234770f4be9824ec81a10585c3d
+#: 592727f6b17d40f288ddd9070e9eb349
+msgid "21"
+msgstr ""
+
+#: ../../27.10/schedule.md 53f791cbe1a84846ba8b6d16ea9326b9
+#: 999be53c1e054261946458a14d59108d
+msgid "September 16"
+msgstr ""
+
+#: ../../27.10/schedule.md e42116af0e5a48718765a9b5810bd94d
+msgid ""
+"[Documentation String "
+"Freeze](https://wiki.ubuntu.com/DocumentationStringFreeze), [Kernel "
+"Feature Freeze](https://wiki.ubuntu.com/KernelFeatureFreeze)"
+msgstr ""
+
+#: ../../27.10/schedule.md 8d99e84c7547474bb3edb026e0237822
+#: 9b6cb028428242d8a23055f01c206e12
+msgid "22"
+msgstr ""
+
+#: ../../27.10/schedule.md cd85331315944467961e07540300363e
+msgid "September 20 (Monday)"
+msgstr ""
+
+#: ../../27.10/schedule.md cb9e26e4d4404779ad9094da0e5eec98
+msgid ""
+"[Beta Freeze](https://wiki.ubuntu.com/BetaFreeze), [Hardware Enablement "
+"Freeze](https://wiki.ubuntu.com/HardwareEnablementFreeze)"
+msgstr ""
+
+#: ../../27.10/schedule.md db72d1ec5c4340ff8f19629a2f22ae26
+msgid "⠀"
+msgstr ""
+
+#: ../../27.10/schedule.md 31c040d66be047008b9653eaf753e613
+#: 94da1021c2f0442a91667d18b96f08e2
+msgid "September 23"
+msgstr ""
+
+#: ../../27.10/schedule.md 4d5d5816728243a69ce76ab0c99f9365
+msgid "Beta (mandatory)"
+msgstr ""
+
+#: ../../27.10/schedule.md 3b488901848647fb98ec963d200c0218
+#: 3baa39c5d0594191a0ef8324d0074893
+msgid "23"
+msgstr ""
+
+#: ../../27.10/schedule.md 01a1113d693a4789b287a015be6ac860
+#: e143164371c94b6b80dbde19c9696094
+msgid "September 30"
+msgstr ""
+
+#: ../../27.10/schedule.md 4caa99dc020649d5a2fb451d9217e9dc
+msgid ""
+"[Kernel Freeze](https://wiki.ubuntu.com/KernelFreeze), [Non Language Pack"
+" Translation "
+"Deadline](https://wiki.ubuntu.com/NonLanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../27.10/schedule.md 075f566f5bae45b8af78e94f91326a56
+#: 1319e38060d44aac98cf8e7396ddd816
+msgid "**October 2027**"
+msgstr ""
+
+#: ../../27.10/schedule.md 65adb6faeff040129d90c7ed4729ff02
+#: e946048962b54f01b72d5520b7f87cf6
+msgid "24"
+msgstr ""
+
+#: ../../27.10/schedule.md 1263d998592c470d9ba53feae0e4bdad
+#: c4165324cfec419eae51dbcbda65911a
+msgid "October 07"
+msgstr ""
+
+#: ../../27.10/schedule.md 49656fcfbd184ea2858785461a471304
+msgid ""
+"[Final Freeze](https://wiki.ubuntu.com/FinalFreeze), [Release "
+"Candidate](https://wiki.ubuntu.com/ReleaseCandidate), [Language Pack "
+"Translation "
+"Deadline](https://wiki.ubuntu.com/LanguagePackTranslationDeadline)"
+msgstr ""
+
+#: ../../27.10/schedule.md 2494e5fa960e42909aae52f301e20481
+#: df2e2af9466c44dcba3dd0272eaa1646
+msgid "25"
+msgstr ""
+
+#: ../../27.10/schedule.md 49ed6bb2f79f45bbafff93cb0aba9e04
+#: 93e57cb7efba479fa155469091a2d7ea
+msgid "October 14"
+msgstr ""
+
+#: ../../27.10/schedule.md 8f17411747cf4746ac0335c807584b0f
+msgid "[Final Release](https://wiki.ubuntu.com/FinalRelease)"
+msgstr ""
+
+#: ../../27.10/schedule.md:42 bd49f29b89e841329ce243200ccb9218
+msgid "Planned and potentially disruptive archive-wide activities"
+msgstr ""
+
+#: ../../27.10/schedule.md:44 d82cb2caa3e646a7885ab7b4f70de4b1
+msgid ""
+"If you’re planning a change that might have a disruptive effect on the "
+"archive - e.g. transitions or switches of important defaults (such as "
+"compiler versions) - list it here."
+msgstr ""
+
+#: ../../27.10/schedule.md 0cf5ed2bb0a74f20a143e993ade5e49a
+msgid "Planned activity"
+msgstr ""
+
+#: ../../27.10/schedule.md:81 63a7a2fc3b1845228ab0088888de08e1
+msgid "Ubuntu U U Release Task Signup Sheet"
+msgstr ""
+
+#: ../../27.10/schedule.md:83 52a5ea2470904416be66e248fbf50986
+msgid "This signup sheet is to be used for planning release milestone tasks."
+msgstr ""
+
+#: ../../27.10/schedule.md:85 a55739245c224fdc898c75fad4c173c3
+msgid ""
+"The Alpha and Beta 1 milestones have been replaced with [Testing "
+"Weeks](https://lists.ubuntu.com/archives/ubuntu-"
+"release/2018-April/004434.html), which are organized ad hoc at this "
+"point."
+msgstr ""
+
+#: ../../27.10/schedule.md 25f2ca9b52554e20be40e71bfd102b91
+msgid "Milestone"
+msgstr ""
+
+#: ../../27.10/schedule.md f15fa166bd6d452eb7e392ca398294fc
+msgid "Date"
+msgstr ""
+
+#: ../../27.10/schedule.md cbc409cea59f4294a2a71ff0e1fa4ee4
+msgid "Image (Nusakan) Engineering"
+msgstr ""
+
+#: ../../27.10/schedule.md 1ad0c60bdff140e68a02d2f1d79aafd2
+msgid "Checklist Tracking"
+msgstr ""
+
+#: ../../27.10/schedule.md 7130cd58f6144c7faef152ef2eb892fb
+msgid "Announcement Email"
+msgstr ""
+
+#: ../../27.10/schedule.md ba85b29c765b49d79bb92f23074f95aa
+msgid "Feature Freeze"
+msgstr ""
+
+#: ../../27.10/schedule.md 1105c7965c0747baa6140c76d1e3742f
+#: 13edf6cb60b64121a2c788412ecba9fe 5c9d5320ed71455ba90bc4c4d8bf11bd
+#: 8c893800e3634fcdbfbcd4edfc29a5d0 ab3b512fadcb4240ad430b2e7611523e
+msgid "n/a"
+msgstr ""
+
+#: ../../27.10/schedule.md be2a412d57ba4a049671fea5da6dda4e
+msgid "UI Freeze"
+msgstr ""
+
+#: ../../27.10/schedule.md 78aeb092b4c94359b8513ddd8d53c6d3
+msgid "Doc String Freeze"
+msgstr ""
+
+#: ../../27.10/schedule.md 6cd11b220f0a4bce903cef77a74e9212
+msgid "27.10 Beta"
+msgstr ""
+
+#: ../../27.10/schedule.md d5f346acef9d468ea18527af9268f646
+msgid "Final Freeze"
+msgstr ""
+
+#: ../../27.10/schedule.md 9022fc2274604e32808d27f0d77f8ded
+msgid "27.10 Release"
+msgstr ""
+
+#: ../../27.10/schedule.md 938d28f9922146a08cc1c094148e8f85
+msgid "October 14 2027"
+msgstr ""
+
+#: ../../27.10/schedule.md:96 3119df568f754fde90cbc74a63c5d689
+msgid ""
+"When the archive is frozen, all members of the release team are expected "
+"to participate in bug fix reviews."
+msgstr ""
+
+#: ../../27.10/schedule.md:98 79a557cfe6b24b94864dff67ad9b9ff6
+msgid ""
+"After [Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), all "
+"members of the release team are expected to participate in Feature Freeze"
+" Exception reviews in their particular area of expertise."
+msgstr ""
+
+#: ../../27.10/schedule.md:100 581327cfdc294df9b84b85eef0c832fe
+msgid ""
+"After [Final Beta](https://wiki.ubuntu.com/FinalBetaRelease), all members"
+" of the release team are expected to participate in Bug fix reviews in "
+"their particular area of expertise."
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/archive.po
+++ b/docs/locale/ja/LC_MESSAGES/archive.po
@@ -1,0 +1,34 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../archive.md:3
+msgid "25.04 (Plucky Puffin)"
+msgstr ""
+
+#: ../../archive.md:3
+msgid "24.10 (Oracular Oriole)"
+msgstr ""
+
+#: ../../archive.md:1 042f17b77713463bb0d4e66fb9b7b7cc
+msgid "Older Ubuntu releases"
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/contribute.po
+++ b/docs/locale/ja/LC_MESSAGES/contribute.po
@@ -1,0 +1,282 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../contribute.md:1 ecbfbe8522f84272ba223848a3da758b
+msgid "How to contribute to Ubuntu release notes"
+msgstr ""
+
+#: ../../contribute.md:3 a13d8dd9e6254680a820d95d461f1e23
+msgid ""
+"Ubuntu release notes have recently moved from Discourse to this location."
+" Read more: [New Ubuntu release notes](https://discourse.ubuntu.com/t"
+"/new-ubuntu-release-notes/78722)."
+msgstr ""
+
+#: ../../contribute.md:5 a3af67fc8bf6454d9a79d3afb6240d1f
+msgid "Add a new release note"
+msgstr ""
+
+#: ../../contribute.md:7 9d263643191f4bc299a6cda3b921df7e
+msgid ""
+"Anyone can add or modify release notes using the GitHub interface. The "
+"process is open for community members and Canonical employees."
+msgstr ""
+
+#: ../../contribute.md:9 e841098411074eb28b5534608dbb8d8e
+msgid "Simplified: file an issue"
+msgstr ""
+
+#: ../../contribute.md:11 90b894f6cbce41fb9a981e598b2acf92
+msgid ""
+"The easiest way to submit a release note is to [fill out an issue "
+"form](https://github.com/ubuntu/ubuntu-release-"
+"notes/issues/new?template=add-a-release-note.yml)."
+msgstr ""
+
+#: ../../contribute.md:13 78b51f064df1498bac23234af98c9294
+msgid "There, provide all the requested information about the change in Ubuntu."
+msgstr ""
+
+#: ../../contribute.md:15 ea0085c19e59488e9aeffcadfb5b0a17
+msgid ""
+"After you file the issue, the repository maintainers will review the "
+"information and publish the release note based on it."
+msgstr ""
+
+#: ../../contribute.md:17 92054264f3ca44b6b652567129e7436c
+msgid "More complex: open a pull request"
+msgstr ""
+
+#: ../../contribute.md:19 c31530ab71b64235a134083bb3a25f45
+msgid ""
+"If you want more control over the process, you can propose changes "
+"directly through a pull request:"
+msgstr ""
+
+#: ../../contribute.md:21 5fa6ebd8f75742ad9a6371ca197820cc
+msgid ""
+"[Fork](https://github.com/ubuntu/ubuntu-release-notes/fork) the release "
+"notes repository."
+msgstr ""
+
+#: ../../contribute.md:23 409bfab28b8e4eceadf7dce486e0805a
+msgid "Make changes in your fork."
+msgstr ""
+
+#: ../../contribute.md:25 77e7b03e80ed4afda8b87028418c7634
+msgid ""
+"Every Ubuntu release is represented as a directory under `docs/`, named "
+"after the Ubuntu version: for example, `docs/26.04/` stores Ubuntu 26.04 "
+"LTS (Resolute Raccoon) release notes."
+msgstr ""
+
+#: ../../contribute.md:27 588ca7fd694142348b79176249a1a7ed
+#, python-brace-format
+msgid ""
+"When writing your release note, keep in mind the documentation standards "
+"described in {ref}`contribute-review-release-notes`."
+msgstr ""
+
+#: ../../contribute.md:29 3f1c783fe89c4e2585f85db6fd926ba3
+msgid ""
+"[Create a pull request](https://github.com/ubuntu/ubuntu-release-"
+"notes/pulls) to propose your changes."
+msgstr ""
+
+#: ../../contribute.md:31 798ff31c025d40a5b5c61d1e59fa28a8
+msgid "Let the repository maintainers review and merge your changes."
+msgstr ""
+
+#: ../../contribute.md:34 88c336beddf747b1a77ea5501ef83c7e
+msgid "Review the release notes"
+msgstr ""
+
+#: ../../contribute.md:36 ad22c2c690a74fbf818e5083233a0617
+msgid ""
+"Before each Ubuntu release, every team working on a certain part of "
+"Ubuntu should review their release notes."
+msgstr ""
+
+#: ../../contribute.md:38 fff0997a71134442ae50a92ba0f55bd1
+msgid ""
+"Maintainers should monitor the [issues](https://github.com/ubuntu/ubuntu-"
+"release-notes/issues) and [pull requests](https://github.com/ubuntu"
+"/ubuntu-release-notes/pulls) in the release notes repository, review them"
+" and merge them."
+msgstr ""
+
+#: ../../contribute.md:40 864bbe22481142a18a56996175d49819
+msgid ""
+"Label every issue and pull request with the version number of the Ubuntu "
+"release where the release note applies, such as `26.04`. Add the `New "
+"release note` label if this introduces a new release note."
+msgstr ""
+
+#: ../../contribute.md:42 94b21d730a534ce5ae632d9631522cd5
+msgid "Information correctness"
+msgstr ""
+
+#: ../../contribute.md:44 a2843b48291a49aab8e0f2fe269e5d35
+msgid "**Engineers** are mainly responsible for this review."
+msgstr ""
+
+#: ../../contribute.md:46 92310e90a6374dc1b049a81a5273f913
+#, python-brace-format
+msgid ""
+"Review the changes since the previous interim release, such as {ref}`here"
+" <ubuntu-26.04-lts-changes-since-25.10>` for Ubuntu 26.04 LTS."
+msgstr ""
+
+#: ../../contribute.md:48 f49985406d974db1a15180be649f0255
+msgid ""
+"In this document, cover what you've been working on for the past 6 "
+"months. Make sure that the information related to your team there is "
+"correct and complete. Go into detail: this part of the release notes "
+"should be exhaustive."
+msgstr ""
+
+#: ../../contribute.md:50 a70548061f2b4aed851a01d3423f87c6
+msgid ""
+"Decide which of the 6-month changes you want to highlight as major "
+"changes. These will be gathered later as the basis of the next (or "
+"currently prepared) LTS release notes. Interim release notes contain a "
+"highlights section at the start."
+msgstr ""
+
+#: ../../contribute.md:52 42436bff1ee9470d8c542826ff4c0bcf
+#, python-brace-format
+msgid ""
+"If this is an LTS release, review the summary since the previous LTS "
+"release, such as {ref}`here <ubuntu-26.04-lts-summary>` for Ubuntu 26.04 "
+"LTS."
+msgstr ""
+
+#: ../../contribute.md:54 8cfb6b8c3d6a477a992f9061586cee22
+msgid ""
+"These are the highlights of the major changes in the past two years. "
+"Primarily, include significant new features and breaking changes to alert"
+" upgrading users."
+msgstr ""
+
+#: ../../contribute.md:56 2684cb5459e44798bcbe88e892cdfac1
+msgid ""
+"This part of the release notes should be less detailed. You can link to "
+"older interim release notes for additional details. If you want to repeat"
+" the same release note in an interim and LTS section, you can rely on "
+"[content reuse](https://canonical-starter-pack.readthedocs-"
+"hosted.com/stable/reference/myst-syntax-reference/#reuse)."
+msgstr ""
+
+#: ../../contribute.md:58 c41e910751714a27bd680f96b5fd45cf
+msgid "Writing style and content placement"
+msgstr ""
+
+#: ../../contribute.md:60 4a746b57d45840abb4ee0fea5228f4f2
+msgid "**Technical Authors** are mainly responsible for this review."
+msgstr ""
+
+#: ../../contribute.md:62 17a88614b085403595e0835c09860c0c
+msgid ""
+"Check that the writing is fine. Adjust headings to summarize every "
+"release note."
+msgstr ""
+
+#: ../../contribute.md:64 f1e947523fbf4409927cd629cad419ec
+msgid ""
+"Check the markup. Focus on code elements such as package names, tool "
+"names, function names and similar: format them as code literals. Code "
+"elements without any markup show up as spelling issues."
+msgstr ""
+
+#: ../../contribute.md:66 ed422911030a44ecbce4bb437abd8748
+msgid ""
+"In case of LTS, clarify the timeline of the change: Is this a change "
+"since the previous interim release or since the previous LTS release? "
+"Based on that, move the release note to the appropriate section."
+msgstr ""
+
+#: ../../contribute.md:68 16184dd04b6943159af7f2136d1996f8
+msgid ""
+"Check that the placement of each release note is correct. Separate the "
+"news into the following categories:"
+msgstr ""
+
+#: ../../contribute.md:70 b815ab41cc4f4e50a7be1a72b1a5db91
+msgid "New features or improvements"
+msgstr ""
+
+#: ../../contribute.md:71 05d55ae1e77b4c74891a1e37cce52b56
+msgid ""
+"Strictly improvements in functionality, performance, reliability, support"
+" level and similar."
+msgstr ""
+
+#: ../../contribute.md:73 8fc3ecf341b649da89f5066988a8dbd0
+msgid "Backwards-incompatible changes, including removed features"
+msgstr ""
+
+#: ../../contribute.md:74 e60df11b15d94fb6adbbca17a13996ba
+msgid ""
+"Something that worked in an earlier Ubuntu release no longer works. The "
+"user needs to actively change their configuration: rewrite a "
+"configuration file, switch to another application etc."
+msgstr ""
+
+#: ../../contribute.md:76 5b8450f471c340829b86c8bac458f564
+msgid "Deprecated features"
+msgstr ""
+
+#: ../../contribute.md:77 0ecd451dc31543439a3aa02ab1741a73
+msgid ""
+"Features that are planned to be removed in a later Ubuntu release. They "
+"still work as expected in the current release. We're giving Ubuntu users "
+"a heads-up."
+msgstr ""
+
+#: ../../contribute.md:79 e57a2716b714499385ae783635f142f4
+msgid "Bug fixes"
+msgstr ""
+
+#: ../../contribute.md:80 624c89eef46447ca916950f306c7d5c4
+msgid ""
+"Bugs that were present in an earlier Ubuntu release are fixed in this "
+"release. Also include updates to new upstream releases that only contain "
+"bug fixes."
+msgstr ""
+
+#: ../../contribute.md:82 886b373d1d484c6db0ce3547729983ee
+msgid "Known issues"
+msgstr ""
+
+#: ../../contribute.md:83 30d55636f79246fcae2ec80f781326f4
+msgid ""
+"Something doesn't work as expected in this Ubuntu release and the team is"
+" working on a fix. In each case, try to provide a workaround for users."
+msgstr ""
+
+#: ../../contribute.md:86 21bf2620e4be482a9b0a86429f81e3de
+msgid ""
+"In the LTS summary, these change types aren't separated the same way as "
+"in interim release notes. This is an experiment for now and we'll revisit"
+" the organization with upcoming releases."
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/future.po
+++ b/docs/locale/ja/LC_MESSAGES/future.po
@@ -1,0 +1,38 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../future.md:3
+msgid "27.10 (U U)"
+msgstr ""
+
+#: ../../future.md:3
+msgid "27.04 (T T)"
+msgstr ""
+
+#: ../../future.md:3
+msgid "26.10 (S S)"
+msgstr ""
+
+#: ../../future.md:1 9dc138609f584c8ab1f2c590a0bbd1c2
+msgid "Future Ubuntu release schedules"
+msgstr ""
+

--- a/docs/locale/ja/LC_MESSAGES/index.po
+++ b/docs/locale/ja/LC_MESSAGES/index.po
@@ -1,0 +1,375 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 02:01+0900\n"
+"PO-Revision-Date: 2025-04-13 02:01+0900\n"
+"Last-Translator: Mitsuya Shibata <mty.shibata@gmail.com>\n"
+"Language: ja\n"
+"Language-Team: Ubuntu Japanese Team <ubuntu-jp@ubuntu.com>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../index.md:7 ../../index.md:59 33900ee4109b46e89971daab5c0e5fcf
+msgid "24.04 LTS (Noble Numbat)"
+msgstr "24.04 LTS（Noble Numbat）"
+
+#: ../../index.md:7 ../../index.md:68 a86d8502b45a4cd98b266637f9fe7230
+msgid "22.04 LTS (Jammy Jellyfish)"
+msgstr "22.04 LTS（Jammy Jellyfish）"
+
+#: ../../index.md:7
+msgid "Supported LTS releases"
+msgstr "サポート中のLTSリリース"
+
+#: ../../index.md:16 ../../index.md:80 b7be201c353048f0b2db547556d1d61b
+msgid "25.10 (Questing Quokka)"
+msgstr "25.10（Questing Quokka）"
+
+#: ../../index.md:16
+msgid "Supported interim releases"
+msgstr "サポート中の中間（interim）リリース"
+
+#: ../../index.md:24
+msgid "26.04 LTS (Resolute Raccoon)"
+msgstr "26.04 LTS（Resolute Raccoon）"
+
+#: ../../index.md:24
+msgid "Currently in development"
+msgstr "現在開発中"
+
+#: ../../index.md:32
+msgid "Future releases"
+msgstr "将来リリース予定"
+
+#: ../../index.md:32
+msgid "Older releases"
+msgstr "古いリリース"
+
+#: ../../index.md:32
+msgid "Other releases"
+msgstr "その他のリリース"
+
+#: ../../index.md:41
+msgid "Contribute to release notes"
+msgstr "リリースノートに貢献するには"
+
+#: ../../index.md:1 1ed2cde11d3743e59f46531747bdd19c
+msgid "Ubuntu release notes"
+msgstr "Ubuntuリリースノート"
+
+#: ../../index.md:3 41de6d9a0cc24f00bfafad8bb6fcdb80
+msgid ""
+"Release notes for Ubuntu, summarizing new features, bug fixes and "
+"backwards-incompatible changes in each version."
+msgstr ""
+"Ubuntuのリリースノートでは、それぞれのリリースにおける新機能や不具合修正、非互換な変更点などをまとめています。"
+
+#: ../../index.md:5 a3bab2a443be4d3788dcce1a3b465402
+msgid ""
+"Release notes contain specific upgrade instructions for that particular "
+"release. See also the general guidance on how to prepare for, and "
+"perform, an upgrade: [Ubuntu "
+"Desktop](https://documentation.ubuntu.com/desktop/en/latest/how-to"
+"/upgrade-ubuntu-desktop/) or [Ubuntu "
+"Server](https://ubuntu.com/server/docs/how-to/software/upgrade-your-"
+"release/)."
+msgstr ""
+"リリースノートには、個々のリリースにおけるアップグレード手順を記載しています。"
+"アップグレードの準備や実行に関する一般的なガイドについては、"
+"[Ubuntu Desktop](https://documentation.ubuntu.com/desktop/en/latest/how-to/upgrade-ubuntu-desktop/)や"
+"[Ubuntu Server](https://ubuntu.com/server/docs/how-to/software/upgrade-your-release/)を参照してください。"
+
+#: ../../index.md:48 061da2c23bbf4abeb97e6f3d17ba3a4f
+msgid "LTS releases"
+msgstr "LTSリリース"
+
+#: ../../index.md:61 972a735e6fbf488d888c772260aaca05
+#, python-brace-format
+msgid "{ref}`changes-in-ubuntu-24.04.4`"
+msgstr "{ref}`changes-in-ubuntu-24.04.4`"
+
+#: ../../index.md:62 a28a5efd46ee449ba90ae2a8c755d201
+#, python-brace-format
+msgid "{ref}`changes-in-ubuntu-24.04.3`"
+msgstr "{ref}`changes-in-ubuntu-24.04.3`"
+
+#: ../../index.md:63 94b2cf8b0b584ab1aed68221cc0fce7b
+#, python-brace-format
+msgid "{ref}`changes-in-ubuntu-24.04.2`"
+msgstr "{ref}`changes-in-ubuntu-24.04.2`"
+
+#: ../../index.md:64 06c74abbeda644dab16edb779a8b7abc
+#, python-brace-format
+msgid "{ref}`changes-in-ubuntu-24.04.1`"
+msgstr "{ref}`changes-in-ubuntu-24.04.1`"
+
+#: ../../index.md:65 2a57829abdb84216b944057935515e4c
+#, python-brace-format
+msgid "{ref}`ubuntu-24.04-lts-release-notes`"
+msgstr "{ref}`ubuntu-24.04-lts-release-notes`"
+
+#: ../../index.md:66 3109da44cbc74040be8159bf6250bae3
+#, python-brace-format
+msgid "{ref}`noble-numbat-schedule`"
+msgstr "{ref}`noble-numbat-schedule`"
+
+#: ../../index.md:70 bb1625584a31479596f898d12fa223a4
+#, python-brace-format
+msgid "{ref}`changes-in-ubuntu-22.04.5`"
+msgstr "{ref}`changes-in-ubuntu-22.04.5`"
+
+#: ../../index.md:71 0314a2bf199f40ca8e652b9a980dea03
+#, python-brace-format
+msgid "{ref}`changes-in-ubuntu-22.04.4`"
+msgstr "{ref}`changes-in-ubuntu-22.04.4`"
+
+#: ../../index.md:72 9b8a31c65be44f19aefda66188f40f4d
+#, python-brace-format
+msgid "{ref}`changes-in-ubuntu-22.04.3`"
+msgstr "{ref}`changes-in-ubuntu-22.04.3`"
+
+#: ../../index.md:73 1d419e27be2447e4b34893f95826f244
+#, python-brace-format
+msgid "{ref}`changes-in-ubuntu-22.04.2`"
+msgstr "{ref}`changes-in-ubuntu-22.04.2`"
+
+#: ../../index.md:74 44f2904e6be14855acbc3c5a814729d4
+#, python-brace-format
+msgid "{ref}`changes-in-ubuntu-22.04.1`"
+msgstr "{ref}`changes-in-ubuntu-22.04.1`"
+
+#: ../../index.md:75 b2344c51726e4ae98b5648659bd74ad7
+#, python-brace-format
+msgid "{ref}`ubuntu-22.04-lts-release-notes`"
+msgstr "{ref}`ubuntu-22.04-lts-release-notes`"
+
+#: ../../index.md:76 2aae1c83047e45b192bb5beedb3c45da
+#, python-brace-format
+msgid "{ref}`jammy-jellyfish-schedule`"
+msgstr "{ref}`jammy-jellyfish-schedule`"
+
+#: ../../index.md:78 ../../index.md:93 582ee9c1b0104ed8baf2221cd090ff5e
+#: c77832f5ebc742e8a750c1225cb11cd5
+msgid "Interim releases"
+msgstr "中間（Interim）リリース"
+
+#: ../../index.md:82 c8d00fe46f0940599ec6f51703a1e30d
+#, python-brace-format
+msgid "{ref}`ubuntu-25.10-release-notes`"
+msgstr ""
+
+#: ../../index.md:85 040bdcb70316431999842dc08b14a0d9
+msgid "Release policy and schedule"
+msgstr "リリースポリシーとスケジュール"
+
+#: ../../index.md:87 dea879a905a6405abd519ed7a769158b
+msgid ""
+"Ubuntu releases a new version every six months. Releases of Ubuntu get a "
+"development codename (‘Questing Quokka’) and are versioned by the year "
+"and month of delivery – for example, Ubuntu 25.10 was released in October"
+" 2025."
+msgstr ""
+"Ubuntuは6ヶ月ごとにリリースを行います。Ubuntuのリリースは開発コードネーム"
+"（「Questing Quokka」）とリリース年と月に基づいたバージョンが付けられます。"
+"具体的にはUbuntu 25.10は、2025年の10月にリリースされました。"
+
+#: ../../index.md:89 673510a8416f414da333e1b881fb0786
+msgid ""
+"Each version includes the latest features, updates, and security patches "
+"during its supported lifecycle."
+msgstr ""
+"それぞれのバージョンには、最新の機能や更新、そのサポート期間におけるセキュリティパッチが提供されます。"
+
+#: ../../index.md:91 923377cbf4fb4671a3351046cff65de3
+msgid ""
+"For details, see [Ubuntu release cycle](https://ubuntu.com/about/release-"
+"cycle)."
+msgstr ""
+"詳細は[Ubuntu release cycle](https://ubuntu.com/about/release-cycle)を参照してください。"
+
+#: ../../index.md:95 17396abaca644f74a107ba9b3e51605e
+msgid ""
+"Ubuntu’s interim releases are designed for users and teams who move fast "
+"and need access to the latest kernels, languages, and toolchains. They "
+"provide cutting-edge features and hardware support every six months, but "
+"with only 9 months of updates. For long-term stability, production "
+"environments should use the LTS version, while interim releases suit "
+"those prioritizing speed and rapid feature testing."
+msgstr ""
+"Ubuntuの中間リリースは、素早く更新し、最新のカーネル、言語、ツールチェーンへのアクセスを必要とするユーザーやチームのために設計されています。"
+"これは6ヶ月ごとに最先端の機能とハードウェアサポートを提供しますが、更新期間は9ヶ月のみとなります。"
+"長期的な安定性が求められる本番環境ではLTSを利用すべきであり、中間リリースは速度や迅速な機能テストを優先する場合に適しています。"
+
+#: ../../index.md:97 4542544bfdaf4538b7e5ff1357cfa3a9
+msgid "Long-term support (LTS)"
+msgstr "長期サポート（LTS）"
+
+#: ../../index.md:99 446cc195bb7f494eb38dcf7872998425
+msgid ""
+"LTS are released every two years and receive 5 years of standard security"
+" maintenance."
+msgstr ""
+"LTSは2年ごとにリリースし、5年間のセキュリティメンテナンスアップデートを受けられます。"
+
+#: ../../index.md:101 d7ccf6b17a4f45b59c7123eb44eead29
+msgid ""
+"LTS releases are the go-to choice for users who value stability and "
+"extended support. These versions are security maintained for 5 years with"
+" CVE patches for packages in the Main repository. They are recommended "
+"for production environments, enterprises, and long-term projects."
+msgstr ""
+"LTSリリースは、安定性と長期的なサポートを重視するユーザーにとって最適な選択肢です。"
+"これらのバージョンは、mainリポジトリ内のパッケージに対するCVEパッチを含め、5年間セキュリティメンテナンスが提供されます。"
+"本番環境やエンタープライズ、長期プロジェクトなどでの利用に適しています。"
+
+
+#: ../../index.md:103 ce477a70337b4d1db0bca04c17f06eec
+msgid "Security vulnerability policy on release day"
+msgstr "リリース当日におけるセキュリティ脆弱性のポリシー"
+
+#: ../../index.md:105 8fd438cddecb497ebc38dec9e0781467
+msgid ""
+"What happens if there is a high- or critical-priority Common "
+"Vulnerability and Exposure (CVE) during release day?"
+msgstr ""
+"リリース当日に、重要度の高いもしくは緊急性のあるCommon Vulnerability and Exposure（CVE）が発行された場合はどうなるのでしょうか？"
+
+#: ../../index.md:107 f05158b9d8cb4662a6ec5d21a8240aab
+msgid ""
+"Server, Desktop and Cloud plan to release in lockstep on release day, but"
+" there are some exceptions."
+msgstr ""
+"サーバー、デスクトップおよびクラウドは、リリース当日に足並みを揃えてリリースする予定です。ただし、いくつかの例外があります。"
+
+#: ../../index.md:109 bb9aa1492bd6441bb70ecea994a9200f
+msgid ""
+"In the unlikely event that a critical- or high-priority CVE is announced "
+"on release day, the release team have agreed on the following plan of "
+"action:"
+msgstr ""
+"リリース日に緊急性があるか重要度の高いCVEがアナウンスされた場合、"
+"リリースチームは次の対応を行うこと合意しています："
+
+#: ../../index.md:111 09d1af0b92e24b55b748e97c648a5b30
+msgid ""
+"For critical priority CVEs, the release of Server, Desktop and Cloud will"
+" be blocked until new images can be built addressing the CVE."
+msgstr ""
+"緊急性がある（criticalな）CVEの場合、サーバー・デスクトップ・クラウドのリリースは、"
+"その脆弱性が解消された新しいイメージがビルドされるまで停止します。"
+
+#: ../../index.md:113 b41f75b735854e2db21534e86f1a740c
+msgid ""
+"For high-priority CVEs, the decision to block release will be made on a "
+"per-product (Server, Desktop and Cloud) basis and will depend on the "
+"nature of the CVE, which might result in images not being released on the"
+" same day."
+msgstr ""
+"重要度の高い（high-priorityな）CVEの場合、そのCVEの状態に依存して、"
+"リリースを停止するかどうかをプロダクト（サーバー・デスクトップ・クラウド）ごとに判断します。"
+"結果的に、同じ日にすべてのイメージがリリースされないこともあります。"
+
+#: ../../index.md:115 77ce520212234d00bc214516b060501b
+msgid ""
+"This was discussed in the [`ubuntu–release` mailing list March/April "
+"2023](https://lists.ubuntu.com/archives/ubuntu-"
+"release/2023-April/005610.html)."
+msgstr ""
+"これは[`ubuntu–release`メーリングリストの2023年3月から4月にかけて](https://lists.ubuntu.com/archives/ubuntu-release/2023-April/005610.html)議論されました。"
+
+
+#: ../../index.md:117 777218d1b94e4e55ac52c88841cd43d3
+msgid ""
+"The mailing list thread also confirmed there is no technical or policy "
+"reason why a package cannot be pushed to the Updates or Security pocket "
+"to address high or critical-priority CVEs prior to the release."
+msgstr ""
+"また、このメーリングリストのスレッドでは、重要度の高いまたは緊急性のあるCVEに対応するにあたって、"
+"リリース前にUpdatesまたはSecurityポケットへパッケージをプッシュできない技術的またはポリシー上の理由はないことも確認されています。"
+
+#: ../../index.md:121 60e749c2bc064690b558678e0ff9b65f
+msgid "Project and community"
+msgstr "プロジェクトとコミュニティ"
+
+#: ../../index.md:123 284c9760b67d4233bcabdb18ded89d62
+msgid ""
+"Ubuntu is an open source project that warmly welcomes community projects,"
+" contributions, suggestions, fixes and constructive feedback."
+msgstr ""
+"Ubuntuはオープンソースプロジェクトであり、コミュティプロジェクトや貢献、"
+"提案、修正、建設的なフィードバックを歓迎しています。"
+
+#: ../../index.md:125 a6f134a9971a4ead9b507247a84cb456
+msgid ""
+"You can find out more about Ubuntu on the [Ubuntu "
+"website](https://ubuntu.com/)."
+msgstr ""
+"Ubuntuについては[Ubuntuのウェブサイト](https://ubuntu.com/)を確認してください。"
+
+
+#: ../../index.md:127 3eafd8022d494af4aad42be1c529e7b2
+msgid "Report bugs"
+msgstr "不具合の報告"
+
+#: ../../index.md:129 0749ec22967249dc96eaecf29cd7cf2d
+msgid ""
+"Your comments, bug reports, patches and suggestions help fix bugs and "
+"improve the quality of future releases. Please [report bugs using the "
+"tools provided](http://help.ubuntu.com/community/ReportingBugs). If you "
+"want to help with bugs, the [Bug Squad](http://wiki.ubuntu.com/BugSquad) "
+"is always looking for help."
+msgstr ""
+"あなたのコメントや不具合報告・パッチの投稿・提案は、不具合の修正や将来のリリース品質の改善につながります。"
+"[ツールを用いて不具合の報告をお願いします](http://help.ubuntu.com/community/ReportingBugs)。"
+"不具合について貢献したいのであれば、[Bug Squad](http://wiki.ubuntu.com/BugSquad)のページも参考になるでしょう。"
+
+#: ../../index.md:131 7b78afa9d2aa4aa7913b1c459bc36d82
+msgid "Get involved"
+msgstr "参加するには"
+
+#: ../../index.md:133 e9b20b356d7e4d2583158fe0e100c7a8
+msgid ""
+"[Sign up for future Ubuntu development "
+"announcements](https://lists.ubuntu.com/mailman/listinfo/ubuntu-devel-"
+"announce)"
+msgstr ""
+"[Ubuntuの開発アナウンス用メーリングリストに登録してください](https://lists.ubuntu.com/mailman/listinfo/ubuntu-devel-announce)。"
+
+#: ../../index.md:134 a3ee9004bc304ce2a95159582f3d85ff
+msgid "[Get support](https://ubuntu.com/support/community-support)"
+msgstr "[サポートを得るには](https://ubuntu.com/support/community-support)"
+
+#: ../../index.md:135 041487690bbd4a86a75ae3c8226370f7
+msgid "[Join our Discourse forum](https://discourse.ubuntu.com)"
+msgstr "[Discourseフォーラムに参加する](https://discourse.ubuntu.com)"
+
+#: ../../index.md:136 9c08ca0956af439592cbe5add9125b53
+msgid "[Join our online chat on Matrix](https://matrix.to/#/#release:ubuntu.com)"
+msgstr "[Matrix上のオンラインチャットに参加する](https://matrix.to/#/#release:ubuntu.com)"
+
+#: ../../index.md:137 b3f50123ee1e477285566aa9d7016624
+msgid ""
+"If you'd like to help shape Ubuntu, look at the list of ways you can "
+"participate at community.ubuntu.com/contribute."
+msgstr ""
+"Ubuntuを改善したいと考えているのであれば、 community.ubuntu.com/contribute 内で参加できそうなものがないかも探してみてください。"
+
+#: ../../index.md:139 6a501f7c9d7a4f0a912569ff5bb29606
+msgid "Governance and policies"
+msgstr "ガバナンスとポリシー"
+
+#: ../../index.md:141 4e50f8c63a2341cdbd373a8f797f703d
+msgid "[Code of conduct](https://ubuntu.com/community/code-of-conduct)"
+msgstr "[Code of conduct](https://ubuntu.com/community/code-of-conduct)"
+

--- a/docs/locale/ja/LC_MESSAGES/sphinx.po
+++ b/docs/locale/ja/LC_MESSAGES/sphinx.po
@@ -1,0 +1,77 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2026
+# This file is distributed under the same license as the Ubuntu release
+# notes package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Ubuntu release notes \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-13 10:02+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../.venv/lib/python3.14/site-packages/canonical_sphinx/theme/templates/components/edit-this-page.html:5
+#: ../../.venv/lib/python3.14/site-packages/canonical_sphinx/theme/templates/components/edit-this-page.html:7
+#: 59ca11bf6a574da79833c071c9940e28 72a62e88578e4812ad5485fc887feb71
+msgid "Contribute to this page"
+msgstr ""
+
+#: ../../.venv/lib/python3.14/site-packages/canonical_sphinx/theme/templates/components/view-this-page.html:6
+#: ../../.venv/lib/python3.14/site-packages/canonical_sphinx/theme/templates/components/view-this-page.html:8
+#: 4f5e73fdfb2d40bdb47f3dc39418a616 730a496490a349ef815f6f55987c0838
+msgid "View this page"
+msgstr ""
+
+#: ../../.venv/lib/python3.14/site-packages/canonical_sphinx/theme/templates/footer.html:16
+#: e4d8cad333d44752b175d5cb2b70aad9
+msgid "Next"
+msgstr ""
+
+#: ../../.venv/lib/python3.14/site-packages/canonical_sphinx/theme/templates/footer.html:28
+#: 33808cf3c3c84e1a848820819dd04523
+msgid "Previous"
+msgstr ""
+
+#: ../../.venv/lib/python3.14/site-packages/canonical_sphinx/theme/templates/footer.html:31
+#: a532b823b46b4964a84089f82ddf5d5d
+msgid "Home"
+msgstr ""
+
+#: ../../.venv/lib/python3.14/site-packages/canonical_sphinx/theme/templates/footer.html:45
+#: fcdaf1bf40ae457582774676e8656fdc
+#, python-format
+msgid "<a href=\"%(path)s\">&copy; %(copyright)s %(author)s</a>"
+msgstr ""
+
+#: ../../.venv/lib/python3.14/site-packages/canonical_sphinx/theme/templates/footer.html:49
+#: 2522ac8140dc45dba05e8889a359a7cf
+#, python-format
+msgid "&copy; %(copyright)s %(author)s"
+msgstr ""
+
+#: ../../.venv/lib/python3.14/site-packages/canonical_sphinx/theme/templates/footer.html:71
+#: bb7897ea29174e06b9c06accebd02eb1
+#, python-format
+msgid "Last updated on %(last_updated)s"
+msgstr ""
+
+#: ../../.venv/lib/python3.14/site-packages/canonical_sphinx/theme/templates/page.html:22
+#: 3b2971779207455a8ccb64390601cf96
+msgid "Contents"
+msgstr ""
+
+#: ../../.venv/lib/python3.14/site-packages/canonical_sphinx/theme/templates/sidebar/search.html:2
+#: 532b373635d145a9bb5abdbfb06472ad a3782a3c61974678813acb79486e3fd4
+msgid "Search"
+msgstr ""
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -27,6 +27,7 @@ packaging
 sphinxcontrib-svg2pdfconverter[CairoSVG]
 sphinx-last-updated-by-git
 sphinx-sitemap
+sphinx-intl
 
 # Vale dependencies
 rst2html


### PR DESCRIPTION
This PR adds basic support for translating the documentation using sphinx-intl.

It introduces the necessary configuration and a minimal workflow for maintaining `.po` files and building language-specific documentation.

This is intended as a first step toward multi-language support (e.g. Japanese). Further improvements and actual translations can be added incrementally.

Please let me know if you would like any changes.

Related to #138