### PR TITLE
26.04-summary: add coreutils instructions and known issues 

### DIFF
--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -1018,6 +1018,31 @@ See the Ubuntu bug at [LP: #2138215](https://bugs.launchpad.net/ubuntu/+source/a
 
 This issue was also present in Ubuntu 25.10.
 
+#### `rust-coreutils` vulnerabilities
+
+This release includes the following known vulnerabilities. Please review their impact and apply recommended mitigations or updates as needed.
+
+* [CVE-2026-35341](https://www.cve.org/CVERecord?id=CVE-2026-35341)
+* [CVE-2026-35344](https://www.cve.org/CVERecord?id=CVE-2026-35344)
+* [CVE-2026-35345](https://www.cve.org/CVERecord?id=CVE-2026-35345)
+* [CVE-2026-35348](https://www.cve.org/CVERecord?id=CVE-2026-35348)
+* [CVE-2026-35350](https://www.cve.org/CVERecord?id=CVE-2026-35350)
+* [CVE-2026-35351](https://www.cve.org/CVERecord?id=CVE-2026-35351)
+* [CVE-2026-35352](https://www.cve.org/CVERecord?id=CVE-2026-35352)
+* [CVE-2026-35354](https://www.cve.org/CVERecord?id=CVE-2026-35354)
+* [CVE-2026-35357](https://www.cve.org/CVERecord?id=CVE-2026-35357)
+* [CVE-2026-35359](https://www.cve.org/CVERecord?id=CVE-2026-35359)
+* [CVE-2026-35360](https://www.cve.org/CVERecord?id=CVE-2026-35360)
+* [CVE-2026-35363](https://www.cve.org/CVERecord?id=CVE-2026-35363)
+* [CVE-2026-35364](https://www.cve.org/CVERecord?id=CVE-2026-35364)
+* [CVE-2026-35367](https://www.cve.org/CVERecord?id=CVE-2026-35367)
+* [CVE-2026-35368](https://www.cve.org/CVERecord?id=CVE-2026-35368)
+* [CVE-2026-35370](https://www.cve.org/CVERecord?id=CVE-2026-35370)
+* [CVE-2026-35371](https://www.cve.org/CVERecord?id=CVE-2026-35371)
+* [CVE-2026-35373](https://www.cve.org/CVERecord?id=CVE-2026-35373)
+* [CVE-2026-35374](https://www.cve.org/CVERecord?id=CVE-2026-35374)
+* [CVE-2026-35377](https://www.cve.org/CVERecord?id=CVE-2026-35346)
+
 
 ## Official flavors
 

--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -1020,7 +1020,7 @@ This issue was also present in Ubuntu 25.10.
 
 #### `rust-coreutils` vulnerabilities
 
-This release includes the following known vulnerabilities. Please review their impact and apply recommended mitigations or updates as needed.
+This release includes the following known vulnerabilities. Please, review their impact and apply recommended mitigations or updates as needed.
 
 * [CVE-2026-35341](https://www.cve.org/CVERecord?id=CVE-2026-35341)
 * [CVE-2026-35344](https://www.cve.org/CVERecord?id=CVE-2026-35344)

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -951,7 +951,7 @@ See [Ubuntu Server Docs](https://documentation.ubuntu.com/server/how-to/security
 
 The core utilities of the operating system are now provided by the [`rust-coreutils`](https://launchpad.net/ubuntu/+source/rust-coreutils) package. Among other things, this brings significant performance improvements, such as in the `base64` tool.
 
-Since `rust-coreutils` are not necessarily fully compatible yet, we continue to provide the classic GNU utilities as well. These are accessed by running `gnu` prefixed to the desired command. For example:
+Because `rust-coreutils` are not fully compatible yet, we continue to provide the classic GNU utilities as well. These are accessed by running `gnu` prefixed to the desired command. For example:
 
 ```bash
 gnuls

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -951,7 +951,25 @@ See [Ubuntu Server Docs](https://documentation.ubuntu.com/server/how-to/security
 
 The core utilities of the operating system are now provided by the [`rust-coreutils`](https://launchpad.net/ubuntu/+source/rust-coreutils) package. Among other things, this brings significant performance improvements, such as in the `base64` tool.
 
-Since `rust-coreutils` are not necessarily fully compatible yet, we continue to provide the classic GNU utilities as well. You can switch back and forth between them.
+Since `rust-coreutils` are not necessarily fully compatible yet, we continue to provide the classic GNU utilities as well. These are accessed by running `gnu` prefixed to the desired command. For example:
+
+```bash
+gnuls
+```
+
+Alternatively, you can switch between the two sets of utilities by running the following command:
+
+```bash
+# To switch to GNU coreutils
+sudo apt install coreutils-from-gnu --allow-remove-essential
+
+# To switch back to rust-coreutils
+sudo apt install coreutils-from-uutils --allow-remove-essential
+```
+
+Because of unresolved bugs, `cp`, `mp`, and `rm` are still from GNU in
+`rust-coreutils`.
+Please see for more information https://discourse.ubuntu.com/t/an-update-on-rust-coreutils/80773
 
 
 ### Architecture variants and `amd64v3`

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -959,13 +959,15 @@ gnuls
 
 Alternatively, you can switch between the two sets of utilities by running the following commands:
 
-```bash
-# To switch to GNU coreutils
-sudo apt install coreutils-from-gnu --allow-remove-essential
+To switch to GNU coreutils:
+: ```none
+  sudo apt install coreutils-from-gnu --allow-remove-essential
+  ```
 
-# To switch back to rust-coreutils
-sudo apt install coreutils-from-uutils --allow-remove-essential
-```
+To switch back to rust-coreutils:
+: ```none
+  sudo apt install coreutils-from-uutils --allow-remove-essential
+  ```
 
 Because of unresolved bugs, `cp`, `mp`, and `rm` are still from GNU in `rust-coreutils`.
 For more information please see: https://discourse.ubuntu.com/t/an-update-on-rust-coreutils/80773

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -967,9 +967,8 @@ sudo apt install coreutils-from-gnu --allow-remove-essential
 sudo apt install coreutils-from-uutils --allow-remove-essential
 ```
 
-Because of unresolved bugs, `cp`, `mp`, and `rm` are still from GNU in
-`rust-coreutils`.
-Please see for more information https://discourse.ubuntu.com/t/an-update-on-rust-coreutils/80773
+Because of unresolved bugs, `cp`, `mp`, and `rm` are still from GNU in `rust-coreutils`.
+For more information please see: https://discourse.ubuntu.com/t/an-update-on-rust-coreutils/80773
 
 
 ### Architecture variants and `amd64v3`

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -970,7 +970,7 @@ To switch back to rust-coreutils:
   ```
 
 Because of unresolved bugs, the `cp`, `mp`, and `rm` utilities are still from GNU in `rust-coreutils`.
-For more information please see: https://discourse.ubuntu.com/t/an-update-on-rust-coreutils/80773
+For more information, see [An update on rust-coreutils](https://discourse.ubuntu.com/t/an-update-on-rust-coreutils/80773).
 
 
 ### Architecture variants and `amd64v3`

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -969,7 +969,7 @@ To switch back to rust-coreutils:
   sudo apt install coreutils-from-uutils --allow-remove-essential
   ```
 
-Because of unresolved bugs, `cp`, `mp`, and `rm` are still from GNU in `rust-coreutils`.
+Because of unresolved bugs, the `cp`, `mp`, and `rm` utilities are still from GNU in `rust-coreutils`.
 For more information please see: https://discourse.ubuntu.com/t/an-update-on-rust-coreutils/80773
 
 

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -953,7 +953,7 @@ The core utilities of the operating system are now provided by the [`rust-coreut
 
 Because `rust-coreutils` are not fully compatible yet, we continue to provide the classic GNU utilities as well. These are accessed by running `gnu` prefixed to the desired command. For example:
 
-```bash
+```none
 gnuls
 ```
 

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -957,7 +957,7 @@ Because `rust-coreutils` are not fully compatible yet, we continue to provide th
 gnuls
 ```
 
-Alternatively, you can switch between the two sets of utilities by running the following command:
+Alternatively, you can switch between the two sets of utilities by running the following commands:
 
 ```bash
 # To switch to GNU coreutils


### PR DESCRIPTION
Previously the release notes mention being able to switch between uutils and GNU, but did not show how. Add those instructions and mention the utilities that still come from GNU in uutils. 

Also, list the known CVEs for `rust-coreutils` in the known issues section. This should maybe be sorted higher and is currently at the bottom of its section.