### PR TITLE
Add 'microarchitecture' to custom wordlist

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -572,6 +572,7 @@ memlock
 metacharacters
 metapackage
 micmute
+microarchitecture
 microversion
 microvm
 middleware


### PR DESCRIPTION
This word is triggering spellcheck failures. Apparently it's the (small c) canonical spelling from AWS, which is the context for the usage in this repo

