### PR TITLE
Kernel changes for 26.04

### DIFF
--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -34,16 +34,18 @@ Systems running TPM/FDE will now prompt for the recovery key before firmware upd
 
 #### Linux kernel 7.0 🐧
 
-* Ubuntu 26.04 is shipping with the Linux kernel 7.0, based on the upstream final release.
+Ubuntu 26.04 LTS is shipping with the Linux kernel 7.0, based on the upstream final release. Some notable features and changes:
+
 * Following the [upstream change](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=9fa7153c31a3), the Rust programming language experiement has been deemed concluded and its support is not flagged as experimental anymore. 
 * Upstream Linux kernel 7.0 delivers improved support for Intel® Core™ Ultra Series 3 processors (codenamed Panther Lake), introducing targeted optimizations for Intel Xe3 integrated graphics and the integrated NPU (Neural Processing Unit).
 * `cgroupfs` is now mounted with `nsdelegate,memory_recursiveprot,memory_hugetlb_accounting`.
 * Integrated IgH EtherCAT Master module and Generic driver ([LP: #2138621](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2138621)). These modules provide real-time performance for industrial EtherCAT networks.
-* The real-time linux kernel is available in the main archive (outside of Ubuntu Pro) in 26.04. Following the `PREEMPT_RT` patches being upstreamed, the 26.04 release of the real-time kernel is available for free for anyone to use.
+* The real-time Linux kernel is available in the main archive (outside of Ubuntu Pro) in Ubuntu 26.04 LTS. Following the `PREEMPT_RT` patches being upstreamed, the Ubuntu 26.04 LTS release of the real-time kernel is available for free for anyone to use.
 * Kernel Livepatch now supports the ARM64 architecture.
-* ZFS updated to the latest 2.4.1 version ([upstream changelog](https://github.com/openzfs/zfs/releases/tag/zfs-2.4.1)).
+* ZFS has been updated to the latest 2.4.1 version ([upstream changelog](https://github.com/openzfs/zfs/releases/tag/zfs-2.4.1)).
 * DOCA-OFED 26.01 kernel modules are available for the Ubuntu generic and select derivative kernels.
-* Other features can be found in the [Linux 7.0 upstream changelog](https://kernelnewbies.org/Linux_7.0).
+
+Other features can be found in the [Linux 7.0 upstream changelog](https://kernelnewbies.org/Linux_7.0).
 
 #### Netplan v1.1.2 🌐
 

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -34,7 +34,16 @@ Systems running TPM/FDE will now prompt for the recovery key before firmware upd
 
 #### Linux kernel 7.0 🐧
 
-* `cgroupfs` is now mounted with `nsdelegate,memory_recursiveprot,memory_hugetlb_accounting`
+* Ubuntu 26.04 is shipping with the Linux kernel 7.0, based on the upstream final release.
+* Following the [upstream change](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=9fa7153c31a3), the Rust programming language experiement has been deemed concluded and its support is not flagged as experimental anymore. 
+* Upstream Linux kernel 7.0 delivers improved support for Intel® Core™ Ultra Series 3 processors (codenamed Panther Lake), introducing targeted optimizations for Intel Xe3 integrated graphics and the integrated NPU (Neural Processing Unit).
+* `cgroupfs` is now mounted with `nsdelegate,memory_recursiveprot,memory_hugetlb_accounting`.
+* Integrated IgH EtherCAT Master module and Generic driver ([LP: #2138621](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2138621)). These modules provide real-time performance for industrial EtherCAT networks.
+* The real-time linux kernel is available in the main archive (outside of Ubuntu Pro) in 26.04. Following the `PREEMPT_RT` patches being upstreamed, the 26.04 release of the real-time kernel is available for free for anyone to use.
+* Kernel Livepatch now supports the ARM64 architecture.
+* ZFS updated to the latest 2.4.1 version ([upstream changelog](https://github.com/openzfs/zfs/releases/tag/zfs-2.4.1)).
+* DOCA-OFED 26.01 kernel modules are available for the Ubuntu generic and select derivative kernels.
+* Other features can be found in the [Linux 7.0 upstream changelog](https://kernelnewbies.org/Linux_7.0).
 
 #### Netplan v1.1.2 🌐
 

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -665,6 +665,7 @@ If you wish to keep specific applications, simply "install" them with `apt` firs
 
 The creation of the swap file on the desktop images is now handled by [`cloud-init`](https://cloudinit.readthedocs.io/en/latest/) ([LP: #2116275](https://launchpad.net/bugs/2116275)). You may customize the size of the swap file by editing `user-data` on the boot partition prior to first boot (commented examples are included in the image).
 
+(resolute-new-risc-v-requirements)=
 ### New RISC-V requirements
 :::{versionchanged} 25.10
 :::
@@ -729,12 +730,9 @@ For users running the GA generic stack, the Linux kernel has been updated from v
 
 * The RISC-V kernel supports only architectures compliant with the RVA23S64 ISA profile.
 
-    :::{versionadded} 25.10
-    :::
+    For details, see {ref}`resolute-new-risc-v-requirements`.
 
-* Because the RISC-V RVA23 profile requires newer instruction sets, most first-generation RISC-V development boards are incompatible with Ubuntu 26.04. Users of older hardware are encouraged to remain on Ubuntu 24.04 LTS.
-
-    :::{versionremoved} 25.10
+    :::{versionchanged} 25.10
     :::
 
 * `linux-generic` for arm64 provides via `stubble` broader compatibility for arm64 desktop platforms that utilize UEFI for booting ([LP: #2121352](https://bugs.launchpad.net/ubuntu/+source/linux-signed/+bug/2121352)).

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -710,7 +710,7 @@ Since `rust-coreutils` are not necessarily fully compatible yet, we continue to 
 
 ### Linux kernel 7.0
 
-The Linux kernel has been updated from version 6.8 to 7.0.
+For users running the GA generic stack, the Linux kernel has been updated from version 6.8 to 7.0. For users running the Hardware Enablement (HWE) stack, the Linux kernel has been updated from version 6.17 (25.10 backport) to 7.0.
 
 * Crash dumps are now [enabled by default](https://documentation.ubuntu.com/server/how-to/software/kernel-crash-dump/#kdump-enabled-by-default) for desktop and server installations.
 
@@ -726,6 +726,47 @@ The Linux kernel has been updated from version 6.8 to 7.0.
 
     :::{versionadded} 25.04
     :::
+
+* The RISC-V kernel supports only architectures compliant with the RVA23S64 ISA profile.
+
+    :::{versionadded} 25.10
+    :::
+
+* Because the RISC-V RVA23 profile requires newer instruction sets, most first-generation RISC-V development boards are incompatible with Ubuntu 26.04. Users of older hardware are encouraged to remain on Ubuntu 24.04 LTS.
+
+    :::{versionremoved} 25.10
+    :::
+
+* `linux-generic` for arm64 provides via `stubble` broader compatibility for arm64 desktop platforms that utilize UEFI for booting ([LP: #2121352](https://bugs.launchpad.net/ubuntu/+source/linux-signed/+bug/2121352)).
+
+    :::{versionadded} 25.10
+    :::
+
+* Upstream Linux kernel 7.0 delivers improved support for Intel® Core™ Ultra Series 3 processors (codenamed Panther Lake), introducing targeted optimizations for Intel Xe3 integrated graphics and the integrated NPU (Neural Processing Unit).
+
+    :::{versionadded} 26.04
+    :::
+
+* Integrated IgH EtherCAT Master module and Generic driver ([LP: #2138621](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2138621)). These modules provide real-time performance for industrial EtherCAT networks.
+
+    :::{versionadded} 26.04
+    :::
+
+* The real-time linux kernel is available in the main archive (outside of Ubuntu Pro) in 26.04. Following the `PREEMPT_RT` patches being upstreamed, the 26.04 release of the real-time kernel is available for free for anyone to use.
+
+    :::{versionadded} 26.04
+    :::
+
+* Kernel Livepatch now supports the ARM64 architecture.
+
+    :::{versionadded} 26.04
+    :::
+
+* DOCA-OFED 26.01 kernel modules are available for the Ubuntu generic and select derivative kernels.
+
+    :::{versionadded} 26.04
+    :::
+
 
 ### `systemd` 259
 


### PR DESCRIPTION
# Adding a release note

Feel free to delete this template if you're making a minor or unrelated change.

## Which Ubuntu release is affected by this change?

26.04

## What kind of change is this? Try to select just one if possible.

- [X] New feature or improvement
- [ ] Backwards-incompatible change, including removed features
- [ ] Deprecated feature – will be removed in a later release
- [ ] Bug fix
- [ ] Known issue
- [X] Something else (please describe) - Removed RISC-V hardware support from 25.10

## Workaround

N/A

## Which part of Ubuntu does the change affect? Try to select just one if possible.

- [ ] Desktop
- [ ] Server
- [ ] Containers
- [ ] Virtualization
- [ ] Databases
- [ ] High availability and clustering
- [ ] Development tools
- [ ] Enterprise
- [ ] Cloud
- [ ] Security
- [ ] WSL
- [ ] Real-time Ubuntu
- [ ] Hardware support
- [X] A common, underlying change

## Major change

N/A

## Tickets

N/A

## Upstream release notes

Already added to the PR.