### PR TITLE
docs: add known issue for ACL for 26.04

### DIFF
--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -874,9 +874,15 @@ A bug prevents the I/O scheduler from being reset to “none” ([LP: #2083845](
 
 Support for FAN networking has been dropped in the 6.11 release kernel. It will be re-introduced in the next 6.11 kernel update shortly.
 
-#### POSIX ACL Inheritance with `mkdir`
+#### POSIX ACL inheritance with `mkdir`
 
-On 26.04 (and 25.10 systems), POSIX ACLs are not always appropriately being inherited from parent directories. If a directory has ACLs set, and `mkdir -p` is called, the created parents do not appropriately inherit ACLs. There is also a possibility of more open permissions being set for the directories. This is tracked in [LP: #2138215](https://bugs.launchpad.net/ubuntu/+source/acl/+bug/2138215) and upstream at [Issue #11036](https://github.com/uutils/coreutils/issues/11036).
+POSIX Access Control Lists (ACLs) are not always appropriately inherited from parent directories. If a directory has ACLs set, and you create a directory path using `mkdir -p`, the created parents do not appropriately inherit ACLs.
+
+There is also a possibility of more open permissions being set for the directories.
+
+See the Ubuntu bug at [LP: #2138215](https://bugs.launchpad.net/ubuntu/+source/acl/+bug/2138215) and the upstream bug at [Issue #11036](https://github.com/uutils/coreutils/issues/11036).
+
+This issue was also present in Ubuntu 25.10.
 
 ### Desktop issues
 

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -874,7 +874,9 @@ A bug prevents the I/O scheduler from being reset to “none” ([LP: #2083845](
 
 Support for FAN networking has been dropped in the 6.11 release kernel. It will be re-introduced in the next 6.11 kernel update shortly.
 
+#### POSIX ACL Inheritance with `mkdir`
 
+On 26.04 (and 25.10 systems), POSIX ACLs are not always appropriately being inherited from parent directories. If a directory has ACLs set, and `mkdir -p` is called, the created parents do not appropriately inherit ACLs. There is also a possibility of more open permissions being set for the directories. This is tracked in [LP: #2138215](https://bugs.launchpad.net/ubuntu/+source/acl/+bug/2138215) and upstream at [Issue #11036](https://github.com/uutils/coreutils/issues/11036).
 
 ### Desktop issues
 


### PR DESCRIPTION
Known issue for ACL inheritance added for 26.04.

# Adding a release note

## Which Ubuntu release is affected by this change?

26.04

## What kind of change is this? Try to select just one if possible.

- [ ] New feature or improvement
- [ ] Backwards-incompatible change, including removed features
- [ ] Deprecated feature – will be removed in a later release
- [ ] Bug fix
- [X ] Known issue
- [ ] Something else (please describe)

## Workaround

nope, it's broken captain

## Which part of Ubuntu does the change affect? Try to select just one if possible.

- [ X] A common, underlying change (bug in rust-coreutils)

## Tickets

https://bugs.launchpad.net/ubuntu/+source/acl/+bug/2138215
https://github.com/uutils/coreutils/issues/11036
