### PR TITLE
Correct Edubuntu release notes link for 26.04 LTS

### DIFF
--- a/docs/26.04/index.md
+++ b/docs/26.04/index.md
@@ -79,7 +79,7 @@ While an internet connection is recommended for updates and additional software,
 
 Find the release notes for the official flavors at the following links:
 
-* [Edubuntu Release Notes](https://discourse.ubuntu.com/t/edubuntu-26-04-released/)
+* [Edubuntu Release Notes](https://discourse.ubuntu.com/t/edubuntu-26-04-lts-released/)
 * [Kubuntu Release Notes](https://kubuntu.org/news/kubuntu-26-04-release-notes/)
 * [Lubuntu Release Notes](https://lubuntu.me/lubuntu-26-04-lts-released/)
 * [Ubuntu Budgie Release Notes](https://ubuntubudgie.org/blog/ubuntu-budgie-2604-lts-release-notes/)


### PR DESCRIPTION
I had typo'd the link somehow. This has been fixed and is the correct link from #199 .