### PR TITLE
26.04: fix firefox and gimp release note links

### DIFF
--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -15,10 +15,10 @@ The following is an overview of the major changes.
 
 ### Updated applications
 
-* Firefox 🔥🦊 has been updated [to version 149](https://www.firefox.com/en-US/firefox/148.0/releasenotes/) / [150](https://www.firefox.com/en-US/firefox/148.0/releasenotes/).
+* Firefox 🔥🦊 has been updated [to version 149](https://www.firefox.com/en-US/firefox/149.0/releasenotes/) / [150](https://www.firefox.com/en-US/firefox/150.0/releasenotes/).
 * LibreOffice 📚 has been updated from version 24.2 [to 25.8](https://wiki.documentfoundation.org/ReleaseNotes/25.8).
 * Thunderbird 🌩️🐦 has been updated [to version 140 "Eclipse"](https://blog.thunderbird.net/2025/07/welcome-to-thunderbird-140-eclipse/).
-* GNU Image Manipulation Program 🖼️ has received a major update from version 2.10 [to 3.0](https://www.gimp.org/news/2025/03/16/gimp-3-0-released/).
+* GNU Image Manipulation Program 🖼️ has received a major update from version 2.10 [via 3.0](https://www.gimp.org/news/2025/03/16/gimp-3-0-released/) to [3.2](https://www.gimp.org/news/2026/03/14/gimp-3-2-released/).
 
 ### GNOME 50
 


### PR DESCRIPTION
firefox links were to 148 both, and we have gimp 3.2 in 26.04.