### PR TITLE
Add .NET toolchain release notes

### DIFF
--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -498,6 +498,7 @@ For the full list of [upstream release highlights](https://releases.openstack.or
 * `glibc` 2.42 now ships non-UTF8 encodings as `libc-gconv-modules-extra`.
 * LLVM 21 is the default LLVM toolchain.
 * Rust 1.93.1 is the default Rust toolchain.
+* .NET 10 is now available
 
 #### OpenJDK
 
@@ -505,7 +506,31 @@ OpenJDK 25 package is the default and is TCK (Technology Compatibility Kit) cert
 
 #### .NET
 
-...
+.NET 10 is available in the Ubuntu archive. Install it with `sudo apt install dotnet10`.
+
+.NET 8 and .NET 9 are also available for 26.04 via the [Backports PPA](https://documentation.ubuntu.com/ubuntu-for-developers/reference/availability/dotnet/#backports-ppa). To install .NET 8 or .NET 9, first add the Backports PPA to your system:
+
+```bash
+sudo add-apt-repository ppa:dotnet/backports
+```
+
+Alternatively, .NET 8, 9 and 10 are available via the official [.NET snap](https://snapcraft.io/dotnet).
+
+##### NetCoreDbg Snap
+
+NetCoreDbg is now available as a [snap](https://snapcraft.io/netcoredbg), providing a convenient way to install and use the .NET debugger on Ubuntu. NetCoreDbg is a cross-platform debugger for .NET applications, supporting features like breakpoints, stepping, and variable inspection. To install NetCoreDbg via snap, run the following command:
+
+```bash
+sudo snap install netcoredbg --classic
+```
+
+##### MSBuild Structured Log Viewer
+
+The MSBuild Structured Log Viewer is now available as a [snap](https://snapcraft.io/msbuild-structured-log-viewer). This tool allows developers to visualize and troubleshoot build processes by providing insights into the build execution from MSBuild binary log files. To install the MSBuild Structured Log Viewer via snap, run the following command:
+
+```bash
+sudo snap install msbuild-structured-log-viewer
+```
 
 #### Rust + cargo-auditable
 

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -510,13 +510,13 @@ OpenJDK 25 package is the default and is TCK (Technology Compatibility Kit) cert
 
 Application developers may get other .NET releases, such as .NET 8 or .NET 9, via the [Backports PPA](https://launchpad.net/~dotnet/+archive/ubuntu/backports). Note that PPA builds are made available as a best-effort and support is limited to the upstream lifespan of the .NET release.
 
-Alternatively, .NET 8, 9 and 10 are available via the official [.NET snap](https://snapcraft.io/dotnet).
+Alternatively, .NET 8, 9, and 10 are available via the official [.NET snap](https://snapcraft.io/dotnet).
 
 ##### NetCoreDbg Snap
 
 NetCoreDbg is now available as a [snap](https://snapcraft.io/netcoredbg), providing a convenient way to install and use the .NET debugger on Ubuntu. NetCoreDbg is a cross-platform debugger for .NET applications, supporting features like breakpoints, stepping, and variable inspection. To install NetCoreDbg via snap, run the following command:
 
-```bash
+```none
 sudo snap install netcoredbg --classic
 ```
 
@@ -524,7 +524,7 @@ sudo snap install netcoredbg --classic
 
 The MSBuild Structured Log Viewer is now available as a [snap](https://snapcraft.io/msbuild-structured-log-viewer). This tool allows developers to visualize and troubleshoot build processes by providing insights into the build execution from MSBuild binary log files. To install the MSBuild Structured Log Viewer via snap, run the following command:
 
-```bash
+```none
 sudo snap install msbuild-structured-log-viewer
 ```
 

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -508,11 +508,7 @@ OpenJDK 25 package is the default and is TCK (Technology Compatibility Kit) cert
 
 .NET 10 is available in the Ubuntu archive. Install it with `sudo apt install dotnet10`.
 
-.NET 8 and .NET 9 are also available for 26.04 via the [Backports PPA](https://documentation.ubuntu.com/ubuntu-for-developers/reference/availability/dotnet/#backports-ppa). To install .NET 8 or .NET 9, first add the Backports PPA to your system:
-
-```bash
-sudo add-apt-repository ppa:dotnet/backports
-```
+Application developers may get other .NET releases, such as .NET 8 or .NET 9, via the [Backports PPA](https://launchpad.net/~dotnet/+archive/ubuntu/backports). Note that PPA builds are made available as a best-effort and support is limited to the upstream lifespan of the .NET release.
 
 Alternatively, .NET 8, 9 and 10 are available via the official [.NET snap](https://snapcraft.io/dotnet).
 

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -480,9 +480,7 @@ GraalVM Community Edition for JDK versions 21, 24 and 25 is now available as a [
 
 ### .NET 10
 
-.NET has been updated from version 8 to 10.
-
-We have also expanded .NET support to the IBM Power platform, further broadening the platform’s reach.
+.NET 10 is now available in the Ubuntu archive for the `amd64`, `arm64`, `s390x`, and `ppc64el` architectures.
 
 ### .NET snap
 :::{versionadded} 24.10


### PR DESCRIPTION
# Adding a release note

## Which Ubuntu release is affected by this change?

Ubuntu 26.04 LTS

## What kind of change is this? Try to select just one if possible.

- [X] New feature or improvement
- [ ] Backwards-incompatible change, including removed features
- [ ] Deprecated feature – will be removed in a later release
- [ ] Bug fix
- [ ] Known issue
- [ ] Something else (please describe)

## Workaround

N/A

## Which part of Ubuntu does the change affect? Try to select just one if possible.

- [ ] Desktop
- [ ] Server
- [ ] Containers
- [ ] Virtualization
- [ ] Databases
- [ ] High availability and clustering
- [X] Development tools
- [ ] Enterprise
- [ ] Cloud
- [ ] Security
- [ ] WSL
- [ ] Real-time Ubuntu
- [ ] Hardware support
- [ ] A common, underlying change

## Major change

Adding .NET toolchain release notes for Ubuntu 26.04.

## Tickets

N/A

## Upstream release notes

N/A