### PR TITLE
26.04: add link to Subiquity release notes

### DIFF
--- a/docs/26.04/changes-since-previous-interim.md
+++ b/docs/26.04/changes-since-previous-interim.md
@@ -742,6 +742,10 @@ The Manila V1 API and the Manila shell utility have been removed.
 
 For details, see the Manila [release highlights](https://releases.openstack.org/gazpacho/highlights#manila) and [release notes](https://docs.openstack.org/releasenotes/manila/2026.1.html).
 
+#### Installer
+
+The Subiquity installer has been updated. Please see the [Subiquity 26.04 release notes](https://github.com/canonical/subiquity/releases/26.04) on GitHub.
+
 ### System changes
 
 (cgroup-v1-removed)=

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -600,7 +600,13 @@ per-release changes and the related upstream announcements.
 
 ### Installer
 
-The Subiquity installer has been updated. Please see the [Subiquity 26.04 release notes](https://github.com/canonical/subiquity/releases/26.04) on GitHub.
+The Subiquity installer has been updated. See the Subiquity release notes on GitHub:
+
+- [24.08.1](https://github.com/canonical/subiquity/releases/tag/24.08.1)
+- [24.10.1](https://github.com/canonical/subiquity/releases/tag/24.10.1)
+- [25.04](https://github.com/canonical/subiquity/releases/tag/25.04)
+- [25.10](https://github.com/canonical/subiquity/releases/tag/25.10)
+- [26.04](https://github.com/canonical/subiquity/releases/26.04)
 
 ## WSL
 

--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -598,6 +598,10 @@ per-release changes and the related upstream announcements.
 
 * Pacemaker was updated to version 3. All new features and breaking changes are described in the [upstream release notes](https://projects.clusterlabs.org/w/projects/pacemaker/pacemaker_3.0_changes/).
 
+### Installer
+
+The Subiquity installer has been updated. Please see the [Subiquity 26.04 release notes](https://github.com/canonical/subiquity/releases/26.04) on GitHub.
+
 ## WSL
 
 ### Ubuntu Insights


### PR DESCRIPTION
Adding a link to the Subiquity upstream release notes for 26.04.