### PR TITLE
foundations: mention full rust-coreutils

### DIFF
--- a/docs/26.10/index.md
+++ b/docs/26.10/index.md
@@ -29,7 +29,7 @@ Release schedule <schedule>
 
 #### 100% Rust coreutils
 
-The default core utilities now run entirely on the Rust-based uutils
+The default core utilities now run entirely on the Rust-based `uutils`
 implementation. The remaining GNU utilities (`cp`, `mv`, and `rm`), previously
 retained due to compatibility issues, have now been migrated.
 

--- a/docs/26.10/index.md
+++ b/docs/26.10/index.md
@@ -26,6 +26,13 @@ Release schedule <schedule>
 ### Default configuration changes ⚙️
 ### Ubuntu Desktop
 ### Ubuntu Foundations
+
+#### 100% Rust coreutils
+
+The default core utilities now run entirely on the Rust-based uutils
+implementation. The remaining GNU utilities (`cp`, `mv`, and `rm`), previously
+retained due to compatibility issues, have now been migrated.
+
 ### Ubuntu Server
 ### OpenStack
 ### Platforms


### PR DESCRIPTION
# Adding a release note

## Which Ubuntu release is affected by this change?

Ubuntu 26.10 Stonking Stingray

## What kind of change is this? Try to select just one if possible.

- [ ] New feature or improvement
- [ ] Backwards-incompatible change, including removed features
- [ ] Deprecated feature – will be removed in a later release
- [X] Bug fix
- [ ] Known issue
- [ ] Something else (please describe)

## Which part of Ubuntu does the change affect? Try to select just one if possible.

- [ ] Desktop
- [ ] Server
- [ ] Containers
- [ ] Virtualization
- [ ] Databases
- [ ] High availability and clustering
- [ ] Development tools
- [ ] Enterprise
- [ ] Cloud
- [ ] Security
- [ ] WSL
- [ ] Real-time Ubuntu
- [ ] Hardware support
- [X] A common, underlying change

## Tickets

- GitHub: #243 
