### PR TITLE
Resolute changes for raspi sections

### DIFF
--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -849,8 +849,6 @@ PMDK sees some hardware-specific failures in its test suite, which may make the 
 
 * With the removal of the `crda` package in 22.04, the method of setting the WiFi regulatory domain (editing `/etc/default/crda`) no longer operates. On server images, use the `regulatory-domain` option in the Netplan configuration. On desktop images, append `cfg80211.ieee80211_regdom=GB` (substituting `GB` for the relevant country code) to the kernel command line in the `cmdline.txt` file on the boot partition  ([LP: #1951586](https://launchpad.net/bugs/1951586)).
 
-* Colors appear incorrectly in the Ubuntu App Center ([LP: #2076919](https://launchpad.net/bugs/2076919))
-
 * On server images, re-authentication to WiFi APs when regulatory domain is set result in `dmesg` spam to the console ([LP: #2063365](https://launchpad.net/bugs/2063365))
 
 #### Netboot installs

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -842,7 +842,6 @@ PMDK sees some hardware-specific failures in its test suite, which may make the 
 #### Raspberry Pi
 
 * The new `gnome-initial-setup` has issues preventing it from working properly:
-  - The selected key layout does not persist ([LP: #2127782](https://launchpad.net/bugs/2127782))
   - Time zone input dropdown can "wobble" ([LP: #2084611](https://launchpad.net/bugs/2084611))
   - The hostname change is mandatory ([LP: #2093132](https://launchpad.net/bugs/2093132))
 

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -845,7 +845,9 @@ PMDK sees some hardware-specific failures in its test suite, which may make the 
   - Time zone input dropdown can "wobble" ([LP: #2084611](https://launchpad.net/bugs/2084611))
   - The hostname change is mandatory ([LP: #2093132](https://launchpad.net/bugs/2093132))
 
-* During boot on the server image, if your `cloud-init` configuration (in `user-data` on the boot partition) relies upon networking (importing SSH keys, installing packages, etc.) you *must* ensure that at least one network interface is required (`optional: false`) in `network-config` on the boot partition. This is due to Netplan changes to the `wait-online` service (~~[LP: #2060311](https://launchpad.net/bugs/2060311)~~). Furthermore, a current issue may cause `cloud-init` to run before the network is ready ([LP: #2144891](https://launchpad.net/bugs/2144891))
+* During boot on the server image, if your `cloud-init` configuration (in `user-data` on the boot partition) relies upon networking (importing SSH keys, installing packages, etc.) you *must* ensure that at least one network interface is required (`optional: false`) in `network-config` on the boot partition.
+  - This is due to Netplan changes to the `wait-online` service ([LP: #2060311](https://launchpad.net/bugs/2060311)).
+  - Furthermore, a current issue may still cause `cloud-init` to run before the network is ready ([LP: #2144891](https://launchpad.net/bugs/2144891))
 
 * With the removal of the `crda` package in 22.04, the method of setting the WiFi regulatory domain (editing `/etc/default/crda`) no longer operates. On server images, use the `regulatory-domain` option in the Netplan configuration. On desktop images, append `cfg80211.ieee80211_regdom=GB` (substituting `GB` for the relevant country code) to the kernel command line in the `cmdline.txt` file on the boot partition  ([LP: #1951586](https://launchpad.net/bugs/1951586)).
 

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -676,6 +676,8 @@ The `linux-generic` kernel for ARM64 provides broader compatibility for ARM64 de
 ### A new boot layout for Raspberry Pi
 :::{versionadded} 25.10
 :::
+:::{versionchanged} 26.04
+:::
 
 A new layout of the boot partition is introduced to enhance the reliability of the boot process ([LP: #2116266](https://launchpad.net/bugs/2116266)). This will automatically "test" new boot assets written to the boot partition before committing them as the current "known good" set. See the [call for testing](https://discourse.ubuntu.com/t/call-for-testing-a-b-boot-on-raspberry-pi/64173) for more information, or [the blog post](https://waldorf.waveform.org.uk/2025/pull-yourself-up-by-your-bootstraps.html) covering the feature for the full details (including advice on how to opt-out of this feature, where required). The {manpage}`piboot-try(1)` man-page may also be consulted for advanced operations.
 
@@ -686,10 +688,12 @@ For Pi 3, 3+, CM3+, and Zero 2W
 : No action required, the boot firmware is in the image itself.
 
 For Pi 4, 400, CM4
-: Your boot firmware *must* be dated no earlier than **2022-11-25**. To check, run `sudo rpi-eeprom-update`. If your firmware is dated earlier, using Ubuntu 24.04 LTS (Noble Numbat) or later, run `sudo rpi-eeprom-update -a` and reboot.
+: Your boot firmware *must* be dated no earlier than **2022-11-25**.
 
 For Pi 5, 500, CM5
-: No action required, all firmware since release of the platform are compatible.
+: Your boot firmware *must* be dated no earlier than **2025-02-11**.
+
+To check, run `sudo rpi-eeprom-update`. If your firmware is dated earlier, using Ubuntu 24.04 LTS (Noble Numbat) or later, run `sudo rpi-eeprom-update -a` and reboot.
 :::
 
 ### Raspberry Pi is based on the minimal image

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -682,13 +682,13 @@ A new layout of the boot partition is introduced to enhance the reliability of t
 :::{warning}
 Please note that, due to the new boot process, the boot firmware on your Pi *must* be up to date.
 
-For Pi 3, 3+, and Zero 2W
+For Pi 3, 3+, CM3+, and Zero 2W
 : No action required, the boot firmware is in the image itself.
 
-For Pi 4
+For Pi 4, 400, CM4
 : Your boot firmware *must* be dated no earlier than **2022-11-25**. To check, run `sudo rpi-eeprom-update`. If your firmware is dated earlier, using Ubuntu 24.04 LTS (Noble Numbat) or later, run `sudo rpi-eeprom-update -a` and reboot.
 
-For Pi 5
+For Pi 5, 500, CM5
 : No action required, all firmware since release of the platform are compatible.
 :::
 


### PR DESCRIPTION
## Which Ubuntu release is affected by this change?

26.04

## What kind of change is this? Try to select just one if possible.

- [ ] New feature or improvement
- [ ] Backwards-incompatible change, including removed features
- [ ] Deprecated feature – will be removed in a later release
- [x] Bug fix
- [ ] Known issue
- [x] Something else (addition of minimum boot EEPROM date for Pi 5)

Each change is a separate commit for ease of review.

## Which part of Ubuntu does the change affect? Try to select just one if possible.

- [ ] Desktop
- [ ] Server
- [ ] Containers
- [ ] Virtualization
- [ ] Databases
- [ ] High availability and clustering
- [ ] Development tools
- [ ] Enterprise
- [ ] Cloud
- [ ] Security
- [ ] WSL
- [ ] Real-time Ubuntu
- [x] Hardware support
- [ ] A common, underlying change

## Major change

Is this a major change? Major changes are highlighted in an overview and are repeated when the next LTS release comes out.

## Tickets

[LP: #2146383](https://bugs.launchpad.net/ubuntu/+source/ubuntu-release-upgrader/+bug/2146383)

This ticket is not mentioned in the PR because it implements functionality that will be presented to upgraders if/when required (and otherwise should not appear for upgraders).