### PR TITLE
QEMU: OpenSBI is not provided by QEMU

### DIFF
--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -321,8 +321,6 @@ Other notable new features:
 
   * Add `riscv64` to `FirmwareArchitecture`
 
-  * Update OpenSBI to v1.8.1
-
   * Implement MonitorDef HMP API
 
 * X86


### PR DESCRIPTION
Ubuntu's QEMU does not comprise OpenSBI.
Instead we use the opensbi package.

Don't copy the upstream OpenSBI release information into the QEMU section.