### PR TITLE
Update sos release notes for resolute

### DIFF
--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -220,7 +220,12 @@ For a list of all changes and fixes, please check the [upstream releases page](h
 
 #### SoS (`sosreport`)
 
-SoS was updated to 4.10.2. This upgrade introduces new plugins and also adds new features to existing plugins.
+`sos` was updated to version 4.10.2. Key updates below
+
+- The temporary directory has now been changed from `/tmp` to `/var/tmp`. This follows changed in systemd-tmpfiles and the cleaning of `/var/tmp`, this aligns with other distros.
+- Additional plugins include `aws` and `spyre`.
+- The openstack plugins have all been improved to obfuscate passwords more effectively and consistent.
+- Many other plugins have also been updated.
 
 For more information see the [4.10.1](https://github.com/sosreport/sos/releases/tag/4.10.1) and [4.10.2](https://github.com/sosreport/sos/releases/tag/4.10.2) upstream release notes.
 

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -222,7 +222,7 @@ For a list of all changes and fixes, please check the [upstream releases page](h
 
 `sos` was updated to version 4.10.2. Key updates include:
 
-- The temporary directory has now been changed from `/tmp` to `/var/tmp`. This follows changed in systemd-tmpfiles and the cleaning of `/var/tmp`, this aligns with other distros.
+- The temporary directory has now been changed from `/tmp` to `/var/tmp`. This follows the change in `systemd-tmpfiles` and the cleaning of `/var/tmp`, and it aligns with other distributions.
 - Additional plugins include `aws` and `spyre`.
 - The openstack plugins have all been improved to obfuscate passwords more effectively and consistent.
 - Many other plugins have also been updated.

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -220,7 +220,7 @@ For a list of all changes and fixes, please check the [upstream releases page](h
 
 #### SoS (`sosreport`)
 
-`sos` was updated to version 4.10.2. Key updates below
+`sos` was updated to version 4.10.2. Key updates include:
 
 - The temporary directory has now been changed from `/tmp` to `/var/tmp`. This follows changed in systemd-tmpfiles and the cleaning of `/var/tmp`, this aligns with other distros.
 - Additional plugins include `aws` and `spyre`.

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -224,7 +224,7 @@ For a list of all changes and fixes, please check the [upstream releases page](h
 
 - The temporary directory has now been changed from `/tmp` to `/var/tmp`. This follows the change in `systemd-tmpfiles` and the cleaning of `/var/tmp`, and it aligns with other distributions.
 - Additional plugins include `aws` and `spyre`.
-- The openstack plugins have all been improved to obfuscate passwords more effectively and consistent.
+- The OpenStack plugins have all been improved to obfuscate passwords more effectively and consistently.
 - Many other plugins have also been updated.
 
 For more information see the [4.10.1](https://github.com/sosreport/sos/releases/tag/4.10.1) and [4.10.2](https://github.com/sosreport/sos/releases/tag/4.10.2) upstream release notes.


### PR DESCRIPTION
# Adding a release note

I am one of the upstream maintainers of, sos, so want to reflect the release notes here to reflect the changes.

## Which Ubuntu release is affected by this change?

Resolute

## What kind of change is this? Try to select just one if possible.

- [x] New feature or improvement
- [ ] Backwards-incompatible change, including removed features
- [ ] Deprecated feature – will be removed in a later release
- [ ] Bug fix
- [ ] Known issue
- [ ] Something else (please describe)

## Workaround

If this is a known issue, how can users work around it for now? Add here if you haven't already described it in the PR.

## Which part of Ubuntu does the change affect? Try to select just one if possible.

- [ ] Desktop
- [x] Server
- [ ] Containers
- [ ] Virtualization
- [ ] Databases
- [ ] High availability and clustering
- [ ] Development tools
- [ ] Enterprise
- [ ] Cloud
- [ ] Security
- [ ] WSL
- [ ] Real-time Ubuntu
- [ ] Hardware support
- [ ] A common, underlying change

## Major change

One main change is that the tmp directory where sos stores the data is now in `/var/tmp` and not in `/tmp`

## Tickets

N/A

## Upstream release notes

This was first introduced in 4.10.0, but as this is the LTS, it made sense to enforce, and ensure that this is documented.