### PR TITLE
fix(26.04): correct versions of binutils, glibc.

### DIFF
--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -525,7 +525,7 @@ For the full list of [upstream release highlights](https://releases.openstack.or
 
 #### Toolchain upgrades 🛠️
 
-* `glibc` 2.42 now ships non-UTF8 encodings as `libc-gconv-modules-extra`.
+* `glibc` is now at [version 2.43](https://sourceware.org/pipermail/libc-alpha/2026-January/174374.html) which includes ISO C23 changes.
 * LLVM 21 is the default LLVM toolchain.
 * Rust 1.93.1 is the default Rust toolchain.
 

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -525,7 +525,7 @@ For the full list of [upstream release highlights](https://releases.openstack.or
 
 #### Toolchain upgrades 🛠️
 
-* `glibc` is now at [version 2.43](https://sourceware.org/pipermail/libc-alpha/2026-January/174374.html) which includes ISO C23 changes.
+* `glibc` is now at [version 2.43](https://sourceware.org/pipermail/libc-alpha/2026-January/174374.html), which includes ISO C23 changes.
 * LLVM 21 is the default LLVM toolchain.
 * Rust 1.93.1 is the default Rust toolchain.
 

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -497,7 +497,7 @@ Documentation and download resources are available in [the documentation](https:
 
 ## Development
 
-* GCC 🐄 has been updated from version 14 to 15.2, `binutils` from 2.42 to 2.45, and `glibc` from 2.39 to 2.42.
+* GCC 🐄 has been updated from version 14 to 15.2, `binutils` from 2.42 to 2.46, and `glibc` from 2.39 to 2.43.
 * Python 🐍 has been updated from version 3.12 to 3.13.9, while 3.14 is also available.
 * LLVM 🐉 has been updated from version 18 to 21.
 * Rust 🦀 has been updated from version 1.75 to 1.93, while 1.91 and 1.92 are also available.


### PR DESCRIPTION
Correct versions of binutils, glibc for 26.04
Point to upstream glibc changelog.