### PR TITLE
Add virt highlights

### DIFF
--- a/docs/24.10/index.md
+++ b/docs/24.10/index.md
@@ -275,6 +275,7 @@ The Exim4 update in Oracular to 4.98 includes selected fixes from the upstream G
 #### HAProxy
 The HAProxy package was upgraded to version 2.9.9. This new version introduces performance improvements, better integration, more reliability, and a new reverse-http feature. You can learn more about it at https://www.haproxy.com/blog/announcing-haproxy-2-9.  A complete list of changes is available at https://www.haproxy.org/download/2.9/src/CHANGELOG.
 
+(libvirt-24.10)=
 #### libvirt
 The [libvirt](https://libvirt.org) package was upgraded to version 10.6.0.  Here are the changes since Ubuntu Noble:
 

--- a/docs/25.04/index.md
+++ b/docs/25.04/index.md
@@ -485,6 +485,7 @@ PostgreSQL was updated to version 17, which contains several new features and en
 
 For more details, see the [upstream release notes](https://www.postgresql.org/docs/17/release-17.html).
 
+(qemu-25.04)=
 #### QEMU
 
 The [QEMU ](https://qemu.org/) package was updated to version 9.2.0. Here are the changes since Ubuntu Oracular.

--- a/docs/25.10/index.md
+++ b/docs/25.10/index.md
@@ -300,6 +300,7 @@ Additionally, Dovecot 2.4 brings new features including support for the ARGON2 p
 
 Notably, support for building for 32-bit architectures has ended, so dovecot will no longer be natively installable on i386 and armhf platforms.
 
+(edk2-25.10)=
 #### EDK2
 
 * Added firmware for Intel ® TDX guests with secure boot capability ([LP#2125123](https://bugs.launchpad.net/ubuntu/+source/edk2/+bug/2125123))

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -328,7 +328,7 @@ The QEMU package was upgraded to version 10.2.1. Here is the important changes s
 
 * qemu: The HPET device does not take the big QEMU lock anymore.
 
-* qemu: QEMU now supports loading multiple x509 cert+key identities, to allow use of parallel certificates with different algorithms, needwed to facilitate the transition to post-quantum cryptography
+* qemu: QEMU now supports loading multiple x509 cert+key identities, to allow use of parallel certificates with different algorithms, needed to facilitate the transition to post-quantum cryptography
 
 * ARM
 

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -297,19 +297,11 @@ virtualization stack of the following interim releases while otherwise staying o
 
 The libvirt package was upgraded to version 12.0.0. Here is the important changes since Ubuntu Questing:
 
-* Several new features have been added into the `bhyve` driver:
+* libvirt: improved firmware selection
 
-* Experimental NAT networking support using the Packet Filter (`pf`) firewall.
+* libvirt Add more statistics for block devices on QEMU domains
 
-* Querying domain block, interface, and memory statistics. Not all statistics fields are supported though.
-
-* SLIRP networking support
-
-* NVMe device support
-
-* `virtio-scsi` support
-
-* Initial ARM64 support
+* libvirt: Add support for NUMA affinity of PCI devices
 
 * Multi-GPU: Add support for NUMA affinity of PCI devices
 
@@ -333,15 +325,9 @@ Some additional notable changes:
 
 The QEMU package was upgraded to version 10.2.1. Here is the important changes since Ubuntu Questing:
 
-Upgrading Windows 11 makes the VM stop working and to fix this issue and ensure the migration path, we added new machine types for Resolute and old Ubuntu releases:
+* qemu: The HPET device does not take the big QEMU lock anymore.
 
-* `pc-i440fx-questing-v2` Ubuntu 25.10 PC v2 (i440FX + PIIX, + 10.1 machine, 1996)
-
-* `pc-i440fx-noble-v2`   Ubuntu 24.04 LTS PC v2 (i440FX + PIIX, `arch-caps` fix, 1996)
-
-* `pc-q35-noble-v2`      Ubuntu 24.04 LTS PC v2 (Q35 + ICH9, `arch-caps` fix, 2009)
-
-Other notable new features:
+* qemu: QEMU now supports loading multiple x509 cert+key identities, to allow use of parallel certificates with different algorithms, needwed to facilitate the transition to post-quantum cryptography
 
 * ARM
 
@@ -804,6 +790,19 @@ A noteworthy change in the packaging of Postfix is that **by default it is no lo
 #### `unbound` 1.24.2
 
 Update to version 1.24.2. See the [upstream changelog](https://github.com/NLnetLabs/unbound/releases/tag/release-1.24.2).
+
+#### Qemu - Handling Windows 11 upgrades
+
+* Upgrading [Windows 11 can make the VM stop working](https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2131822), to fix this issue and ensure the migration path, we added new machine types:
+
+* `pc-i440fx-questing-v2`
+* `pc-i440fx-noble-v2`
+* `pc-q35-noble-v2`
+
+This also affects the same guest on the related active releases, the CPU types with the fix have been provided there as well.
+Any newly started guest on these older releases will automatically pick up the new versions and now be able to migrate.
+Action is only needed if you specified them explicitly.
+26.04 and later is not affected right from the start.
 
 <!--
 ### Development fixes

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -292,17 +292,17 @@ For a comprehensive list of changes, please check the [upstream release notes](h
 ```{include} /reuse/26.04/virt-hwe-feature.txt
 ```
 
-In addition, the virtualization stack got following updates since Ubuntu Questing 25.10:
+In addition, the virtualization stack got following updates since Ubuntu 25.10 (Questing):
 
 #### libvirt
 
 The libvirt package was upgraded to version 12.0.0. Here is the important changes since Ubuntu Questing:
 
-* libvirt: improved firmware selection
+* libvirt: Better firmware selection
 
-* libvirt Add more statistics for block devices on QEMU domains
+* libvirt: More statistics for block devices on QEMU domains
 
-* libvirt: Add support for NUMA affinity of PCI devices
+* libvirt: Support for NUMA affinity of PCI devices
 
 * Multi-GPU: Add support for NUMA affinity of PCI devices
 
@@ -328,7 +328,7 @@ The QEMU package was upgraded to version 10.2.1. Here is the important changes s
 
 * qemu: The HPET device does not take the big QEMU lock anymore.
 
-* qemu: QEMU now supports loading multiple x509 cert+key identities, to allow use of parallel certificates with different algorithms, needed to facilitate the transition to post-quantum cryptography
+* qemu: Loading multiple x509 cert+key identities to allow the use of parallel certificates with different algorithms. This is needed to facilitate the transition to post-quantum cryptography.
 
 * ARM
 

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -794,16 +794,18 @@ Update to version 1.24.2. See the [upstream changelog](https://github.com/NLnetL
 
 #### Qemu - Handling Windows 11 upgrades
 
-* Upgrading [Windows 11 can make the VM stop working](https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2131822), to fix this issue and ensure the migration path, we added new machine types:
+* Upgrading [Windows 11 can make the VM stop working](https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2131822).
+  On the qemu version in 26.04 LTS this is already fixed right away. But to to fix this issue in 24.04 Noble
+  and 25.10 Questing we needed to add new machine types. To ensure the migration path to 26.04 LTS
+  and ensure the migration path the same types are kept here as well:
 
 * `pc-i440fx-questing-v2`
 * `pc-i440fx-noble-v2`
 * `pc-q35-noble-v2`
 
-This also affects the same guest on the related active releases, the CPU types with the fix have been provided there as well.
-Any newly started guest on these older releases will automatically pick up the new versions and now be able to migrate.
-Action is only needed if you specified them explicitly.
-26.04 and later is not affected right from the start.
+Any newly started guest on these older releases will automatically pick up the
+new versions but due to the above still able to migrate.
+Action is only needed if you specified them old types explicitly in your old systems.
 
 <!--
 ### Development fixes

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -795,7 +795,7 @@ Update to version 1.24.2. See the [upstream changelog](https://github.com/NLnetL
 #### Qemu - Handling Windows 11 upgrades
 
 * Upgrading [Windows 11 can make the VM stop working](https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2131822).
-  On the qemu version in 26.04 LTS this is already fixed right away. But to to fix this issue in 24.04 Noble
+  On the qemu version in 26.04 LTS this is already fixed right away. But to fix this issue in 24.04 Noble
   and 25.10 Questing we needed to add new machine types. To ensure the migration path to 26.04 LTS
   and ensure the migration path the same types are kept here as well:
 
@@ -805,7 +805,7 @@ Update to version 1.24.2. See the [upstream changelog](https://github.com/NLnetL
 
 Any newly started guest on these older releases will automatically pick up the
 new versions but due to the above still able to migrate.
-Action is only needed if you specified them old types explicitly in your old systems.
+Action is only needed if you specified the old types explicitly in your old systems.
 
 <!--
 ### Development fixes

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -36,7 +36,7 @@ Systems running TPM/FDE will now prompt for the recovery key before firmware upd
 
 Ubuntu 26.04 LTS is shipping with the Linux kernel 7.0, based on the upstream final release. Some notable features and changes:
 
-* Following the [upstream change](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=9fa7153c31a3), the Rust programming language experiement has been deemed concluded and its support is not flagged as experimental anymore. 
+* Following the [upstream change](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=9fa7153c31a3), the Rust programming language experiment has been deemed concluded and its support is not flagged as experimental anymore. 
 * Upstream Linux kernel 7.0 delivers improved support for Intel® Core™ Ultra Series 3 processors (codenamed Panther Lake), introducing targeted optimizations for Intel Xe3 integrated graphics and the integrated NPU (Neural Processing Unit).
 * `cgroupfs` is now mounted with `nsdelegate,memory_recursiveprot,memory_hugetlb_accounting`.
 * Integrated IgH EtherCAT Master module and Generic driver ([LP: #2138621](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2138621)). These modules provide real-time performance for industrial EtherCAT networks.

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -289,9 +289,10 @@ For a comprehensive list of changes, please check the [upstream release notes](h
 
 #### Virtualization stack
 
-The virtualization stack got various updates and to provide more flexibility an additional
-hardware enablement option was added that will in addition allow to switch to the
-virtualization stack of the following interim releases while otherwise staying on the LTS.
+```{include} /reuse/26.04/virt-hwe-feature.txt
+```
+
+In addition, the virtualization stack got following updates since Ubuntu Questing 25.10:
 
 #### libvirt
 

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -39,7 +39,7 @@ Ubuntu 26.04 LTS is shipping with the Linux kernel 7.0, based on the upstream fi
 * Following the [upstream change](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=9fa7153c31a3), the Rust programming language experiment has been deemed concluded and its support is not flagged as experimental anymore. 
 * Upstream Linux kernel 7.0 delivers improved support for Intel® Core™ Ultra Series 3 processors (codenamed Panther Lake), introducing targeted optimizations for Intel Xe3 integrated graphics and the integrated NPU (Neural Processing Unit).
 * `cgroupfs` is now mounted with `nsdelegate,memory_recursiveprot,memory_hugetlb_accounting`.
-* Integrated IgH EtherCAT Master module and Generic driver ([LP: #2138621](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2138621)). These modules provide real-time performance for industrial EtherCAT networks.
+* Integrated IgH EtherCAT module and Generic driver ([LP: #2138621](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2138621)). These modules provide real-time performance for industrial EtherCAT networks.
 * The real-time Linux kernel is available in the main archive (outside of Ubuntu Pro) in Ubuntu 26.04 LTS. Following the `PREEMPT_RT` patches being upstreamed, the Ubuntu 26.04 LTS release of the real-time kernel is available for free for anyone to use.
 * Kernel Livepatch now supports the ARM64 architecture.
 * ZFS has been updated to the latest 2.4.1 version ([upstream changelog](https://github.com/openzfs/zfs/releases/tag/zfs-2.4.1)).

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -439,15 +439,15 @@ For the `containerd` and `runc` packages, we established a pattern to either kee
 
 ### Virtualization stack
 
-A stack as active as that of qemu, libvirt, edk2 and seabios had way too many
-great new features and fixes to list them all. The upgrades between each
+A stack as active as that of `qemu`, `libvirt`, `edk2` and `seabios` had way too
+many great new features and fixes to list them all. The upgrades between each
 interim release like {ref}`libvirt@24.10 <libvirt-24.10>`,
 {ref}`qemu@25.10 <qemu-25.04>` or {ref}`edk2@25.10 <edk2-25.10>`
 are already so huge they can only cover a selected high level summary.
 Each version adds various new emulated instructions, new cpu types and
 virtualized platforms which would is beyond the scope of this.
 Here are just a few to motivate you to check out all the other
-per-release changes and the related upstream annoucments.
+per-release changes and the related upstream announcements.
 
 :::{versionadded} 26.04
 :::
@@ -491,9 +491,9 @@ per-release changes and the related upstream annoucments.
 :::
 
 * qemu: `virtio-blk` device has gained true multiqueue support where different queues of a single disk can be processed by different I/O threads. This can improve scalability in cases where the guest submitted enough I/O to saturate the host CPU running a single I/O thread processing the virtio-blk requests. Multiple I/O threads can be configured using the new iothread-vq-mapping property.
-* qemu: can emulate various new RISC-V instructions like the Zacas, B, Zaamo, Zalrsc, Ztso extensions
+* qemu: can emulate various new RISC-V instructions like the `Zacas`, `Zaamo`, `Zalrsc` and `Ztso` extensions
 * libvirt: Now supports clusters in CPU topology.
-* libvirt: Introduces dynamicMemslots attribute for virtio-mem
+* libvirt: Introduces `dynamicMemslots` attribute for virtio-mem
 
 ### High availability and clustering
 

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -460,7 +460,11 @@ per-release changes and the related upstream annoucments.
 * qemu: The HPET device does not take the big QEMU lock anymore.
 * qemu: QEMU now supports loading multiple x509 cert+key identities (for transition to post-quantum cryptography)
 
-* The virt stack as a whole added a hardware enablement model.
+:::{versionadded} 26.04
+:::
+
+```{include} /reuse/26.04/virt-hwe-feature.txt
+```
 
 :::{versionadded} 25.10
 :::

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -439,26 +439,26 @@ For the `containerd` and `runc` packages, we established a pattern to either kee
 
 ### Virtualization stack
 
-A stack as active as that of `qemu`, `libvirt`, `edk2` and `seabios` had way too
+A stack as active as that of `qemu`, `libvirt`, `edk2`, and `seabios` had too
 many great new features and fixes to list them all. The upgrades between each
 interim release like {ref}`libvirt@24.10 <libvirt-24.10>`,
-{ref}`qemu@25.10 <qemu-25.04>` or {ref}`edk2@25.10 <edk2-25.10>`
-are already so huge they can only cover a selected high level summary.
-Each version adds various new emulated instructions, new cpu types and
-virtualized platforms which would is beyond the scope of this.
+{ref}`qemu@25.10 <qemu-25.04>`, or {ref}`edk2@25.10 <edk2-25.10>`
+are already so huge they can only cover a selected high-level summary.
+Each version adds various new emulated instructions, new CPU types and
+virtualized platforms, which would is beyond the scope of release notes.
 Here are just a few to motivate you to check out all the other
 per-release changes and the related upstream announcements.
 
 :::{versionadded} 26.04
 :::
 
-* libvirt: improved firmware selection
-* libvirt Add more statistics for block devices on QEMU domains
-* libvirt: Add support for NUMA affinity of PCI devices
-* libvirt+qemu: Support NVIDIA Multi-Instance GPU (MIG) configurations
+* libvirt: Better firmware selection
+* libvirt More statistics for block devices on QEMU domains
+* libvirt: Support for NUMA affinity of PCI devices
+* libvirt+qemu: Support for NVIDIA Multi-Instance GPU (MIG) configurations
 * qemu: Hyper-V host model mode
-* qemu: The HPET device does not take the big QEMU lock anymore.
-* qemu: QEMU now supports loading multiple x509 cert+key identities (for transition to post-quantum cryptography)
+* qemu: The HPET device does not take the big QEMU lock anymore
+* qemu: Support for loading multiple x509 cert+key identities (for transition to post-quantum cryptography)
 
 :::{versionadded} 26.04
 :::
@@ -470,30 +470,30 @@ per-release changes and the related upstream announcements.
 :::
 
 * libvirt: ppc64 POWER11 processor support
-* libvirt: Allow control over QEMU TLS priority strings
-* libvirt: Add support for NVMe disks
-* libvirt: add support for AMD IOMMU device
+* libvirt: Control over QEMU TLS priority strings
+* libvirt: Support for NVMe disks
+* libvirt: Support for AMD IOMMU device
 * libvirt+qemu+edk2: Support for Intel TDX
 * qemu: Support for the [RVA23 Profile](https://riscv.org/blog/risc-v-rva23-a-major-milestone/)
 * qemu: Support for s390x generation 17 mainframe CPUs
-* qemu: `virtio-scsi` has gained true multiqueue support
+* qemu: Support for true `virtio-scsi` multiqueue
 
 :::{versionadded} 25.04
 :::
 
 * libvirt: Zero block detection for non-shared-storage migration
-* libvirt: Add support for versioned qemu CPU models
+* libvirt: Support for versioned qemu CPU models
 * libvirt+qemu+edk2: Support for AMD `SEV-SNP`
-* qemu: Support RISC-V privilege 1.13 spec
-* qemu: Arm KVM-based VMs can now support MTE
+* qemu: Support for RISC-V privilege 1.13 spec
+* qemu: Support for MTE on ARM KVM-based VMs
 
 :::{versionadded} 24.10
 :::
 
-* qemu: `virtio-blk` device has gained true multiqueue support where different queues of a single disk can be processed by different I/O threads. This can improve scalability in cases where the guest submitted enough I/O to saturate the host CPU running a single I/O thread processing the virtio-blk requests. Multiple I/O threads can be configured using the new iothread-vq-mapping property.
-* qemu: can emulate various new RISC-V instructions like the `Zacas`, `Zaamo`, `Zalrsc` and `Ztso` extensions
-* libvirt: Now supports clusters in CPU topology.
-* libvirt: Introduces `dynamicMemslots` attribute for virtio-mem
+* qemu: `virtio-blk` device has gained true multiqueue support where different queues of a single disk can be processed by different I/O threads. This can improve scalability in cases where the guest submitted enough I/O to saturate the host CPU running a single I/O thread processing the virtio-blk requests. Multiple I/O threads can be configured using the new `iothread-vq-mapping` property.
+* qemu: Support for emulating various new RISC-V instructions like the `Zacas`, `Zaamo`, `Zalrsc`, and `Ztso` extensions
+* libvirt: Support for clusters in CPU topology.
+* libvirt: New `dynamicMemslots` attribute for virtio-mem
 
 ### High availability and clustering
 

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -437,6 +437,60 @@ MySQL Shell was updated from major version 8.0 to 8.4 to coincide with MySQL 8.4
 
 For the `containerd` and `runc` packages, we established a pattern to either keep the regular updates to the latest version or to opt for slower, more stable updates throughout the time the release is active. For more please read [Ubuntu Server Gazette - Issue 8 - Containers: Steady paths for agile stacks](https://discourse.ubuntu.com/t/ubuntu-server-gazette-issue-8-containers-steady-paths-for-agile-stacks/68680).
 
+### Virtualization stack
+
+A stack as active as that of qemu, libvirt, edk2 and seabios had way too many
+great new features and fixes to list them all. The upgrades between each
+interim release like {ref}`libvirt@24.10 <libvirt-24.10>`,
+{ref}`qemu@25.10 <qemu-25.04>` or {ref}`edk2@25.10 <edk2-25.10>`
+are already so huge they can only cover a selected high level summary.
+Each version adds various new emulated instructions, new cpu types and
+virtualized platforms which would is beyond the scope of this.
+Here are just a few to motivate you to check out all the other
+per-release changes and the related upstream annoucments.
+
+:::{versionadded} 26.04
+:::
+
+* libvirt: improved firmware selection
+* libvirt Add more statistics for block devices on QEMU domains
+* libvirt: Add support for NUMA affinity of PCI devices
+* libvirt+qemu: Support NVIDIA Multi-Instance GPU (MIG) configurations
+* qemu: Hyper-V host model mode
+* qemu: The HPET device does not take the big QEMU lock anymore.
+* qemu: QEMU now supports loading multiple x509 cert+key identities (for transition to post-quantum cryptography)
+
+* The virt stack as a whole added a hardware enablement model.
+
+:::{versionadded} 25.10
+:::
+
+* libvirt: ppc64 POWER11 processor support
+* libvirt: Allow control over QEMU TLS priority strings
+* libvirt: Add support for NVMe disks
+* libvirt: add support for AMD IOMMU device
+* libvirt+qemu+edk2: Support for Intel TDX
+* qemu: Support for the [RVA23 Profile](https://riscv.org/blog/risc-v-rva23-a-major-milestone/)
+* qemu: Support for s390x generation 17 mainframe CPUs
+* qemu: `virtio-scsi` has gained true multiqueue support
+
+:::{versionadded} 25.04
+:::
+
+* libvirt: Zero block detection for non-shared-storage migration
+* libvirt: Add support for versioned qemu CPU models
+* libvirt+qemu+edk2: Support for AMD `SEV-SNP`
+* qemu: Support RISC-V privilege 1.13 spec
+* qemu: Arm KVM-based VMs can now support MTE
+
+:::{versionadded} 24.10
+:::
+
+* qemu: `virtio-blk` device has gained true multiqueue support where different queues of a single disk can be processed by different I/O threads. This can improve scalability in cases where the guest submitted enough I/O to saturate the host CPU running a single I/O thread processing the virtio-blk requests. Multiple I/O threads can be configured using the new iothread-vq-mapping property.
+* qemu: can emulate various new RISC-V instructions like the Zacas, B, Zaamo, Zalrsc, Ztso extensions
+* libvirt: Now supports clusters in CPU topology.
+* libvirt: Introduces dynamicMemslots attribute for virtio-mem
+
 ### High availability and clustering
 
 * The **`kpartx-boot`** package has been discontinued to align with Debian. Originally introduced to support `dmraid` booting, its functionality is preserved, as the `kpartx` package now includes everything previously provided by `kpartx-boot`.

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -445,7 +445,7 @@ interim release like {ref}`libvirt@24.10 <libvirt-24.10>`,
 {ref}`qemu@25.10 <qemu-25.04>`, or {ref}`edk2@25.10 <edk2-25.10>`
 are already so huge they can only cover a selected high-level summary.
 Each version adds various new emulated instructions, new CPU types and
-virtualized platforms, which would is beyond the scope of release notes.
+virtualized platforms, which would be beyond the scope of release notes.
 Here are just a few to motivate you to check out all the other
 per-release changes and the related upstream announcements.
 

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -897,7 +897,7 @@ For users running the GA generic stack, the Linux kernel has been updated from v
     :::{versionadded} 26.04
     :::
 
-* Integrated IgH EtherCAT Master module and Generic driver ([LP: #2138621](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2138621)). These modules provide real-time performance for industrial EtherCAT networks.
+* Integrated IgH EtherCAT module and Generic driver ([LP: #2138621](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2138621)). These modules provide real-time performance for industrial EtherCAT networks.
 
     :::{versionadded} 26.04
     :::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -254,6 +254,8 @@ linkcheck_ignore = [
     r"https://lubuntu\.me/.*",
     # Filenames in text incorrectly parsed as URLs by the link checker
     r"http://[^\s/]+\.(py|sh|mk|in)$",
+    # Servers being migrated right now - ignore for now
+    r"https://ubuntukylin\.com/.*",
     # Dead links in existing content (historical; not worth updating)
     r"https://github\.com/docker-snap/.*",
     r"https://github\.com/ipxe/.*",

--- a/docs/reuse/26.04/virt-hwe-feature.txt
+++ b/docs/reuse/26.04/virt-hwe-feature.txt
@@ -1,19 +1,19 @@
-The Ubuntu 26.04 Resolute release introduces a new Hardware Enablement (HWE)
+The Ubuntu 26.04 LTS (Resolute) release introduces a new Hardware Enablement (HWE)
 virtualization stack, which will be continuously updated to align with the
 latest versions delivered in upcoming interim releases.
 
-This virtualization stack is delivered like the [HWE kernel](https://canonical-kernel-docs.readthedocs-hosted.com/reference/hwe-kernels/),
-using them together is recommended but not a strict requirement.
+This virtualization stack is delivered like the [HWE kernel](https://canonical-kernel-docs.readthedocs-hosted.com/reference/hwe-kernels/).
+Using them together is recommended but not a strict requirement.
 
 This allows the user to benefit from the latest capabilities of
 the virtualization stack while otherwise staying on the well established
 Ubuntu LTS.
 
 This virt-hwe stack is composed of the following source packages:
- - qemu-hwe
- - libvirt-hwe
- - seabios-hwe
- - edk2-hwe
+ - `qemu-hwe`
+ - `libvirt-hwe`
+ - `seabios-hwe`
+ - `edk2-hwe`
 
 Initially those are mostly identical to the base packages, but twice a year
 they will move to a newer release.

--- a/docs/reuse/26.04/virt-hwe-feature.txt
+++ b/docs/reuse/26.04/virt-hwe-feature.txt
@@ -1,12 +1,24 @@
-The Ubuntu Resolute release introduces a new Hardware Enablement (HWE) virtualization stack,
-which will be continuously updated to align with the latest upstream versions delivered in
-upcoming interim releases. This virtualization stack is delivered in lockstep with the HWE
-kernel—though this is not a strict requirement—helping to ensure strong compatibility
-between kernel-level hardware enablement and userspace virtualization components.
+The Ubuntu 26.04 Resolute release introduces a new Hardware Enablement (HWE)
+virtualization stack, which will be continuously updated to align with the
+latest versions delivered in upcoming interim releases.
 
-This hwe stacks is composed of the following source packages:
+This virtualization stack is delivered like the [HWE kernel](https://canonical-kernel-docs.readthedocs-hosted.com/reference/hwe-kernels/),
+using them together is recommended but not a strict requirement.
+
+This allows the user to benefit from the latest capabilities of
+the virtualization stack while otherwise staying on the well established
+Ubuntu LTS.
+
+This virt-hwe stack is composed of the following source packages:
  - qemu-hwe
  - libvirt-hwe
  - seabios-hwe
  - edk2-hwe
 
+Initially those are mostly identical to the base packages, but twice a year
+they will move to a newer release.
+They generally resolve the same dependencies as the base stack and are therefore
+interchangeable but mutually exclusive to each other.
+
+The tool `ubuntu_virt_helper` assists administrators in switching between
+the two stacks.

--- a/docs/reuse/26.04/virt-hwe-feature.txt
+++ b/docs/reuse/26.04/virt-hwe-feature.txt
@@ -16,7 +16,7 @@ This virt-hwe stack is composed of the following source packages:
  - `edk2-hwe`
 
 Initially those are mostly identical to the base packages, but twice a year
-they will move to a newer release and become stable once the match the following
+they will move to a newer release and become stable once they match the following
 Ubuntu LTS release.
 They generally resolve the same dependencies as the base stack and are therefore
 interchangeable but mutually exclusive to each other.

--- a/docs/reuse/26.04/virt-hwe-feature.txt
+++ b/docs/reuse/26.04/virt-hwe-feature.txt
@@ -16,7 +16,8 @@ This virt-hwe stack is composed of the following source packages:
  - `edk2-hwe`
 
 Initially those are mostly identical to the base packages, but twice a year
-they will move to a newer release.
+they will move to a newer release and become stable once the match the following
+Ubuntu LTS release.
 They generally resolve the same dependencies as the base stack and are therefore
 interchangeable but mutually exclusive to each other.
 

--- a/docs/reuse/26.04/virt-hwe-feature.txt
+++ b/docs/reuse/26.04/virt-hwe-feature.txt
@@ -1,0 +1,12 @@
+The Ubuntu Resolute release introduces a new Hardware Enablement (HWE) virtualization stack,
+which will be continuously updated to align with the latest upstream versions delivered in
+upcoming interim releases. This virtualization stack is delivered in lockstep with the HWE
+kernel—though this is not a strict requirement—helping to ensure strong compatibility
+between kernel-level hardware enablement and userspace virtualization components.
+
+This hwe stacks is composed of the following source packages:
+ - qemu-hwe
+ - libvirt-hwe
+ - seabios-hwe
+ - edk2-hwe
+


### PR DESCRIPTION
This updates the virt section in the server context
It described the HWE functions, revises some of the content and ensures there is a "since LTS" overview.

## Major change

Some are, I think repeating is not needed (for anything btw)

## Tickets

nope

## Upstream release notes

There are, but they already have been linked from the sections in the "since interim" page. No change needed
