### PR TITLE
Add amdv3 and bad intel platforms

### DIFF
--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -676,6 +676,12 @@ The `oracledb` and `zabbixagent` agents were replaced by the `oracle` and `zabbi
 `lsscsi`
 : This package was initially introduced to support ADE. It has been removed from all minimal Ubuntu image-lines to maintain the minimal footprint assertion. However, it remains a pre-installed package for all non-minimized Ubuntu images on Azure since it is a valuable debugging tool for individual instances and server deployments.
 
+#### Google Cloud
+
+As all `AMD64` images are now built with `AMD64v3` the following CPU platforms (available on `N1` machine types only) are no longer supported:
+* Intel Ivy Bridge
+* Intel Sandy Bridge
+
 <!--
 ### Development changes
 

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -974,6 +974,12 @@ On systems booting via U-Boot, U-Boot should be updated to the current Plucky ve
 
 * Network interfaces left unconfigured at install time are assumed to be configured via dhcp4. If this doesn’t happen (for example, because the interface is physically not connected) the boot process will block and wait for a few minutes ([LP: #2063331](https://bugs.launchpad.net/subiquity/+bug/2063331)). This can be fixed by removing the extra interfaces from `/etc/netplan/50-cloud-init.conf` or by marking them as `optional: true`. Cloud-init is disabled on systems installed from ISO images, so settings will persist.
 
+### Cloud issues
+
+#### Google cloud
+
+On first boot, 26.04 images may be slowed by up to 30s due to an outstanding issue with `cloud-init` and `systemd` [(LP: #2148619)](https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/2148619)
+
 ## Official flavors
 
 Find the release notes for the official flavors at the following links:

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -528,6 +528,8 @@ All Resolute 26.04 images are now built with `AMD64v3` by default. However, this
 * Intel Ivy Bridge
 * Intel Sandy Bridge
 
+Automatic in-place upgrades to Ubuntu Pro will be fixed in [ubuntu-pro-client](https://github.com/canonical/ubuntu-pro-client/pull/3532) (to be included in the next point release)
+
 ## Security
 
 ### New AppArmor sandboxing profiles

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -522,6 +522,12 @@ The Active Directory Group Policy client for Ubuntu supports the latest Polkit a
 
 On all cloud providers, `AMD64` based images are now built with `AMD64v3` by default. This effort begins with 26.04 Resolute Racoon images and will continue with future releases.
 
+### Google Cloud
+
+All Resolute 26.04 images are now built with `AMD64v3` by default. However, this means that the following CPU platforms available on `N1` machine types are no longer supported:
+* Intel Ivy Bridge
+* Intel Sandy Bridge
+
 ## Security
 
 ### New AppArmor sandboxing profiles

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -520,6 +520,7 @@ The Active Directory Group Policy client for Ubuntu supports the latest Polkit a
 
 ## Cloud
 
+On all cloud providers, `AMD64` based images are now built with `AMD64v3` by default. This effort begins with 26.04 Resolute Racoon images and will continue with future releases.
 
 ## Security
 


### PR DESCRIPTION
# Adding a release note

## Which Ubuntu release is affected by this change?
26.04 onwards

## What kind of change is this? Try to select just one if possible.

- [x] New feature or improvement
- [ ] Backwards-incompatible change, including removed features
- [ ] Deprecated feature – will be removed in a later release
- [ ] Bug fix
- [ ] Known issue
- [ ] Something else (please describe)

## Which part of Ubuntu does the change affect? Try to select just one if possible.

- [ ] Desktop
- [ ] Server
- [ ] Containers
- [ ] Virtualization
- [ ] Databases
- [ ] High availability and clustering
- [ ] Development tools
- [ ] Enterprise
- [x] Cloud
- [ ] Security
- [ ] WSL
- [ ] Real-time Ubuntu
- [ ] Hardware support
- [ ] A common, underlying change