### PR TITLE
fix: typo in IBM Z architecture name

### DIFF
--- a/docs/26.04/summary-for-lts-users.md
+++ b/docs/26.04/summary-for-lts-users.md
@@ -997,7 +997,7 @@ As of April 2026, no RVA23S64 hardware is available yet. The only supported RISC
 :::{versionchanged} 26.04
 :::
 
-On the IBM Z (s390s) architecture, Ubuntu 26.04 LTS now requires the z15 architectural level at minimum. As a result, you can't install Ubuntu 26.04 LTS on IBM Z generation z14 (LinuxONE II) or older.
+On the IBM Z (s390x) architecture, Ubuntu 26.04 LTS now requires the z15 architectural level at minimum. As a result, you can't install Ubuntu 26.04 LTS on IBM Z generation z14 (LinuxONE II) or older.
 
 The performance on IBM Z generation z15 (LinuxONE III) and newer has improved.
 


### PR DESCRIPTION
# Adding a release note

After the previous PR (#167) was closed, I immediately found the same error in another doc, fixing the typo here as well

## Which Ubuntu release is affected by this change?
Release notes (summary) for 26.04 LTS

## What kind of change is this? Try to select just one if possible.

- [ ] New feature or improvement
- [ ] Backwards-incompatible change, including removed features
- [ ] Deprecated feature – will be removed in a later release
- [X] Bug fix (typo)
- [ ] Known issue
- [ ] Something else (please describe)