### PR TITLE
add WSL 26.04 release notes

### DIFF
--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -440,6 +440,50 @@ For the `containerd` and `runc` packages, we established a pattern to either kee
 
 * Pacemaker was updated to version 3. All new features and breaking changes are described in the [upstream release notes](https://projects.clusterlabs.org/w/projects/pacemaker/pacemaker_3.0_changes/).
 
+## WSL
+
+### Ubuntu Insights
+
+[Ubuntu Insights](https://github.com/ubuntu/ubuntu-insights) is introduced as a successor to [Ubuntu Report](https://github.com/ubuntu/ubuntu-report), providing enhanced user control over the submission of non-personally identifying system metrics to Canonical. This opt-in metrics collection is now integrated into Ubuntu on WSL. 
+
+Users initializing a WSL instance for the first time will be prompted for system metrics collection consent. This consent is persisted on the Windows host, eliminating repeated prompts for subsequent WSL instance setups. Consent management is also available on an individual per-instance basis.
+
+ For additional information on data collection for Ubuntu on WSL, refer to the [documentation](https://documentation.ubuntu.com/wsl/latest/explanation/data-collection/).
+
+### Chrony
+
+:::{versionchanged} 25.10
+:::
+
+Ubuntu on WSL follows the platform-wide migration from `systemd-timesyncd` to `chrony` for network time synchronization that was implemented during the 25.10 cycle. Further details on this change in the WSL context are provided in the [documentation on time synchronization within WSL](https://documentation.ubuntu.com/wsl/latest/explanation/time-sync/).
+
+### systemd-binfmt.service
+
+:::{versionchanged} 25.10 
+:::
+
+`Binfmt` miscellaneous registrations are integral to Windows binary interoperability within WSL. Previously, the `systemd-binfmt.service` unit was disabled to mitigate against various potential issues. As of WSL 2.5.7, this system override is no longer necessary because the platform now incorporates a robust fix utilizing `systemd generators`.
+
+Users relying on `systemd-binfmt.service` to apply new registrations when installing packages, for example, will now find it works without compromising the binary interop. To learn more, please check out [our docs about binfmt](https://documentation.ubuntu.com/wsl/stable/explanation/binfmt/).
+
+### User setup
+
+:::{versionchanged} 25.10
+:::
+
+Enhancements were implemented for Windows username processing during the initial WSL instance setup:
+
+* Addressed an issue that resulted in the erroneous removal of uppercase letters from the Windows username before generating the suggested Linux username. See [LP: \#2122047](https://bugs.launchpad.net/ubuntu/+source/wsl-setup/+bug/2122047).
+* Resolved failures occurring when the Windows username included non-ASCII characters. See [LP: \#2118617](https://bugs.launchpad.net/ubuntu/+source/wsl-setup/+bug/2118617).
+
+### Ubuntu Pro for WSL version 1.0 released
+
+**Ubuntu Pro for WSL** is a dedicated Windows application that streamlines the management of Ubuntu Pro subscriptions across WSL instances. 
+
+For individual users, it eliminates the necessity of manually attaching each new Ubuntu instance to Ubuntu Pro for access to security benefits. For enterprise deployments, the application provides automated Pro-attachment and registration with Landscape, facilitating large-scale device fleet management. 
+
+Documentation and download resources are available in [the documentation](https://documentation.ubuntu.com/wsl/stable/tutorials/getting-started-with-up4w) and [the download page](https://ubuntu.com/wsl/organizations).
+
 ## Development
 
 * GCC 🐄 has been updated from version 14 to 15.2, `binutils` from 2.42 to 2.45, and `glibc` from 2.39 to 2.42.

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -464,7 +464,7 @@ Ubuntu on WSL follows the platform-wide migration from `systemd-timesyncd` to `c
 
 `Binfmt` miscellaneous registrations are integral to Windows binary interoperability within WSL. Previously, the `systemd-binfmt.service` unit was disabled to mitigate against various potential issues. As of WSL 2.5.7, this system override is no longer necessary because the platform now incorporates a robust fix utilizing `systemd generators`.
 
-Users relying on `systemd-binfmt.service` to apply new registrations when installing packages, for example, will now find it works without compromising the binary interop. To learn more, please check out [our docs about binfmt](https://documentation.ubuntu.com/wsl/stable/explanation/binfmt/).
+Users relying on `systemd-binfmt.service` to apply new registrations when installing packages, for example, will now find it works without compromising the binary interoperability. To learn more, please check out [our docs about `binfmt`](https://documentation.ubuntu.com/wsl/stable/explanation/binfmt/).
 
 ### User setup
 


### PR DESCRIPTION
# Adding a release note

Feel free to delete this template if you're making a minor or unrelated change.

## Which Ubuntu release is affected by this change?

26.04

## What kind of change is this? Try to select just one if possible.

- [X] New feature or improvement
- [ ] Backwards-incompatible change, including removed features
- [ ] Deprecated feature – will be removed in a later release
- [X] Bug fix
- [ ] Known issue
- [ ] Something else (please describe)

## Which part of Ubuntu does the change affect? Try to select just one if possible.

- [ ] Desktop
- [ ] Server
- [ ] Containers
- [ ] Virtualization
- [ ] Databases
- [ ] High availability and clustering
- [ ] Development tools
- [ ] Enterprise
- [ ] Cloud
- [ ] Security
- [X] WSL
- [ ] Real-time Ubuntu
- [ ] Hardware support
- [ ] A common, underlying change

## Major change

N/A

## Tickets

N/A

## Upstream release notes

N/A