### PR TITLE
Fix release schedule

### DIFF
--- a/docs/24.04/schedule.md
+++ b/docs/24.04/schedule.md
@@ -63,6 +63,10 @@ Week | Date (Thursday) | 24.04 events
 |... | ||
 |**February 2026**| ||
 |121 | February 12 | [24.04.4 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)|
+|... | ||
+|**August 2026**| ||
+|149 | August 27 | [24.04.5 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)|
+|... | ||
 
 ## Planned and potentially disruptive archive-wide activities
 

--- a/docs/24.04/schedule.md
+++ b/docs/24.04/schedule.md
@@ -50,19 +50,19 @@ Week | Date (Thursday) | 24.04 events
 45 | August 29 | [24.04.1 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)
 ... | ... | 
 **February 2025** |
-67 | February 06 | 
-68 | February 13 | [24.04.2 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)
-69 | February 20 | 
-70 | February 27 | 
+68 | February 06 |
+69 | February 13 | [24.04.2 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)
+70 | February 20 |
+71 | February 27 |
 |... |  | |
 |**August 2025** |  | |
-|93 | August 07 | [24.04.3 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)|
-|94 | August 14 | |
-|95 | August 21 | |
-|96 | August 28 | |
+|94 | August 07 | [24.04.3 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)|
+|95 | August 14 | |
+|96 | August 21 | |
+|97 | August 28 | |
 |... | ||
 |**February 2026**| ||
-|110 | February 12 | [24.04.4 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)|
+|121 | February 12 | [24.04.4 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)|
 
 ## Planned and potentially disruptive archive-wide activities
 

--- a/docs/26.04/schedule.md
+++ b/docs/26.04/schedule.md
@@ -57,6 +57,9 @@
 | 26 | April 09 | [Kernel Freeze](https://wiki.ubuntu.com/KernelFreeze), [Non Language Pack Translation Deadline](https://wiki.ubuntu.com/NonLanguagePackTranslationDeadline) |
 | 27 | April 16 | [Final Freeze](https://wiki.ubuntu.com/FinalFreeze), [Release Candidate](https://wiki.ubuntu.com/ReleaseCandidate), [Language Pack Translation Deadline](https://wiki.ubuntu.com/LanguagePackTranslationDeadline) |
 | 28 | April 23 | [Final Release](https://wiki.ubuntu.com/FinalRelease) |
+|... | ||
+| **July 2026**| ||
+| 39 | July 9 | [26.04.1 Point Release ](https://wiki.ubuntu.com/PointReleaseProcess)]
 
 ## Planned and potentially disruptive archive-wide activities
 


### PR DESCRIPTION
Update release schedule to include 24.04.5 and 26.04.1 point releases. Also fix off-by-one in 24.04 schedule.