### PR TITLE
Add updates for OpenJDK CRaC and Zig, refine the TCK section

### DIFF
--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -398,6 +398,7 @@ For the full list of [upstream release highlights](https://releases.openstack.or
 * `glibc` is now at [version 2.43](https://sourceware.org/pipermail/libc-alpha/2026-January/174374.html), which includes ISO C23 changes.
 * LLVM 21 is the default LLVM toolchain.
 * Rust 1.93.1 is the default Rust toolchain.
+* Zig 0.15.2 is now available, additionally for riscv64.
 
 #### OpenJDK
 

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -616,6 +616,10 @@ Documentation and download resources are available in [the documentation](https:
 
 OpenJDK 25 package is available and is TCK (Technology Compatibility Kit) certified on AMD64, ARM64, S390X, PPC64EL. The Java TCK is the most comprehensive test suite that covers all aspects of Java SE specification including language features, libraries and APIs. This guarantees interoperability and conformance to standard. OpenJDK 21 and 17 are also TCK certified.
 
+### OpenJDK CRaC
+
+OpenJDK CRaC (Co-ordinated Restore at Checkpoint) packages for versions 25, 21 and 17 are available on AMD64.
+
 ### Spring® snaps
 :::{versionadded} 25.04
 :::
@@ -628,7 +632,7 @@ Developers can now quickly build Ubuntu ROCK images for their Java applications 
 :::{versionadded} 25.04
 :::
 
-GraalVM Community Edition for JDK versions 21, 24 and 25 is now available as a [snap](https://snapcraft.io/graalvm-jdk). Java developers now have a choice to build and deploy their applications with standard OpenJDK, with OpenJDK-CRaC or as a GraalVM native image.
+GraalVM Community Edition for JDK versions 21, 24 and 25 is now available as a [snap](https://snapcraft.io/graalvm-jdk). Java developers now have a choice to build and deploy their applications with standard OpenJDK, with OpenJDK CRaC or as a GraalVM native image.
 
 
 ### .NET 10

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -618,7 +618,7 @@ OpenJDK 25 package is available and is TCK (Technology Compatibility Kit) certif
 
 ### OpenJDK CRaC
 
-OpenJDK CRaC (Co-ordinated Restore at Checkpoint) packages for versions 25, 21 and 17 are available on AMD64.
+OpenJDK CRaC (Co-ordinated Restore at Checkpoint) packages for versions 25, 21, and 17 are available on AMD64.
 
 ### Spring® snaps
 :::{versionadded} 25.04

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -614,13 +614,7 @@ Documentation and download resources are available in [the documentation](https:
 :::{versionadded} 25.10
 :::
 
-OpenJDK 25 package is available and is TCK (Technology Compatibility Kit) certified on AMD64, ARM64, S390X, PPC64EL. The Java TCK is the most comprehensive test suite that covers all aspects of Java SE specification including language features, libraries and APIs. This guarantees interoperability and conformance to standard.
-
-### OpenJDK 21 and TCK certification
-:::{versionadded} 24.10
-:::
-
-OpenJDK 21 and OpenJDK 17 packages are now TCK (Technology Compatibility Kit) certified on AMD64, ARM64, s390x, ppc64el. The Java TCK is the most comprehensive test suite that covers all aspects of Java SE specification including language features, libraries and APIs. This guarantees interoperability and conformance to standard.
+OpenJDK 25 package is available and is TCK (Technology Compatibility Kit) certified on AMD64, ARM64, S390X, PPC64EL. The Java TCK is the most comprehensive test suite that covers all aspects of Java SE specification including language features, libraries and APIs. This guarantees interoperability and conformance to standard. OpenJDK 21 and 17 are also TCK certified.
 
 ### Spring® snaps
 :::{versionadded} 25.04


### PR DESCRIPTION
1. Removed section on TCK for OpenJDK 17 and 21 because the Ubuntu 24.04 mentioned this.
2. Added an OpenJDK CRaC section in `summary-for-lts-users`
3. Added the Zig version update in `changes-since-previous-interim`.