### PR TITLE
Document new docker image ls output

### DIFF
--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -253,6 +253,8 @@ There is a new experimental support for `nftables` which can be enabled by setti
 
 The `containerd` image store is now the default for **fresh installs**. This doesn’t apply to daemons configured with `userns-remap` or for users upgrading from a previous [docker.io](http://docker.io) version.
 
+The `docker image ls` command output has changed to use a new view (like `--tree` but collapsed) by default.
+
 For a comprehensive list of changes, please check the [upstream release notes](https://docs.docker.com/engine/release-notes/29/).
 
 #### Virtualization stack


### PR DESCRIPTION
## Which Ubuntu release is affected by this change?
26.04
## What kind of change is this? Try to select just one if possible.

- [ ] New feature or improvement
- [x] Backwards-incompatible change, including removed features
- [ ] Deprecated feature – will be removed in a later release
- [ ] Bug fix
- [ ] Known issue
- [ ] Something else (please describe)

## Workaround

Users need to review their parsing code in case it breaks

## Which part of Ubuntu does the change affect? Try to select just one if possible.

- [ ] Desktop
- [ ] Server
- [x] Containers
- [ ] Virtualization
- [ ] Databases
- [ ] High availability and clustering
- [ ] Development tools
- [ ] Enterprise
- [ ] Cloud
- [ ] Security
- [ ] WSL
- [ ] Real-time Ubuntu
- [ ] Hardware support
- [ ] A common, underlying change

## Major change

## Upstream release notes

https://docs.docker.com/engine/release-notes/29/#new-2
